### PR TITLE
build: bump typstyle to v0.11.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,9 +4441,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.28"
+version = "0.11.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cfef0bd8b71907de640287bef88b33e4e55b6a6ff5227bb8f36ae308a0e2da"
+checksum = "3986aeeab2d56070e7a63a86f04d1f0d4aec98abaf5cec8fb4c3616caf6fe331"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ typst-ts-core = { version = "0.5.0-rc5", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc5" }
 typst-ts-svg-exporter = { version = "0.5.0-rc5" }
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
-typstyle = { version = "0.11.28", default-features = false }
+typstyle = { version = "0.11.29", default-features = false }
 
 # LSP
 crossbeam-channel = "0.5.12"


### PR DESCRIPTION
This version improves dot chain format. Changelog: https://enter-tainer.github.io/typstyle/changelog/#v01129---2024-07-13