### PR TITLE
dev: nightly 0.11.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.32"
+version = "4.5.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a01f4f9ee6c066d42a1c8dedf0dcddad16c72a8981a309d6398de3a75b0c39"
+checksum = "9646e2e245bf62f45d39a0f3f36f1171ad1ea0d6967fd114bca72cb02a8fcdfb"
 dependencies = [
  "clap",
 ]
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete_nushell"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e"
+checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
 dependencies = [
  "clap",
  "clap_complete",
@@ -577,9 +577,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17415fd4dfbea46e3274fcd8d368284519b358654772afb700dc2e8d2b24eeb"
+checksum = "fbae9cbfdc5d4fa8711c09bd7b83f644cb48281ac35bf97af3e47b0675864bdf"
 dependencies = [
  "clap",
  "roff",
@@ -2089,9 +2089,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2750,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "reflexo"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "reflexo-typst"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "codespan-reporting",
  "comemo 0.4.0",
@@ -3006,17 +3006,17 @@ dependencies = [
 [[package]]
 name = "reflexo-typst-shim"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "cfg-if",
  "typst",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
 ]
 
 [[package]]
 name = "reflexo-typst2vec"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "bitvec",
  "comemo 0.4.0",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "reflexo-vec2svg"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "base64 0.22.1",
  "comemo 0.4.0",
@@ -3054,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "reflexo-vfs"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "indexmap 2.6.0",
  "log",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "reflexo-world"
 version = "0.5.0-rc7"
-source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-v0.11.31#f7d013d8792304a4a4543d7adce8e5e574049724"
+source = "git+https://github.com/paran3xus/typst.ts?tag=tinymist-typst-0.12-rc1#73f5e7d681f37e09ebf6f7f11ef760d7e328ce5d"
 dependencies = [
  "chrono",
  "codespan-reporting",
@@ -4249,7 +4249,7 @@ dependencies = [
  "typlite",
  "typst",
  "typst-ansi-hl",
- "typst-assets",
+ "typst-assets 0.11.0",
  "typst-pdf",
  "typst-preview",
  "typst-render",
@@ -4277,7 +4277,7 @@ dependencies = [
  "toml 0.8.19",
  "typst",
  "typst-svg",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
 ]
 
 [[package]]
@@ -4334,7 +4334,7 @@ dependencies = [
  "ttf-parser 0.20.0",
  "typlite",
  "typst",
- "typst-assets",
+ "typst-assets 0.11.0",
  "typst-shim",
  "unscanny",
  "walkdir",
@@ -4372,7 +4372,7 @@ dependencies = [
  "tar",
  "tinymist-assets 0.11.32",
  "typst",
- "typst-assets",
+ "typst-assets 0.11.0",
 ]
 
 [[package]]
@@ -4585,9 +4585,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "try-lock"
@@ -4675,7 +4675,7 @@ dependencies = [
  "tinymist-world",
  "typst",
  "typst-svg",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
 ]
 
 [[package]]
@@ -4690,8 +4690,8 @@ dependencies = [
 
 [[package]]
 name = "typst"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "arrayvec 0.7.6",
  "az",
@@ -4741,9 +4741,9 @@ dependencies = [
  "ttf-parser 0.24.1",
  "two-face 0.4.0",
  "typed-arena",
- "typst-assets",
+ "typst-assets 0.12.0-rc1",
  "typst-macros",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
  "typst-timing",
  "typst-utils",
  "unicode-bidi",
@@ -4777,9 +4777,15 @@ version = "0.11.0"
 source = "git+https://github.com/typst/typst-assets?rev=4afd428#4afd428838a8fc99151c00dcf52f26b94c367aa0"
 
 [[package]]
+name = "typst-assets"
+version = "0.12.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c698edbfa8c49019246abe01c692d92f3d47e0b600da1ab4dbf1e8f3a7e53f"
+
+[[package]]
 name = "typst-macros"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4789,8 +4795,8 @@ dependencies = [
 
 [[package]]
 name = "typst-pdf"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "arrayvec 0.7.6",
  "base64 0.22.1",
@@ -4807,7 +4813,7 @@ dependencies = [
  "svg2pdf",
  "ttf-parser 0.24.1",
  "typst",
- "typst-assets",
+ "typst-assets 0.12.0-rc1",
  "typst-macros",
  "typst-timing",
  "unscanny",
@@ -4832,13 +4838,13 @@ dependencies = [
  "tinymist-assets 0.11.32",
  "tokio",
  "typst",
- "typst-assets",
+ "typst-assets 0.11.0",
 ]
 
 [[package]]
 name = "typst-render"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "bytemuck",
  "comemo 0.4.0",
@@ -4860,13 +4866,13 @@ version = "0.11.31"
 dependencies = [
  "cfg-if",
  "typst",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
 ]
 
 [[package]]
 name = "typst-svg"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "base64 0.22.1",
  "comemo 0.4.0",
@@ -4899,7 +4905,24 @@ dependencies = [
 [[package]]
 name = "typst-syntax"
 version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3db69f2f41613b1ff6edbec44fd7dc524137f099ee36c46f560cedeaadb40c4"
+dependencies = [
+ "comemo 0.4.0",
+ "ecow 0.2.2",
+ "once_cell",
+ "serde",
+ "unicode-ident",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+ "unscanny",
+]
+
+[[package]]
+name = "typst-syntax"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "ecow 0.2.2",
  "once_cell",
@@ -4915,19 +4938,19 @@ dependencies = [
 
 [[package]]
 name = "typst-timing"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
 ]
 
 [[package]]
 name = "typst-utils"
-version = "0.11.1"
-source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-v0.11.31#f7302261f0c33ed7dcae082cbe4c3adbc628d130"
+version = "0.12.0-rc1"
+source = "git+https://github.com/paran3xus/typst.git?tag=tinymist-typst-0.12-rc1#f9556de71da9cd6a24a4239c8cb3ad57e802e882"
 dependencies = [
  "once_cell",
  "portable-atomic",
@@ -4953,13 +4976,13 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.35"
-source = "git+https://github.com/paran3xus/typstyle?tag=tinymist-v0.11.31#59754625b4af164d03a7837647a0c2ab8bebba50"
+version = "0.11.34"
+source = "git+https://github.com/paran3xus/typstyle?tag=tinymist-typst-0.12-rc1#22c17bd1599227d59c76b056861a05f7bf3acc9f"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
  "pretty",
- "typst-syntax 0.11.1",
+ "typst-syntax 0.12.0-rc1",
  "vergen",
 ]
 
@@ -5201,9 +5224,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5212,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
@@ -5227,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5239,9 +5262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5249,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5262,9 +5285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "wasmi"
@@ -5317,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,30 +89,30 @@ env_logger = "0.11.3"
 log = "0.4"
 
 # Typst
-reflexo = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31", default-features = false, features = [
+reflexo = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1", default-features = false, features = [
     "flat-vector",
 ] }
-reflexo-world = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31", features = [
+reflexo-world = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1", features = [
     "system",
 ] }
-reflexo-typst = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31", features = [
+reflexo-typst = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1", features = [
     "system",
 ], default-features = false }
-reflexo-vec2svg = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31" }
-reflexo-typst-shim = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31", features = [
+reflexo-vec2svg = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1" }
+reflexo-typst-shim = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1", features = [
     "nightly",
 ] }
 
 
-typst = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-timing = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-svg = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-render = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-pdf = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-syntax = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
+typst = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-timing = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-svg = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-render = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-pdf = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-syntax = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
 typst-assets = { git = "https://github.com/typst/typst-assets", rev = "4afd428" }
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
-typstyle = { git = "https://github.com/paran3xus/typstyle", tag = "tinymist-v0.11.31", default-features = false }
+typstyle = { git = "https://github.com/paran3xus/typstyle", tag = "tinymist-typst-0.12-rc1", default-features = false }
 typlite = { path = "./crates/typlite" }
 typst-shim = { path = "./crates/typst-shim", features = ["nightly"] }
 
@@ -182,13 +182,13 @@ undocumented_unsafe_blocks = "warn"
 
 # tinymist-assets = { path = "./crates/tinymist-assets/" }
 
-typst = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-timing = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-svg = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-render = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-pdf = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-typst-syntax = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-v0.11.31" }
-reflexo-typst-shim = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-v0.11.31" }
+typst = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-timing = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-svg = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-render = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-pdf = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+typst-syntax = { git = "https://github.com/paran3xus/typst.git", tag = "tinymist-typst-0.12-rc1" }
+reflexo-typst-shim = { git = "https://github.com/paran3xus/typst.ts", tag = "tinymist-typst-0.12-rc1" }
 
 # typst = { path = "../typst/crates/typst" }
 # typst-timing = { path = "../typst/crates/typst-timing" }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:b0f1e0e806e1e0096a6f524e35c09051");
+        insta::assert_snapshot!(hash, @"siphash128_13:15a08be74736a4a10d294122ea15614e");
     }
 
     {
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:568bae919e5c00bbc7125ee3cb5ba17f");
+        insta::assert_snapshot!(hash, @"siphash128_13:72d75c6eae04815e42d7a0d4c57dcd21");
     }
 }
 


### PR DESCRIPTION
This version is at [build: bump node version to 22 (#654)](https://github.com/Myriad-Dreamin/tinymist/commits/f5520691fa3ff8ed7ecaf697d1908500534b39b0), using [ParaN3xus/typst tinymist-typst-0.12-rc1](https://github.com/ParaN3xus/typst/tree/tinymist-typst-0.12-rc1), a.k.a. [typst/typst v0.12.0-rc1](https://github.com/typst/typst/commits/v0.12.0-rc1).