### PR TITLE
feat: allow multiple-tasked preview

### DIFF
--- a/crates/tinymist/src/actor/mod.rs
+++ b/crates/tinymist/src/actor/mod.rs
@@ -8,6 +8,7 @@ pub mod typ_server;
 
 use std::sync::Arc;
 
+use reflexo::ImmutPath;
 use tinymist_query::analysis::Analysis;
 use tinymist_query::ExportKind;
 use tinymist_render::PeriscopeRenderer;
@@ -26,16 +27,42 @@ use crate::{
 };
 
 impl LanguageState {
+    /// Restart the primary server.
+    pub fn restart_primary(&mut self) {
+        let entry = self.compile_config().determine_default_entry_path();
+        self.restart_server("primary", entry);
+    }
+
     /// Restart the server with the given group.
-    pub fn restart_server(&mut self, group: &str) {
+    pub fn restart_dedicate(&mut self, dedicate: &str, entry: Option<ImmutPath>) {
+        self.restart_server(dedicate, entry);
+    }
+
+    /// Restart the server with the given group.
+    fn restart_server(&mut self, group: &str, entry: Option<ImmutPath>) {
         let server = self.server(
             group.to_owned(),
-            self.compile_config()
-                .determine_entry(self.compile_config().determine_default_entry_path()),
+            self.compile_config().determine_entry(entry),
             self.compile_config().determine_inputs(),
             self.vfs_snapshot(),
         );
-        if let Some(mut prev) = self.primary.replace(server) {
+
+        let prev = if group == "primary" {
+            self.primary.replace(server)
+        } else {
+            let cell = self
+                .dedicates
+                .iter_mut()
+                .find(|dedicate| dedicate.handle.diag_group == group);
+            if let Some(dedicate) = cell {
+                Some(std::mem::replace(dedicate, server))
+            } else {
+                self.dedicates.push(server);
+                None
+            }
+        };
+
+        if let Some(mut prev) = prev {
             self.client.handle.spawn(async move { prev.settle().await });
         }
     }

--- a/crates/tinymist/src/actor/typ_client.rs
+++ b/crates/tinymist/src/actor/typ_client.rs
@@ -104,6 +104,13 @@ impl CompileHandler {
         let _ = self.intr_tx.send(Interrupt::ChangeTask(task_inputs));
     }
 
+    pub async fn settle(&self) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.intr_tx.send(Interrupt::Settle(tx));
+        rx.await?;
+        Ok(())
+    }
+
     fn push_diagnostics(&self, revision: usize, diagnostics: Option<DiagnosticsMap>) {
         let dv = DocVersion {
             group: self.diag_group.clone(),
@@ -317,7 +324,7 @@ impl CompilationHandle<LspCompilerFeat> for CompileHandler {
                 .doc
                 .clone()
                 .map_err(|_| typst_preview::CompileStatus::CompileError);
-            inner.notify_compile(res, snap.signal.by_fs_events || snap.signal.by_entry_update);
+            inner.notify_compile(res, snap.signal.by_fs_events, snap.signal.by_entry_update);
         }
     }
 }
@@ -381,9 +388,7 @@ impl CompileClientActor {
     pub async fn settle(&mut self) {
         let _ = self.change_entry(None);
         info!("TypstActor({}): settle requested", self.handle.diag_group);
-        let (tx, rx) = oneshot::channel();
-        let _ = self.handle.intr_tx.send(Interrupt::Settle(tx));
-        match rx.await {
+        match self.handle.settle().await {
             Ok(()) => info!("TypstActor({}): settled", self.handle.diag_group),
             Err(err) => error!(
                 "TypstActor({}): failed to settle: {err:#}",

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -58,7 +58,9 @@ impl LanguageState {
     /// Clear all cached resources.
     pub fn clear_cache(&mut self, _arguments: Vec<JsonValue>) -> AnySchedulableResponse {
         comemo::evict(0);
-        self.primary().clear_cache();
+        for ded in self.servers_mut() {
+            ded.clear_cache();
+        }
         just_ok(JsonValue::Null)
     }
 
@@ -124,21 +126,41 @@ impl LanguageState {
             return Err(invalid_params("entry file must be absolute path"));
         };
 
+        let task_id = cli_args.preview.task_id.clone();
+        if task_id == "primary" {
+            return Err(invalid_params("task id 'primary' is reserved"));
+        }
+
         // Disble control plane host
         cli_args.preview.control_plane_host = String::default();
 
-        let primary = self.primary().handle.clone();
-
         let previewer = typst_preview::PreviewBuilder::new(cli_args.preview.clone());
 
-        if !primary.register_preview(previewer.compile_watcher()) {
-            return Err(internal_error("preview is already running"));
-        }
+        let primary = self.primary().handle.clone();
+        if !cli_args.not_as_primary && primary.register_preview(previewer.compile_watcher()) {
+            // todo: recover pin status reliably
+            self.pin_entry(Some(entry))
+                .map_err(|e| internal_error(format!("could not pin file: {e}")))?;
 
-        // todo: recover pin status reliably
-        self.pin_entry(Some(entry))
-            .map_err(|e| internal_error(format!("could not pin file: {e}")))?;
-        self.preview.start(cli_args, previewer, primary)
+            self.preview.start(cli_args, previewer, primary, true)
+        } else {
+            self.restart_dedicate(&task_id, Some(entry));
+            let Some(dedicate) = self.dedicate(&task_id) else {
+                return Err(invalid_params(
+                    "just restarted compiler instance for the task is not found",
+                ));
+            };
+
+            let handle = dedicate.handle.clone();
+
+            if !handle.register_preview(previewer.compile_watcher()) {
+                return Err(invalid_params(
+                    "cannot register preview to the compiler instance",
+                ));
+            }
+
+            self.preview.start(cli_args, previewer, handle, false)
+        }
     }
 
     /// Kill a preview instance.

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -193,6 +193,10 @@ pub struct PreviewCliArgs {
     )]
     pub static_file_host: String,
 
+    /// Let it not be the primary instance.
+    #[clap(long = "not-primary", hide(true))]
+    pub not_as_primary: bool,
+
     /// Don't open the preview in the browser after compilation.
     #[clap(long = "no-open")]
     pub dont_open_in_browser: bool,
@@ -231,6 +235,7 @@ pub struct StartPreviewResponse {
     static_server_port: Option<u16>,
     static_server_addr: Option<String>,
     data_plane_port: Option<u16>,
+    is_primary: bool,
 }
 
 impl PreviewState {
@@ -240,6 +245,7 @@ impl PreviewState {
         args: PreviewCliArgs,
         mut previewer: PreviewBuilder,
         compile_handler: Arc<CompileHandler>,
+        is_primary: bool,
     ) -> SchedulableResponse<StartPreviewResponse> {
         let task_id = args.preview.task_id.clone();
         log::info!("PreviewTask({task_id}): arguments: {args:#?}");
@@ -297,7 +303,7 @@ impl PreviewState {
         just_future(async move {
             let previewer = previewer.await;
 
-            // Put a fence to ensure the previewer can receive the first compilation.   z
+            // Put a fence to ensure the previewer can receive the first compilation.
             // The fence must be put after the previewer is initialized.
             compile_handler.flush_compile();
 
@@ -309,6 +315,7 @@ impl PreviewState {
                 static_server_port: Some(ss_addr.port()),
                 static_server_addr: Some(ss_addr.to_string()),
                 data_plane_port: Some(previewer.data_plane_port()),
+                is_primary,
             };
 
             let sent = preview_tx.send(PreviewRequest::Started(PreviewTab {
@@ -318,6 +325,7 @@ impl PreviewState {
                 ss_handle,
                 ctl_tx,
                 compile_handler,
+                is_primary,
             }));
             sent.map_err(|_| internal_error("failed to register preview tab"))?;
 

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -444,8 +444,13 @@ impl CompileWatcher {
             .send(EditorActorRequest::CompileStatus(status));
     }
 
-    pub fn notify_compile(&self, res: Result<Arc<Document>, CompileStatus>, is_on_saved: bool) {
-        if self.refresh_style == RefreshStyle::OnSave && !is_on_saved {
+    pub fn notify_compile(
+        &self,
+        res: Result<Arc<Document>, CompileStatus>,
+        is_on_saved: bool,
+        is_by_entry_update: bool,
+    ) {
+        if !is_by_entry_update && (self.refresh_style == RefreshStyle::OnSave && !is_on_saved) {
             return;
         }
 

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -2,8 +2,18 @@ import { LanguageClient } from "vscode-languageclient/node";
 import * as vscode from "vscode";
 
 export let client: LanguageClient | undefined = undefined;
+
 export function setClient(newClient: LanguageClient) {
     client = newClient;
+    clientPromiseResolve(newClient);
+}
+
+let clientPromiseResolve = (_client: LanguageClient) => {};
+let clientPromise: Promise<LanguageClient> = new Promise((resolve) => {
+    clientPromiseResolve = resolve;
+});
+export async function getClient(): Promise<LanguageClient> {
+    return clientPromise;
 }
 
 interface ResourceRoutes {

--- a/editors/vscode/src/preview-compat.ts
+++ b/editors/vscode/src/preview-compat.ts
@@ -307,11 +307,12 @@ function runServer(
 
 interface LaunchTask {
     context: vscode.ExtensionContext;
-    activeEditor: vscode.TextEditor;
+    editor: vscode.TextEditor;
     bindDocument: vscode.TextDocument;
     mode: "doc" | "slide";
     webviewPanel?: vscode.WebviewPanel;
     isDev?: boolean;
+    isNotPrimary?: boolean;
 }
 
 export interface LaunchInBrowserTask extends LaunchTask {
@@ -325,7 +326,7 @@ export interface LaunchInWebViewTask extends LaunchTask {
 export const launchPreviewCompat = async (task: LaunchInBrowserTask | LaunchInWebViewTask) => {
     let shadowDispose: vscode.Disposable | undefined = undefined;
     let shadowDisposeClose: vscode.Disposable | undefined = undefined;
-    const { context, activeEditor, bindDocument, webviewPanel } = task;
+    const { context, editor: activeEditor, bindDocument, webviewPanel } = task;
     const filePath = bindDocument.uri.fsPath;
 
     const refreshStyle =


### PR DESCRIPTION
Previous PRs:
- #368
- #364 
- #337
- #332 
- #323 

--- 
Introducing dedicate servers that handle compilations and send diagnostics. The LSP will still always respond LSP requests according to the primary server's compilations.

Problem:
- It is not intuitive to distinguish primary preview instance and other instances. We need to merge lsp responses according to multiple instances.
- make `comemo::evict` work correctly on multiple compilers.
- we should improve performance on multiple instances.