### PR TITLE
build: bump version to 0.11.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "sync-lsp"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3956,7 +3956,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sync-lsp",
- "tinymist-assets 0.11.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets 0.11.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinymist-query",
  "tinymist-render",
  "tinymist-world",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-analysis"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "base64 0.22.1",
  "comemo 0.4.0",
@@ -3999,17 +3999,17 @@ dependencies = [
 
 [[package]]
 name = "tinymist-assets"
-version = "0.11.28"
+version = "0.11.32"
 
 [[package]]
 name = "tinymist-assets"
-version = "0.11.28"
+version = "0.11.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08ac1383bf5177ca572a0f88fb2175373ebe591d0c1bde0b85d6e0fa25d2f6b"
+checksum = "ea141357280a85cdacb962dc64b07ae6fa4381df468f6aba1d3dd93483afdc38"
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -4071,7 +4071,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-world"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4086,7 +4086,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "tinymist-assets 0.11.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets 0.11.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "typst-assets",
 ]
 
@@ -4348,7 +4348,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typlite"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "base64 0.22.1",
  "comemo 0.4.0",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "typst-preview"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "clap",
  "comemo 0.4.0",
@@ -4505,7 +4505,7 @@ dependencies = [
  "reflexo-vec2svg",
  "serde",
  "serde_json",
- "tinymist-assets 0.11.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets 0.11.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "typst",
  "typst-assets",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "typst-shim"
-version = "0.11.28"
+version = "0.11.32"
 dependencies = [
  "cfg-if",
  "typst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.11.28"
+version = "0.11.32"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -137,7 +137,7 @@ insta = { version = "1.39", features = ["glob"] }
 
 # Our Own Crates
 typst-preview = { path = "./crates/typst-preview/" }
-tinymist-assets = { version = "0.11.28" }
+tinymist-assets = { version = "0.11.32" }
 tinymist = { path = "./crates/tinymist/" }
 tinymist-analysis = { path = "./crates/tinymist-analysis/" }
 tinymist-query = { path = "./crates/tinymist-query/" }

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.11.32 - [2024-10-10]
+
+* Fix accidentally released nightly version.
+
 ## v0.11.28 - [2024-10-05]
 
 ### Compiler

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymist",
-  "version": "0.11.28",
+  "version": "0.11.32",
   "description": "An integrated language service for Typst",
   "categories": [
     "Programming Languages",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.11.28",
+  "version": "0.11.32",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.mjs",


### PR DESCRIPTION
Note the real revision used by `v0.11.32` is [here](https://github.com/Myriad-Dreamin/tinymist/commits/v0.11.32), which is only a republish of `v0.11.28`.