### PR TITLE
feat(ci): upgrade macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
             rust-target: arm-unknown-linux-gnueabihf
             platform: linux
             arch: armhf
-          - os: macos-11
+          - os: macos-13
             rust-target: x86_64-apple-darwin
             platform: darwin
             arch: x64
-          - os: macos-11
+          - os: macos-13
             rust-target: aarch64-apple-darwin
             platform: darwin
             arch: arm64


### PR DESCRIPTION
`macos-11` runner is removed in GitHub Q3. See https://github.com/actions/runner-images/issues/9255.