### PR TITLE
build: bump version to 0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,7 +3766,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync-lsp",
- "tinymist-assets 0.11.15-rc3",
+ "tinymist-assets 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinymist-query",
  "tinymist-render",
  "tokio",
@@ -3793,13 +3793,13 @@ dependencies = [
 
 [[package]]
 name = "tinymist-assets"
-version = "0.11.15-rc3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee30d36918e2179d63c49633e4f7e742b024a318629486c19c330dfaa467d0eb"
+version = "0.11.15"
 
 [[package]]
 name = "tinymist-assets"
 version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a903925a80e7eb0726472180da9b8a7cc7d14bc97f639e32110aa597f77f6e4"
 
 [[package]]
 name = "tinymist-query"
@@ -4245,7 +4245,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "tinymist-assets 0.11.15-rc3",
+ "tinymist-assets 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tokio-tungstenite",
  "typst",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "sync-lsp"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3766,7 +3766,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync-lsp",
- "tinymist-assets 0.11.15-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets 0.11.15-rc3",
  "tinymist-query",
  "tinymist-render",
  "tokio",
@@ -3794,16 +3794,16 @@ dependencies = [
 [[package]]
 name = "tinymist-assets"
 version = "0.11.15-rc3"
-
-[[package]]
-name = "tinymist-assets"
-version = "0.11.15-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee30d36918e2179d63c49633e4f7e742b024a318629486c19c330dfaa467d0eb"
 
 [[package]]
+name = "tinymist-assets"
+version = "0.11.15"
+
+[[package]]
 name = "tinymist-query"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "anyhow",
  "biblatex",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -4123,7 +4123,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typlite"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "insta",
  "typst-syntax 0.11.1",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "typst-preview"
-version = "0.11.15-rc3"
+version = "0.11.15"
 dependencies = [
  "clap",
  "comemo 0.4.0",
@@ -4245,7 +4245,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "tinymist-assets 0.11.15-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets 0.11.15-rc3",
  "tokio",
  "tokio-tungstenite",
  "typst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.15-rc3"
+version = "0.11.15"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -132,7 +132,7 @@ insta = { version = "1.39", features = ["glob"] }
 
 # Our Own Crates
 typst-preview = { path = "./crates/typst-preview/" }
-tinymist-assets = { version = "0.11.15-rc3" }
+tinymist-assets = { version = "0.11.15" }
 tinymist = { path = "./crates/tinymist/" }
 tinymist-query = { path = "./crates/tinymist-query/" }
 tinymist-render = { path = "./crates/tinymist-render/" }

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## v0.11.15 - [2024-07-14]
+## v0.11.15 - [2024-07-15]
 
-* Bumped typstyle to v0.11.29 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/410
+* Bumped typstyle to v0.11.30 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/416
 
 ## Compiler
 
@@ -29,14 +29,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * (Fix) Fixed some corner cases of serving preview in https://github.com/Myriad-Dreamin/tinymist/pull/385
 * (Fix) Scrolling source correctly when no text editor is active in https://github.com/Myriad-Dreamin/tinymist/pull/395
 * (Fix) Updating content preview incrementally again in https://github.com/Myriad-Dreamin/tinymist/pull/413
+* (Fix) wrong serialization of `task_id` v.s. `taskId` in https://github.com/Myriad-Dreamin/tinymist/pull/417
 
 ## Misc
 
 * Added typlite for typst's doc comments in https://github.com/Myriad-Dreamin/tinymist/pull/398
 * Documented tinymist crate in https://github.com/Myriad-Dreamin/tinymist/pull/390
 * (Fix) Performing cyclic loop dependence correctly when checking def-use relation across module in https://github.com/Myriad-Dreamin/tinymist/pull/396
-
-**Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.14...v0.11.15
 
 ## v0.11.14 - [2024-07-07]
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist",
-    "version": "0.11.15-rc3",
+    "version": "0.11.15",
     "description": "An integrated language service for Typst",
     "categories": [
         "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.15-rc3",
+  "version": "0.11.15",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.js",


### PR DESCRIPTION

* Bumped typstyle to v0.11.30 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/416

## Compiler

* (Fix) Noting `formatter_print_width` change on changed configuration in https://github.com/Myriad-Dreamin/tinymist/pull/387
* Keeping entry on language query in https://github.com/Myriad-Dreamin/tinymist/pull/406
* Allowed deferred snapshot event processing in https://github.com/Myriad-Dreamin/tinymist/pull/408

## Editor

* (Fix) Showing views in activity bar whenever the extension is activated in https://github.com/Myriad-Dreamin/tinymist/pull/414

## Hover (Tooltip)

* Rendering example code in typst docs as typst syntax in https://github.com/Myriad-Dreamin/tinymist/pull/397

## Preview

* Using `requestIdleCallback` to wait for updating canvas pages when editor is in idle in https://github.com/Myriad-Dreamin/tinymist/pull/412
  * Improve performance when updating document quickly.
* (Fix) Fixed some corner cases of serving preview in https://github.com/Myriad-Dreamin/tinymist/pull/385
* (Fix) Scrolling source correctly when no text editor is active in https://github.com/Myriad-Dreamin/tinymist/pull/395
* (Fix) Updating content preview incrementally again in https://github.com/Myriad-Dreamin/tinymist/pull/413
* (Fix) wrong serialization of `task_id` v.s. `taskId` in https://github.com/Myriad-Dreamin/tinymist/pull/417

## Misc

* Added typlite for typst's doc comments in https://github.com/Myriad-Dreamin/tinymist/pull/398
* Documented tinymist crate in https://github.com/Myriad-Dreamin/tinymist/pull/390
* (Fix) Performing cyclic loop dependence correctly when checking def-use relation across module in https://github.com/Myriad-Dreamin/tinymist/pull/396
