### PR TITLE
chore: bump typstyle to v0.11.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8556b6c8261a6d205674be583443714a9887911a392df630ea95c2900caf2710"
+checksum = "38f04e5495bff9deed2a9155dca07889ec0fe1c79f48eb2d9ea99fc272459499"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ typst-ts-core = { version = "0.5.0-rc3", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc3" }
 typst-ts-svg-exporter = { version = "0.5.0-rc3" }
 typst-preview = { version = "0.11.3" }
-typstyle = "0.11.11"
+typstyle = "0.11.13"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 
 lsp-server = "0.7.6"


### PR DESCRIPTION
I mark this pr as draft in case of there is another version before tinymist's next release

Changelog: https://github.com/Enter-tainer/typstyle/releases/tag/v0.11.13