### PR TITLE
feat: conditionally open activity icon when lang id is typst

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -38,7 +38,8 @@
                 {
                     "id": "tinymist.side-symbol-view",
                     "type": "webview",
-                    "name": "Symbol View"
+                    "name": "Symbol View",
+                    "when": "resourceLangId == typst"
                 }
             ]
         },


### PR DESCRIPTION
Hide activity bar icon when res lang id is not typst

see 
- https://github.com/Enter-tainer/typst-preview/pull/288
- https://github.com/microsoft/vscode/issues/49145