### PR TITLE
docs: add coc.nvim config example

### DIFF
--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -98,6 +98,23 @@ return {
 
 See #link("https://github.com/Myriad-Dreamin/tinymist/tree/main/editors/neovim/Configuration.md")[Tinymist Server Configuration] for references.
 
+=== Configuring Language Server for COC
+<configuring-coc-language-server>
+To configure language server for #link("https://github.com/neoclide/coc.nvim")[coc.nvim], you can edit the `coc-settings.json` by executing `:CocConfig`:
+
+```json
+"languageserver": {
+  "tinymist": {
+    "command": "tinymist",
+    "filetypes": ["typst"],
+    "settings": {
+      "exportPdf": "onType",
+      "outputPath" = "$root/target/$dir/$name",
+    }
+  }
+}
+```
+
 === Configuring Folding Range for Neovim Client
 <configuring-folding-range-for-neovim-client>
 Enable LSP-based folding range with `kevinhwang91/nvim-ufo`:

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -118,6 +118,23 @@ return {
 
 See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/tree/main/editors/neovim/Configuration.md) for references.
 
+### Configuring Language Server for COC
+
+To configure language server for [coc.nvim](https://github.com/neoclide/coc.nvim), you can edit the `coc-settings.json` by executing `:CocConfig`:
+
+```json
+"languageserver": {
+  "tinymist": {
+    "command": "tinymist",
+    "filetypes": ["typst"],
+    "settings": {
+      "exportPdf": "onType",
+      "outputPath" = "$root/target/$dir/$name",
+    }
+  }
+}
+```
+
 ### Configuring Folding Range for Neovim Client
 
 Enable LSP-based folding range with `kevinhwang91/nvim-ufo`:


### PR DESCRIPTION
This adds a simple example about how to config tinymist for coc.nvim users. Coc.nvim provides LSP support and is quite popular among both vim and, even after the builtin LSP support, nvim users. Having a coc section can be helpful to them.
