### PR TITLE
fix: handle the conversion of offset at the EOF

### DIFF
--- a/crates/tinymist-query/src/lsp_typst_boundary.rs
+++ b/crates/tinymist-query/src/lsp_typst_boundary.rs
@@ -213,6 +213,10 @@ pub mod typst_to_lsp {
         lsp_position_encoding: LspPositionEncoding,
         typst_source: &Source,
     ) -> LspPosition {
+        if typst_offset >= typst_source.len_bytes() {
+            return LspPosition::new(typst_source.len_lines() as u32, 0);
+        }
+
         let line_index = typst_source.byte_to_line(typst_offset).unwrap();
         let column_index = typst_source.byte_to_column(typst_offset).unwrap();
 

--- a/crates/tinymist-query/src/lsp_typst_boundary.rs
+++ b/crates/tinymist-query/src/lsp_typst_boundary.rs
@@ -213,7 +213,7 @@ pub mod typst_to_lsp {
         lsp_position_encoding: LspPositionEncoding,
         typst_source: &Source,
     ) -> LspPosition {
-        if typst_offset >= typst_source.len_bytes() {
+        if typst_offset > typst_source.len_bytes() {
             return LspPosition::new(typst_source.len_lines() as u32, 0);
         }
 
@@ -364,6 +364,31 @@ mod test {
                 assert!(off.is_some(), "line: {line}, character: {character}");
             }
         }
+    }
+
+    #[test]
+    fn overflow_offset_to_position() {
+        let source = Source::detached("test");
+
+        let offset = source.len_bytes();
+        let position = typst_to_lsp::offset_to_position(offset, PositionEncoding::Utf16, &source);
+        assert_eq!(
+            position,
+            LspPosition {
+                line: 0,
+                character: 4
+            }
+        );
+
+        let offset = source.len_bytes() + 1;
+        let position = typst_to_lsp::offset_to_position(offset, PositionEncoding::Utf16, &source);
+        assert_eq!(
+            position,
+            LspPosition {
+                line: 1,
+                character: 0
+            }
+        );
     }
 
     #[test]

--- a/crates/tinymist-query/src/semantic_tokens/mod.rs
+++ b/crates/tinymist-query/src/semantic_tokens/mod.rs
@@ -181,7 +181,10 @@ impl Tokenizer {
                 token_modifiers_bitset: token.modifiers.bitset(),
             });
         } else {
-            let final_line = self.source.byte_to_line(utf8_end).unwrap() as u32;
+            let final_line = self
+                .source
+                .byte_to_line(utf8_end)
+                .unwrap_or_else(|| self.source.len_lines()) as u32;
             let next_offset = self
                 .source
                 .line_to_byte((self.curr_pos.line + 1) as usize)

--- a/crates/tinymist/src/actor/export.rs
+++ b/crates/tinymist/src/actor/export.rs
@@ -27,7 +27,7 @@ pub struct ExportConfig {
 #[derive(Debug)]
 pub enum ExportRequest {
     OnTyped,
-    OnSaved(PathBuf),
+    OnSaved,
     Oneshot(Option<ExportKind>, oneshot::Sender<Option<PathBuf>>),
     ChangeConfig(ExportConfig),
     ChangeExportPath(EntryState),
@@ -61,7 +61,7 @@ impl ExportActor {
                     ExportRequest::ChangeConfig(config) => self.config = config,
                     ExportRequest::ChangeExportPath(entry) => self.entry = entry,
                     ExportRequest::OnTyped => need_export |= self.config.mode == ExportMode::OnType,
-                    ExportRequest::OnSaved(..) => match self.config.mode {
+                    ExportRequest::OnSaved => match self.config.mode {
                         ExportMode::OnSave => need_export = true,
                         ExportMode::OnDocumentHasTitle => need_export |= doc.title.is_some(),
                         _ => {}

--- a/crates/tinymist/src/actor/typ_client.rs
+++ b/crates/tinymist/src/actor/typ_client.rs
@@ -456,7 +456,7 @@ impl CompileClientActor {
 
     pub fn on_save_export(&self, path: PathBuf) -> anyhow::Result<()> {
         info!("CompileActor: on save export: {}", path.display());
-        let _ = self.export_tx.send(ExportRequest::OnSaved(path));
+        let _ = self.export_tx.send(ExportRequest::OnSaved);
 
         Ok(())
     }

--- a/crates/tinymist/src/lib.rs
+++ b/crates/tinymist/src/lib.rs
@@ -32,7 +32,7 @@ pub mod harness;
 mod resource;
 mod server;
 mod state;
-mod tools;
+pub mod tools;
 pub mod transport;
 mod utils;
 mod world;


### PR DESCRIPTION
The `byte_to_line` api will panic if the offset equals to the length in bytes.