### PR TITLE
feat: claim list of maintainers

### DIFF
--- a/MAINTAINERS.typ
+++ b/MAINTAINERS.typ
@@ -1,0 +1,69 @@
+
+#import "typ/templates/maintainer.typ": *
+#show: main
+
+#let editor-integration = [Editor Integration]
+#let language-service = [Language Service]
+#let document-previewing = [Document Previewing]
+#let vs-code-client-side-support = [VS Code Client-Side Support]
+#let nightly-releases = [Nightly Releases]
+
+== Maintainers
+
+#maintainers[
+  - Myriad-Dreamin
+    - #github("Myriad-Dreamin")
+    - #email("camiyoru@gmail.com")
+    - #maintains[
+        - #editor-integration
+        - #language-service
+        - #document-previewing
+        - #vs-code-client-side-support
+        - #nightly-releases
+      ]
+  - Enter-tainer
+    - #github("Enter-tainer")
+    - #email("mgt@oi-wiki.org")
+    - #maintains[
+        - #editor-integration
+        - #language-service
+        - #document-previewing
+        - #vs-code-client-side-support
+      ]
+]
+
+== Features
+
+#features[
+  - #editor-integration
+    - #scope("crates/tinymist/", "editors/")
+    - #description[
+        Integrate tinymist server with popular editors like VS Code, Neovim, etc.
+      ]
+  - #language-service
+    - #scope("crates/tinymist/", "crates/tinymist-query/")
+    - #description[
+        Perform code analysis and provide language support for Typst.
+      ]
+  - #document-previewing
+    - #scope(
+        "crates/tinymist/",
+        "crates/typst-preview/",
+        "contrib/typst-preview/",
+        "tools/typst-dom/",
+        "tools/typst-preview-frontend/",
+      )
+    - #description[
+        Provide instant preview of the document being edited.
+      ]
+  - #vs-code-client-side-support
+    - #scope("crates/tinymist/", "crates/typst-preview/", "tools/editor-tools/")
+    - #description[
+        Enrich the VS Code features with the client-side extension.
+      ]
+  - #nightly-releases
+    - #scope("crates/tinymist/", "typst-shim/")
+    - #description[
+        Build and Publish nightly releases of tinymist. The nightly releases are built upon the main branches of both tinymist and typst.
+      ]
+]

--- a/MAINTAINERS.typ
+++ b/MAINTAINERS.typ
@@ -57,7 +57,7 @@
         Provide instant preview of the document being edited.
       ]
   - #vs-code-client-side-support
-    - #scope("crates/tinymist/", "crates/typst-preview/", "tools/editor-tools/")
+    - #scope("crates/tinymist/", "editors/vscode/", "tools/editor-tools/")
     - #description[
         Enrich the VS Code features with the client-side extension.
       ]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ Nightly Channel:
 
 Please read the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution guidelines.
 
+## Maintainers
+
+Get list of maintainers from [MAINTAINERS.typ](MAINTAINERS.typ). Or programmatically by `yarn maintainers`
+
+> [!TIP]
+> You can add extra arguments for specific information. For example, `yarn maintainers --input="action=maintainers"`.
+
 ## Acknowledgements
 
 - Partially code is inherited from [typst-lsp](https://github.com/nvarner/typst-lsp)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build:editor-tools": "cd tools/editor-tools/ && yarn run build",
     "build:preview": "cd tools/typst-preview-frontend && yarn run build && rimraf ../../crates/tinymist-assets/src/typst-preview.html && cpr ./dist/index.html ../../crates/tinymist-assets/src/typst-preview.html",
-    "maintainers": "typst query MAINTAINERS.typ \"<maintainer-meta>\" --pretty --one --field value",
+    "maintainers": "typst query MAINTAINERS.typ \"<maintainer-meta>\" --pretty --one --field value --input=action=help",
     "docs": "shiroa serve --font-path assets/fonts -w . docs/tinymist",
     "docs:typ": "node scripts/link-docs.mjs",
     "docs:rs": "cargo doc --workspace --no-deps",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build:editor-tools": "cd tools/editor-tools/ && yarn run build",
     "build:preview": "cd tools/typst-preview-frontend && yarn run build && rimraf ../../crates/tinymist-assets/src/typst-preview.html && cpr ./dist/index.html ../../crates/tinymist-assets/src/typst-preview.html",
+    "maintainers": "typst query MAINTAINERS.typ \"<maintainer-meta>\" --pretty --one --field value",
     "docs": "shiroa serve --font-path assets/fonts -w . docs/tinymist",
     "docs:typ": "node scripts/link-docs.mjs",
     "docs:rs": "cargo doc --workspace --no-deps",

--- a/typ/templates/maintainer.typ
+++ b/typ/templates/maintainer.typ
@@ -70,13 +70,42 @@
 #let cli-query(content) = {
   let action = sys.inputs.at("action", default: "")
 
-  if action == "maintainers" {
-    content.maintainers
-  } else if action == "features" {
-    content.features
-  } else {
-    content
-  }
+  let actions = (
+    help: (
+      description: "show help",
+      action: actions => {
+        for (k, v) in actions {
+          (
+            (
+              action: k,
+              description: v.description,
+              example: "<program> --input=action=" + k,
+            ),
+          )
+        }
+      },
+    ),
+    maintainers: (
+      description: "show maintainers",
+      action: actions => {
+        content.maintainers
+      },
+    ),
+    features: (
+      description: "show features",
+      action: actions => {
+        content.features
+      },
+    ),
+    all: (
+      description: "show all",
+      action: actions => {
+        content
+      },
+    ),
+  )
+
+  (actions.at(action, default: actions.all).action)(actions)
 }
 
 #let embed-query() = {

