### PR TITLE
feat: remove useless `tinymist.preview.showInActivityBar`

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -50,12 +50,12 @@
           "id": "tinymist.preview.content-preview",
           "type": "webview",
           "name": "Content",
-          "when": "ext.tinymistActivated && (config.tinymist.preview.showInActivityBar || config.typst-preview.showInActivityBar)"
+          "when": "ext.tinymistActivated"
         },
         {
           "id": "tinymist.preview.outline",
           "name": "Outline",
-          "when": "ext.tinymistActivated && (config.tinymist.preview.showInActivityBar || config.typst-preview.showInActivityBar)"
+          "when": "ext.tinymistActivated"
         }
       ]
     },
@@ -515,11 +515,6 @@
         },
         "tinymist.preview.cursorIndicator": {
           "description": "(Experimental) Show typst cursor indicator in preview.",
-          "type": "boolean",
-          "default": false
-        },
-        "tinymist.preview.showInActivityBar": {
-          "description": "(Experimental) Show a preview panel in activity bar.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
These features can still be hidden by vscode's owned separated flags.

![image](https://github.com/user-attachments/assets/92fc0c27-7413-4a28-8587-ff6719f7206b)
