### PR TITLE
fix: Modifies static host to send Content-Type: text/html

### DIFF
--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -369,15 +369,18 @@ pub fn make_static_host(
                 async move {
                     if req.uri().path() == "/" {
                         log::info!("Serve frontend: {:?}", mode);
-                        Ok::<_, hyper::Error>(hyper::Response::new(hyper::Body::from(html)))
+                        let res = hyper::Response::builder()
+                            .header(hyper::header::CONTENT_TYPE, "text/html")
+                            .body(html)
+                            .unwrap();
+                        Ok::<_, hyper::Error>(res)
                     } else {
                         // jump to /
-                        let mut res = hyper::Response::new(hyper::Body::empty());
-                        *res.status_mut() = hyper::StatusCode::FOUND;
-                        res.headers_mut().insert(
-                            hyper::header::LOCATION,
-                            hyper::header::HeaderValue::from_static("/"),
-                        );
+                        let res = hyper::Response::builder()
+                            .status(hyper::StatusCode::FOUND)
+                            .header(hyper::header::LOCATION, "/")
+                            .body(String::from(""))
+                            .unwrap();
                         Ok(res)
                     }
                 }


### PR DESCRIPTION
Resolves #463 

Disclaimer: these are my first lines of Rust ever.  It appears to work.

Thanks for having a straightforward `CONTRIBUTING.md` file.  I ran `./scripts/e2e.sh` successfully.  At first, `cargo insta` failed, but I figured out what it was and installed it.  A link to [cargo-insta](https://crates.io/crates/cargo-insta) might help other first-timers.