### PR TITLE
dev: ensure to run a single compiler instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,7 +3603,6 @@ dependencies = [
  "reflexo",
  "serde",
  "serde_json",
- "tinymist",
 ]
 
 [[package]]

--- a/crates/tinymist/src/server/lsp_init.rs
+++ b/crates/tinymist/src/server/lsp_init.rs
@@ -380,14 +380,15 @@ impl Init {
         tokio::spawn(cluster_actor.run());
 
         // Respond to the host (LSP client)
+
+        // Register these capabilities statically if the client does not support dynamic
+        // registration
         let semantic_tokens_provider = match service.config.semantic_tokens {
             SemanticTokensMode::Enable if !cc.sema_tokens_dynamic_registration => {
                 Some(get_semantic_tokens_options().into())
             }
             _ => None,
         };
-
-        //  if !cc.doc_fmt_dynamic_registration
         let document_formatting_provider = match service.config.formatter {
             FormatterMode::Typstyle | FormatterMode::Typstfmt
                 if !cc.doc_fmt_dynamic_registration =>
@@ -467,7 +468,6 @@ fn create_font_book(opts: CompileFontOpts) -> ZResult<SharedFontResolver> {
     let res = crate::world::LspWorldBuilder::resolve_fonts(opts)?;
     Ok(SharedFontResolver {
         inner: Arc::new(res),
-        // inner: res,
     })
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,7 +9,6 @@ name = "tinymist-e2e-tests"
 path = "e2e/main.rs"
 
 [dev-dependencies]
-tinymist.workspace = true
 lsp-server.workspace = true
 lsp-types.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Previously we run two instances if users or typst-preview request pinning, which is not optimal. Now we can gracefully run with a single compiler instance. The dedicate-compiler design is still reserved for concurrent task in future.