### PR TITLE
fix: remove feature texmath

### DIFF
--- a/crates/typlite/Cargo.toml
+++ b/crates/typlite/Cargo.toml
@@ -24,8 +24,5 @@ typst-assets = { workspace = true, features = ["fonts"] }
 insta.workspace = true
 regex.workspace = true
 
-[features]
-texmath = []
-
 [lints]
 workspace = true

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -404,7 +404,6 @@ impl TypliteWorker {
         self.reduce(node)
     }
 
-    #[cfg(not(feature = "texmath"))]
     fn equation(&mut self, node: &SyntaxNode) -> Result<Value> {
         let equation: ast::Equation = node.cast().unwrap();
 

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -56,7 +56,6 @@ Some inlined raw `a`, ```c b```
         2. A
         1. B
         "###);
-    #[cfg(not(feature = "texmath"))]
     insta::assert_snapshot!(conv(r###"
 $
 1/2 + 1/3 = 5/6


### PR DESCRIPTION
A very basic fix for #531 , this fix just remove the feature `texmath` as the defualt implementation is good enough and `texmath` is not implemented