### PR TITLE
feat: full compatible with typst-preview extension

### DIFF
--- a/editors/neovim/Configuration.md
+++ b/editors/neovim/Configuration.md
@@ -106,3 +106,64 @@ Set the print width for the formatter, which is a **soft limit** of characters p
 
 - **Type**: `number`
 - **Default**: `120`
+
+## `preview`
+
+Enable or disable preview features of Typst. Note: restarting the editor is required to change this setting.
+
+- **Type**: `string`
+- **Enum**:
+  - `enable`
+  - `disable`
+- **Default**: `"enable"`
+
+## `preview.refresh`
+
+Refresh preview when the document is saved or when the document is changed
+
+- **Type**: `string`
+- **Enum**:
+  - `onSave`: Refresh preview on save
+  - `onType`: Refresh preview on type
+- **Default**: `"onType"`
+
+## `preview.scrollSync`
+
+Configure scroll sync mode.
+
+- **Type**: `string`
+- **Enum**:
+  - `never`: Disable automatic scroll sync
+  - `onSelectionChangeByMouse`: Scroll preview to current cursor position when selection changes by mouse
+  - `onSelectionChange`: Scroll preview to current cursor position when selection changes by mouse or keyboard (any source)
+- **Default**: `"onSelectionChangeByMouse"`
+
+## `preview.partialRendering`
+
+Only render visible part of the document. This can improve performance but still being experimental.
+
+- **Type**: `boolean`
+- **Default**: `true`
+
+## `preview.invertColors`
+
+Invert colors of the preview (useful for dark themes without cost). Please note you could see the origin colors when you hover elements in the preview.
+
+- **Type**: `string`
+- **Enum**:
+  - `never`: Disable color inversion of the preview
+  - `auto`: Invert colors smartly by detecting dark/light themes in browser environment or by `typst query` your document
+  - `always`: Always invert colors of the preview
+- **Default**: `"never"`
+
+## `preview.cursorIndicator`
+
+(Experimental) Show typst cursor indicator in preview.
+
+- **Type**: `boolean`
+
+## `preview.showInActivityBar`
+
+(Experimental) Show a preview panel in activity bar.
+
+- **Type**: `boolean`

--- a/editors/vscode/Configuration.md
+++ b/editors/vscode/Configuration.md
@@ -107,7 +107,17 @@ Set the print width for the formatter, which is a **soft limit** of characters p
 - **Type**: `number`
 - **Default**: `120`
 
-## `typst-preview.refresh`
+## `tinymist.preview`
+
+Enable or disable preview features of Typst. Note: restarting the editor is required to change this setting.
+
+- **Type**: `string`
+- **Enum**:
+  - `enable`
+  - `disable`
+- **Default**: `"enable"`
+
+## `tinymist.preview.refresh`
 
 Refresh preview when the document is saved or when the document is changed
 
@@ -117,7 +127,7 @@ Refresh preview when the document is saved or when the document is changed
   - `onType`: Refresh preview on type
 - **Default**: `"onType"`
 
-## `typst-preview.scrollSync`
+## `tinymist.preview.scrollSync`
 
 Configure scroll sync mode.
 
@@ -128,14 +138,14 @@ Configure scroll sync mode.
   - `onSelectionChange`: Scroll preview to current cursor position when selection changes by mouse or keyboard (any source)
 - **Default**: `"onSelectionChangeByMouse"`
 
-## `typst-preview.partialRendering`
+## `tinymist.preview.partialRendering`
 
 Only render visible part of the document. This can improve performance but still being experimental.
 
 - **Type**: `boolean`
 - **Default**: `true`
 
-## `typst-preview.invertColors`
+## `tinymist.preview.invertColors`
 
 Invert colors of the preview (useful for dark themes without cost). Please note you could see the origin colors when you hover elements in the preview.
 
@@ -146,13 +156,13 @@ Invert colors of the preview (useful for dark themes without cost). Please note 
   - `always`: Always invert colors of the preview
 - **Default**: `"never"`
 
-## `typst-preview.cursorIndicator`
+## `tinymist.preview.cursorIndicator`
 
 (Experimental) Show typst cursor indicator in preview.
 
 - **Type**: `boolean`
 
