### PR TITLE
chore: bump typstyle to v0.11.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.23"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb15ec2ba1f804eab4f8f2ae1bbbe8a7d2f882bb8acabaee0b101de46ee28c56"
+checksum = "b08c00b01698330e3c46dd9454c3472e4107866de14fc52aeb1a55aa260bfc7b"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ typst-ts-core = { version = "0.5.0-rc4", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc4" }
 typst-ts-svg-exporter = { version = "0.5.0-rc4" }
 typst-preview = { version = "0.11.3" }
-typstyle = "0.11.23"
+typstyle = "0.11.26"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 
 lsp-server = "0.7.6"


### PR DESCRIPTION
changelog: https://enter-tainer.github.io/typstyle/changelog/#v01123---2024-05-25

table formatting enhancement