### PR TITLE
build: bump version to 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "comemo 0.4.0",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "base64 0.22.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.5 - [2024-04-20]
+
+### Completion
+
+* Fixed wrong check of param completion position at comma in https://github.com/Myriad-Dreamin/tinymist/pull/205
+* Completing text.lang/region in https://github.com/Myriad-Dreamin/tinymist/pull/199
+* Completing array/tuple literals in https://github.com/Myriad-Dreamin/tinymist/pull/201
+  * New array types completed: columns/ros/gutter/column-gutter/row-gutter/size/dash on various functions
+* Completing function arguments on signatures inferred by type checking in https://github.com/Myriad-Dreamin/tinymist/pull/203
+* Completing function arguments of func.where and func.with by its method target (this) in https://github.com/Myriad-Dreamin/tinymist/pull/204
+* Completing functions with where/with snippets in https://github.com/Myriad-Dreamin/tinymist/pull/206
+
+### Inlay Hint
+
+* Checking variadic/content arguments rules of inlay hints correctly in https://github.com/Myriad-Dreamin/tinymist/pull/202
+
+### Syntax/Semantic Highlighting
+
+* (Fix) Corrected parsing on reference names of which trailing dots or colons cannot be followed by space or EOF in https://github.com/Myriad-Dreamin/tinymist/pull/195
+* (Fix) Identifying string literals in math mode in https://github.com/Myriad-Dreamin/tinymist/pull/196
+
+### Misc
+
+* Bumped to typstyle v0.11.14 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/200
+* Preferring less uses of `analzer_expr` during definition analysis in https://github.com/Myriad-Dreamin/tinymist/pull/192
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.4...v0.11.5
+
 ## v0.11.4 - [2024-04-14]
 
 This version is published with mostly internal optimizations.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.4",
+    "version": "0.11.5",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",

--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -205,7 +205,7 @@ export const Summary = () => {
         { style: "margin: 0.8em; margin-left: 0.5em" },
         div(
           `Its version is `,
-          a({ href: "javascript:void(0)" }, "0.11.4"),
+          a({ href: "javascript:void(0)" }, "0.11.5"),
           `.`
         ),
         div(`It is compiled with optimization level `, "3", `.`),


### PR DESCRIPTION

### Completion

* Fixed wrong check of param completion position at comma in https://github.com/Myriad-Dreamin/tinymist/pull/205
* Completing text.lang/region in https://github.com/Myriad-Dreamin/tinymist/pull/199
* Completing array/tuple literals in https://github.com/Myriad-Dreamin/tinymist/pull/201
  * New array types completed: columns/ros/gutter/column-gutter/row-gutter/size/dash on various functions
* Completing function arguments on signatures inferred by type checking in https://github.com/Myriad-Dreamin/tinymist/pull/203
* Completing function arguments of func.where and func.with by its method target (this) in https://github.com/Myriad-Dreamin/tinymist/pull/204
* Completing functions with where/with snippets in https://github.com/Myriad-Dreamin/tinymist/pull/206

### Inlay Hint

* Checking variadic/content arguments rules of inlay hints correctly in https://github.com/Myriad-Dreamin/tinymist/pull/202

### Syntax/Semantic Highlighting

* (Fix) Corrected parsing on reference names of which trailing dots or colons cannot be followed by space or EOF in https://github.com/Myriad-Dreamin/tinymist/pull/195
* (Fix) Identifying string literals in math mode in https://github.com/Myriad-Dreamin/tinymist/pull/196

### Misc

* Bumped to typstyle v0.11.14 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/200
* Preferring less uses of `analzer_expr` during definition analysis in https://github.com/Myriad-Dreamin/tinymist/pull/192

**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.4...v0.11.5
