### PR TITLE
fix: use plural for 0 items

### DIFF
--- a/editors/vscode/src/test/e2e/index.ts
+++ b/editors/vscode/src/test/e2e/index.ts
@@ -47,7 +47,7 @@ class Suite {
       }
     }
     if (failed) {
-      const plural = failed > 1 ? "s" : "";
+      const plural = failed != 1 ? "s" : "";
       throw new Error(`${failed} failed test${plural}`);
     }
   }

--- a/editors/vscode/src/ui-extends.ts
+++ b/editors/vscode/src/ui-extends.ts
@@ -81,7 +81,7 @@ ${cjkChars} CJK ${plural("Character", cjkChars)}
   }
 }
 function plural(w: string, words: number): string {
-  if (words <= 1) {
+  if (words == 1) {
     return w;
   } else {
     return w + "s";


### PR DESCRIPTION
Previously, zero items would use the singular noun (e.g. "0 Word"). However, zero should also be followed by a plural (i.e. only 1 is followed by a singular). This PR fixes that.