### PR TITLE
feat: supports vscode variables in configurations and ..

### DIFF
--- a/crates/tinymist/src/lib.rs
+++ b/crates/tinymist/src/lib.rs
@@ -841,7 +841,9 @@ impl TypstLanguageServer {
             Ok(()) => {}
             Err(err) => {
                 error!("error applying new settings: {err}");
-                return Err(internal_error("Internal error"));
+                return Err(invalid_params(format!(
+                    "error applying new settings: {err}"
+                )));
             }
         }
 

--- a/editors/vscode/src/vscode-variables.d.ts
+++ b/editors/vscode/src/vscode-variables.d.ts
@@ -1,3 +1,3 @@
 declare module "vscode-variables" {
-    export default function vscodeVariables<T>(arg: T): T;
+    export default function vscodeVariables<T>(arg: string, recursive?: boolean): string;
 }

--- a/tools/editor-tools/src/global.d.ts
+++ b/tools/editor-tools/src/global.d.ts
@@ -1,2 +1,2 @@
 interface Window {}
-const acquireVsCodeApi: any;
+declare const acquireVsCodeApi: any;


### PR DESCRIPTION
You can set root/server/font path(s) with vscode variables. The variables are listed in https://www.npmjs.com/package/vscode-variables.

+ more testing and validation