### PR TITLE
fix: enclose fallback docs in code block

### DIFF
--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -162,7 +162,20 @@ impl<'a> DocsChecker<'a> {
             Ok(c) => Ok(c),
             Err(e) => {
                 let e = e.replace("`", "\\`");
-                let fallback_docs = eco_format!("```\nfailed to parse docs: {e}\n```\n\n{docs}");
+                let max_consecutive_backticks = docs
+                    .chars()
+                    .fold((0, 0), |(max, count), c| {
+                        if c == '`' {
+                            (max.max(count + 1), count + 1)
+                        } else {
+                            (max, 0)
+                        }
+                    })
+                    .0;
+                let backticks = "`".repeat((max_consecutive_backticks + 1).max(3));
+                let fallback_docs = eco_format!(
+                    "```\nfailed to parse docs: {e}\n```\n\n{backticks}typ\n{docs}\n{backticks}\n"
+                );
                 Err(DocString {
                     docs: Some(fallback_docs),
                     var_bounds: HashMap::new(),

--- a/tools/editor-tools/src/features/docs.ts
+++ b/tools/editor-tools/src/features/docs.ts
@@ -38,7 +38,7 @@ export const Docs = () => {
       },
       (_dom?: Element) => {
         const v = parsedDocs.val;
-        console.log("updated", v);
+        // console.log("updated", v);
         return div(MakeDoc(v));
       }
     )
@@ -213,7 +213,7 @@ async function recoverDocsStructure(content: string) {
         current = structStack.pop()!;
         break;
       case TokenKind.Comment:
-        console.log("Comment", token[1]);
+        // console.log("Comment", token[1]);
         break;
       case TokenKind.Text:
         current.contents.push(token[1]);
@@ -298,7 +298,7 @@ function MakeDoc(root: DocElement) {
   // module-symbol-module-src.lib-barchart
   getKnownPackages(root);
   processInternalModules(root);
-  console.log("MakeDoc", root, knownFiles, knownPackages);
+  // console.log("MakeDoc", root, knownFiles, knownPackages);
 
   function getKnownPackages(v: DocElement) {
     for (const child of v.children) {
@@ -391,7 +391,7 @@ function MakeDoc(root: DocElement) {
   }
 
   function ShortItemDoc(v: DocElement): ChildDom[] {
-    console.log("item ref to ", v);
+    // console.log("item ref to ", v);
     return [ItemDoc(v)];
   }
 
@@ -484,7 +484,7 @@ function MakeDoc(root: DocElement) {
     const fileLoc = v.data.loc;
     const fid = genFileId(knownFiles[fileLoc]);
     const isInternal = knownFiles[fileLoc]?.isInternal;
-    console.log("ModuleItem", v, fid);
+    // console.log("ModuleItem", v, fid);
 
     const title = [];
     if (isInternal) {
@@ -510,7 +510,7 @@ function MakeDoc(root: DocElement) {
   }
 
   function PackageItem(v: DocElement) {
-    console.log("PackageItem", v);
+    // console.log("PackageItem", v);
     return div(
       h1(`@${v.data.namespace}/${v.data.name}:${v.data.version}`),
       p(


### PR DESCRIPTION
Otherwise the markup in typst syntax may corrupt entire generated docs.