### PR TITLE
fix: steal the latest compiled document for lsp functions

### DIFF
--- a/crates/tinymist/src/actor/typst.rs
+++ b/crates/tinymist/src/actor/typst.rs
@@ -673,7 +673,7 @@ impl CompileActor {
         &self,
         f: impl FnOnce(&TypstSystemWorld, Option<VersionedDocument>) -> T + Send + Sync + 'static,
     ) -> anyhow::Result<T> {
-        let fut = self.steal(move |compiler| f(compiler.compiler.world(), compiler.doc()));
+        let fut = self.steal(move |compiler| f(compiler.compiler.world(), compiler.success_doc()));
 
         Ok(fut?)
     }


### PR DESCRIPTION
close #66 