### PR TITLE
feat: strictly match module-level comments

### DIFF
--- a/crates/tinymist-query/src/fixtures/completion/base.typ
+++ b/crates/tinymist-query/src/fixtures/completion/base.typ
@@ -1,4 +1,4 @@
-// contains: aa,aab,aac,aabc
+/// contains: aa,aab,aac,aabc
 
 #let aa() = 1;
 #let aab() = 1;

--- a/crates/tinymist-query/src/fixtures/completion/bug_cite_function_infer.typ
+++ b/crates/tinymist-query/src/fixtures/completion/bug_cite_function_infer.typ
@@ -1,4 +1,4 @@
-// path: references.bib
+/// path: references.bib
 @article{Russell:1908,
 Author = {Bertand Russell},
 Journal = {American Journal of Mathematics},
@@ -16,8 +16,8 @@ Year = 1908}
 
 -----
 
-// contains:Russell:1908,Mathematical logic based on the theory of types
-// compile:true
+/// contains:Russell:1908,Mathematical logic based on the theory of types
+/// compile: true
 
 #set heading(numbering: "1.1")
 

--- a/crates/tinymist-query/src/fixtures/completion/bug_cite_function_infer2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/bug_cite_function_infer2.typ
@@ -1,4 +1,4 @@
-// path: references.bib
+/// path: references.bib
 @article{Russell:1908,
 Author = {Bertand Russell},
 Journal = {American Journal of Mathematics},
@@ -15,8 +15,8 @@ Volume = 30,
 Year = 1908}
 
 -----
-// contains:Russell:1908,Mathematical logic based on the theory of types
-// compile:true
+/// contains:Russell:1908,Mathematical logic based on the theory of types
+/// compile: true
 
 #set heading(numbering: "1.1")
 

--- a/crates/tinymist-query/src/fixtures/completion/bug_mix_context_type.typ
+++ b/crates/tinymist-query/src/fixtures/completion/bug_mix_context_type.typ
@@ -1,4 +1,4 @@
-// contains: base
+/// contains: base
 #let tmpl2(x, y) = {
   assert(type(x) in (int, str) and type(y) == int)
   x + y

--- a/crates/tinymist-query/src/fixtures/completion/cite_heading.typ
+++ b/crates/tinymist-query/src/fixtures/completion/cite_heading.typ
@@ -1,10 +1,10 @@
-// path: references.bib
+/// path: references.bib
 @article{t,}
 
 -----
 
-// contains:form,test
-// compile:true
+/// contains:form,test
+/// compile: true
 
 #set heading(numbering: "1.1")
 

--- a/crates/tinymist-query/src/fixtures/completion/colon_markup.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_markup.typ
@@ -1,2 +1,2 @@
-// contains: attach
+/// contains: attach
 $: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_markup2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_markup2.typ
@@ -1,3 +1,3 @@
-// contains: attach
-// trigger_character: :
+/// contains: attach
+/// trigger_character: :
 $: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_math.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_math.typ
@@ -1,2 +1,2 @@
-// contains: attach
+/// contains: attach
 $: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_math2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_math2.typ
@@ -1,3 +1,3 @@
-// contains: attach
-// trigger_character: :
+/// contains: attach
+/// trigger_character: :
 $: /* range -1..0 */$

--- a/crates/tinymist-query/src/fixtures/completion/colon_param.typ
+++ b/crates/tinymist-query/src/fixtures/completion/colon_param.typ
@@ -1,3 +1,3 @@
-// contains: length
-// trigger_character: :
+/// contains: length
+/// trigger_character: :
 #set text(baseline: /* range -1..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/complete_purely_label.typ
+++ b/crates/tinymist-query/src/fixtures/completion/complete_purely_label.typ
@@ -1,5 +1,5 @@
-// contains:test
-// compile:true
+/// contains:test
+/// compile: true
 
 #set heading(numbering: "1.1")
 

--- a/crates/tinymist-query/src/fixtures/completion/complete_purely_ref.typ
+++ b/crates/tinymist-query/src/fixtures/completion/complete_purely_ref.typ
@@ -1,5 +1,5 @@
-// contains:test
-// compile:true
+/// contains:test
+/// compile: true
 
 #set heading(numbering: "1.1")
 

--- a/crates/tinymist-query/src/fixtures/completion/completion_title.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title.typ
@@ -1,4 +1,4 @@
-// path: references.bib
+/// path: references.bib
 @article{Russell:1908,
 Author = {Bertand Russell},
 Journal = {American Journal of Mathematics},
@@ -8,8 +8,8 @@ Volume = 30,
 Year = 1908}
 
 -----
