### PR TITLE
fix: description for exportPdf setting

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -81,7 +81,6 @@
                         "onDocumentHasTitle"
                     ],
                     "enumDescriptions": [
-                        "Select best solution automatically. (Recommended)",
                         "Never export PDFs, you will manually run typst.",
                         "Export PDFs when you save a file.",
                         "Export PDFs as you type in a file.",


### PR DESCRIPTION
Currently there are 5 descriptions and 4 values, so they do not match (e.g. when hovering the value in VS Code settings). This removes the "recommended" description, as the value does not seem to exist.