### PR TITLE
build: bump version to 0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "comemo 0.4.0",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "base64 0.22.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution guideli
 ## Acknowledgements
 
 - Partially code is inherited from [typst-lsp](https://github.com/nvarner/typst-lsp)
+- The service [integrating](https://github.com/Myriad-Dreamin/tinymist/tree/main/editors/vscode#symbol-view) *offline* handwritten-stroke recognizer is powered by [Detypify](https://detypify.quarticcat.com/).

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.6 - [2024-04-27]
+
+### Editor
+
+* Added more auto closing pairs, surrounding pairs, and characters that could make auto closing before in https://github.com/Myriad-Dreamin/tinymist/pull/209
+* Hiding Status bar until the recent focus file is closed in https://github.com/Myriad-Dreamin/tinymist/pull/212
+
+### Compiler
+
+* (Fix) Removed a stupid debugging which may cause panic in https://github.com/Myriad-Dreamin/tinymist/pull/215
+
+### Commands/Tools
+
+* Completed symbol view in https://github.com/Myriad-Dreamin/tinymist/pull/218
+  * Not all symbols are categorized yet. If not, they are put into the "Misc" category.
+  * It is now showing in the activity bar (sidebar). Feel free to report any issues or suggestions for improvement.
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.5...v0.11.6
+
 ## v0.11.5 - [2024-04-20]
 
 ### Completion

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -38,6 +38,16 @@ Tips: to enable formatting on save, you should add extra settings for typst lang
 }
 ```
 
+### Configuring/Using Tinymist's Activity Bar (Sidebar)
+
+If you don't like the activity bar, you can right-click on the activity bar and uncheck "Tinymist" to hide it.
+
+#### Symbol View
+
+- Search symbols by keywords, descriptions, or handwriting.
+- See symbols grouped by categories.
+- Click on a symbol, then it will be inserted into the editor.
+
 ### Configuring path to search fonts
 
 To configure path to search fonts:

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",

--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -205,7 +205,7 @@ export const Summary = () => {
         { style: "margin: 0.8em; margin-left: 0.5em" },
         div(
           `Its version is `,
-          a({ href: "javascript:void(0)" }, "0.11.5"),
+          a({ href: "javascript:void(0)" }, "0.11.6"),
           `.`
         ),
         div(`It is compiled with optimization level `, "3", `.`),


### PR DESCRIPTION

### Editor

* Added more auto closing pairs, surrounding pairs, and characters that could make auto closing before in https://github.com/Myriad-Dreamin/tinymist/pull/209
* Hiding Status bar until the recent focus file is closed in https://github.com/Myriad-Dreamin/tinymist/pull/212

### Compiler

* (Fix) Removed a stupid debugging which may cause panic in https://github.com/Myriad-Dreamin/tinymist/pull/215

### Commands/Tools

* Completed symbol view in https://github.com/Myriad-Dreamin/tinymist/pull/218
  * Not all symbols are categorized yet. If not, they are put into the "Misc" category.
  * It is now showing in the activity bar (sidebar). Feel free to report any issues or suggestions for improvement.

**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.5...v0.11.6
