### PR TITLE
build: bump version to 0.11.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "biblatex",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "base64 0.22.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.7"
+version = "0.11.8"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.8 - [2024-05-07]
+
+### Hover
+
+* Improved open document tooltip in https://github.com/Myriad-Dreamin/tinymist/pull/254
+
+### Completion
+
+* Inserting commas in argument context for completing before identifiers in https://github.com/Myriad-Dreamin/tinymist/pull/251
+* Improved identifying literal expressions in https://github.com/Myriad-Dreamin/tinymist/pull/252
+* Identifying let context completely in https://github.com/Myriad-Dreamin/tinymist/pull/255
+  * To help complete after equal marker in `let b = ..`
+* Restoring left parenthesis and comma as trigger characters in https://github.com/Myriad-Dreamin/tinymist/pull/253
+  * This is needed for completion on literal expressions.
+
+### Type Checking
+
+* (Fix) Avoiding infinite loop in simplifying recursive functions in https://github.com/Myriad-Dreamin/tinymist/pull/246
+  * Fix a stack overflow in `ty.rs`
+* (Fix) Instantiating variable before applying variable function in https://github.com/Myriad-Dreamin/tinymist/pull/247
+  * Fix a deadlock in `ty.rs`
+* (Fix) Simplifying all substructure in https://github.com/Myriad-Dreamin/tinymist/pull/248
+  * Fix a panic in `ty.rs`
+* Improved join type inference in https://github.com/Myriad-Dreamin/tinymist/pull/249
+* Weakening inference from outer use in https://github.com/Myriad-Dreamin/tinymist/pull/250
+  * to reduce noise slightly for completion
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.7...v0.11.8
+
 ## v0.11.7 - [2024-05-05]
 
 ### Editor

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.7",
+    "version": "0.11.8",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",


### PR DESCRIPTION

### Hover

* Improved open document tooltip in https://github.com/Myriad-Dreamin/tinymist/pull/254

### Completion

* Inserting commas in argument context for completing before identifiers in https://github.com/Myriad-Dreamin/tinymist/pull/251
* Improved identifying literal expressions in https://github.com/Myriad-Dreamin/tinymist/pull/252
* Identifying let context completely in https://github.com/Myriad-Dreamin/tinymist/pull/255
  * To help complete after equal marker in `let b = ..`
* Restoring left parenthesis and comma as trigger characters in https://github.com/Myriad-Dreamin/tinymist/pull/253
  * This is needed for completion on literal expressions.

### Type Checking

* (Fix) Avoiding infinite loop in simplifying recursive functions in https://github.com/Myriad-Dreamin/tinymist/pull/246
  * Fix a stack overflow in `ty.rs`
* (Fix) Instantiating variable before applying variable function in https://github.com/Myriad-Dreamin/tinymist/pull/247
  * Fix a deadlock in `ty.rs`
* (Fix) Simplifying all substructure in https://github.com/Myriad-Dreamin/tinymist/pull/248
  * Fix a panic in `ty.rs`
* Improved join type inference in https://github.com/Myriad-Dreamin/tinymist/pull/249
* Weakening inference from outer use in https://github.com/Myriad-Dreamin/tinymist/pull/250
  * to reduce noise slightly for completion

**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.7...v0.11.8
