### PR TITLE
feat: provide dhat instrumenting feature for heap usage analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2131,12 @@ dependencies = [
  "adler",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
@@ -3523,6 +3545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,6 +3624,7 @@ dependencies = [
  "codespan-reporting",
  "comemo",
  "crossbeam-channel",
+ "dhat",
  "env_logger",
  "futures",
  "itertools 0.12.1",

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -52,11 +52,13 @@ typst-preview = { workspace = true, optional = true }
 lsp-server.workspace = true
 crossbeam-channel.workspace = true
 lsp-types.workspace = true
+dhat = { version = "0.3.3", optional = true }
 
 [features]
 default = ["cli", "preview"]
 cli = ["clap"]
 preview = ["typst-preview"]
+dhat-heap = ["dhat"]
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/tinymist/README.md
+++ b/crates/tinymist/README.md
@@ -22,3 +22,24 @@ tinymist --mirror input.txt
 # Replay the input
 tinymist --replay input.txt
 ```
+
+## Analyze memory usage with DHAT
+
+You can build the program with `dhat-heap` feature to collect memory usage with DHAT. The DHAT will instrument the allocator dynamically, so it will slow down the program significantly.
+
+```sh
+cargo build --release --bin tinymist --features dhat-heap
+```
+
+The instrumented program is nothing different from the normal program, so you can mine the specific memory usage with a lsp session (recorded with `--mirror`) by replaying the input.
+
+```sh
+./target/release/tinymist --replay input.txt
+...
+dhat: Total:     740,668,176 bytes in 1,646,987 blocks
+dhat: At t-gmax: 264,604,009 bytes in 317,241 blocks
+dhat: At t-end:  259,597,420 bytes in 313,588 blocks
+dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
+```
+
+Once you have the `dhat-heap.json`, you can visualize the memory usage with [the DHAT viewer](https://nnethercote.github.io/dh_view/dh_view.html).

--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -204,6 +204,14 @@ impl<R: Read + BufRead, W: Write> BufRead for MirrorWriter<R, W> {
     }
 
     fn consume(&mut self, amt: usize) {
+        let buf = self.0.fill_buf().unwrap();
+
+        if let Err(err) = self.1.write_all(&buf[..amt]) {
+            self.2.call_once(|| {
+                warn!("failed to write to mirror: {err}");
+            });
+        }
+
         self.0.consume(amt);
     }
 }

--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -24,6 +24,10 @@ use crate::args::CliArguments;
 
 use lsp_server::{Connection, Message, Response};
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn from_json<T: DeserializeOwned>(
     what: &'static str,
     json: &serde_json::Value,
@@ -35,6 +39,9 @@ fn from_json<T: DeserializeOwned>(
 /// The main entry point.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     // Start logging
     let _ = {
         use log::LevelFilter::*;


### PR DESCRIPTION

## Analyze memory usage with DHAT

You can build the program with `dhat-heap` feature to collect memory usage with DHAT. The DHAT will instrument the allocator dynamically, so it will slow down the program significantly.

```sh
cargo build --release --bin tinymist --features dhat-heap
```

The instrumented program is nothing different from the normal program, so you can mine the specific memory usage with a lsp session (recorded with `--mirror`) by replaying the input.

```sh
./target/release/tinymist --replay input.txt
...
dhat: Total:     740,668,176 bytes in 1,646,987 blocks
dhat: At t-gmax: 264,604,009 bytes in 317,241 blocks
dhat: At t-end:  259,597,420 bytes in 313,588 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
```

Once you have the `dhat-heap.json`, you can visualize the memory usage with [the DHAT viewer](https://nnethercote.github.io/dh_view/dh_view.html).