### PR TITLE
feat: generate shell completion

### DIFF
--- a/crates/tinymist/src/args.rs
+++ b/crates/tinymist/src/args.rs
@@ -23,6 +23,8 @@ pub enum Commands {
     Preview(tinymist::tool::preview::PreviewCliArgs),
     /// Probe
     Probe,
+    /// Completion script for current Shell(from env)
+    Completion,
 }
 
 impl Default for Commands {

--- a/crates/tinymist/src/args.rs
+++ b/crates/tinymist/src/args.rs
@@ -13,24 +13,32 @@ pub struct CliArguments {
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum Commands {
-    /// Run Language Server
+    /// Generates completion script to stdout
+    Completion(ShellCompletionArgs),
+    /// Runs language server
     Lsp(LspArgs),
-    /// Run Language Server for tracing some typst program.
+    /// Runs language server for tracing some typst program.
     #[clap(hide(true))]
     TraceLsp(CompileArgs),
-    /// Run Preview Server
+    /// Runs preview server
     #[cfg(feature = "preview")]
     Preview(tinymist::tool::preview::PreviewCliArgs),
-    /// Probe
+    /// Probes existence (Nop run)
     Probe,
-    /// Completion script for current Shell(from env)
-    Completion,
 }
 
 impl Default for Commands {
     fn default() -> Self {
         Self::Lsp(Default::default())
     }
+}
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct ShellCompletionArgs {
+    /// The shell to generate the completion script for. If not provided, it
+    /// will be inferred from the environment.
+    #[clap(value_enum)]
+    pub shell: Option<clap_complete::Shell>,
 }
 
 #[derive(Debug, Clone, Default, clap::Parser)]

--- a/crates/tinymist/src/main.rs
+++ b/crates/tinymist/src/main.rs
@@ -2,10 +2,12 @@
 
 mod args;
 
-use std::{path::PathBuf, sync::Arc};
+use std::{io, path::PathBuf, sync::Arc};
 
 use anyhow::bail;
 use clap::Parser;
+use clap_builder::{Command, CommandFactory, Subcommand};
+use clap_complete::{generate, Shell};
 use comemo::Prehashed;
 use futures::future::MaybeDone;
 use lsp_server::RequestId;
@@ -77,6 +79,12 @@ fn main() -> anyhow::Result<()> {
             RUNTIMES.tokio_runtime.block_on(preview_main(args))
         }
         Commands::Probe => Ok(()),
+        Commands::Completion => {
+            let mut cmd = CliArguments::command();
+            generate(Shell::from_env().unwrap(), &mut cmd, "tinymist", &mut io::stdout());
+
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
I saw `clap_complete` is in Cargo.toml, but did not see it's usage, so I created a simple completion subcommand with it. Feel free to remove it if it's redundant work.

---

我看依赖里有`clap_complete`但是好像没有实现shell补全，就随便写了一个。假如其实已经有了就把这个issue 关了好了。