-// contains:Russell:1908,Mathematical logic based on the theory of types
-// compile:true
+/// contains:Russell:1908,Mathematical logic based on the theory of types
+/// compile: true
 
 #set heading(numbering: "1.")
 == Test <R>

--- a/crates/tinymist-query/src/fixtures/completion/completion_title2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title2.typ
@@ -1,4 +1,4 @@
-// path: references.bib
+/// path: references.bib
 @article{Russell:1908,
 Author = {Bertand Russell},
 Journal = {American Journal of Mathematics},
@@ -8,8 +8,8 @@ Volume = 30,
 Year = 1908}
 
 -----
-// contains:Russell:1908,Mathematical logic based on the theory of types
-// compile:true
+/// contains:Russell:1908,Mathematical logic based on the theory of types
+/// compile: true
 
 #cite(<Russell:1908>)/* range -5..-4 */
 

--- a/crates/tinymist-query/src/fixtures/completion/completion_title3.typ
+++ b/crates/tinymist-query/src/fixtures/completion/completion_title3.typ
@@ -1,4 +1,4 @@
-// path: references.yaml
+/// path: references.yaml
 harry:
     type: Book
     title: Harry Potter and the Order of the Phoenix
@@ -15,8 +15,8 @@ electronic:
     url: http://www.techno.org/electronic-music-guide/
 
 -----
-// contains:harry,Harry Potter and the Order of the Phoenix,electronic,Ishkur's Guide to Electronic Music
-// compile:true
+/// contains:harry,Harry Potter and the Order of the Phoenix,electronic,Ishkur's Guide to Electronic Music
+/// compile: true
 
 #cite(<harry>) /* range -2..-1 */
 

--- a/crates/tinymist-query/src/fixtures/completion/element_where.typ
+++ b/crates/tinymist-query/src/fixtures/completion/element_where.typ
@@ -1,3 +1,3 @@
-// contains: caption
+/// contains: caption
 
 #figure.where(/* range 0..1 */)

--- a/crates/tinymist-query/src/fixtures/completion/fp_dict_filter.typ
+++ b/crates/tinymist-query/src/fixtures/completion/fp_dict_filter.typ
@@ -1,4 +1,4 @@
-// contains:a,ab,ac,ad
+/// contains:a,ab,ac,ad
 
 #let x = (
   a: false,

