### PR TITLE
feat: don't trigger trivial completion when trigger char is punc

### DIFF
--- a/crates/tinymist-query/src/completion.rs
+++ b/crates/tinymist-query/src/completion.rs
@@ -46,6 +46,8 @@ pub struct CompletionRequest {
     pub position: LspPosition,
     /// Whether the completion is triggered explicitly.
     pub explicit: bool,
+    /// The character that triggered the completion, if any.
+    pub trigger_character: Option<char>,
     /// Whether to trigger suggest completion, a.k.a. auto-completion.
     pub trigger_suggest: bool,
     /// Whether to trigger named parameter completion.
@@ -145,6 +147,7 @@ impl StatefulRequest for CompletionRequest {
                 &source,
                 cursor,
                 explicit,
+                self.trigger_character,
                 self.trigger_suggest,
                 self.trigger_parameter_hints,
                 self.trigger_named_completion,
@@ -336,6 +339,11 @@ mod tests {
 
             let docs = find_module_level_docs(&source).unwrap_or_default();
             let properties = get_test_properties(&docs);
+
+            let trigger_character = properties
+                .get("trigger_character")
+                .map(|v| v.chars().next().unwrap());
+
             let mut includes = HashSet::new();
             let mut excludes = HashSet::new();
 
@@ -389,6 +397,7 @@ mod tests {
                     path: ctx.path_for_id(id).unwrap(),
                     position: ctx.to_lsp_pos(s, &source),
                     explicit: false,
+                    trigger_character,
                     trigger_suggest: true,
                     trigger_parameter_hints: true,
                     trigger_named_completion: true,

--- a/crates/tinymist-query/src/fixtures/completion/colon_markup.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_markup.typ
@@ -1,0 +1,2 @@
+// contains: attach
+$: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_markup2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_markup2.typ
@@ -1,0 +1,3 @@
+// contains: attach
+// trigger_character: :
+$: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_math.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_math.typ
@@ -1,0 +1,2 @@
+// contains: attach
+$: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_math2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_math2.typ
@@ -1,0 +1,3 @@
+// contains: attach
+// trigger_character: :
+$: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_param.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_param.typ
@@ -1,0 +1,3 @@
+// contains: length
+// trigger_character: :
+#set text(baseline: /* range -1..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_markup.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_markup.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on   (22..23)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/colon_markup.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "attach",
+    "labelDetails": {
+     "description": "(content, b: content | none, bl: content | none, br: content | none, t: content | none, tl: content | none, tr: content | none) => attach"
+    },
+    "textEdit": {
+     "newText": "attach(${1:})",
+     "range": {
+      "end": {
+       "character": 2,
+       "line": 1
+      },
+      "start": {
+       "character": 1,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_markup2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_markup2.typ.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on   (46..47)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/colon_markup2.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_math.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_math.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on   (22..23)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/colon_math.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "attach",
+    "labelDetails": {
+     "description": "(content, b: content | none, bl: content | none, br: content | none, t: content | none, tl: content | none, tr: content | none) => attach"
+    },
+    "textEdit": {
+     "newText": "attach(${1:})",
+     "range": {
+      "end": {
+       "character": 2,
+       "line": 1
+      },
+      "start": {
+       "character": 1,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_math2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_math2.typ.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on   (46..47)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/colon_math2.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_param.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@colon_param.typ.snap
@@ -1,0 +1,31 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on   (63..64)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/colon_param.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 15,
+    "label": "length",
+    "sortText": "000",
+    "textEdit": {
+     "newText": " ${1:length}",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 2
+      },
+      "start": {
+       "character": 19,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]


### PR DESCRIPTION
Don't trigger trivial completion when the trigger char is an ascii punctuation. Specifically, don't trigger them if the trigger character is one of:
- `:` and `,` for capturing parameter completion.
- `<` and `@` for capturing label completion.
- and more.
