### PR TITLE
fix: wrong diff_path

### DIFF
--- a/crates/tinymist-query/src/upstream/complete/ext.rs
+++ b/crates/tinymist-query/src/upstream/complete/ext.rs
@@ -1484,10 +1484,17 @@ pub fn complete_path(
             // diff with root
             unix_slash(path.vpath().as_rooted_path())
         } else {
-            let base = base.vpath().as_rooted_path();
-            let path = path.vpath().as_rooted_path();
-            let w = pathdiff::diff_paths(path, base)?;
-            unix_slash(&w)
+            let base = base.vpath().as_rooted_path().parent();
+            let path = path.vpath();
+            match base {
+                Some(base) => {
+                    let w = pathdiff::diff_paths(path.as_rooted_path(), base)?;
+                    unix_slash(&w)
+                }
+                None => {
+                    unix_slash(path.as_rootless_path())
+                }
+            }
         };
         log::debug!("compl_label: {label:?}");
 

--- a/crates/tinymist-query/src/upstream/complete/ext.rs
+++ b/crates/tinymist-query/src/upstream/complete/ext.rs
@@ -1484,17 +1484,14 @@ pub fn complete_path(
             // diff with root
             unix_slash(path.vpath().as_rooted_path())
         } else {
-            let base = base.vpath().as_rooted_path().parent();
-            let path = path.vpath();
-            match base {
-                Some(base) => {
-                    let w = pathdiff::diff_paths(path.as_rooted_path(), base)?;
-                    unix_slash(&w)
-                }
-                None => {
-                    unix_slash(path.as_rootless_path())
-                }
-            }
+            let base = base
+                .vpath()
+                .as_rooted_path()
+                .parent()
+                .unwrap_or(Path::new("/"));
+            let path = path.vpath().as_rooted_path();
+            let w = pathdiff::diff_paths(path, base)?;
+            unix_slash(&w)
         };
         log::debug!("compl_label: {label:?}");
 


### PR DESCRIPTION
A fix for #852

In short the crate pathdiff::diff_paths is used incorrectly. Here is an example:
```rust
assert_eq!(diff_paths("/foo/bar/quux", "/foo/bar/baz"),  Some("../quux".into())); // thus the following
assert_eq!(diff_paths("/foo/bar/image.jpg", "/foo/bar/file.typ"),  Some("../image.jpg".into()));
```
We might add more test to inspect other cases