### PR TITLE
feat: disable inlay hints

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -179,7 +179,8 @@
             "[typst]": {
                 "editor.wordWrap": "on",
                 "editor.semanticHighlighting.enabled": true,
-                "editor.tabSize": 2
+                "editor.tabSize": 2,
+                "editor.inlayHints.enabled": "off"
             }
         },
         "languages": [


### PR DESCRIPTION
Enable it if you would like to have it:
```json
{
    "[typst]": {
        "editor.inlayHints.enabled": "on"
    }
}
```