### PR TITLE
feat: Add compatibility layer for Typst stable and nightly APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,6 +3825,7 @@ dependencies = [
  "typst-pdf",
  "typst-preview",
  "typst-render",
+ "typst-shim",
  "typst-svg",
  "typst-timing",
  "typstfmt_lib",
@@ -3885,6 +3886,7 @@ dependencies = [
  "ttf-parser",
  "typst",
  "typst-assets",
+ "typst-shim",
  "unscanny",
  "walkdir",
  "yaml-rust2",
@@ -4364,6 +4366,15 @@ dependencies = [
  "typst-macros",
  "typst-timing",
  "usvg",
+]
+
+[[package]]
+name = "typst-shim"
+version = "0.11.20"
+dependencies = [
+ "cfg-if",
+ "typst",
+ "typst-syntax 0.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ if_chain = "1"
 itertools = "0.13"
 once_cell = "1"
 paste = "1.0"
+cfg-if = "1.0"
 strum = { version = "0.26.2", features = ["derive"] }
 triomphe = { version = "0.1.10", default-features = false, features = ["std"] }
 
@@ -108,6 +109,7 @@ typst-syntax = "0.11.1"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
 typstyle = { version = "0.11.32", default-features = false }
 typlite = { path = "./crates/typlite" }
+typst-shim = { path = "./crates/typst-shim", features = [] }
 
 # LSP
 crossbeam-channel = "0.5.12"

--- a/crates/tinymist-query/Cargo.toml
+++ b/crates/tinymist-query/Cargo.toml
@@ -37,6 +37,7 @@ chrono.workspace = true
 typst.workspace = true
 
 reflexo.workspace = true
+typst-shim.workspace = true
 
 lsp-types.workspace = true
 if_chain.workspace = true

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -12,8 +12,8 @@ use typst::{
         ast::{self, AstNode},
         LinkedNode, Span, SyntaxKind,
     },
-    util::LazyHash,
 };
+use typst_shim::utils::LazyHash;
 
 use crate::adt::interner::Interned;
 use crate::analysis::resolve_callee;

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -8,14 +8,12 @@ use ecow::{eco_vec, EcoVec};
 use log::info;
 use lsp_types::SymbolKind;
 use serde::{Deserialize, Serialize};
-use typst::{
-    syntax::{
-        ast::{self, AstNode},
-        package::PackageSpec,
-        LinkedNode, Source, SyntaxKind,
-    },
-    util::LazyHash,
+use typst::syntax::{
+    ast::{self, AstNode},
+    package::PackageSpec,
+    LinkedNode, Source, SyntaxKind,
 };
+use typst_shim::utils::LazyHash;
 
 use super::IdentRef;
 

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -1244,7 +1244,7 @@ impl<'a, 'w> CompletionContext<'a, 'w> {
         docs: Option<&str>,
     ) {
         // Prevent duplicate completions from appearing.
-        if !self.seen_casts.insert(typst::util::hash128(value)) {
+        if !self.seen_casts.insert(typst_shim::utils::hash128(value)) {
             return;
         }
 

--- a/crates/tinymist-query/src/upstream/tooltip.rs
+++ b/crates/tinymist-query/src/upstream/tooltip.rs
@@ -7,8 +7,8 @@ use typst::foundations::{repr, Capturer, CastInfo, Value};
 use typst::layout::Length;
 use typst::model::Document;
 use typst::syntax::{ast, LinkedNode, Source, SyntaxKind};
-use typst::util::{round_2, Numeric};
 use typst::World;
+use typst_shim::utils::{round_2, Numeric};
 
 use super::{plain_docs_sentence, summarize_font_family, truncated_repr};
 use crate::analysis::{analyze_expr_, analyze_labels, DynLabel};

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -55,6 +55,7 @@ typstfmt_lib.workspace = true
 reflexo.workspace = true
 reflexo-typst.workspace = true
 reflexo-vec2svg.workspace = true
+typst-shim.workspace = true
 codespan-reporting.workspace = true
 toml.workspace = true
 walkdir.workspace = true

--- a/crates/tinymist/src/actor/typ_server.rs
+++ b/crates/tinymist/src/actor/typ_server.rs
@@ -19,7 +19,8 @@ use reflexo_typst::{
     CompileEnv, CompileReport, Compiler, ConsoleDiagReporter, EntryReader, GenericExporter,
     Revising, TaskInputs, TypstDocument, WorldDeps,
 };
-use typst::{diag::SourceResult, util::Deferred};
+use typst::diag::SourceResult;
+use typst_shim::utils::Deferred;
 
 use crate::task::CacheTask;
 

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -18,7 +18,7 @@ use tinymist_query::{get_semantic_tokens_options, PositionEncoding};
 use tinymist_render::PeriscopeArgs;
 use typst::foundations::IntoValue;
 use typst::syntax::{FileId, VirtualPath};
-use typst::util::Deferred;
+use typst_shim::utils::Deferred;
 
 // todo: svelte-language-server responds to a Goto Definition request with
 // LocationLink[] even if the client does not report the

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -38,7 +38,7 @@ fn conv(s: &str) -> EcoString {
         // let hash = _captures.get(1).unwrap().as_str();
         // format!(
         //     "data:image-hash/svg+xml;base64,siphash128:{:x}",
-        //     typst::util::hash128(hash)
+        //     typst_shim::utils::hash128(hash)
         // )
         "data:image-hash/svg+xml;base64,redacted"
     });

--- a/crates/typst-shim/Cargo.toml
+++ b/crates/typst-shim/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "typst-shim"
+description = "A compatibility layer for Typst release and mainline versions."
+authors = ["The Typst Project Developers"]
+version.workspace = true
+edition.workspace = true
+readme.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+nightly = []
+
+[dependencies]
+typst-syntax.workspace = true
+typst.workspace = true
+cfg-if.workspace = true
+
+[lints]
+workspace = true

--- a/crates/typst-shim/src/lib.rs
+++ b/crates/typst-shim/src/lib.rs
@@ -1,0 +1,13 @@
+//! # typst-shim
+
+pub use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        mod nightly;
+        pub use nightly::*;
+    } else {
+        mod stable;
+        pub use stable::*;
+    }
+}

--- a/crates/typst-shim/src/nightly/mod.rs
+++ b/crates/typst-shim/src/nightly/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/crates/typst-shim/src/nightly/utils.rs
+++ b/crates/typst-shim/src/nightly/utils.rs
@@ -1,0 +1,2 @@
+//! Typst utils
+pub use typst::utils::*;

--- a/crates/typst-shim/src/stable/mod.rs
+++ b/crates/typst-shim/src/stable/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/crates/typst-shim/src/stable/utils.rs
+++ b/crates/typst-shim/src/stable/utils.rs
@@ -1,0 +1,2 @@
+//! Typst utils
+pub use typst::util::*;


### PR DESCRIPTION
This PR introduces a compatibility layer to support both the stable and nightly versions of the Typst API. 

As an example, the `util` module in the stable version and the `utils` module in the nightly version have been unified under a single `utils` module in this crate. The correct API is chosen based on the feature flag (`nightly` or default).

