### PR TITLE
build: bump version to 0.11.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "biblatex",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.10"
+version = "0.11.11"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.11 - [2024-06-17]
+
+* Bumped typstyle to v0.11.26 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/326
+
+## Compiler
+
+* (Fix): Handling the conversion of offset at the EOF in https://github.com/Myriad-Dreamin/tinymist/pull/325
+* (Fix) Accumulating export events correctly in https://github.com/Myriad-Dreamin/tinymist/pull/330
+
+## Document Highlighting (New)
+
+* highlighting all break points for that loop context in https://github.com/Myriad-Dreamin/tinymist/pull/317
+
+## On Enter (New)
+
+* Implemented `experimental/onEnter` in https://github.com/Myriad-Dreamin/tinymist/pull/328
+
+## Completion
+
+* Generating names for destructuring closure params by @wrenger in https://github.com/Myriad-Dreamin/tinymist/pull/319
+
+## Misc
+
+* Combined CompileClient and CompileClientActor by @QuarticCat in https://github.com/Myriad-Dreamin/tinymist/pull/318
+* Simplified pin_entry by @QuarticCat in https://github.com/Myriad-Dreamin/tinymist/pull/320
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.10...v0.11.11
+
 ## v0.11.10 - [2024-05-26]
 
 * Bumped typstyle to v0.11.23 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/315

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -15,7 +15,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Document Highlighting (New)
 
-* highlighting all break points for that loop context in https://github.com/Myriad-Dreamin/tinymist/pull/317
+* Highlighting all break points for that loop context in https://github.com/Myriad-Dreamin/tinymist/pull/317
 
 ## On Enter (New)
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.10",
+    "version": "0.11.11",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",


### PR DESCRIPTION
* Bumped typstyle to v0.11.26 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/326

## Compiler

* (Fix): Handling the conversion of offset at the EOF in https://github.com/Myriad-Dreamin/tinymist/pull/325
* (Fix) Accumulating export events correctly in https://github.com/Myriad-Dreamin/tinymist/pull/330

## Document Highlighting (New)

* Highlighting all break points for that loop context in https://github.com/Myriad-Dreamin/tinymist/pull/317

## On Enter (New)

* Implemented `experimental/onEnter` in https://github.com/Myriad-Dreamin/tinymist/pull/328

## Completion

* Generating names for destructuring closure params by @wrenger in https://github.com/Myriad-Dreamin/tinymist/pull/319

## Misc

* Combined CompileClient and CompileClientActor by @QuarticCat in https://github.com/Myriad-Dreamin/tinymist/pull/318
* Simplified pin_entry by @QuarticCat in https://github.com/Myriad-Dreamin/tinymist/pull/320

**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.10...v0.11.11
