### PR TITLE
feat: allow deferred snapshot event processing

### DIFF
--- a/crates/tinymist/src/lib.rs
+++ b/crates/tinymist/src/lib.rs
@@ -28,6 +28,7 @@ pub mod tool;
 mod utils;
 mod world;
 
+pub use actor::typ_server::NO_DEFERRED_SNAPSHOT;
 pub use init::*;
 pub use server::*;
 pub use sync_lsp::LspClient;

--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -14,6 +14,7 @@ use serde_json::Value as JsonValue;
 use sync_lsp::{transport::with_stdio_transport, LspBuilder, LspClientRoot};
 use tinymist::{
     CompileConfig, Config, ConstConfig, LanguageState, LspWorld, RegularInit, SuperInit,
+    NO_DEFERRED_SNAPSHOT,
 };
 use typst::World;
 use typst::{eval::Tracer, foundations::IntoValue, syntax::Span};
@@ -85,6 +86,9 @@ pub fn lsp_main(args: LspArgs) -> anyhow::Result<()> {
     log::info!("starting LSP server: {:#?}", args);
 
     let is_replay = !args.mirror.replay.is_empty();
+    if is_replay {
+        NO_DEFERRED_SNAPSHOT.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
 
     with_stdio_transport(args.mirror.clone(), |conn| {
         let client = LspClientRoot::new(RUNTIMES.tokio_runtime.handle().clone(), conn.sender);

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -980,6 +980,7 @@ impl LanguageState {
 
         just_future(async move {
             let snap = snap.snapshot().await?;
+            // todo: whether it is safe to inherit success_doc with changed entry
             let snap = snap.task(TaskInputs {
                 entry,
                 ..Default::default()


### PR DESCRIPTION
Let `R` be the marker of revision-changed events, `S` be the snapshot events, and `O` be others. The sequence of user triggering events usually have the snapshot:
```
`R`, `S`,  `S`,  `S`, `S`, `S`, `R`, `S`, `R`, `S`, `R`, `O`
```

In short the client usually changes the state and follows many state queries.

This will prevent optimization about the event accumulation since current `COMPILE_CONCURRENCY` is `0` and we cannot combine `R`s if there is any `S` between them.

The correct fix is to increase `COMPILE_CONCURRENCY` but I find it not very trivial. For example, if they hit keyboard fast, one's machine may be overwhelmed with compilation threads and cause poor performance (when most of you cpus are used for compilations and analysis tasks will cry) and power efficiency.

---

To fix it temporarily, I allowed snapshot to be put and responded together. This will make e2e fail so I also introduce a `NO_DEFERRED_SNAPSHOT` which will be removed in future.

