### PR TITLE
chore: bump typstyle to v0.11.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.31"
+version = "0.11.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04207b151e637bcf307d974e5963fc51c2912688343a0b7575246a3acb6aeab9"
+checksum = "87f3e79e77aac4d80934811be14abd1e2b0e7d3b4059653e24b841ab1ac5bae0"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ typst-ts-core = { version = "0.5.0-rc5", default-features = false }
 typst-ts-compiler = { version = "0.5.0-rc5" }
 typst-ts-svg-exporter = { version = "0.5.0-rc5" }
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
-typstyle = { version = "0.11.31", default-features = false }
+typstyle = { version = "0.11.32", default-features = false }
 typlite = { path = "./crates/typlite" }
 
 # LSP


### PR DESCRIPTION
https://enter-tainer.github.io/typstyle/changelog/#v01132---2024-08-19