--- a/crates/tinymist-query/src/fixtures/completion/func_args.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_args.typ
@@ -1,4 +1,4 @@
-// contains: content,authors,font,class
+/// contains: content,authors,font,class
 
 #let tmpl(content, authors: (), font: none, class: "article") = {
   if class != "article" and class != "letter" {

--- a/crates/tinymist-query/src/fixtures/completion/func_args2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_args2.typ
@@ -1,4 +1,4 @@
-// contains: content,authors,font,class
+/// contains: content,authors,font,class
 
 #let tmpl(content, authors: (), font: none, class: "article") = {
   if class != "article" and class != "letter" {

--- a/crates/tinymist-query/src/fixtures/completion/func_args_after.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_args_after.typ
@@ -1,4 +1,4 @@
-// contains: content,authors,font,class
+/// contains: content,authors,font,class
 
 #let tmpl(content, authors: (), font: none, class: "article") = {
   if class != "article" and class != "letter" {

--- a/crates/tinymist-query/src/fixtures/completion/func_params.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_params.typ
@@ -1,4 +1,4 @@
-// contains: aa,aab,aac,aabc
+/// contains: aa,aab,aac,aabc
 
 #let aa(aab, aac, aabc) = {
   aac(/* range -2..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/func_with_args.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_with_args.typ
@@ -1,4 +1,4 @@
-// contains: content,authors,font,class
+/// contains: content,authors,font,class
 
 #let tmpl(content, authors: (), font: none, class: "article") = {
   if class != "article" and class != "letter" {

--- a/crates/tinymist-query/src/fixtures/completion/half_completion.typ
+++ b/crates/tinymist-query/src/fixtures/completion/half_completion.typ
@@ -1,3 +1,3 @@
-// contains: font
+/// contains: font
 
 #set text(fo /* range -2..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/import.ty_
+++ b/crates/tinymist-query/src/fixtures/completion/import.ty_
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let x = 1;
 #x
 -----

--- a/crates/tinymist-query/src/fixtures/completion/import.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ": aab, aac
 #aac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/import_self.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_self.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ"
 #bac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/import_self2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_self2.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ": *
 #bac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/import_self3.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_self3.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,baz,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,baz,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ" as baz
 #bac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/import_self4.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_self4.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,baz,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,baz,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ" as baz: *
 #bac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/import_star.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_star.typ
@@ -1,10 +1,10 @@
-// path: base.typ
+/// path: base.typ
 #let aa() = 1;
 #let aab() = 1;
 #let aac() = 1;
 #let aabc() = 1;
 
 -----
-// contains: base,aa,aab,aac,aabc,aa.with,aa.where
+/// contains: base,aa,aab,aac,aabc,aa.with,aa.where
 #import "base.typ": *
 #aac(/* range -2..0 */);

--- a/crates/tinymist-query/src/fixtures/completion/item_shadow.typ
+++ b/crates/tinymist-query/src/fixtures/completion/item_shadow.typ
@@ -1,4 +1,4 @@
-// contains: aa,aac
+/// contains: aa,aac
 
 #let aa = 1;
 #let aa() = 1;

--- a/crates/tinymist-query/src/fixtures/completion/keyword_ident.typ
+++ b/crates/tinymist-query/src/fixtures/completion/keyword_ident.typ
@@ -1,2 +1,2 @@
-// contains: inset
+/// contains: inset
 #set block(in /* range -2..-1 */)

--- a/crates/tinymist-query/src/fixtures/completion/let-context.typ
+++ b/crates/tinymist-query/src/fixtures/completion/let-context.typ
@@ -1,4 +1,4 @@
-// contains: a
+/// contains: a
 
 #let a = 1;
 #let b = /* range after 1..2 */                                     #();

--- a/crates/tinymist-query/src/fixtures/completion/let.typ
+++ b/crates/tinymist-query/src/fixtures/completion/let.typ
@@ -1,4 +1,4 @@
-// contains: aa,aab,aac,aabc
+/// contains: aa,aab,aac,aabc
 
 #let aa() = 1;
 #let aab = 1;

--- a/crates/tinymist-query/src/fixtures/completion/modify_string.typ
+++ b/crates/tinymist-query/src/fixtures/completion/modify_string.typ
@@ -1,3 +1,3 @@
-// contains: "New Computer Modern"
+/// contains: "New Computer Modern"
 
 #set text(font: ""/* range -2..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/modify_string_2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/modify_string_2.typ
@@ -1,3 +1,3 @@
-// contains: "New Computer Modern"
+/// contains: "New Computer Modern"
 
 #set text(font: (""/* range -2..0 */))

--- a/crates/tinymist-query/src/fixtures/completion/sig_dict.typ
+++ b/crates/tinymist-query/src/fixtures/completion/sig_dict.typ
@@ -1,3 +1,3 @@
-// contains: paint,cap
+/// contains: paint,cap
 
 #text(stroke: (/* range after 1..2 */ ))[]

--- a/crates/tinymist-query/src/fixtures/completion/sig_dict_rest.typ
+++ b/crates/tinymist-query/src/fixtures/completion/sig_dict_rest.typ
@@ -1,3 +1,3 @@
-// contains: paint,cap
+/// contains: paint,cap
 
 #text(stroke: (paint: red, /* range after 1..2 */ ))[]

--- a/crates/tinymist-query/src/fixtures/docs/base.typ
+++ b/crates/tinymist-query/src/fixtures/docs/base.typ
@@ -1,2 +1,2 @@
-// This is X.
+/// This is X.
 #let x /* ident */ = 1;

--- a/crates/tinymist-query/src/fixtures/docs/multiple_line.typ
+++ b/crates/tinymist-query/src/fixtures/docs/multiple_line.typ
@@ -1,3 +1,3 @@
-// This is X.
-// Note: this is not Y.
+/// This is X.
+/// Note: this is not Y.
 #let x /* ident */ = 1;

--- a/crates/tinymist-query/src/fixtures/docs/not_attach2.typ
+++ b/crates/tinymist-query/src/fixtures/docs/not_attach2.typ
@@ -1,3 +1,3 @@
-// This is X
+/// This is X
 
 #let x /* ident */ = 1;

--- a/crates/tinymist-query/src/fixtures/docs/param.typ
+++ b/crates/tinymist-query/src/fixtures/docs/param.typ
@@ -1,4 +1,4 @@
-// Docs for f.
+/// Docs for f.
 #let f(/* ident after */ a) = {
   show it: it => it;
 };

--- a/crates/tinymist-query/src/fixtures/docs/param_in_init.typ
+++ b/crates/tinymist-query/src/fixtures/docs/param_in_init.typ
@@ -1,4 +1,4 @@
-// Docs for f.
+/// Docs for f.
 #let f(a) = {
   show it: it => /* ident after */ it;
 };

--- a/crates/tinymist-query/src/fixtures/docs/snaps/docs@base.typ.snap
+++ b/crates/tinymist-query/src/fixtures/docs/snaps/docs@base.typ.snap
@@ -4,4 +4,4 @@ expression: "snap.join(\"\\n\")"
 input_file: crates/tinymist-query/src/fixtures/docs/base.typ
 ---
 = docstings
-Pattern(..)@19..20 in /s0.typ -> DocString { docs: Some("This is X."), var_bounds: {}, vars: {}, res_ty: None }
+Pattern(..)@20..21 in /s0.typ -> DocString { docs: Some("This is X."), var_bounds: {}, vars: {}, res_ty: None }

--- a/crates/tinymist-query/src/fixtures/docs/snaps/docs@multiple_line.typ.snap
+++ b/crates/tinymist-query/src/fixtures/docs/snaps/docs@multiple_line.typ.snap
@@ -4,4 +4,4 @@ expression: "snap.join(\"\\n\")"
 input_file: crates/tinymist-query/src/fixtures/docs/multiple_line.typ
 ---
 = docstings
-Pattern(..)@43..44 in /s0.typ -> DocString { docs: Some("This is X.\nNote: this is not Y."), var_bounds: {}, vars: {}, res_ty: None }
+Pattern(..)@45..46 in /s0.typ -> DocString { docs: Some("This is X.\nNote: this is not Y."), var_bounds: {}, vars: {}, res_ty: None }

--- a/crates/tinymist-query/src/fixtures/docs/snaps/docs@param.typ.snap
+++ b/crates/tinymist-query/src/fixtures/docs/snaps/docs@param.typ.snap
@@ -4,4 +4,4 @@ expression: "snap.join(\"\\n\")"
 input_file: crates/tinymist-query/src/fixtures/docs/param.typ
 ---
 = docstings
-Func(f)@20..21 in /s0.typ -> DocString { docs: Some("Docs for f."), var_bounds: {}, vars: {}, res_ty: None }
+Func(f)@21..22 in /s0.typ -> DocString { docs: Some("Docs for f."), var_bounds: {}, vars: {}, res_ty: None }

--- a/crates/tinymist-query/src/fixtures/docs/snaps/docs@param_in_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/docs/snaps/docs@param_in_init.typ.snap
@@ -4,4 +4,4 @@ expression: "snap.join(\"\\n\")"
 input_file: crates/tinymist-query/src/fixtures/docs/param_in_init.typ
 ---
 = docstings
-Func(f)@20..21 in /s0.typ -> DocString { docs: Some("Docs for f."), var_bounds: {}, vars: {}, res_ty: None }
+Func(f)@21..22 in /s0.typ -> DocString { docs: Some("Docs for f."), var_bounds: {}, vars: {}, res_ty: None }

--- a/crates/tinymist-query/src/fixtures/expr_of/base.typ
+++ b/crates/tinymist-query/src/fixtures/expr_of/base.typ
@@ -1,3 +1,3 @@
-// most simple def-use case
+/// most simple def-use case
 #let x = 1;
 #x

--- a/crates/tinymist-query/src/fixtures/expr_of/import_by_ident.typ
+++ b/crates/tinymist-query/src/fixtures/expr_of/import_by_ident.typ
@@ -1,7 +1,7 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
-// path: derive.typ
+/// path: derive.typ
 #import "base.typ"
 -----
 #import "derive.typ": *

--- a/crates/tinymist-query/src/fixtures/expr_of/import_star.typ
+++ b/crates/tinymist-query/src/fixtures/expr_of/import_star.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let x = 1;
 #x
 -----

--- a/crates/tinymist-query/src/fixtures/expr_of/import_star_recursive.typ
+++ b/crates/tinymist-query/src/fixtures/expr_of/import_star_recursive.typ
@@ -1,8 +1,8 @@
-// path: base.typ
+/// path: base.typ
 #let x = 1;
 #x
 -----
-// path: base2.typ
+/// path: base2.typ
 #import "base.typ": *
 #let y = 2;
 -----

--- a/crates/tinymist-query/src/fixtures/expr_of/snaps/scope@base.typ.snap
+++ b/crates/tinymist-query/src/fixtures/expr_of/snaps/scope@base.typ.snap
@@ -4,7 +4,7 @@ expression: "snap.join(\"\\n\")"
 input_file: crates/tinymist-query/src/fixtures/expr_of/base.typ
 ---
 = resolves
-Var(x)@33..34 in /s0.typ -> Var(x)@33..34 in /s0.typ, root Var(x)@33..34 in /s0.typ, val: None
-IdentRef(x)@41..42 in /s0.typ -> Var(x)@33..34 in /s0.typ, root Var(x)@33..34 in /s0.typ, val: None
+Var(x)@34..35 in /s0.typ -> Var(x)@34..35 in /s0.typ, root Var(x)@34..35 in /s0.typ, val: None
+IdentRef(x)@42..43 in /s0.typ -> Var(x)@34..35 in /s0.typ, root Var(x)@34..35 in /s0.typ, val: None
 = exports
-x -> Var(x)@33..34 in /s0.typ
+x -> Var(x)@34..35 in /s0.typ

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_alias.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_alias.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 #import "base.typ": f as one

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_ident.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_ident.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 #import "base.typ": f

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_new_name.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_new_name.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 -----
 #import "base.typ" as x
 #(/* position after */ x);

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_package.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_package.typ
@@ -1,3 +1,3 @@
-// path: base.typ
+/// path: base.typ
 #import "@preview/example:0.1.0";
 #(/* ident after */ example.add(1, 1))

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_package_self.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_package_self.typ
@@ -1,3 +1,3 @@
-// path: base.typ
+/// path: base.typ
 #import "@preview/example:0.1.0";
 #(/* ident after */ example)

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_path_inner.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_path_inner.typ
@@ -1,3 +1,3 @@
-// path: base.typ
+/// path: base.typ
 -----
 #import /* position after */ "base.typ"

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_self.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_self.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 -----
 #import "base.typ"
 #(/* position after */ base);

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_star.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_star.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/import_star_variable.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/import_star_variable.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let x = 2;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/inside_block.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/inside_block.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/inside_import.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/inside_import.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/inside_import_alias.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/inside_import_alias.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/inside_import_alias2.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/inside_import_alias2.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
 .

--- a/crates/tinymist-query/src/fixtures/goto_definition/label.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/label.typ
@@ -1,4 +1,4 @@
-// compile:true
+/// compile: true
 
 #set heading(numbering: "1.")
 

--- a/crates/tinymist-query/src/fixtures/goto_definition/label_indir.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/label_indir.typ
@@ -1,4 +1,4 @@
-// compile: true
+/// compile: true
 
 #let test1(body) = figure(body)
 #test1([Test1]) <fig:test1>

--- a/crates/tinymist-query/src/fixtures/goto_definition/label_indir2.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/label_indir2.typ
@@ -1,4 +1,4 @@
-// compile: true
+/// compile: true
 
 #let test1(body) = figure(body)
 #test1([Test1]) <fig:test1>

--- a/crates/tinymist-query/src/fixtures/goto_definition/module_select.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/module_select.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 

--- a/crates/tinymist-query/src/fixtures/goto_definition/module_select_alias.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/module_select_alias.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 

--- a/crates/tinymist-query/src/fixtures/hover/module_alias.typ
+++ b/crates/tinymist-query/src/fixtures/hover/module_alias.typ
@@ -1,4 +1,4 @@
-// path: themod.typ
+/// path: themod.typ
 /// = The Module (Alias)
 -----
 #import "themod.typ" as thatmod

--- a/crates/tinymist-query/src/fixtures/hover/module_path.typ
+++ b/crates/tinymist-query/src/fixtures/hover/module_path.typ
@@ -1,4 +1,4 @@
-// path: some-module.typ
+/// path: some-module.typ
 /// = Some Module
 -----
 #import /* position after */ "some-module.typ"

--- a/crates/tinymist-query/src/fixtures/hover/module_var.typ
+++ b/crates/tinymist-query/src/fixtures/hover/module_var.typ
@@ -1,4 +1,4 @@
-// path: themod.typ
+/// path: themod.typ
 /// = The Module
 -----
 #import "themod.typ"

--- a/crates/tinymist-query/src/fixtures/lexical_hierarchy/base.typ
+++ b/crates/tinymist-query/src/fixtures/lexical_hierarchy/base.typ
@@ -1,3 +1,3 @@
-// most simple def-use case
+/// most simple def-use case
 #let x = 1;
 #x

--- a/crates/tinymist-query/src/fixtures/lexical_hierarchy/import_by_ident.typ
+++ b/crates/tinymist-query/src/fixtures/lexical_hierarchy/import_by_ident.typ
@@ -1,7 +1,7 @@
-// path: base.typ
+/// path: base.typ
 #let f() = 1;
 -----
-// path: derive.typ
+/// path: derive.typ
 #import "base.typ"
 -----
 #import "derive.typ": *

--- a/crates/tinymist-query/src/fixtures/modules/base.typ
+++ b/crates/tinymist-query/src/fixtures/modules/base.typ
@@ -1,3 +1,3 @@
-// path: may_import.typ
+/// path: may_import.typ
 -----
 #import "may_import.typ"

--- a/crates/tinymist-query/src/fixtures/modules/may_import.typ
+++ b/crates/tinymist-query/src/fixtures/modules/may_import.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 -----
-// this may happens in cetz
+/// this may happens in cetz
 #let evil_import() = import "base.typ"

--- a/crates/tinymist-query/src/fixtures/pkgs/touying-utils-_size-to-pt.typ
+++ b/crates/tinymist-query/src/fixtures/pkgs/touying-utils-_size-to-pt.typ
@@ -1,5 +1,5 @@
-// path: lib.typ
-// - level (auto, ): The level
+/// path: lib.typ
+/// - level (auto, ): The level
 #let _size-to-pt(size, container-dimension) = {
   let to-convert = size
   if type(size) == ratio {
@@ -8,18 +8,18 @@
   measure(v(to-convert)).height
 }
 -----
-// contains: level, hierachical, depth
+/// contains: level, hierachical, depth
 #import "lib.typ": *
 #current-heading(/* range 0..1 */)[];
 -----
-// contains: "body"
+/// contains: "body"
 #import "lib.typ": *
 #current-heading(level: /* range 0..1 */)[];
 -----
-// contains: false, true
+/// contains: false, true
 #import "lib.typ": *
 #current-heading(hierachical: /* range 0..1 */)[];
 -----
-// contains: false, true
+/// contains: false, true
 #import "lib.typ": *
 #current-heading(depth: /* range 0..1 */)[];

--- a/crates/tinymist-query/src/fixtures/pkgs/touying-utils-current-heading.typ
+++ b/crates/tinymist-query/src/fixtures/pkgs/touying-utils-current-heading.typ
@@ -1,5 +1,5 @@
-// path: lib.typ
-// - level (auto, int): The level
+/// path: lib.typ
+/// - level (auto, int): The level
 #let current-heading(level: auto, hierachical: true, depth: 9999) = {
   let current-page = here().page()
   if not hierachical and level != auto {
@@ -26,18 +26,18 @@
   }
 }
 -----
