### PR TITLE
feat: support entry configuration

### DIFF
--- a/crates/tinymist/src/actor.rs
+++ b/crates/tinymist/src/actor.rs
@@ -74,7 +74,7 @@ impl CompileServer {
             let entry = entry.clone();
             let font_resolver = self.font.clone();
             move || {
-                log::info!("TypstActor: creating server for {diag_group}");
+                log::info!("TypstActor: creating server for {diag_group}, entry: {entry:?}, inputs: {inputs:?}");
 
                 // Create the world
                 let font_resolver = font_resolver.wait().clone();

--- a/crates/tinymist/src/actor/typ_client.rs
+++ b/crates/tinymist/src/actor/typ_client.rs
@@ -292,6 +292,10 @@ impl CompileClientActor {
         }
     }
 
+    pub fn sync_config(&mut self, config: CompileConfig) {
+        self.config = config;
+    }
+
     pub fn change_entry(&self, path: Option<ImmutPath>) -> Result<(), Error> {
         if path
             .as_deref()

--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -13,7 +13,7 @@ use tinymist::{
     compiler_init::{CompileInit, CompileInitializeParams},
     harness::{lsp_harness, InitializedLspDriver, LspDriver, LspHost},
     transport::with_stdio_transport,
-    CompileFontOpts, CompileOpts, Init, LspWorld, TypstLanguageServer,
+    CompileFontOpts, Init, LspWorld, TypstLanguageServer,
 };
 use tokio::sync::mpsc;
 use typst::{foundations::IntoValue, syntax::Span};
@@ -82,12 +82,9 @@ pub fn lsp_main(args: LspArgs) -> anyhow::Result<()> {
         ) {
             Init {
                 host,
-                compile_opts: CompileOpts {
-                    font: CompileFontOpts {
-                        font_paths: self.args.font.font_paths.clone(),
-                        no_system_fonts: self.args.font.no_system_fonts,
-                        ..Default::default()
-                    },
+                compile_opts: CompileFontOpts {
+                    font_paths: self.args.font.font_paths.clone(),
+                    no_system_fonts: self.args.font.no_system_fonts,
                     ..Default::default()
                 },
             }

--- a/crates/tinymist/src/server/compiler.rs
+++ b/crates/tinymist/src/server/compiler.rs
@@ -315,6 +315,10 @@ impl CompileServer {
             }
         }
 
+        if let Some(e) = self.compiler.as_mut() {
+            e.sync_config(self.config.clone());
+        }
+
         info!("new settings applied");
         if config.output_path != self.config.output_path
             || config.export_pdf != self.config.export_pdf

--- a/crates/tinymist/src/server/lsp.rs
+++ b/crates/tinymist/src/server/lsp.rs
@@ -66,7 +66,7 @@ use crate::compiler_init::CompilerConstConfig;
 use crate::harness::{InitializedLspDriver, LspHost};
 use crate::tools::package::InitTask;
 use crate::world::SharedFontResolver;
-use crate::{run_query, CompileOnceOpts, LspResult};
+use crate::{run_query, LspResult};
 
 pub type MaySyncResult<'a> = Result<JsonValue, BoxFuture<'a, JsonValue>>;
 
@@ -176,7 +176,6 @@ fn as_path_pos(inp: TextDocumentPositionParams) -> (PathBuf, Position) {
 
 pub struct TypstLanguageServerArgs {
     pub client: LspHost<TypstLanguageServer>,
-    pub compile_opts: CompileOnceOpts,
     pub const_config: ConstConfig,
     pub diag_tx: mpsc::UnboundedSender<(String, Option<DiagnosticsMap>)>,
     pub font: Deferred<SharedFontResolver>,
@@ -205,8 +204,6 @@ pub struct TypstLanguageServer {
     /// Const configuration initialized at the start of the session.
     /// For example, the position encoding.
     pub const_config: ConstConfig,
-    /// The default opts for the compiler.
-    pub compile_opts: CompileOnceOpts,
 
     // Command maps
     /// Extra commands provided with `textDocument/executeCommand`.
@@ -255,7 +252,6 @@ impl TypstLanguageServer {
             formatter_registered: None,
             config: Default::default(),
             const_config: args.const_config,
-            compile_opts: args.compile_opts,
 
             exec_cmds: Self::get_exec_commands(),
             regular_cmds: Self::get_regular_cmds(),


### PR DESCRIPTION
support it by a `CompileExtraOpts` that applied in low priority. An entry configuration could be overridden by dynamic pinning command.

```rs
#[derive(Debug, Clone, PartialEq, Default)]
pub struct CompileExtraOpts {
    /// The root directory for compilation routine.
    pub root_dir: Option<PathBuf>,

    /// Path to entry
    pub entry: Option<ImmutPath>,

    /// Additional input arguments to compile the entry file.
    pub inputs: ImmutDict,

    /// will remove later
    pub font_paths: Vec<PathBuf>,
}
```

The `CompileExtraOpts` is purposed for allowing users specify arguments for lsp like what they do for `typst-cli`. The `CompileExtraOpts` is easy to use but error-prone, so it is applied in low priority.

Example for VSCode:

```jsonc
{
  "tinymist.typstExtraArgs": [
    // specify sys.inputs
    "--input=theme=dark", "--input=context={\"preview\": true}", 
    // entry path relative to root, or an absolute path if you are unsure where the root is.
    "main.typ"
  ]
}
```

After changing configuration, you should reload editor to ensure it to work.

---

Here is help doc:

```
Compiles an input file into a supported output format

Usage: typst.exe compile [OPTIONS] <INPUT> [OUTPUT]

Arguments:
  <INPUT>
          Path to input Typst file, use `-` to read input from stdin

  [OUTPUT]
          Path to output file (PDF, PNG, or SVG)

Options:
      --root <DIR>
          Configures the project root (for absolute paths)

          [env: TYPST_ROOT=]

      --input <key=value>
          Add a string key-value pair visible through `sys.inputs`

      --font-path <DIR>
          Adds additional directories to search for fonts

          [env: TYPST_FONT_PATHS=]

  -f, --format <FORMAT>
          The format of the output file, inferred from the extension by default

          [possible values: pdf, png, svg]

      --ppi <PPI>
          The PPI (pixels per inch) to use for PNG export

          [default: 144]

  -h, --help
          Print help (see a summary with '-h')
```