-## `typst-preview.showInActivityBar`
+## `tinymist.preview.showInActivityBar`
 
 (Experimental) Show a preview panel in activity bar.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -42,15 +42,15 @@
                     "when": "resourceLangId == typst"
                 },
                 {
-                    "id": "typst-preview.content-preview",
+                    "id": "tinymist.preview.content-preview",
                     "type": "webview",
                     "name": "Content",
-                    "when": "config.typst-preview.showInActivityBar && resourceLangId == typst"
+                    "when": "(config.tinymist.preview.showInActivityBar || config.typst-preview.showInActivityBar) && resourceLangId == typst"
                 },
                 {
-                    "id": "typst-preview.outline",
+                    "id": "tinymist.preview.outline",
                     "name": "Outline",
-                    "when": "config.typst-preview.showInActivityBar && resourceLangId == typst"
+                    "when": "(config.tinymist.preview.showInActivityBar || config.typst-preview.showInActivityBar) && resourceLangId == typst"
                 }
             ]
         },
@@ -191,7 +191,17 @@
                     "type": "number",
                     "default": 120
                 },
-                "typst-preview.sysInputs": {
+                "tinymist.preview": {
+                    "title": "Enable preview features",
+                    "description": "Enable or disable preview features of Typst. Note: restarting the editor is required to change this setting.",
+                    "type": "string",
+                    "default": "enable",
+                    "enum": [
+                        "enable",
+                        "disable"
+                    ]
+                },
+                "tinymist.preview.sysInputs": {
                     "type": "object",
                     "items": {
                         "type": "string"
@@ -200,13 +210,13 @@
                     "description": "key-value pairs visible through `sys.inputs`, corresponds to `--input` argument of typst cli",
                     "markdownDeprecationMessage": "The configuration item is ignored. Please see `tinymist.typstExtraArgs` for inputs."
                 },
-                "typst-preview.systemFonts": {
+                "tinymist.preview.systemFonts": {
                     "type": "boolean",
                     "default": true,
                     "description": "Whether to load system fonts. If disabled, only fonts in `typst-preview.fontPaths` is loaded",
                     "markdownDeprecationMessage": "The configuration item is ignored. Please use `tinymist.systemFonts` instead."
                 },
-                "typst-preview.fontPaths": {
+                "tinymist.preview.fontPaths": {
                     "type": "array",
                     "items": {
                         "type": "string",
@@ -217,7 +227,7 @@
                     "description": "List of *additional* paths to font assets used by typst-preview.",
                     "markdownDeprecationMessage": "The configuration item is ignored. Please use `tinymist.fontPaths` instead."
                 },
-                "typst-preview.refresh": {
+                "tinymist.preview.refresh": {
                     "title": "Refresh preview",
                     "description": "Refresh preview when the document is saved or when the document is changed",
                     "type": "string",
@@ -231,7 +241,7 @@
                         "Refresh preview on type"
                     ]
                 },
-                "typst-preview.scrollSync": {
+                "tinymist.preview.scrollSync": {
                     "description": "Configure scroll sync mode.",
                     "type": "string",
                     "enum": [
@@ -246,12 +256,12 @@
                         "Scroll preview to current cursor position when selection changes by mouse or keyboard (any source)"
                     ]
                 },
-                "typst-preview.partialRendering": {
+                "tinymist.preview.partialRendering": {
                     "description": "Only render visible part of the document. This can improve performance but still being experimental.",
                     "type": "boolean",
                     "default": true
                 },
-                "typst-preview.invertColors": {
+                "tinymist.preview.invertColors": {
                     "description": "Invert colors of the preview (useful for dark themes without cost). Please note you could see the origin colors when you hover elements in the preview.",
                     "type": "string",
                     "enum": [
@@ -266,17 +276,17 @@
                         "Always invert colors of the preview"
                     ]
                 },
-                "typst-preview.cursorIndicator": {
+                "tinymist.preview.cursorIndicator": {
                     "description": "(Experimental) Show typst cursor indicator in preview.",
                     "type": "boolean",
                     "default": false
                 },
-                "typst-preview.showInActivityBar": {
+                "tinymist.preview.showInActivityBar": {
                     "description": "(Experimental) Show a preview panel in activity bar.",
                     "type": "boolean",
                     "default": false
                 },
-                "typst-preview.pinPreviewFile": {
+                "tinymist.preview.pinPreviewFile": {
                     "description": "Declare current previewing file as entrypoint for typst-lsp or tinymist. This will make typst-lsp or tinymist to use this file as entrypoint instead of the file opened in vscode. This can improve diagnostics messages and auto completion but still being experimental.",
                     "type": "boolean",
                     "default": false,
@@ -658,7 +668,7 @@
             "view/title": [
                 {
                     "command": "typst-preview.noteOutline",
-                    "when": "view == typst-preview.outline",
+                    "when": "view == tinymist.preview.outline",
                     "group": "navigation"
                 }
             ]


### PR DESCRIPTION
- Added a configuration to turn on/off preview feature globally.
- Changed the configuration items in tinymist extension's `package.json` now, as I find vscode will warn conflict items when both typst-preview and tinymist extension are installed and enabed.
- Changed the name of components as well.