### PR TITLE
chore: bump typstyle to v0.11.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9697d141856bfe6c865c9ef74d04c62dd6cd1b3b63c1e284b96974871a2fc7"
+checksum = "5d347101bcf1d3469e1fde1d623b749791a6122a2b1a87729381097e35c6bd9c"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ typst-ts-core = { version = "0.5.0-rc4", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc4" }
 typst-ts-svg-exporter = { version = "0.5.0-rc4" }
 typst-preview = { version = "0.11.3" }
-typstyle = "0.11.21"
+typstyle = "0.11.22"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 
 lsp-server = "0.7.6"


### PR DESCRIPTION
This version add basic table formatting