### PR TITLE
feat: cache `dirs::data_dir` and `dirs::cache_dir`

### DIFF
--- a/crates/tinymist-world/src/lib.rs
+++ b/crates/tinymist-world/src/lib.rs
@@ -17,15 +17,32 @@ use reflexo_typst::error::prelude::*;
 use reflexo_typst::font::system::SystemFontSearcher;
 use reflexo_typst::foundations::{Str, Value};
 use reflexo_typst::vfs::{system::SystemAccessModel, Vfs};
-use reflexo_typst::TypstDict;
+use reflexo_typst::{CompilerFeat, CompilerUniverse, CompilerWorld, TypstDict};
 use serde::{Deserialize, Serialize};
 
 pub mod https;
-use https::{
-    HttpsRegistry, SystemCompilerFeatExtend, TypstSystemUniverseExtend, TypstSystemWorldExtend,
-};
+use https::HttpsRegistry;
 
 const ENV_PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
+
+/// Compiler feature for LSP universe and worlds without typst.ts to implement
+/// more for tinymist. type trait of [`TypstSystemWorld`].
+#[derive(Debug, Clone, Copy)]
+pub struct SystemCompilerFeatExtend;
+
+impl CompilerFeat for SystemCompilerFeatExtend {
+    /// Uses [`FontResolverImpl`] directly.
+    type FontResolver = FontResolverImpl;
+    /// It accesses a physical file system.
+    type AccessModel = SystemAccessModel;
+    /// It performs native HTTP requests for fetching package data.
+    type Registry = HttpsRegistry;
+}
+
+/// The compiler universe in system environment.
+pub type TypstSystemUniverseExtend = CompilerUniverse<SystemCompilerFeatExtend>;
+/// The compiler world in system environment.
+pub type TypstSystemWorldExtend = CompilerWorld<SystemCompilerFeatExtend>;
 
 /// The font arguments for the compiler.
 #[derive(Debug, Clone, Default, Parser, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/tinymist/src/args.rs
+++ b/crates/tinymist/src/args.rs
@@ -19,6 +19,10 @@ pub enum Commands {
     Completion(ShellCompletionArgs),
     /// Runs language server
     Lsp(LspArgs),
+    /// Runs language query
+    #[clap(hide(true))] // still in development
+    #[clap(subcommand)]
+    Query(QueryCommands),
     /// Runs language server for tracing some typst program.
     #[clap(hide(true))]
     TraceLsp(CompileArgs),
@@ -129,6 +133,37 @@ pub struct LspArgs {
     pub mirror: MirrorArgs,
     #[clap(flatten)]
     pub font: CompileFontArgs,
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+#[clap(rename_all = "camelCase")]
+pub enum QueryCommands {
+    /// Get the documentation for a specific package.
+    PackageDocs(PackageDocsArgs),
+}
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct PackageDocsArgs {
+    /// The path of the package to request docs for.
+    #[clap(long)]
+    pub path: Option<String>,
+    /// The package of the package to request docs for.
+    #[clap(long)]
+    pub id: String,
+    /// The output path for the requested docs.
+    #[clap(short, long)]
+    pub output: String,
+    // /// The format of requested docs.
+    // #[clap(long)]
+    // pub format: Option<QueryDocsFormat>,
+}
+
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+#[clap(rename_all = "camelCase")]
+pub enum QueryDocsFormat {
+    #[default]
+    Json,
+    Markdown,
 }
 
 pub static LONG_VERSION: Lazy<String> = Lazy::new(|| {

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -37,6 +37,8 @@ use super::{init::*, *};
 use crate::actor::editor::EditorRequest;
 use crate::actor::typ_client::CompileClientActor;
 
+pub(crate) use futures::Future;
+
 pub(super) fn as_path(inp: TextDocumentIdentifier) -> PathBuf {
     as_path_(inp.uri)
 }


### PR DESCRIPTION
Intel vtune says `dirs::data_dir` and `dirs::cache_dir` make syscall on windows for each check existence of package files. This is a disaster on large packages.

With caching, the time used of `tinymist query packageDocs --id @preview/cetz:0.2.2` goes down from 0.9s to 0.7s.

Intel vtune also says `sys::stat` syscall takes 0.2s to check existence of package files, but this need more careful cache strategy.

Though we currently don't response changes of these two cached directory paths, it is less likely to be changed in application wide.
