### PR TITLE
feat: implicitly focus entry on no focus request sent

### DIFF
--- a/crates/tinymist/src/actor/typ_client.rs
+++ b/crates/tinymist/src/actor/typ_client.rs
@@ -330,7 +330,7 @@ impl CompileClientActor {
         self.config = config;
     }
 
-    pub fn change_entry(&mut self, path: Option<ImmutPath>) -> Result<(), Error> {
+    pub fn change_entry(&mut self, path: Option<ImmutPath>) -> Result<bool, Error> {
         if path
             .as_deref()
             .is_some_and(|p| !p.is_absolute() && !p.starts_with("/untitled"))
@@ -340,7 +340,7 @@ impl CompileClientActor {
 
         let next_entry = self.config.determine_entry(path);
         if next_entry == self.entry {
-            return Ok(());
+            return Ok(false);
         }
 
         let diag_group = &self.diag_group;
@@ -373,7 +373,7 @@ impl CompileClientActor {
 
         self.entry = next_entry;
 
-        Ok(())
+        Ok(true)
     }
 
     pub fn add_memory_changes(&self, event: MemoryEvent) {

--- a/crates/tinymist/src/server/lsp.rs
+++ b/crates/tinymist/src/server/lsp.rs
@@ -833,10 +833,12 @@ impl TypstLanguageServer {
             log::info!("first manual focusing is coming");
         }
 
-        let update_result = self.focus_entry(new_entry.clone());
-        update_result.map_err(|err| internal_error(format!("could not focus file: {err}")))?;
+        let ok = self.focus_entry(new_entry.clone());
+        let ok = ok.map_err(|err| internal_error(format!("could not focus file: {err}")))?;
 
-        info!("file focused: {entry:?}", entry = new_entry);
+        if ok {
+            info!("file focused: {new_entry:?}");
+        }
         Ok(JsonValue::Null)
     }
 

--- a/crates/tinymist/src/state.rs
+++ b/crates/tinymist/src/state.rs
@@ -19,13 +19,11 @@ use crate::{actor::typ_client::CompileClientActor, compiler::CompileServer, Typs
 
 impl CompileServer {
     /// Focus main file to some path.
-    pub fn do_change_entry(&mut self, new_entry: Option<ImmutPath>) -> Result<(), Error> {
+    pub fn do_change_entry(&mut self, new_entry: Option<ImmutPath>) -> Result<bool, Error> {
         self.compiler
             .as_mut()
             .unwrap()
-            .change_entry(new_entry.clone())?;
-
-        Ok(())
+            .change_entry(new_entry.clone())
     }
 }
 
@@ -48,10 +46,10 @@ impl TypstLanguageServer {
     }
 
     /// Updates the primary (focusing) entry
-    pub fn focus_entry(&mut self, new_entry: Option<ImmutPath>) -> Result<(), Error> {
+    pub fn focus_entry(&mut self, new_entry: Option<ImmutPath>) -> Result<bool, Error> {
         if self.pinning || self.config.compile.has_default_entry_path {
             self.focusing = new_entry;
-            return Ok(());
+            return Ok(false);
         }
 
         self.primary.do_change_entry(new_entry.clone())
@@ -61,6 +59,10 @@ impl TypstLanguageServer {
     /// performing any focus command request.
     ///
     /// See https://github.com/microsoft/language-server-protocol/issues/718
+    ///
+    /// we do want to focus the file implicitly by `textDocument/diagnostic`
+    /// (pullDiagnostics mode), as suggested by language-server-protocol#718,
+    /// however, this has poor support, e.g. since neovim 0.10.0.
     pub fn implicit_focus_entry(
         &mut self,
         new_entry: impl FnOnce() -> Option<ImmutPath>,
@@ -86,10 +88,14 @@ impl TypstLanguageServer {
         let new_entry = new_entry();
 
         let update_result = self.focus_entry(new_entry.clone());
-        if let Err(err) = update_result {
-            log::warn!("could not focus file: {err}");
-        } else {
-            log::info!("file focused[implicit]: {entry:?}", entry = new_entry);
+        match update_result {
+            Ok(true) => {
+                log::info!("file focused[implicit,{site}]: {new_entry:?}");
+            }
+            Err(err) => {
+                log::warn!("could not focus file: {err}");
+            }
+            Ok(false) => {}
         }
     }
 }


### PR DESCRIPTION
> After opening the file it doesn't show the error unless I save the file (no-op).
> > vscode invokes lsp's focus command but neovim doesn't. should add an issue, and discuss a suitable behavior to change focus file if the client is neovim.

It is nice if client focus entry explicitly, however neovim/helix/zed clients don't do that. Adding many activity hooks to track activating document status if a client is not performing any focus command request.

We do want to focus the file implicitly by `textDocument/diagnostic` (pullDiagnostics mode), as suggested by language-server-protocol#718, however, this has poor support, e.g. since neovim 0.10.0.

See https://github.com/microsoft/language-server-protocol/issues/718
