### PR TITLE
feat: emit errors into docs instead of causing failures

### DIFF
--- a/crates/tinymist-query/src/fixtures/hover/annotate_docs_error.typ
+++ b/crates/tinymist-query/src/fixtures/hover/annotate_docs_error.typ
@@ -1,0 +1,12 @@
+/// Speaker notes are a way to add additional information to your slides that is not visible to the audience. This can be useful for providing additional context or reminders to yourself.
+///
+/// == Example
+///
+/// #example(```typ
+/// #speaker-note[This is a speaker note]
+/// ```)
+#let speaker-note(mode: "typ", setting: it => it, note) = {
+  touying-fn-wrapper(utils.speaker-note, mode: mode, setting: setting, note)
+}
+
+#(/* ident after */ speaker-note);

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@annotate_docs_error.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@annotate_docs_error.typ.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tinymist-query/src/hover.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/hover/annotate_docs_error.typ
+---
+{
+ "contents": "```typc\nlet speaker-note(\n  note,\n  mode: str = \"typ\",\n  setting: (any) => any = Closure(..),\n) = none;\n```\n\n---\nSpeaker notes are a way to add additional information to your slides that is not visible to the audience. This can be useful for providing additional context or reminders to yourself.\n\n ## Example\n\n ```typ\n#speaker-note[This is a speaker note]\n\n```\n```\nRender Error\ncompiling node: error: unknown variable: speaker-note at \"/__render__.typ\":201..213\nHint: if you meant to use subtraction, try adding spaces around the minus sign: \\`speaker - note\\`\n\n```\n\n## Parameters\n\n@positional `note`\n\n@named `mode`\n\n@named `setting`",
+ "range": "11:20:11:32"
+}

--- a/crates/tinymist-world/src/lib.rs
+++ b/crates/tinymist-world/src/lib.rs
@@ -1,5 +1,6 @@
 //! World implementation of typst for tinymist.
 
+pub use reflexo_typst;
 pub use reflexo_typst::config::CompileFontOpts;
 pub use reflexo_typst::error::prelude;
 pub use reflexo_typst::font::FontResolverImpl;


### PR DESCRIPTION
Previously, all content of documentation is gone if there is any error in docstring. Now we emit errors instead, so conversion never fails. The format of errors can be improved in future.