### PR TITLE
feat: add gitpod layer

### DIFF
--- a/editors/vscode/src/gitpod.ts
+++ b/editors/vscode/src/gitpod.ts
@@ -1,0 +1,33 @@
+/**
+ * Check if the current environment is Gitpod.
+ * @return True if the current environment is Gitpod, false otherwise.
+ */
+export function isGitpod(): boolean {
+  return !!process.env.GITPOD_WORKSPACE_ID && !!process.env.GITPOD_WORKSPACE_CLUSTER_HOST;
+}
+
+/**
+ * Create a Gitpod URL for the given URL string.
+ * @param urlstr The URL string to create a Gitpod URL for.
+ * @return The Gitpod URL
+ */
+export function translateGitpodURL(urlstr: string): string {
+  const url = new URL(urlstr);
+  if (!url.port) {
+    throw new Error("port is not specified in the URL");
+  }
+  if (!isGitpod()) {
+    throw new Error("Not in Gitpod environment");
+  }
+  if (url.protocol.match("ws")) {
+    url.protocol = "wss";
+  }
+  url.hostname =
+    url.port.toString() +
+    "-" +
+    process.env.GITPOD_WORKSPACE_ID +
+    "." +
+    process.env.GITPOD_WORKSPACE_CLUSTER_HOST;
+  url.port = "";
+  return url.toString();
+}

--- a/editors/vscode/src/gitpod.ts
+++ b/editors/vscode/src/gitpod.ts
@@ -17,7 +17,7 @@ export function translateGitpodURL(urlstr: string): string {
     throw new Error("port is not specified in the URL");
   }
   if (!isGitpod()) {
-    throw new Error("Not in Gitpod environment");
+    throw new Error("not in Gitpod environment");
   }
   if (url.protocol.match("ws")) {
     url.protocol = "wss";

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -38,6 +38,9 @@ function retrieveWsArgs() {
     /// The string `ws://127.0.0.1:23625` is a placeholder
     /// Also, it is the default url to connect to.
     let url = "ws://127.0.0.1:23625";
+    if (location.href.startsWith("https://")) {
+        url = url.replace("ws://", "wss://")
+    }
 
     /// Return a `WsArgs` object.
     return { url, previewMode, isContentPreview: false };


### PR DESCRIPTION
Closes #382

Hi, thank you for this fantastic project.

Following the resolution of issue #382, I continued to investigate Tinymist on Gitpod. During my investigation, I discovered that Gitpod exposes local ports as subdomains of the workspace,
 for example, `www.example.com:8000` is mapped to `8000-www.example.com`.

This pull request adds a translation layer for the Typst preview URLs to accommodate this behavior.