### PR TITLE
feat: add font list export panel in summary tool

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -506,7 +506,8 @@
     },
     "dependencies": {
         "vscode-languageclient": "^9.0.1",
-        "vscode-variables": "^0.1.3"
+        "vscode-variables": "^0.1.3",
+        "editor-tools": "file:../../tools/editor-tools"
     },
     "devDependencies": {
         "@types/node": "^20.8.10",

--- a/tools/editor-tools/package.json
+++ b/tools/editor-tools/package.json
@@ -12,6 +12,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "csv-stringify": "^6.5.0",
     "detypify-service": "0.2.4",
     "minisearch": "^6.3.0",
     "vanjs-core": "^1.5.0"

--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -1,8 +1,9 @@
-import van, { ChildDom } from "vanjs-core";
-import { requestRevealPath } from "../vscode";
+import van, { ChildDom, State } from "vanjs-core";
+import { stringify as csvStringify } from "csv-stringify/browser/esm/sync";
+import { requestRevealPath, requestSaveFontsExportConfigure, saveDataToFile } from "../vscode";
 import { CopyIcon } from "../icons";
 import { startModal } from "../components/modal";
-const { div, a, span, code, br, button, textarea, label, input } = van.tags;
+const { div, a, span, code, br, button, form, textarea, label, input } = van.tags;
 
 interface ServerInfo {
   root: string;
@@ -291,94 +292,356 @@ interface fontsExportPannelProps {
   sources: FontSource[],
 }
 
-const fontsExportPannel = ({ fonts, sources }: fontsExportPannelProps) => {
-  const fsOnly = van.state(true);
-  const needName = van.state(false);
-  const needDetail = van.state(false);
-  const needPath = van.state(true);
-  const fieldSep = van.state("; ");
+interface fontInfoWithSource extends Omit<FontInfo, "source"> {
+  source: FontSource | null,
+}
 
-  const data = fonts.map(font => {
-    let kindIsFs = false
-    let path = "none";
-    if (typeof font.source === "number") {
-      let w = sources[font.source];
-      if (w.kind == "fs") {
-        path = w.path;
-        kindIsFs = true;
-      } else {
-        path = `memory://${font.fullName ?? font.name}`;
-      }
+export type fontsCSVHeader = "name" | "postscript" | "style" | "weight" | "stretch" | "location" | "path";
+
+interface csvFieldExtractor<H, T> {
+  fieldName: H,
+  extractor: (input: T) => string | number,
+}
+
+type fontCSVFieldExtractor = csvFieldExtractor<fontsCSVHeader, fontInfoWithSource>
+
+class fontsCSVGenerator {
+  public static readonly fieldExtractors: fontCSVFieldExtractor[] = [
+    {
+      fieldName: "name",
+      extractor: info => info.fullName ?? "",
+    },
+    {
+      fieldName: "postscript",
+      extractor: info => info.postscriptName,
+    },
+    {
+      fieldName: "style",
+      extractor: info => info.style ?? "",
+    },
+    {
+      fieldName: "weight",
+      extractor: info => info.weight ?? "",
+    },
+    {
+      fieldName: "stretch",
+      extractor: info => info.stretch ?? "",
+    },
+    {
+      fieldName: "location",
+      extractor: info => { 
+        switch (info.source?.kind ?? "") {
+          case "fs": return "fileSystem";
+          case "memory": return "memory";
+          default: return "unknown";
+        }
+      },
+    },
+    {
+      fieldName: "path",
+      extractor: info => info.source?.kind === "fs" ? info.source.path : "",
     }
-    return {
-      kindIsFs: kindIsFs,
-      name: `${font.fullName ?? font.name}`,
-      detail: [`style: ${font.style}`, `weight: ${font.weight}`, `stretch: ${font.stretch}`],
-      path,
+  ];
+
+  public generate(fonts: fontInfoWithSource[], config: fontsExportCSVConfigure): string {
+    const fields = fontsCSVGenerator.fieldExtractors.filter(field => config.fields.includes(field.fieldName));
+    const headers = fields.map(field => field.fieldName);
+
+    let rows = fonts.map(font => fields.map(field => field.extractor(font)));
+
+    // If only field is file path, do a dedupp
+    if (fields.length === 1 && fields[0].fieldName === "path") {
+      const dedup = new Set();
+      rows = rows.reduce((acc, item) => {
+        const path = item[0];
+        if (!dedup.has(path)) {
+          dedup.add(path);
+          acc.push(item);
+        }
+        return acc;
+      }, [] as typeof rows);
     }
+
+    return csvStringify(rows, {
+      header: config.header,
+      columns: headers,
+      delimiter: config.delimiter,
+    });
+  }
+}
+
+export type fontLocation = FontSource extends { kind: (infer Kind) } ? Kind : never;
+
+export interface fontsExportCSVConfigure {
+  header: boolean,
+  delimiter: string,
+  fields: fontsCSVHeader[],
+}
+
+export interface fontsExportJSONConfigure {
+  indent: number,
+}
+
+export interface fontsExportFormatConfigure {
+  csv: fontsExportCSVConfigure,
+  json: fontsExportJSONConfigure,
+}
+
+export type fontsExportFormat = keyof fontsExportFormatConfigure;
+
+interface fontsExportCommonConfigure {
+  format: fontsExportFormat,
+  filters: {
+    location: fontLocation[],
+  },
+}
+
+export type fontsExportConfigure = fontsExportCommonConfigure & fontsExportFormatConfigure;
+
+export const fontsExportDefaultConfigure: fontsExportConfigure = {
+  format: "csv",
+  filters: {
+    location: ["fs"],
+  },
+  csv: {
+      header: false,
+      delimiter: ",",
+      fields: ["name", "path"],
+  },
+  json: {
+      indent: 2,
+  },
+};
+
+let savedConfigureData = `:[[preview:FontsExportConfigure]]:`;
+
+const fontsExportPannel = ({ fonts, sources }: fontsExportPannelProps) => {
+  const savedConfigure: fontsExportConfigure = savedConfigureData.startsWith(":")
+    ? fontsExportDefaultConfigure
+    : JSON.parse(atob(savedConfigureData));
+
+  const exportFormat = van.state<fontsExportFormat>(savedConfigure.format);
+  const locationFilter = van.state<fontLocation[]>(savedConfigure.filters.location);
+  const csvConfigure = van.state<fontsExportCSVConfigure>(savedConfigure.csv);
+  const jsonConfigure = van.state<fontsExportJSONConfigure>(savedConfigure.json);
+
+  // Save state when changed
+  van.derive(() => {
+    const configure: fontsExportConfigure = {
+      format: exportFormat.val,
+      filters: {
+        location: locationFilter.val,
+      },
+      csv: csvConfigure.val,
+      json: jsonConfigure.val,
+    };
+
+    savedConfigureData = btoa(JSON.stringify(configure));
+    requestSaveFontsExportConfigure(configure);
   });
 
-  type dataType = typeof data extends (infer ElementType)[] ? ElementType : never;
+  const data: fontInfoWithSource[] = fonts.map(font => {
+    let source = typeof font.source === "number" ? sources[font.source] : null;
+    return Object.assign({}, font, { source });
+  });
+
+  const filteredData = van.derive(() => {
+    return data.filter(font => locationFilter.val.includes(font.source?.kind ?? "" as any));
+  });
 
   const exportText = van.derive<string>(() => {
-    const exportLine = (d: dataType) => [
-      ...(needName.val ? [d.name] : []),
-      ...(needName.val && needDetail.val ? d.detail : []), // detail without name seems meaningless
-      ...(needPath.val ? [d.path] : []),
-    ].join(fieldSep.val);
-
-    if (needName.val || needPath.val) {
-      let lines = data.filter(d => fsOnly.val ? d.kindIsFs : true).map(exportLine);
-
-      // If only font path, do a deduplication
-      if (!needName.val) {
-        lines = [...new Set(lines)];
+    switch (exportFormat.val) {
+      case "csv": {
+        const csvGenerator = new fontsCSVGenerator();
+        return csvGenerator.generate(filteredData.val, csvConfigure.val);
       }
-
-      return lines.join("\n")
-    } else {
-      return "";
+      case "json": {
+        return JSON.stringify(filteredData.val, null, jsonConfigure.val.indent);
+      }
     }
   });
 
-  return div(
-    { style: "display: flex; flex-direction: column; gap: 4px; width: 100%; height: 100%" },
-    div(
-      { style: "flex: 0" },
-      label({ for: "fs-only", }, "FS Only:"),
-      input({ id: "fs-only", type: "checkbox", checked: fsOnly, 
-        onchange: e => fsOnly.val = e.target.checked }),
-      label({ for: "font-name", style: "margin-left: 16px" }, "Name:"),
-      input({ id: "font-name", type: "checkbox", checked: needName, 
-        onchange: e => needName.val = e.target.checked }),
-      label({ for: "font-detail", style: "margin-left: 16px" }, "Detail:"),
-      input({ id: "font-detail", type: "checkbox", disabled: van.derive(() => !needName.val), checked: needDetail, 
-        onchange: e => needDetail.val = e.target.checked }),
-      label({ for: "path", style: "margin-left: 16px" }, "Path:"),
-      input({ id: "path", type: "checkbox", checked: needPath, 
-        onchange: e => needPath.val = e.target.checked }),
-      label({ for: "sep", style: "margin-left: 16px" }, "Sep:"),
-      input({
-        id: "sep", type: "input", style: "width: 40px", value: fieldSep,
-        oninput: e => fieldSep.val = e.target.value,
-        onkeydown: e => e.stopPropagation(), // prevent modal window closed by space when input
-      }),
+  const titleWidth = 72;
+  const rowGap = 8;
+
+  const labelInputGap = 4;
+  const itemGap = 10;
+  const groupGap = 20;
+
+  const labeledInput = (
+    title: string, el: HTMLInputElement,
+    { labelStyle } = { labelStyle: "" }
+  ) =>span({ style: `display: inline-flex; column-gap: ${labelInputGap}px; align-items: center` },
+    label({ for: el.id, style: labelStyle }, title), el,
+  );
+
+  const makeArrayCheckbox = (
+    id: string, value: string, state: State<string[]> | string[],
+  ) => {
+    const checked = Array.isArray(state) ? state.includes(value) : state.val.includes(value);
+    return input({
+      id, type: "checkbox", style: "margin: 0px",
+      value, checked,
+      onchange: (e: any) => {
+        if (e.target.checked) {
+          Array.isArray(state) ? state.push(e.target.value) : state.val = [...state.rawVal, e.target.value];
+        } else {
+          if (Array.isArray(state)) {
+            let index = state.indexOf(e.target.value);
+            if (index !== -1) {
+              state.splice(index, 1);
+            }
+          } else {
+            state.val = state.val.filter(v => v !== e.target.value);
+          }
+        }
+      },
+    });
+  };
+
+  const filtersUI = () => div({ class: "flex-col", style: `row-gap: ${rowGap}px` },
+    div({ class: "flex-row", style: "align-items: center" },
+      div({ style: `width: ${titleWidth}px` }, "Location"),
+      div({ class: "flex-row", style: `flex: 1; flex-wrap: wrap; column-gap: ${itemGap}px` },
+        labeledInput("FileSystem", makeArrayCheckbox("filter-locations-fs", "fs", locationFilter)),
+        labeledInput("Memory", makeArrayCheckbox("filter-locations-memory", "memory", locationFilter)),
+      ),
     ),
+  );
+
+  const chooseExportFormatUI = () => div({ class: "flex-row", style: "align-items: center" },
+    div({ style: `width: ${titleWidth}px` }, "Format"),
+    div({ class: "flex-row", style: `flex: 1; flex-wrap: wrap; column-gap: ${itemGap}px`},
+      labeledInput("CSV", input({
+        id: "export-format-csv", type: "radio", name: "export-format", style: "margin: 0px",
+        checked: exportFormat.val === "csv",
+        onchange: (e) => {
+          if (e.target.checked) {
+            exportFormat.val = "csv";
+          }
+        },
+      })),
+      labeledInput("JSON", input({
+        id: "export-format-json", type: "radio", name: "export-format", style: "margin: 0px",
+        checked: exportFormat.val === "json",
+        onchange: (e) => {
+          if (e.target.checked) {
+            exportFormat.val = "json";
+          }
+        },
+      })),
+    ),
+  );
+
+  const csvConfigureUI = () => form(
+    {
+      class: "flex-col", style: `row-gap: ${rowGap}px`,
+      onchange: (_e) => {
+        csvConfigure.val = Object.assign({}, csvConfigure.val);
+      },
+      onsubmit: (e) => e.preventDefault(),
+    },
+    div({ class: "flex-row", style: "align-items: center" },
+      div({ style: `width: ${titleWidth}px` }, "Settings"),
+      div({ class: "flex-row", style: `flex: 1; flex-wrap: wrap; column-gap: ${groupGap}px`},
+        labeledInput("Header", input({
+          id: "csv-header", type: "checkbox", style: "margin: 0px",
+          checked: csvConfigure.val.header,
+          onchange: e => csvConfigure.rawVal.header = e.target.checked
+        })),
+        labeledInput("Delimiter:", input({
+          id: "csv-delimiter", type: "input", style: `width: 40px`,
+          value: csvConfigure.val.delimiter,
+          oninput: e => csvConfigure.rawVal.delimiter = e.target.value,
+          onkeydown: e => e.stopPropagation(), // prevent modal window closed by space when input
+        })),
+      ),
+    ),
+    div(
+      { class: "flex-row", style: "align-items: center"},
+      div({ style: `width: ${titleWidth}px` }, "Fields"),
+      div({ class: "flex-row", style: `flex: 1; flex-wrap: wrap; column-gap: ${itemGap}px`},
+        ...fontsCSVGenerator.fieldExtractors
+          .map(fe => fe.fieldName)
+          .map(field => labeledInput(field, makeArrayCheckbox(`csv-field-${field}`, field, csvConfigure.rawVal.fields))),
+      ),
+    ),
+  );
+
+  const jsonConfigureUI = () => form(
+    {
+      onchange: (_e) => {
+        jsonConfigure.val = Object.assign({}, jsonConfigure.val);
+      },
+      onsubmit: (e) => e.preventDefault(),
+    },
+    div({ class: "flex-row", style: "align-items: center" },
+      div({ style: `width: ${titleWidth}px` }, "Settings"),
+      div({ class: "flex-row", style: `flex: 1; flex-wrap: wrap; column-gap: ${groupGap}px`},
+        labeledInput("Indent:", input({
+          id: "json-indent", type: "number", style: "width: 40px;",
+          min: "0", max: "8", step: "2", value: jsonConfigure.val.indent,
+          onchange: e => jsonConfigure.rawVal.indent = parseInt(e.target.value, 10),
+        }), { labelStyle: "margin-right: 0.5em" }),
+      ),
+    ),
+  );
+
+  const exportFormatConfigureUI = () => {
+    let ui;
+    switch (exportFormat.val) {
+      case "csv": {
+        ui = csvConfigureUI();
+        break;
+      }
+      case "json": {
+        ui = jsonConfigureUI();
+        break;
+      }
+    }
+    return ui;
+  };
+
+  return div({ class: "flex-col", style: `row-gap: ${rowGap}px; width: 100%; height: 100%` },
+    filtersUI,
+    chooseExportFormatUI,
+    exportFormatConfigureUI,
     textarea(
       {
         class: "tinymist-code",
-        style: "resize: none; width: 100%; flex: 1; white-space: pre; overflow-wrap: normal; overflow-x: scroll;",
+        style: "resize: none; width: 100%; flex: 1; white-space: pre; overflow-wrap: normal; overflow-x: scroll",
         readOnly: true, onkeydown: e => e.stopPropagation(),
       },
       exportText,
     ),
-    button(
-      {
-        class: "tinymist-button",
-        style: "flex: 0",
-        onclick: () => navigator.clipboard.writeText(exportText.val),
-      },
-      "Copy",
+    div(
+      { style: `display: flex; align-items: center; column-gap:${itemGap}px` },
+      button(
+        {
+          class: "tinymist-button",
+          style: "flex: 1",
+          onclick: () => {
+            const filterName = `${exportFormat.val.toLocaleUpperCase()} file`;
+            saveDataToFile({
+              data: exportText.val,
+              option: {
+                filters: {
+                  [filterName]: [exportFormat.val],
+                },
+              },
+            });
+          },
+        },
+        "Export",
+      ),
+      button(
+        {
+          class: "tinymist-button",
+          style: "flex: 1",
+          onclick: () => navigator.clipboard.writeText(exportText.val),
+        },
+        "Copy",
+      ),
     ),
   );
 }

--- a/tools/editor-tools/src/icons.ts
+++ b/tools/editor-tools/src/icons.ts
@@ -47,3 +47,20 @@ export const AddIcon = (sz: number = 16) =>
   <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z"></path>
 </svg>`,
   });
+
+export const CopyIcon = (sz: number = 16) =>
+  div({
+    class: "tinymist-icon",
+    style: `height: ${sz}px; width: ${sz}px;`,
+    innerHTML: `<svg width="${sz}px" height="${sz}px" viewBox="0 0 16 16" version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect class="stroke-based" width="9.8202543" height="11.792212" x="1.742749" y="3.4055943" ry="0.49967012" />
+    <path class="stroke-based" d="m 5.1841347,0.82574918 9.0495613,0.0341483 V 12.129165" />
+    <path class="stroke-based" d="M 3.6542046,6.2680732 H 9.3239071" />
+    <path class="stroke-based" d="M 3.6542046,12.48578 H 7.7302609" />
+    <path class="stroke-based" d="M 3.6542046,9.3769264 H 7.7302609" />
+  </g>
+</svg>`,
+  });

--- a/tools/editor-tools/src/style.css
+++ b/tools/editor-tools/src/style.css
@@ -96,6 +96,10 @@ body {
   transition: color 0.05s;
 }
 
+.tinymist-code {
+  font-family: Cascadia Code, Consolas, SF Mono, DejaVu Sans Mono, monospace;
+}
+
 #tinymist-app, .tinymist-main-window {
   margin: 24px 28px;
 }
@@ -167,11 +171,11 @@ body.typst-preview-light .tinymist-button.warning.activated {
   background: rgba(243, 202, 99, 0.9);
 }
 
-.tinymist-icon path {
+.tinymist-icon :is(path, rect) {
   fill: currentColor;
 }
 
-.tinymist-icon path.stroke-based {
+.tinymist-icon :is(path, rect).stroke-based {
   fill: none;
   stroke: currentColor;
 }

--- a/tools/editor-tools/src/vscode.ts
+++ b/tools/editor-tools/src/vscode.ts
@@ -1,4 +1,5 @@
 import van from "vanjs-core";
+import type { fontsExportConfigure } from "./features/summary";
 
 const vscodeAPI = typeof acquireVsCodeApi !== "undefined" && acquireVsCodeApi();
 
@@ -69,6 +70,12 @@ export function requestSavePackageData(data: any) {
   }
 }
 
+export function requestSaveFontsExportConfigure(data: fontsExportConfigure) {
+  if (vscodeAPI?.postMessage) {
+    vscodeAPI.postMessage({ type: "saveFontsExportConfigure", data });
+  }
+}
+
 export function requestInitTemplate(packageSpec: string) {
   if (vscodeAPI?.postMessage) {
     vscodeAPI.postMessage({ type: "initTemplate", packageSpec });
@@ -104,5 +111,11 @@ export function requestTextEdit(edit: TextEdit) {
         ? edit.newText
         : edit.newText.code || edit.newText.rest || ""
     );
+  }
+}
+
+export function saveDataToFile({data, path, option}: { data: string, path?: string, option?: any}) {
+  if (vscodeAPI?.postMessage) {
+    vscodeAPI.postMessage({ type: "saveDataToFile", data, path, option});
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,11 @@ css-what@^6.1.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
+csv-stringify@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.5.0.tgz#7b1491893c917e018a97de9bf9604e23b88647c2"
+  integrity sha512-edlXFVKcUx7r8Vx5zQucsuMg4wb/xT6qyz+Sr1vnLrdXqlLD1+UKyWNyZ9zn6mUW1ewmGxrpVwAcChGF0HQ/2Q==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -1121,6 +1126,14 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+"editor-tools@file:tools/editor-tools":
+  version "0.0.0"
+  dependencies:
+    csv-stringify "^6.5.0"
+    detypify-service "0.2.4"
+    minisearch "^6.3.0"
+    vanjs-core "^1.5.0"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2800,8 +2813,16 @@ std-env@^3.3.3:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2853,7 +2874,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This PR adds a "Copy" icon to the top right corner of the font list card, in the VSCode extension's summary page:

![icon](https://github.com/Myriad-Dreamin/tinymist/assets/7822577/8c04e60b-5c96-4336-83b1-1a264155ceac)

Clicking it opens a font list export panel, which can export the list of fonts  as plain text:

![fontlist](https://github.com/Myriad-Dreamin/tinymist/assets/7822577/5facdcf2-79d3-47c4-b9aa-5b2c851301db)

By default, only the paths of external font files are exported.

The options above can control whether to include Typst built-in fonts and whether to add extra information such as font names:

![fullinfo](https://github.com/Myriad-Dreamin/tinymist/assets/7822577/2952aad0-d272-4ea8-a0f6-76ef6bed3d88)

Click the "Copy" button at the bottom to perform the copy.

---

This feature fully from a personal need of mine. Upon discovering that tinymist already had a feature of showing document font lists, I think implement it here may save my coding time(And it's true).

If the author also finds this feature useful, I am more than happy to polish the code based on review comments.

If you feel this feature is not suitable for the tinymist extension, please feel free to close the PR.