### PR TITLE
chore: bump to typstyle v0.11.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f04e5495bff9deed2a9155dca07889ec0fe1c79f48eb2d9ea99fc272459499"
+checksum = "f701eb3c275c8250b3e5e18c3c081e36861cdd5b2e78538ff4984735cbfd9591"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ typst-ts-core = { version = "0.5.0-rc3", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc3" }
 typst-ts-svg-exporter = { version = "0.5.0-rc3" }
 typst-preview = { version = "0.11.3" }
-typstyle = "0.11.13"
+typstyle = "0.11.14"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 
 lsp-server = "0.7.6"

--- a/crates/tinymist/src/actor/formatting.rs
+++ b/crates/tinymist/src/actor/formatting.rs
@@ -29,7 +29,7 @@ pub fn run_format_thread(
             FormatterMode::Typstyle => {
                 let cw = c.width as usize;
                 let f: FmtFn = Box::new(move |e: Source| {
-                    let res = typstyle_core::pretty_print(e.text(), cw);
+                    let res = typstyle_core::Typstyle::new_with_src(e.clone(), cw).pretty_print();
                     Ok(calc_diff(e, res, position_encoding))
                 });
                 f


### PR DESCRIPTION
Bump typstyle v0.11.14 and use `Source` based API to avoid re-parsing