### PR TITLE
fix: apply label instead of bib title name in `at` completion

### DIFF
--- a/crates/tinymist-query/src/completion.rs
+++ b/crates/tinymist-query/src/completion.rs
@@ -320,6 +320,20 @@ mod tests {
             let mut includes = HashSet::new();
             let mut excludes = HashSet::new();
 
+            let must_compile = properties
+                .get("compile")
+                .map(|v| v.trim() == "true")
+                .unwrap_or(false);
+            let doc = if must_compile {
+                let doc = typst::compile(ctx.world(), &mut Default::default()).unwrap();
+                Some(VersionedDocument {
+                    version: 0,
+                    document: Arc::new(doc),
+                })
+            } else {
+                None
+            };
+
             for kk in properties.get("contains").iter().flat_map(|v| v.split(',')) {
                 // split first char
                 let (kind, item) = kk.split_at(1);
@@ -369,7 +383,7 @@ mod tests {
                     position: ctx.to_lsp_pos(s, &source),
                     explicit: false,
                 };
-                results.push(request.request(ctx, None).map(|resp| {
+                results.push(request.request(ctx, doc.clone()).map(|resp| {
                     // CompletionResponse::Array(items)
                     match resp {
                         CompletionResponse::List(l) => CompletionResponse::List(CompletionList {

--- a/crates/tinymist-query/src/fixtures/completion/completion_title.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title.typ
@@ -1,0 +1,18 @@
+// path: references.bib
+@article{Russell:1908,
+Author = {Bertand Russell},
+Journal = {American Journal of Mathematics},
+Pages = {222--262},
+Title = {Mathematical logic based on the theory of types},
+Volume = 30,
+Year = 1908}
+
+-----
+// contains:Russell:1908,Mathematical logic based on the theory of types
+// compile:true
+
+#set heading(numbering: "1.")
+== Test <R>
+@R/* range -2..0 */
+
+#bibliography("references.bib")

--- a/crates/tinymist-query/src/fixtures/completion/completion_title2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title2.typ
@@ -1,0 +1,16 @@
+// path: references.bib
+@article{Russell:1908,
+Author = {Bertand Russell},
+Journal = {American Journal of Mathematics},
+Pages = {222--262},
+Title = {Mathematical logic based on the theory of types},
+Volume = 30,
+Year = 1908}
+
+-----
+// contains:Russell:1908,Mathematical logic based on the theory of types
+// compile:true
+
+#cite(<Russell:1908>)/* range -5..-4 */
+
+#bibliography("references.bib")

--- a/crates/tinymist-query/src/fixtures/completion/completion_title3.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title3.typ
@@ -1,0 +1,23 @@
+// path: references.yaml
+harry:
+    type: Book
+    title: Harry Potter and the Order of the Phoenix
+    author: Rowling, J. K.
+    volume: 5
+    page-total: 768
+    date: 2003-06-21
+
+electronic:
+    type: Web
+    title: Ishkur's Guide to Electronic Music
+    serial-number: v2.5
+    author: Ishkur
+    url: http://www.techno.org/electronic-music-guide/
+
+-----
+// contains:harry,Harry Potter and the Order of the Phoenix,electronic,Ishkur's Guide to Electronic Music
+// compile:true
+
+#cite(<harry>) /* range -2..-1 */
+
+#bibliography("references.yaml")

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title.typ.snap
@@ -1,0 +1,57 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on @R (132..134)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/completion_title.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 21,
+    "label": "Mathematical logic based on the theory of types",
+    "labelDetails": {
+     "description": "Russell:1908"
+    },
+    "textEdit": {
+     "newText": "Russell:1908",
+     "range": {
+      "end": {
+       "character": 1,
+       "line": 5
+      },
+      "start": {
+       "character": 1,
+       "line": 5
+      }
+     }
+    }
+   },
+   {
+    "kind": 18,
+    "label": "Russell:1908",
+    "labelDetails": {
+     "description": "Mathematical logic based on the theory of types"
+    },
+    "textEdit": {
+     "newText": "Russell:1908",
+     "range": {
+      "end": {
+       "character": 1,
+       "line": 5
+      },
+      "start": {
+       "character": 1,
+       "line": 5
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title2.typ.snap
@@ -1,0 +1,53 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on 9 (106..107)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/completion_title2.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 21,
+    "label": "Mathematical logic based on the theory of types",
+    "labelDetails": {
+     "description": "Russell:1908"
+    },
+    "textEdit": {
+     "newText": "Russell:1908>",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   },
+   {
+    "kind": 18,
+    "label": "Russell:1908",
+    "labelDetails": {
+     "description": "Mathematical logic based on the theory of types"
+    },
+    "textEdit": {
+     "newText": "Russell:1908>",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@completion_title3.typ.snap
@@ -1,0 +1,93 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on ) (136..137)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/completion_title3.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 21,
+    "label": "Harry Potter and the Order of the Phoenix",
+    "labelDetails": {
+     "description": "harry"
+    },
+    "textEdit": {
+     "newText": "harry>",
+     "range": {
+      "end": {
+       "character": 13,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   },
+   {
+    "kind": 21,
+    "label": "Ishkur's Guide to Electronic Music",
+    "labelDetails": {
+     "description": "electronic"
+    },
+    "textEdit": {
+     "newText": "electronic>",
+     "range": {
+      "end": {
+       "character": 13,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   },
+   {
+    "kind": 18,
+    "label": "electronic",
+    "labelDetails": {
+     "description": "Ishkur's Guide to Electronic Music"
+    },
+    "textEdit": {
+     "newText": "electronic>",
+     "range": {
+      "end": {
+       "character": 13,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   },
+   {
+    "kind": 18,
+    "label": "harry",
+    "labelDetails": {
+     "description": "Harry Potter and the Order of the Phoenix"
+    },
+    "textEdit": {
+     "newText": "harry>",
+     "range": {
+      "end": {
+       "character": 13,
+       "line": 3
+      },
+      "start": {
+       "character": 7,
+       "line": 3
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -1117,14 +1117,12 @@ impl<'a, 'w> CompletionContext<'a, 'w> {
             let label: EcoString = label.as_str().into();
             let completion = Completion {
                 kind: CompletionKind::Reference,
-                apply: (open || close).then(|| {
-                    eco_format!(
-                        "{}{}{}",
-                        if open { "<" } else { "" },
-                        label.as_str(),
-                        if close { ">" } else { "" }
-                    )
-                }),
+                apply: Some(eco_format!(
+                    "{}{}{}",
+                    if open { "<" } else { "" },
+                    label.as_str(),
+                    if close { ">" } else { "" }
+                )),
                 label: label.clone(),
                 label_detail: label_desc.clone(),
                 filter_text: Some(label.clone()),
@@ -1133,6 +1131,8 @@ impl<'a, 'w> CompletionContext<'a, 'w> {
             };
 
             if let Some(bib_title) = bib_title {
+                // Note that this completion re-uses the above `apply` field to
+                // alter the `bib_title` to the corresponding label.
                 self.completions.push(Completion {
                     kind: CompletionKind::Constant,
                     label: bib_title.clone(),


### PR DESCRIPTION
When `at` is presented, open/close is neglected, thus the `apply` field is not correctly constructed.

A fix for https://github.com/Myriad-Dreamin/tinymist/issues/483