### PR TITLE
dev: unfocus document on changed to other files

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -68,7 +68,7 @@ async function startClient(context: ExtensionContext): Promise<void> {
 
     window.onDidChangeActiveTextEditor((editor: TextEditor | undefined) => {
         if (editor?.document.languageId !== "typst") {
-            return;
+            return commandActivateDoc(undefined);
         }
         return commandActivateDoc(editor);
     });


### PR DESCRIPTION
to remove diagnostics when you change to other kind of files, for example, some rust file.