### PR TITLE
Fix: Handling unwrap for the args in compile command

### DIFF
--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -105,7 +105,10 @@ pub fn lsp_main(args: LspArgs) -> anyhow::Result<()> {
 
 /// The main entry point for the compiler.
 pub fn compiler_main(args: CompileArgs) -> anyhow::Result<()> {
-    let mut input = PathBuf::from(args.compile.input.unwrap());
+    let mut input = PathBuf::from(match args.compile.input {
+        Some(value) => value,
+        None => return Err(anyhow::Error::msg("Provide a valid path")),
+    });
 
     let mut root_path = args.compile.root.unwrap_or(PathBuf::from("."));
 


### PR DESCRIPTION
I was simply bothered by how the program just panicked if I did not include a path in the compile command, so i replaced the unwrap with a match statement.

**before:**
![image](https://github.com/user-attachments/assets/c00163e5-a9a0-4a18-9f02-02e3589ded2e)

**after:**
![image](https://github.com/user-attachments/assets/3f4e9095-7745-44fa-9036-3319bf52d2d0)