### PR TITLE
feat: evict analysis caches before exact min revision

### DIFF
--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1108,12 +1108,12 @@ impl RevisionManagerLike for AnalysisRevCache {
             .expr_stage
             .global
             .lock()
-            .retain(|_, r| r.0 + 60 >= rev);
+            .retain(|_, r| r.0 >= rev);
         self.default_slot
             .type_check
             .global
             .lock()
-            .retain(|_, r| r.0 + 60 >= rev);
+            .retain(|_, r| r.0 >= rev);
     }
 }
 


### PR DESCRIPTION
This can be done confidently since https://github.com/Myriad-Dreamin/tinymist/pull/806