### PR TITLE
build: bump version to 0.11.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "sync-lsp"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3994,11 +3994,11 @@ dependencies = [
 
 [[package]]
 name = "tinymist-assets"
-version = "0.11.13"
+version = "0.11.14"
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "biblatex",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "typst-preview"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "await-tree",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.13"
+version = "0.11.14"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -100,7 +100,7 @@ insta = { version = "1.36", features = ["glob"] }
 sync-lsp = { path = "./crates/sync-lsp" }
 
 typst-preview = { path = "./crates/typst-preview/" }
-tinymist-assets = { version = "0.11.13" }
+tinymist-assets = { version = "0.11.14" }
 tinymist = { path = "./crates/tinymist/" }
 tinymist-query = { path = "./crates/tinymist-query/" }
 tinymist-render = { path = "./crates/tinymist-render/" }

--- a/contrib/typst-preview/editors/vscode/CHANGELOG.md
+++ b/contrib/typst-preview/editors/vscode/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+This is the change log mirror of the [tinymist changelog](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/vscode/CHANGELOG.md)
+
+## v0.11.14 - [2024-07-07]
+
+## Compiler
+
+This bug is introduced by [Preparing for parallelizing lsp requests](https://github.com/Myriad-Dreamin/tinymist/pull/342).
+
+* (Fix) Lsp should respond errors at tail in https://github.com/Myriad-Dreamin/tinymist/pull/367
+
+### Commands/Tools
+
+* Supported single-task preview commands in https://github.com/Myriad-Dreamin/tinymist/pull/364, https://github.com/Myriad-Dreamin/tinymist/pull/368, https://github.com/Myriad-Dreamin/tinymist/pull/370, and https://github.com/Myriad-Dreamin/tinymist/pull/371
+  * Typst Preview extension is already integrated into Tinymist. It . Please disable Typst Preview extension to avoid conflicts.
+  * Otherwise, you should disable the tinymist's embedded preview feature by `"tinymist.preview": "disable"` in your settings.json.
+
+### Preview
+
+* Persisting webview preview through vscode restarts by @Myriad-Dreamin and @noamzaks in https://github.com/Myriad-Dreamin/tinymist/pull/373
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.13...v0.11.14
+
+# Change Log (v0.1.0 - v0.11.7)
+
 All notable changes to the "typst-preview" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.

--- a/contrib/typst-preview/editors/vscode/CHANGELOG.md
+++ b/contrib/typst-preview/editors/vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-This is the change log mirror of the [tinymist changelog](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/vscode/CHANGELOG.md)
+Mirroring from [Tinymist Changelog](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/vscode/CHANGELOG.md)
 
 ## v0.11.14 - [2024-07-07]
 

--- a/contrib/typst-preview/editors/vscode/package.json
+++ b/contrib/typst-preview/editors/vscode/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/Enter-tainer/typst-preview"
   },
-  "version": "0.11.7",
+  "version": "0.11.14",
   "engines": {
     "vscode": "^1.77.0"
   },

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.14 - [2024-07-07]
+
+## Compiler
+
+This bug is introduced by [Preparing for parallelizing lsp requests](https://github.com/Myriad-Dreamin/tinymist/pull/342).
+
+* (Fix) Lsp should respond errors at tail in https://github.com/Myriad-Dreamin/tinymist/pull/367
+
+### Commands/Tools
+
+* Supported single-task preview commands in https://github.com/Myriad-Dreamin/tinymist/pull/364, https://github.com/Myriad-Dreamin/tinymist/pull/368, https://github.com/Myriad-Dreamin/tinymist/pull/370, and https://github.com/Myriad-Dreamin/tinymist/pull/371
+  * Typst Preview extension is already integrated into Tinymist. It . Please disable Typst Preview extension to avoid conflicts.
+  * Otherwise, you should disable the tinymist's embedded preview feature by `"tinymist.preview": "disable"` in your settings.json.
+
+### Preview
+
+* Persisting webview preview through vscode restarts by @Myriad-Dreamin and @noamzaks in https://github.com/Myriad-Dreamin/tinymist/pull/373
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.13...v0.11.14
+
 ## v0.11.13 - [2024-07-02]
 
 ## Compiler

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.13",
+    "version": "0.11.14",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",


### PR DESCRIPTION

## Compiler

This bug is introduced by [Preparing for parallelizing lsp requests](https://github.com/Myriad-Dreamin/tinymist/pull/342).

* (Fix) Lsp should respond errors at tail in https://github.com/Myriad-Dreamin/tinymist/pull/367

### Commands/Tools

* Supported single-task preview commands in https://github.com/Myriad-Dreamin/tinymist/pull/364, https://github.com/Myriad-Dreamin/tinymist/pull/368, https://github.com/Myriad-Dreamin/tinymist/pull/370, and https://github.com/Myriad-Dreamin/tinymist/pull/371
  * Typst Preview extension is already integrated into Tinymist. It . Please disable Typst Preview extension to avoid conflicts.
  * Otherwise, you should disable the tinymist's embedded preview feature by `"tinymist.preview": "disable"` in your settings.json.

### Preview

* Persisting webview preview through vscode restarts by @Myriad-Dreamin and @noamzaks in https://github.com/Myriad-Dreamin/tinymist/pull/373

**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.13...v0.11.14