### PR TITLE
chore: bump to typstyle v0.11.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25283094eca3cf1200a2105bb339f367e1fb127e69b22ae106d7e706d7eb08d"
+checksum = "c41f34f9969764e33272885d9aafb6d2742d5c4540e927a58b0323a790eb5514"
 dependencies = [
  "anyhow",
  "clap",
@@ -5209,18 +5209,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ typst-ts-core = { version = "0.5.0-rc3", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc3" }
 typst-ts-svg-exporter = { version = "0.5.0-rc3" }
 typst-preview = { version = "0.11.3" }
-typstyle = "0.11.17"
+typstyle = "0.11.19"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 
 lsp-server = "0.7.6"


### PR DESCRIPTION
This version can keep comment attached to the end of the line. It also indent math equations

https://github.com/Enter-tainer/typstyle/releases/tag/v0.11.19