### PR TITLE
feat: client-side control to whether issue completion callback

### DIFF
--- a/crates/tinymist-query/src/upstream/complete/ext.rs
+++ b/crates/tinymist-query/src/upstream/complete/ext.rs
@@ -308,8 +308,9 @@ impl<'a, 'w> CompletionContext<'a, 'w> {
                 let base = Completion {
                     kind: kind.clone(),
                     label_detail: ty_detail,
-                    // todo: only vscode and neovim (0.9.1) support this
-                    command: Some("editor.action.triggerParameterHints"),
+                    command: self
+                        .trigger_parameter_hints
+                        .then_some("editor.action.triggerParameterHints"),
                     ..Default::default()
                 };
 
@@ -648,7 +649,9 @@ pub fn param_completions<'a>(
                 apply: Some(eco_format!("{}: ${{}}", param.name)),
                 detail: docs(),
                 label_detail: None,
-                command: Some("tinymist.triggerNamedCompletion"),
+                command: ctx
+                    .trigger_named_completion
+                    .then_some("tinymist.triggerNamedCompletion"),
                 ..Completion::default()
             };
             match param.ty {
@@ -734,7 +737,9 @@ fn type_completion(
                 label: f.into(),
                 apply: Some(eco_format!("{}: ${{}}", f)),
                 detail: docs.map(Into::into),
-                command: Some("tinymist.triggerNamedCompletion"),
+                command: ctx
+                    .trigger_named_completion
+                    .then_some("tinymist.triggerNamedCompletion"),
                 ..Completion::default()
             });
         }

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -301,6 +301,12 @@ pub struct Config {
     pub formatter_mode: FormatterMode,
     /// Dynamic configuration for the experimental formatter.
     pub formatter_print_width: Option<u32>,
+    /// Whether to trigger suggest completion, a.k.a. auto-completion.
+    pub trigger_suggest: bool,
+    /// Whether to trigger named parameter completion.
+    pub trigger_named_completion: bool,
+    /// Whether to trigger parameter hint, a.k.a. signature help.
+    pub trigger_parameter_hints: bool,
 }
 
 impl Config {
@@ -349,12 +355,21 @@ impl Config {
     /// # Errors
     /// Errors if the update is invalid.
     pub fn update_by_map(&mut self, update: &Map<String, JsonValue>) -> anyhow::Result<()> {
+        macro_rules! deser_or_default {
+            ($key:expr, $ty:ty) => {
+                try_or_default(|| <$ty>::deserialize(update.get($key)?).ok())
+            };
+        }
+
         try_(|| SemanticTokensMode::deserialize(update.get("semanticTokens")?).ok())
             .inspect(|v| self.semantic_tokens = *v);
         try_(|| FormatterMode::deserialize(update.get("formatterMode")?).ok())
             .inspect(|v| self.formatter_mode = *v);
         try_(|| u32::deserialize(update.get("formatterPrintWidth")?).ok())
             .inspect(|v| self.formatter_print_width = Some(*v));
+        self.trigger_suggest = deser_or_default!("triggerSuggest", bool);
+        self.trigger_parameter_hints = deser_or_default!("triggerParameterHints", bool);
+        self.trigger_named_completion = deser_or_default!("triggerNamedCompletion", bool);
         self.compile.update_by_map(update)?;
         self.compile.validate()
     }
@@ -479,9 +494,14 @@ impl CompileConfig {
 
     /// Updates the configuration with a map.
     pub fn update_by_map(&mut self, update: &Map<String, JsonValue>) -> anyhow::Result<()> {
-        self.output_path =
-            try_or_default(|| PathPattern::deserialize(update.get("outputPath")?).ok());
-        self.export_pdf = try_or_default(|| ExportMode::deserialize(update.get("exportPdf")?).ok());
+        macro_rules! deser_or_default {
+            ($key:expr, $ty:ty) => {
+                try_or_default(|| <$ty>::deserialize(update.get($key)?).ok())
+            };
+        }
+
+        self.output_path = deser_or_default!("outputPath", PathPattern);
+        self.export_pdf = deser_or_default!("outputPath", ExportMode);
         self.root_path = try_(|| Some(update.get("rootPath")?.as_str()?.into()));
         self.notify_status = match try_(|| update.get("compileStatus")?.as_str()) {
             Some("enable") => true,

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -501,7 +501,7 @@ impl CompileConfig {
         }
 
         self.output_path = deser_or_default!("outputPath", PathPattern);
-        self.export_pdf = deser_or_default!("outputPath", ExportMode);
+        self.export_pdf = deser_or_default!("exportPdf", ExportMode);
         self.root_path = try_(|| Some(update.get("rootPath")?.as_str()?.into()));
         self.notify_status = match try_(|| update.get("compileStatus")?.as_str()) {
             Some("enable") => true,

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -750,8 +750,21 @@ impl LanguageState {
             .context
             .map(|context| context.trigger_kind == CompletionTriggerKind::INVOKED)
             .unwrap_or(false);
+        let trigger_suggest = self.config.trigger_suggest;
+        let trigger_parameter_hints = self.config.trigger_parameter_hints;
+        let trigger_named_completion = self.config.trigger_named_completion;
 
-        run_query!(req_id, self.Completion(path, position, explicit))
+        run_query!(
+            req_id,
+            self.Completion(
+                path,
+                position,
+                explicit,
+                trigger_suggest,
+                trigger_parameter_hints,
+                trigger_named_completion
+            )
+        )
     }
 
     fn signature_help(

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -67,6 +67,10 @@ export async function doActivate(context: ExtensionContext): Promise<void> {
   vscode.commands.executeCommand("setContext", "ext.tinymistActivated", true);
   // Loads configuration
   const config = loadTinymistConfig();
+  // Inform server that we support named completion callback at the client side
+  config.triggerSuggest = true;
+  config.triggerNamedCompletion = true;
+  config.triggerParameterHints = true;
   // Sets features
   extensionState.features.preview = config.previewFeature === "enable";
   extensionState.features.devKit = isDevMode || config.devKit === "enable";

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:3032733ed0223012cd64233e662dcea2");
+        insta::assert_snapshot!(hash, @"siphash128_13:65fa45388648e656b1ec7cc30c48ad85");
     }
 
     {

--- a/tests/fixtures/initialization/vscode-1.87.2.json
+++ b/tests/fixtures/initialization/vscode-1.87.2.json
@@ -272,6 +272,9 @@
     "noSystemFonts": null,
     "typstExtraArgs": [],
     "trace": { "server": "off" },
+    "triggerSuggest": true,
+    "triggerParameterHints": true,
+    "triggerNamedCompletion": true,
     "experimentalFormatterMode": "disable"
   },
   "trace": "off"


### PR DESCRIPTION
Add three internal options to indicate whether to issue:
- `editor.action.triggerSuggest`
- `editor.action.triggerParameterHints`
- `tinymist.triggerNamedCompletion`

Here are the corresponding configuration items:

```rs
struct Config {
    /// Whether to trigger suggest completion, a.k.a. auto-completion.
    pub trigger_suggest: bool,
    /// Whether to trigger parameter hint, a.k.a. signature help.
    pub trigger_parameter_hints: bool,
    /// Whether to trigger named parameter completion.
    pub trigger_named_completion: bool,
}
```

They won't be exposed as user configuration but only in initialization options. The lsp clients (editor plugins or extensions) must take responsibility to probe related commands and fill these items with true or false. Otherwise, tinymist won't set these commands to completion callback.

Note: some people may also love less aggressive completion, like not completing again intermediately after some snippet completions. We can further extend these  items ans real user configurations.