--- a/typ/templates/maintainer.typ
+++ b/typ/templates/maintainer.typ
@@ -1,0 +1,147 @@
+
+#import "page.typ": plain-text
+
+#let feature-state = state("feature-state")
+#let features(content) = {
+  feature-state.update(content)
+  content
+}
+
+#let maintainer-state = state("maintainer-state")
+#let maintainers(content) = {
+  maintainer-state.update(content)
+  content
+}
+
+#let embedded-meta(key, content) = metadata((
+  kind: "embedded-meta",
+  key: key,
+  content: content,
+))
+
+#let description(content) = {
+  embedded-meta("description", plain-text(content))
+  [Description: ] + content
+}
+
+#let scope(..scopes) = {
+  embedded-meta("scope", scopes.pos())
+  [Scope: ]
+  scopes.pos().map(raw).map(list.item).join()
+}
+
+#let github(content) = {
+  let lnk = {
+    "https://github.com/"
+    content
+  }
+
+  embedded-meta("github-name", content)
+  [Github: ]
+  link(lnk, content)
+}
+
+#let email(content) = {
+
+  // content
+
+  [Email: ]
+  let lnk = {
+    "mailto:"
+    content
+  }
+
+  embedded-meta("email", content)
+  link(lnk, content)
+}
+
+#let maintains(content) = {
+
+  let process-maintain-list(content) = {
+    let is-item = it => it.func() == list.item
+    content.children.filter(is-item).map(it => plain-text(it.body))
+  }
+
+  embedded-meta("maintains", process-maintain-list(content))
+  [Maintains: ]
+  content
+}
+
+#let cli-query(content) = {
+  let action = sys.inputs.at("action", default: "")
+
+  if action == "maintainers" {
+    content.maintainers
+  } else if action == "features" {
+    content.features
+  } else {
+    content
+  }
+}
+
+#let embed-query() = {
+  let is-item = it => it.func() == list.item
+  let feature-list = feature-state.final().children.filter(is-item)
+  let maintainer-list = maintainer-state.final().children.filter(is-item)
+
+  let collect-meta(content, res) = {
+    if type(content) == array {
+      for it in content {
+        res = collect-meta(it, res)
+      }
+    } else if "body" in content.fields() {
+      collect-meta(content.body, res)
+    } else if "children" in content.fields() {
+      collect-meta(content.children, res)
+    } else if content.func() == metadata {
+      let value = content.value
+      if value.at("kind", default: "") == "embedded-meta" {
+        res.insert(value.key, value.content)
+      }
+    }
+
+    res
+  }
+
+  let features = feature-list.map(it => {
+    let chs = it.body.children
+    let p = chs.position(is-item)
+    let name = chs.slice(0, p)
+    let extras = collect-meta(chs.slice(p), (:))
+
+    (
+      name: plain-text(name.join()).trim(),
+      ..extras,
+    )
+  })
+
+  let maintainers = maintainer-list.map(it => {
+    let chs = it.body.children
+    let p = chs.position(is-item)
+    let name = chs.slice(0, p)
+    let extras = collect-meta(chs.slice(p), (:))
+
+    (
+      name: plain-text(name.join()).trim(),
+      ..extras,
+    )
+  })
+
+  [
+    #let meta = (
+      maintainers: maintainers,
+      features: features,
+    )
+    #metadata(cli-query(meta)) <maintainer-meta>
+  ]
+}
+
+#let main(content) = {
+  context embed-query()
+  show heading: it => {
+    set text(2em)
+    set block(above: 0.7em, below: 0.6em)
+    it
+  }
+  content
+}


### PR DESCRIPTION

Get list of maintainers from [MAINTAINERS.typ](MAINTAINERS.typ). Or programmatically by `yarn maintainers`

> [!TIP]
> You can add extra arguments for specific information. For example, `yarn maintainers --input="action=maintainers"`.