### PR TITLE
feat: use rayon::scope for threaded_receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "paste",
+ "rayon",
  "serde",
  "serde_json",
  "tinymist-query",

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 parking_lot.workspace = true
 paste.workspace = true
+rayon = "1.10.0"
 
 clap = { workspace = true, optional = true }
 clap_builder.workspace = true

--- a/crates/tinymist/src/utils.rs
+++ b/crates/tinymist/src/utils.rs
@@ -1,5 +1,3 @@
-use std::thread;
-
 use tokio::sync::oneshot;
 use typst_ts_core::error::prelude::*;
 use typst_ts_core::Error;
@@ -8,14 +6,16 @@ pub fn threaded_receive<T: Send>(f: oneshot::Receiver<T>) -> Result<T, Error> {
     // get current async handle
     if let Ok(e) = tokio::runtime::Handle::try_current() {
         // todo: remove blocking
-        return thread::scope(|s| {
-            s.spawn(move || {
-                e.block_on(f)
-                    .map_err(map_string_err("failed to sync_render"))
+        let mut ret = None;
+        rayon::scope(|s| {
+            s.spawn(|_| {
+                ret = Some(
+                    e.block_on(f)
+                        .map_err(map_string_err("failed to sync_render")),
+                )
             })
-            .join()
-            .map_err(|_| error_once!("failed to join"))?
         });
+        return ret.unwrap();
     }
 
     f.blocking_recv()


### PR DESCRIPTION
A workaround for a workaround. How cursed!

As rayon already exists in typst, there's no extra dependency introduced.

The time of `./target/release/tinymist lsp --replay target/e2e/tinymist/vscode/mirror.log` reduced from ~3.7s to ~3.0s on my machine, measured by `hyperfine --warmup 3`.