-// contains: level, hierachical, depth
+/// contains: level, hierachical, depth
 #import "lib.typ": *
 #current-heading(/* range 0..1 */)[];
 -----
-// contains: "body"
+/// contains: "body"
 #import "lib.typ": *
 #current-heading(level: /* range 0..1 */)[];
 -----
-// contains: false, true
+/// contains: false, true
 #import "lib.typ": *
 #current-heading(hierachical: /* range 0..1 */)[];
 -----
-// contains: 9999, 1
+/// contains: 9999, 1
 #import "lib.typ": *
 #current-heading(depth: /* range 0..1 */)[];

--- a/crates/tinymist-query/src/fixtures/pkgs/touying-utils-fit-to-height.typ
+++ b/crates/tinymist-query/src/fixtures/pkgs/touying-utils-fit-to-height.typ
@@ -1,5 +1,5 @@
-// path: lib.typ
-// - level (auto, ): The level
+/// path: lib.typ
+/// - level (auto, ): The level
 #let fit-to-height(
   width: none,
   prescale-width: none,
@@ -18,14 +18,14 @@
   ]
 }
 -----
-// contains: 1
+/// contains: 1
 #import "lib.typ": *
 #fit-to-height(width: /* range 0..1 */)[];
 -----
-// contains: 1
+/// contains: 1
 #import "lib.typ": *
 #fit-to-height(prescale-width: /* range 0..1 */)[];
 -----
