### PR TITLE
feat: support untitled url scheme for unsaved text buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "lsp-types",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "reflexo",
  "regex",
  "serde",

--- a/crates/tinymist-query/Cargo.toml
+++ b/crates/tinymist-query/Cargo.toml
@@ -37,6 +37,7 @@ reflexo.workspace = true
 
 lsp-types.workspace = true
 if_chain = "1"
+percent-encoding = "2"
 
 [dev-dependencies]
 once_cell.workspace = true

--- a/crates/tinymist-query/src/goto_declaration.rs
+++ b/crates/tinymist-query/src/goto_declaration.rs
@@ -60,7 +60,7 @@ impl SemanticRequest for GotoDeclarationRequest {
             let span_path = ctx.path_for_id(ref_id).ok()?;
             let range = ctx.to_lsp_range(ref_range, ref_source);
 
-            let uri = Url::from_file_path(span_path).ok()?;
+            let uri = path_to_url(&span_path).ok()?;
 
             links.push(LocationLink {
                 origin_selection_range: Some(origin_selection_range),

--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -54,7 +54,7 @@ impl SemanticRequest for GotoDefinitionRequest {
         let def = find_definition(ctx, source.clone(), deref_target)?;
 
         let span_path = ctx.path_for_id(def.fid).ok()?;
-        let uri = Url::from_file_path(span_path).ok()?;
+        let uri = path_to_url(&span_path).ok()?;
 
         let span_source = ctx.source_by_id(def.fid).ok()?;
         let range = ctx.to_lsp_range(def.def_range, &span_source);

--- a/crates/tinymist-query/src/prelude.rs
+++ b/crates/tinymist-query/src/prelude.rs
@@ -30,7 +30,7 @@ pub use typst::World;
 
 pub use crate::analysis::{analyze_expr, AnalysisContext};
 pub use crate::lsp_typst_boundary::{
-    lsp_to_typst, typst_to_lsp, LspDiagnostic, LspRange, LspSeverity, PositionEncoding,
-    TypstDiagnostic, TypstSeverity, TypstSpan,
+    lsp_to_typst, path_to_url, typst_to_lsp, LspDiagnostic, LspRange, LspSeverity,
+    PositionEncoding, TypstDiagnostic, TypstSeverity, TypstSpan,
 };
 pub use crate::VersionedDocument;

--- a/crates/tinymist-query/src/references.rs
+++ b/crates/tinymist-query/src/references.rs
@@ -116,7 +116,7 @@ pub(crate) fn find_references_root(
 ) -> Option<Vec<LspLocation>> {
     let def_source = ctx.source_by_id(def_fid).ok()?;
     let def_path = ctx.path_for_id(def_fid).ok()?;
-    let uri = Url::from_file_path(def_path).ok()?;
+    let uri = path_to_url(&def_path).ok()?;
 
     // todo: reuse uri, range to location
     let mut references = def_use
@@ -140,7 +140,7 @@ pub(crate) fn find_references_root(
             let def_use = ctx.ctx.def_use(ref_source.clone())?;
 
             let uri = ctx.ctx.path_for_id(ref_fid).ok()?;
-            let uri = Url::from_file_path(uri).ok()?;
+            let uri = path_to_url(&uri).ok()?;
 
             let mut redefines = vec![];
             if let Some((id, _def)) = def_use.get_def(def_fid, &def_ident) {
@@ -170,7 +170,7 @@ mod tests {
     use typst_ts_core::path::unix_slash;
 
     use super::*;
-    use crate::tests::*;
+    use crate::{tests::*, url_to_path};
 
     #[test]
     fn test() {
@@ -196,7 +196,7 @@ mod tests {
             let result = result.map(|v| {
                 v.into_iter()
                     .map(|l| {
-                        let fp = unix_slash(&l.uri.to_file_path().unwrap());
+                        let fp = unix_slash(&url_to_path(l.uri));
                         let fp = fp.strip_prefix("C:").unwrap_or(&fp);
                         format!(
                             "{fp}@{}:{}:{}:{}",

--- a/crates/tinymist-query/src/rename.rs
+++ b/crates/tinymist-query/src/rename.rs
@@ -48,7 +48,7 @@ impl SemanticRequest for RenameRequest {
             let def_source = ctx.source_by_id(lnk.fid).ok()?;
 
             let span_path = ctx.path_for_id(lnk.fid).ok()?;
-            let uri = Url::from_file_path(span_path).ok()?;
+            let uri = path_to_url(&span_path).ok()?;
 
             let Some(range) = lnk.name_range else {
                 log::warn!("rename: no name range");

--- a/crates/tinymist-query/src/symbol.rs
+++ b/crates/tinymist-query/src/symbol.rs
@@ -40,7 +40,7 @@ impl SemanticRequest for SymbolRequest {
             let Ok(source) = ctx.source_by_path(path) else {
                 return;
             };
-            let uri = Url::from_file_path(path).unwrap();
+            let uri = path_to_url(path).unwrap();
             let res = get_lexical_hierarchy(source.clone(), LexicalScopeKind::Symbol).and_then(
                 |symbols| {
                     self.pattern.as_ref().map(|pattern| {

--- a/crates/tinymist/src/actor/render.rs
+++ b/crates/tinymist/src/actor/render.rs
@@ -294,6 +294,12 @@ impl ExportActor {
 
 #[comemo::memoize]
 fn substitute_path(substitute_pattern: &str, root: &Path, path: &Path) -> Option<ImmutPath> {
+    if let Ok(path) = path.strip_prefix("/untitled") {
+        let tmp = std::env::temp_dir();
+        let path = tmp.join("typst").join(path);
+        return Some(path.as_path().into());
+    }
+
     if substitute_pattern.is_empty() {
         return Some(path.to_path_buf().clean().into());
     }

--- a/crates/tinymist/src/actor/typ_client.rs
+++ b/crates/tinymist/src/actor/typ_client.rs
@@ -293,7 +293,10 @@ impl CompileClientActor {
     }
 
     pub fn change_entry(&self, path: Option<ImmutPath>) -> Result<(), Error> {
-        if path.as_deref().is_some_and(|p| !p.is_absolute()) {
+        if path
+            .as_deref()
+            .is_some_and(|p| !p.is_absolute() && !p.starts_with("/untitled"))
+        {
             return Err(error_once!("entry file must be absolute", path: path.unwrap().display()));
         }
 

--- a/crates/tinymist/src/server/compiler_init.rs
+++ b/crates/tinymist/src/server/compiler_init.rs
@@ -233,9 +233,17 @@ impl CompileConfig {
         // todo: don't ignore entry from typst_extra_args
         // entry: command.input,
 
+        // todo: formalize untitled path
+        // let is_untitled = entry.as_ref().is_some_and(|p| p.starts_with("/untitled"));
+        // let root_dir = self.determine_root(if is_untitled { None } else {
+        // entry.as_ref() });
         let root_dir = self.determine_root(entry.as_ref());
 
         let entry = match (entry, root_dir) {
+            // (Some(entry), Some(root)) if is_untitled => Some(EntryState::new_rooted(
+            //     root,
+            //     Some(FileId::new(None, VirtualPath::new(entry))),
+            // )),
             (Some(entry), Some(root)) => match entry.strip_prefix(&root) {
                 Ok(stripped) => Some(EntryState::new_rooted(
                     root,


### PR DESCRIPTION
VSCode uses untitled scheme to mark unsaved text buffer that not yet synchronized to disk.