### PR TITLE
feat: Add preview icon when clicking outside the document

### DIFF
--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -2,6 +2,7 @@ tinymist-*.vsix
 *.log
 test-dist
 .vscode-test
+.vscode
 coverage
 icons/ti.svg
 icons/typst-small.svg

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -941,7 +941,7 @@
         },
         {
           "command": "typst-preview.preview",
-          "when": "resourceLangId == typst && editorTextFocus",
+          "when": "resourceLangId == typst",
           "group": "navigation"
         }
       ],

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -119,6 +119,10 @@ export function previewActivate(context: vscode.ExtensionContext, isCompat: bool
         return;
       }
       const bindDocument = activeEditor.document;
+      if (bindDocument.languageId !== "typst") {
+        vscode.window.showWarningMessage("Can't launch preview from outside the document");
+        return;
+      }
       return launchImpl({
         kind,
         context,


### PR DESCRIPTION
Hi !
I tried to fix #615 by showing preview icon even if the document isn't focused. I added a check to avoid errors if the `activeEditor.document` is not a typst document.

It works in file picker and terminal, including output pannel which give another document (That's why I add a check on the document).