-// contains: 1
+/// contains: 1
 #import "lib.typ": *
 #fit-to-height(height: /* range 0..1 */)[];

--- a/crates/tinymist-query/src/fixtures/pkgs/touying-utils-reconstruct.typ
+++ b/crates/tinymist-query/src/fixtures/pkgs/touying-utils-reconstruct.typ
@@ -1,18 +1,18 @@
-// path: lib.typ
+/// path: lib.typ
 #let reconstruct(body-name: "body", labeled: true, named: false, it, ..new-body) = { }
 -----
-// contains: body-name, labeled, named, it, new-body
+/// contains: body-name, labeled, named, it, new-body
 #import "lib.typ": *
 #reconstruct(/* range 0..1 */)[];
 -----
-// contains: "body"
+/// contains: "body"
 #import "lib.typ": *
 #reconstruct(body-name: /* range 0..1 */)[];
 -----
-// contains: false, true
+/// contains: false, true
 #import "lib.typ": *
 #reconstruct(labeled: /* range 0..1 */)[];
 -----
-// contains: false, true
+/// contains: false, true
 #import "lib.typ": *
 #reconstruct(named: /* range 0..1 */)[];

--- a/crates/tinymist-query/src/fixtures/post_type_check/user_external.typ
+++ b/crates/tinymist-query/src/fixtures/post_type_check/user_external.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let tmpl(content, font: none) = {
   set text(font: font)
 

--- a/crates/tinymist-query/src/fixtures/post_type_check/user_external_alias.typ
+++ b/crates/tinymist-query/src/fixtures/post_type_check/user_external_alias.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let tmpl(content, font: none) = {
   set text(font: font)
 

--- a/crates/tinymist-query/src/fixtures/post_type_check/user_external_ever.typ
+++ b/crates/tinymist-query/src/fixtures/post_type_check/user_external_ever.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let tmpl(content, authors: (), font: none, class: "article") = {
   if class != "article" and class != "letter" {
     panic("")

--- a/crates/tinymist-query/src/fixtures/references/cross_file_ref_label.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_file_ref_label.typ
@@ -1,15 +1,15 @@
-// path: base2.typ
+/// path: base2.typ
 == Base 2 <b2>
 Ref to b1 @b1
 Ref to b2 @b2
 Ref to b1 @b1 again
 -----
-// path: base1.typ
+/// path: base1.typ
 == Base 1 <b1>
 Ref to b1 @b1
 Ref to b2 @b2
 -----
-// compile:true
+/// compile: true
 
 #set heading(numbering: "1.")
 = Test Ref Label

--- a/crates/tinymist-query/src/fixtures/references/cross_module.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module.typ
@@ -1,5 +1,5 @@
 #import "base.typ": *
 #x
 -----
-// path: base.typ
+/// path: base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module2.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module2.typ
@@ -1,5 +1,5 @@
 #import "base.typ": x
 #x
 -----
-// path: base.typ
+/// path: base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_absolute.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_absolute.typ
@@ -1,6 +1,6 @@
-// path: /out/main.typ
+/// path: /out/main.typ
 #import "/out/base.typ": x
 #x
 -----
-// path: /out/base.typ
+/// path: /out/base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_alias.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_alias.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let x = 1;
 -----
 #import "base.typ": x as /* ident after */ ff

--- a/crates/tinymist-query/src/fixtures/references/cross_module_alias2.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_alias2.typ
@@ -1,5 +1,5 @@
 #import "base.typ": x as ff
 #ff
 -----
-// path: base.typ
+/// path: base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/cross_module_relative.typ
+++ b/crates/tinymist-query/src/fixtures/references/cross_module_relative.typ
@@ -1,6 +1,6 @@
-// path: /out/main.typ
+/// path: /out/main.typ
 #import "base.typ": x
 #x
 -----
-// path: /out/base.typ
+/// path: /out/base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/label.typ
+++ b/crates/tinymist-query/src/fixtures/references/label.typ
@@ -1,4 +1,4 @@
-// compile: true
+/// compile: true
 #set heading(numbering: "1.")
 
 = Labeled <title_label> /* ident */

--- a/crates/tinymist-query/src/fixtures/references/recursive_import.typ
+++ b/crates/tinymist-query/src/fixtures/references/recursive_import.typ
@@ -1,9 +1,9 @@
 #import "base2.typ": x
 #x
 -----
-// path: base2.typ
+/// path: base2.typ
 #import "base.typ": x
 #x
 -----
-// path: base.typ
+/// path: base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/recursive_import_star.typ
+++ b/crates/tinymist-query/src/fixtures/references/recursive_import_star.typ
@@ -1,9 +1,9 @@
 #import "base2.typ": *
 #x
 -----
-// path: base2.typ
+/// path: base2.typ
 #import "base.typ": *
 #x
 -----
-// path: base.typ
+/// path: base.typ
 #let /* ident after */ x = 1;

--- a/crates/tinymist-query/src/fixtures/references/ref_label.typ
+++ b/crates/tinymist-query/src/fixtures/references/ref_label.typ
@@ -1,4 +1,4 @@
-// compile: true
+/// compile: true
 #set heading(numbering: "1.")
 
 = Labeled <title_label>

--- a/crates/tinymist-query/src/fixtures/references/rename_issue_exercise.typ
+++ b/crates/tinymist-query/src/fixtures/references/rename_issue_exercise.typ
@@ -1,10 +1,10 @@
-// path: basic/writing.typ
+/// path: basic/writing.typ
 #import "mod.typ": *
 #exercise()
 -----
-// path: basic/mod.typ
+/// path: basic/mod.typ
 #import "../mod.typ": exercise
 #exercise()
 -----
-// path: mod.typ
+/// path: mod.typ
 #let /* ident after */ exercise() = [];

--- a/crates/tinymist-query/src/fixtures/rename/cross-module.typ
+++ b/crates/tinymist-query/src/fixtures/rename/cross-module.typ
@@ -1,4 +1,4 @@
-// path: user.typ
+/// path: user.typ
 #let f() = 1;
 -----
 #import "user.typ": f

--- a/crates/tinymist-query/src/fixtures/rename/module_path.typ
+++ b/crates/tinymist-query/src/fixtures/rename/module_path.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 #import /* position after */ "variable.typ"

--- a/crates/tinymist-query/src/fixtures/rename/module_path_abs.typ.skip
+++ b/crates/tinymist-query/src/fixtures/rename/module_path_abs.typ.skip
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 #import /* position after */ "/variable.typ"

--- a/crates/tinymist-query/src/fixtures/rename/module_path_alias.typ
+++ b/crates/tinymist-query/src/fixtures/rename/module_path_alias.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 #import /* position after */ "variable.typ" as t

--- a/crates/tinymist-query/src/fixtures/rename/module_path_non_cano.typ
+++ b/crates/tinymist-query/src/fixtures/rename/module_path_non_cano.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 #import /* position after */ "test/../variable.typ"

--- a/crates/tinymist-query/src/fixtures/rename/module_path_star.typ
+++ b/crates/tinymist-query/src/fixtures/rename/module_path_star.typ
@@ -1,4 +1,4 @@
-// path: variable.typ
+/// path: variable.typ
 #let f(x) = 2;
 -----
 #import /* position after */ "variable.typ": *

--- a/crates/tinymist-query/src/fixtures/signature/import.typ
+++ b/crates/tinymist-query/src/fixtures/signature/import.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f(u, v) = u + v;
 -----
 #import "base.typ": *

--- a/crates/tinymist-query/src/fixtures/signature/import_ident.typ
+++ b/crates/tinymist-query/src/fixtures/signature/import_ident.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let f(u, v) = u + v;
 -----
 #import "base.typ": f

--- a/crates/tinymist-query/src/fixtures/type_check/external.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let bad-instantiate(x) = {
   let y; let z; let w;
   x + y + z + w

--- a/crates/tinymist-query/src/fixtures/type_check/recursive.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/recursive.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let a(x) = a;
 -----
 #import "base.typ": *

--- a/crates/tinymist-query/src/fixtures/type_check/recursive_use.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/recursive_use.typ
@@ -1,4 +1,4 @@
-// path: base.typ
+/// path: base.typ
 #let a(x) = a;
 -----
 #import "base.typ": *

--- a/crates/tinymist-query/src/tests.rs
+++ b/crates/tinymist-query/src/tests.rs
@@ -124,7 +124,7 @@ pub fn run_with_sources<T>(source: &str, f: impl FnOnce(&mut LspUniverse, PathBu
 
         if source.starts_with("//") {
             let first_line = source.lines().next().unwrap();
-            let content = first_line.strip_prefix("//").unwrap().trim();
+            let content = first_line.trim_start_matches("/").trim();
 
             if let Some(path_attr) = content.strip_prefix("path:") {
                 source = source.strip_prefix(first_line).unwrap().trim();


### PR DESCRIPTION
Previously both `// Docs` and `/// Docs` at the start of some file are regarded as docs of the module (file). However, this is not great because people also usually put shebangs and license information in comments.

## Example

```typ
// License: Apache 2.0
/// Some Module Docs.
```

The exact docs should be `Some Module Docs.` instead of `License: Apache 2.0\nSome Module Docs.`

