### PR TITLE
fix: warning no edition set

### DIFF
--- a/contrib/typlite/Cargo.toml
+++ b/contrib/typlite/Cargo.toml
@@ -3,6 +3,11 @@ name = "typlite-cli"
 description = "Converts a subset of typst to markdown."
 categories = ["compilers"]
 keywords = ["language", "typst"]
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "typlite"


### PR DESCRIPTION
- defaulting to the 2015 edition while the latest is 2021