### PR TITLE
feat: support query of cross-module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Language service (LSP) features:
 - [Goto definitions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-definitions-of-a-symbol)
   - Right-click on a symbol and select "Go to Definition".
   - Or ctrl+click on a symbol.
-<!-- - [Goto declarations](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#find-all-references-to-a-symbol)
-  - Also known as "find all references". -->
+- [References](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#find-all-references-to-a-symbol)
+  - Right-click on a symbol and select "Go to References" or "Find References".
+  - Or ctrl+click on a symbol.
 - [Hover tips](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-hovers)
   - Also known as "hovering tooltip".
 - [Inlay hints](https://www.jetbrains.com/help/idea/inlay-hints.html)

--- a/crates/tinymist-query/src/analysis/def_use.rs
+++ b/crates/tinymist-query/src/analysis/def_use.rs
@@ -174,9 +174,13 @@ impl<'a, 'b, 'w> DefUseCollector<'a, 'b, 'w> {
                 | LexicalKind::Mod(super::LexicalModKind::ModuleAlias) => {
                     self.insert_module(Ns::Value, e)
                 }
-                LexicalKind::Mod(super::LexicalModKind::Ident)
-                | LexicalKind::Mod(super::LexicalModKind::Alias { .. }) => {
-                    self.insert_extern(Ns::Value, e)
+                LexicalKind::Mod(super::LexicalModKind::Ident) => {
+                    self.insert(Ns::Value, e);
+                    self.insert_extern(e.info.name.clone(), e.info.range.clone());
+                }
+                LexicalKind::Mod(super::LexicalModKind::Alias { target }) => {
+                    self.insert(Ns::Value, e);
+                    self.insert_extern(target.name.clone(), target.range.clone());
                 }
                 LexicalKind::Var(LexicalVarKind::ValRef) => self.insert_ref(Ns::Value, e),
                 LexicalKind::Block => {
@@ -254,15 +258,11 @@ impl<'a, 'b, 'w> DefUseCollector<'a, 'b, 'w> {
         }
     }
 
-    fn insert_extern(&mut self, label: Ns, e: &LexicalHierarchy) {
-        self.insert(label, e);
+    fn insert_extern(&mut self, name: String, range: Range<usize>) {
         if let Some(src) = &self.ext_src {
             self.info.external_refs.insert(
-                (src.id(), Some(e.info.name.clone())),
-                vec![IdentRef {
-                    name: e.info.name.clone(),
-                    range: e.info.range.clone(),
-                }],
+                (src.id(), Some(name.clone())),
+                vec![IdentRef { name, range }],
             );
         }
     }

--- a/crates/tinymist-query/src/analysis/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/analysis/lexical_hierarchy.rs
@@ -449,6 +449,26 @@ impl LexicalHierarchyWorker {
                         }
                     }
                 }
+                SyntaxKind::RenamedImportItem if self.g.affect_import() => {
+                    let src = node
+                        .cast::<ast::RenamedImportItem>()
+                        .ok_or_else(|| anyhow!("cast to renamed import item failed: {:?}", node))?;
+
+                    let origin_name = src.new_name();
+                    let origin_name_node = node.find(origin_name.span()).context("no pos")?;
+
+                    let target_name = src.original_name();
+                    let target_name_node = node.find(target_name.span()).context("no pos")?;
+
+                    self.push_leaf(LexicalInfo {
+                        name: origin_name.get().to_string(),
+                        kind: LexicalKind::module_import_alias(ImportAlias {
+                            name: target_name.get().to_string(),
+                            range: target_name_node.range(),
+                        }),
+                        range: origin_name_node.range(),
+                    });
+                }
                 SyntaxKind::FieldAccess => {
                     self.get_symbols_in_first_expr(node.children())?;
                 }
@@ -528,23 +548,6 @@ impl LexicalHierarchyWorker {
                 };
 
                 (name, kind)
-            }
-            SyntaxKind::RenamedImportItem if self.g.affect_import() => {
-                let src = node
-                    .cast::<ast::RenamedImportItem>()
-                    .ok_or_else(|| anyhow!("cast to renamed import item failed: {:?}", node))?;
-
-                let name = src.new_name().get().to_string();
-
-                let target_name = src.original_name();
-                let target_name_node = node.find(target_name.span()).context("no pos")?;
-                (
-                    name,
-                    LexicalKind::module_import_alias(ImportAlias {
-                        name: target_name.get().to_string(),
-                        range: target_name_node.range(),
-                    }),
-                )
             }
             SyntaxKind::Equation | SyntaxKind::Raw | SyntaxKind::BlockComment
                 if self.g.affect_markup() =>

--- a/crates/tinymist-query/src/analysis/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/analysis/lexical_hierarchy.rs
@@ -113,7 +113,7 @@ pub enum LexicalVarKind {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum LexicalKind {
+pub enum LexicalKind {
     Heading(i16),
     Var(LexicalVarKind),
     Mod(LexicalModKind),

--- a/crates/tinymist-query/src/fixtures/references/cross_module.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module.typ
@@ -1,0 +1,5 @@
+#import "base.typ": *
+#x
+-----
+// path: base.typ
+#let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module2.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module2.typ
@@ -1,0 +1,5 @@
+#import "base.typ": x
+#x
+-----
+// path: base.typ
+#let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_absolute.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_absolute.typ
@@ -1,0 +1,6 @@
+// path: /out/main.typ
+#import "/out/base.typ": x
+#x
+-----
+// path: /out/base.typ
+#let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_alias.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_alias.typ
@@ -1,0 +1,5 @@
+// path: base.typ
+#let x = 1;
+-----
+#import "base.typ": x as /* ident after */ ff
+#ff

--- a/crates/tinymist-query/src/fixtures/references/cross_module_alias2.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_alias2.typ
@@ -1,0 +1,5 @@
+#import "base.typ": x as ff
+#ff
+-----
+// path: base.typ
+#let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_relative.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_relative.typ
@@ -1,0 +1,6 @@
+// path: /out/main.typ
+#import "base.typ": x
+#x
+-----
+// path: /out/base.typ
+#let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module.typ
+---
+[
+ {
+  "range": "1:1:1:2"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module2.typ.snap
@@ -3,4 +3,8 @@ source: crates/tinymist-query/src/references.rs
 expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
 input_file: crates/tinymist-query/src/fixtures/references/cross_module2.typ
 ---
-null
+[
+ {
+  "range": "0:20:0:21"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module2.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module2.typ
+---
+null

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_absolute.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_absolute.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module_absolute.typ
+---
+[
+ {
+  "range": "0:25:0:26"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_alias.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_alias.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module_alias.typ
+---
+[
+ {
+  "range": "1:1:1:3"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_alias2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_alias2.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module_alias2.typ
+---
+[
+ {
+  "range": "0:20:0:21"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_relative.typ.snap
+++ b/crates/tinymist-query/src/fixtures/references/snaps/test@cross_module_relative.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/references.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/references/cross_module_relative.typ
+---
+[
+ {
+  "range": "0:20:0:21"
+ }
+]

--- a/crates/tinymist-query/src/inlay_hint.rs
+++ b/crates/tinymist-query/src/inlay_hint.rs
@@ -140,10 +140,10 @@ fn inlay_hint(
                         Value::Func(f) => Some(f),
                         _ => None,
                     })?;
-                    log::info!("got function {func:?}");
+                    log::debug!("got function {func:?}");
 
                     let call_info = analyze_call(func, args)?;
-                    log::info!("got call_info {call_info:?}");
+                    log::debug!("got call_info {call_info:?}");
 
                     let check_single_pos_arg = || {
                         let mut pos = 0;


### PR DESCRIPTION
[References](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#find-all-references-to-a-symbol)
- Right-click on a symbol and select "Go to References" or "Find References".
- Or ctrl+click on a symbol.