### PR TITLE
fix: reliably check value of "tinymist.showExportFileIn"

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -530,6 +530,9 @@ async function commandShow(kind: "Pdf" | "Svg" | "Png", extraOpts?: any): Promis
     case "systemDefault":
       break;
     default:
+      vscode.window.showWarningMessage(
+        `Unknown value of "tinymist.showExportFileIn", expected "systemDefault" or "editorTab", got "${openIn}"`,
+      );
     case "editorTab": {
       // find and replace exportUri
       const exportUri = Uri.file(exportPath);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -501,7 +501,7 @@ async function commandShow(kind: "Pdf" | "Svg" | "Png", extraOpts?: any): Promis
   }
 
   const conf = vscode.workspace.getConfiguration("tinymist");
-  const openIn: string = conf.get("showExportFileIn", "editorTab");
+  const openIn: string = conf.get("showExportFileIn") || "editorTab";
 
   // Telling the language server to open the file instead of using
   // ```
@@ -527,9 +527,9 @@ async function commandShow(kind: "Pdf" | "Svg" | "Png", extraOpts?: any): Promis
   }
 
   switch (openIn) {
-    default:
     case "systemDefault":
       break;
+    default:
     case "editorTab": {
       // find and replace exportUri
       const exportUri = Uri.file(exportPath);


### PR DESCRIPTION
VSCode returns null if no configuration is provided even if we tell to use a default value. Moreover, a user might pass an invalid string, so we should redirect the default branch to "editorTab".