### PR TITLE
fix: upgrade WebSocket protocol from ws:// to wss:// to prevent mixed-content errors

### DIFF
--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -38,7 +38,9 @@ function retrieveWsArgs() {
     /// The string `ws://127.0.0.1:23625` is a placeholder
     /// Also, it is the default url to connect to.
     let url = "ws://127.0.0.1:23625";
-
+    if (location.href.startsWith("https://")) {
+        url = url.replace("ws://", "wss://")
+    }
     /// Return a `WsArgs` object.
     return { url, previewMode, isContentPreview: false };
 }


### PR DESCRIPTION
This PR addresses an issue where WebSocket connections using the `ws://` protocol cause mixed-content errors when accessed from a webpage loaded over HTTPS. To ensure secure communication and compatibility with HTTPS pages, the WebSocket protocol has been upgraded to `wss://`.