### PR TITLE
chore: Spellcheck and correct entire code base

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,22 @@ uninlined_format_args = "warn"
 missing_safety_doc = "warn"
 undocumented_unsafe_blocks = "warn"
 
+[workspace.metadata.typos.default]
+locale = "en-us"
+
+[workspace.metadata.typos.default.extend-words]
+labelled = "labelled"
+onces = "onces"
+withs = "withs"
+
+[workspace.metadata.typos.files]
+ignore-hidden = false
+extend-exclude = [
+  "/.git",
+  "fixtures",
+  "upstream",
+]
+
 [patch.crates-io]
 
 # tinymist-assets = { path = "./crates/tinymist-assets/" }

--- a/contrib/typlite/src/main.rs
+++ b/contrib/typlite/src/main.rs
@@ -16,7 +16,7 @@ pub struct CompileArgs {
     #[clap(flatten)]
     pub compile: CompileOnceArgs,
 
-    /// Path to ouput file
+    /// Path to output file
     #[clap(value_name = "OUTPUT")]
     pub output: Option<String>,
 }

--- a/contrib/typst-preview/editors/vscode/README.md
+++ b/contrib/typst-preview/editors/vscode/README.md
@@ -1,4 +1,4 @@
-# [DEPRECATION NOTICE] Typst preivew extension has been integrated into [tinymist](https://github.com/Myriad-Dreamin/tinymist)
+# [DEPRECATION NOTICE] Typst preview extension has been integrated into [tinymist](https://github.com/Myriad-Dreamin/tinymist)
 
 We recommend all users migrate to tinymist for the following benefits:
 

--- a/crates/sync-lsp/src/lib.rs
+++ b/crates/sync-lsp/src/lib.rs
@@ -29,7 +29,7 @@ pub type LspResponseFuture<T> = LspResult<ResponseFuture<T>>;
 pub type SchedulableResponse<T> = LspResponseFuture<LspResult<T>>;
 /// The common future type for the language server.
 pub type AnySchedulableResponse = SchedulableResponse<JsonValue>;
-/// The result of a scheduled response which could be finally catched by
+/// The result of a scheduled response which could be finally caught by
 /// `schedule_tail`.
 /// - Returns Ok(Some()) -> Already responded
 /// - Returns Ok(None) -> Need to respond none

--- a/crates/tinymist-query/src/analysis/bib.rs
+++ b/crates/tinymist-query/src/analysis/bib.rs
@@ -216,7 +216,7 @@ Euclid2:
     }
 
     #[test]
-    fn yaml_bib_imcomplete() {
+    fn yaml_bib_incomplete() {
         let content = r#"
 Euclid:
   type: article

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -601,7 +601,7 @@ impl SharedContext {
     }
 
     /// Get the real definition of a compilation.
-    /// Note: must be called after compliation.
+    /// Note: must be called after compilation.
     pub(crate) fn dependencies(&self) -> EcoVec<reflexo::ImmutPath> {
         let mut v = EcoVec::new();
         self.world.iter_dependencies(&mut |p| {

--- a/crates/tinymist-query/src/code_action.rs
+++ b/crates/tinymist-query/src/code_action.rs
@@ -227,7 +227,7 @@ impl<'a> CodeActionWorker<'a> {
             .ctx
             .to_lsp_range(body_range.end..last_dollar.range().start, &self.current);
 
-        // Retrive punctuation to move
+        // Retrieve punctuation to move
         let mark_after_equation = self
             .current
             .text()

--- a/crates/tinymist-query/src/package.rs
+++ b/crates/tinymist-query/src/package.rs
@@ -97,7 +97,7 @@ pub fn list_package_by_namespace(
         }
         // namespace/package_name/version
         // 2. package_name
-        let Some(package_names) = once_log(std::fs::read_dir(local_path), "read local pacakge")
+        let Some(package_names) = once_log(std::fs::read_dir(local_path), "read local package")
         else {
             continue;
         };

--- a/crates/tinymist-query/src/syntax/expr.rs
+++ b/crates/tinymist-query/src/syntax/expr.rs
@@ -489,11 +489,11 @@ impl<'a> ExprWorker<'a> {
                             Decl::spread(s.span()).into()
                         };
 
-                        let spreaded = Pattern::Expr(this.check(s.expr())).into();
+                        let spread = Pattern::Expr(this.check(s.expr())).into();
                         if inputs.is_empty() {
-                            spread_left = Some((decl.clone(), spreaded));
+                            spread_left = Some((decl.clone(), spread));
                         } else {
-                            spread_right = Some((decl.clone(), spreaded));
+                            spread_right = Some((decl.clone(), spread));
                         }
 
                         this.resolve_as(Decl::as_def(&decl, None));

--- a/crates/tinymist-query/src/syntax/matcher.rs
+++ b/crates/tinymist-query/src/syntax/matcher.rs
@@ -58,7 +58,7 @@ impl<'a> DecenderItem<'a> {
 }
 
 /// Find the decender nodes starting from the given position.
-pub fn node_decenders<T>(
+pub fn node_descenders<T>(
     node: LinkedNode,
     mut recv: impl FnMut(DecenderItem) -> Option<T>,
 ) -> Option<T> {
@@ -99,7 +99,7 @@ pub fn descending_decls<T>(
     node: LinkedNode,
     mut recv: impl FnMut(DescentDecl) -> Option<T>,
 ) -> Option<T> {
-    node_decenders(node, |node| {
+    node_descenders(node, |node| {
         match (&node, node.node().cast::<ast::Expr>()?) {
             (DecenderItem::Sibling(..), ast::Expr::Let(lb)) => {
                 for ident in lb.kind().bindings() {

--- a/crates/tinymist-render/src/lib.rs
+++ b/crates/tinymist-render/src/lib.rs
@@ -97,7 +97,7 @@ impl PeriscopeRenderer {
         doc: VersionedDocument,
         pos: FramePosition,
     ) -> Option<(String, f32, f32)> {
-        // todo: svg viewer compablity
+        // todo: svg viewer compatibility
         type UsingExporter = SvgExporter<PeriscopeExportFeature>;
         let mut doc = UsingExporter::svg_doc(&doc.document);
         doc.module.prepare_glyphs();

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -49,7 +49,7 @@ struct QueryOpts {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct HiglightRangeOpts {
+struct HighlightRangeOpts {
     range: Option<Range>,
 }
 
@@ -175,7 +175,7 @@ impl LanguageState {
     /// Export a range of the current document as Ansi highlighted text.
     pub fn export_ansi_hl(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
         let path = get_arg!(args[0] as PathBuf);
-        let opts = get_arg_or_default!(args[1] as HiglightRangeOpts);
+        let opts = get_arg_or_default!(args[1] as HighlightRangeOpts);
 
         let s = self
             .query_source(path.into(), Ok)
@@ -211,8 +211,8 @@ impl LanguageState {
     /// Clear all cached resources.
     pub fn clear_cache(&mut self, _arguments: Vec<JsonValue>) -> AnySchedulableResponse {
         comemo::evict(0);
-        for ded in self.servers_mut() {
-            ded.clear_cache();
+        for dead in self.servers_mut() {
+            dead.clear_cache();
         }
         just_ok(JsonValue::Null)
     }
@@ -504,7 +504,7 @@ impl LanguageState {
         run_query!(req_id, self.DocumentMetrics(path))
     }
 
-    /// Get all syntatic labels in workspace.
+    /// Get all syntactic labels in workspace.
     pub fn get_workspace_labels(
         &mut self,
         req_id: RequestId,
@@ -541,7 +541,7 @@ impl LanguageState {
         Err(method_not_found())
     }
 
-    /// Get directory of pacakges
+    /// Get directory of packages
     pub fn resource_package_dirs(&mut self, _arguments: Vec<JsonValue>) -> AnySchedulableResponse {
         let snap = self.primary().snapshot().map_err(z_internal_error)?;
         just_future(async move {
@@ -551,7 +551,7 @@ impl LanguageState {
         })
     }
 
-    /// Get writable directory of pacakges
+    /// Get writable directory of packages
     pub fn resource_local_package_dir(
         &mut self,
         _arguments: Vec<JsonValue>,
@@ -569,7 +569,7 @@ impl LanguageState {
         })
     }
 
-    /// Get writable directory of pacakges
+    /// Get writable directory of packages
     pub fn resource_package_by_ns(
         &mut self,
         mut arguments: Vec<JsonValue>,

--- a/crates/tinymist/src/task/user_action.rs
+++ b/crates/tinymist/src/task/user_action.rs
@@ -331,7 +331,7 @@ pub async fn make_http_server(
     // final_tx.send(()).ok();
 
     tokio::spawn(async move {
-        // timemout alive_rx
+        // timeout alive_rx
         loop {
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -330,7 +330,7 @@ impl PreviewState {
             // The fence must be put after the previewer is initialized.
             compile_handler.flush_compile();
 
-            // Relace the data plane port in the html to self
+            // Replace the data plane port in the html to self
             let frontend_html = frontend_html(TYPST_PREVIEW_HTML, args.preview_mode, "/");
 
             let srv = make_http_server(frontend_html, args.data_plane_host, websocket_tx).await;

--- a/docs/tinymist/feature/preview.typ
+++ b/docs/tinymist/feature/preview.typ
@@ -6,7 +6,7 @@ Two ways of previewing a Typst document are provided:
 - PDF Preview: let lsp export your PDF on typed, and open related PDF by your favorite PDF viewer.
 - Web (SVG) Preview: use builtin preview feature.
 
-Whenever you can get a web preview feature, it is recomended since it is much faster than PDF preview and provides bidirectional navigation feature, allowing jumping between the source code and the preview by clicking or lsp commands.
+Whenever you can get a web preview feature, it is recommended since it is much faster than PDF preview and provides bidirectional navigation feature, allowing jumping between the source code and the preview by clicking or lsp commands.
 
 == PDF Preview
 

--- a/docs/tinymist/frontend/vscode.typ
+++ b/docs/tinymist/frontend/vscode.typ
@@ -164,8 +164,8 @@ Supported arguments:
 - entry file: The last string in the array will be treated as the entry file.
   - This is used to specify the *default* entry file for the compiler, which may be overridden by other settings.
 - `--input`: Add a string key-value pair visible through `sys.inputs`.
-- `--font-path` (environment variable: `TYPST_FONT_PATHS`), Font paths, maybe overriden by `tinymist.fontPaths`.
-- `--ignore-system-fonts`: Ensures system fonts won’t be searched, maybe overriden by `tinymist.systemFonts`.
+- `--font-path` (environment variable: `TYPST_FONT_PATHS`), Font paths, maybe overridden by `tinymist.fontPaths`.
+- `--ignore-system-fonts`: Ensures system fonts won’t be searched, maybe overridden by `tinymist.systemFonts`.
 - `--creation-timestamp` (environment variable: `SOURCE_DATE_EPOCH`): The document’s creation date formatted as a #link("https://reproducible-builds.org/specs/source-date-epoch/")[UNIX timestamp];.
 - `--cert` (environment variable: `TYPST_CERT`): Path to CA certificate file for network access, especially for downloading typst packages.
 

--- a/docs/tinymist/guide/completion.typ
+++ b/docs/tinymist/guide/completion.typ
@@ -15,7 +15,7 @@ LSP will serve completion if you enter _trigger characters_ in the editor. Curre
   If ```js Ctrl+Space``` doesn't work, please check your IME settings or keybindings.
 ]
 
-When an item is selected, it will be commited if some character is typed.
+When an item is selected, it will be committed if some character is typed.
 1. press ```js Esc``` to avoid commit.
 1. press ```js Enter``` to commit one.
 2. press ```js '.'``` to commit one for those that can interact with the dot operator.

--- a/docs/tinymist/inputs.typ
+++ b/docs/tinymist/inputs.typ
@@ -103,4 +103,4 @@ This is handled by tinymist by some tricks.
 
 === Record and Replay
 
-Tinymist can record these input events with assigned the logic ticks. By replaying the events, tinymist can reproduce the server state for debugging. This technique is learnt from the well-known LSP, clangd, and the well known emulator, QEMU.
+Tinymist can record these input events with assigned the logic ticks. By replaying the events, tinymist can reproduce the server state for debugging. This technique is learned from the well-known LSP, clangd, and the well known emulator, QEMU.

--- a/docs/tinymist/module/query.typ
+++ b/docs/tinymist/module/query.typ
@@ -1,6 +1,6 @@
 #import "mod.typ": *
 
-#show: book-page.with(title: "Tinymist Languague Queries")
+#show: book-page.with(title: "Tinymist Language Queries")
 
 == Base Analyses
 
@@ -27,7 +27,7 @@ There are seven basic analyzers:
       node-stroke: 1pt,
       edge-stroke: 1pt,
       // edge("-|>", align(center)[Analysis\ Request], label-pos: 0.1),
-      pg-node((0.3, 0.2), [`Lexical`\ `Heirarchy`]),
+      pg-node((0.3, 0.2), [`Lexical`\ `Hierarchy`]),
       edge("<|-", []),
       pg-node((1.2, 0), [`Source`]),
       edge("-|>", []),
@@ -50,7 +50,7 @@ There are seven basic analyzers:
         let j = 1 + i * 0.25;
         edge((j, 1.4), (j, 1.8), "-|>")
       },
-      pg-node((2, 2.3), [`Extented`\
+      pg-node((2, 2.3), [`Extended`\
       `Language Features`]),
       // for i in (1, 3, 5) {
       //   edge((i, 0), (i, -0.5), (5.5, -0.5), (5.6, 0), "-|>")
@@ -104,7 +104,7 @@ Typicial language features are implemented based on basic analyzers:
 
 - The `textDocument/prepareRename` _finds definition_ and determines whether it can be renamed.
 
-- The `textDocument/rename` _finds defintion and references_ and renamed them all.
+- The `textDocument/rename` _finds definition and references_ and renamed them all.
 
 == Contributing
 

--- a/docs/tinymist/type-system.typ
+++ b/docs/tinymist/type-system.typ
@@ -11,7 +11,7 @@ Some tricks are taken for help reducing the complexity of code:
 First, the array literals are identified as tuple type, that each cell of the array has type individually.
 
 #let sig = $sans("sig")$
-#let ags = $sans("args")$
+#let args = $sans("args")$
 
 Second, the $sig$ and the $sans("argument")$ type are reused frequently.
 
@@ -28,11 +28,11 @@ Second, the $sig$ and the $sans("argument")$ type are reused frequently.
   notated as $sig := sig(sans("tup")(tau_1,..,tau_n),sans("rec")(a_1=tau_(n+1),..,a_m=tau_(n+m)),..sans("arr")(tau_(n+m+1))) arrow psi$
 - the $sans("argument")$ is a $sans("signature")$ without rest and body.
 
-  $ags := ags(sig(..))$
+  $args := args(sig(..))$
 
 With aboving constructors, we soonly get typst's type checker.
 
-- it checks array or dictionary literals by converting them with a corresponding $sig$ and $ags$.
+- it checks array or dictionary literals by converting them with a corresponding $sig$ and $args$.
 - it performs the getting element operation by calls a corresponding $sig$.
 - the closure is converted into a typed lambda, in $sig$ type.
 - the pattern destructing are converted to array and dictionary constrains.

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -843,7 +843,7 @@ These bugs are introduced by [Preparing for parallelizing lsp requests](https://
 ### Misc
 
 * Bumped to typstyle v0.11.14 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/200
-* Preferring less uses of `analzer_expr` during definition analysis in https://github.com/Myriad-Dreamin/tinymist/pull/192
+* Preferring less uses of `analyzer_expr` during definition analysis in https://github.com/Myriad-Dreamin/tinymist/pull/192
 
 **Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.4...v0.11.5
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -164,8 +164,8 @@ Supported arguments:
 - entry file: The last string in the array will be treated as the entry file.
   - This is used to specify the **default** entry file for the compiler, which may be overridden by other settings.
 - `--input`: Add a string key-value pair visible through `sys.inputs`.
-- `--font-path` (environment variable: `TYPST_FONT_PATHS`), Font paths, maybe overriden by `tinymist.fontPaths`.
-- `--ignore-system-fonts`: Ensures system fonts won’t be searched, maybe overriden by `tinymist.systemFonts`.
+- `--font-path` (environment variable: `TYPST_FONT_PATHS`), Font paths, maybe overridden by `tinymist.fontPaths`.
+- `--ignore-system-fonts`: Ensures system fonts won’t be searched, maybe overridden by `tinymist.systemFonts`.
 - `--creation-timestamp` (environment variable: `SOURCE_DATE_EPOCH`): The document’s creation date formatted as a [UNIX timestamp](https://reproducible-builds.org/specs/source-date-epoch/).
 - `--cert` (environment variable: `TYPST_CERT`): Path to CA certificate file for network access, especially for downloading typst packages.
 

--- a/editors/vscode/src/test/e2e/simple-docs.test.ts
+++ b/editors/vscode/src/test/e2e/simple-docs.test.ts
@@ -81,7 +81,7 @@ export async function getTests(ctx: Context) {
           edit.replace(new vscode.Range(0, 0, 0, 0), largeDoc0);
         });
         await ctx.timeout(400);
-        // We add non-atomical edit to test lagged diagnostics
+        // We add non-atomic edit to test lagged diagnostics
         return await mainTyp.edit((edit) => {
           edit.replace(new vscode.Range(0, 0, 0, largeDoc0.length), largeDoc);
         });

--- a/syntaxes/textmate/README.md
+++ b/syntaxes/textmate/README.md
@@ -7,7 +7,7 @@ The syntax highlighting is written in TypeScript, and ensures correct grammar by
 
 ### Building
 
-The following script running the TypeSCript program will generate the TextMate grammar file:
+The following script running the TypeScript program will generate the TextMate grammar file:
 
 ```shell
 yarn compile

--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -193,7 +193,7 @@ export const Summary = () => {
                     style:
                       "height: calc(100% - 20px); box-sizing: border-box; padding-top: 4px",
                   },
-                  fontsExportPannel({
+                  fontsExportPanel({
                     fonts: docMetrics.val.fontInfo,
                     sources: docMetrics.val.spanInfo.sources,
                   })
@@ -302,7 +302,7 @@ export const Summary = () => {
   );
 };
 
-interface fontsExportPannelProps {
+interface fontsExportPanelProps {
   fonts: FontInfo[];
   sources: FontSource[];
 }
@@ -457,7 +457,7 @@ export const fontsExportDefaultConfigure: fontsExportConfigure = {
 
 let savedConfigureData = `:[[preview:FontsExportConfigure]]:`;
 
-const fontsExportPannel = ({ fonts, sources }: fontsExportPannelProps) => {
+const fontsExportPanel = ({ fonts, sources }: fontsExportPanelProps) => {
   const savedConfigure: fontsExportConfigure = savedConfigureData.startsWith(
     ":"
   )

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -341,7 +341,7 @@ export function provideSvgDoc<
       const INNER_RECT_UNIT = 100;
       const INNER_RECT_SCALE = "scale(0.01)";
 
-      /// Caclulate width
+      /// Calculate width
       let maxWidth = 0;
 
       interface SvgPage {
@@ -543,12 +543,12 @@ export function provideSvgDoc<
           );
           pageNumberIndicator.setAttribute("x", "0");
           pageNumberIndicator.setAttribute("y", "0");
-          const pnPaddedX = calculatedPaddedX + pageWidth / 2;
-          const pnPaddedY =
+          const onPaddedX = calculatedPaddedX + pageWidth / 2;
+          const onPaddedY =
             calculatedPaddedY + pageHeight + heightMargin + fontSize / 2;
           pageNumberIndicator.setAttribute(
             "transform",
-            `translate(${pnPaddedX}, ${pnPaddedY})`
+            `translate(${onPaddedX}, ${onPaddedY})`
           );
           pageNumberIndicator.setAttribute("font-size", fontSize.toString());
           pageNumberIndicator.textContent = `${i + 1}`;
@@ -616,7 +616,7 @@ export function provideSvgDoc<
 
         console.assert(
           this.canvasRenderCToken === undefined,
-          "Noo!!: canvasRenderCToken should be undefined"
+          "No!!: canvasRenderCToken should be undefined"
         );
 
         const tok = (this.canvasRenderCToken = new TypstCancellationToken());

--- a/tools/typst-dom/src/typst-outline.mts
+++ b/tools/typst-dom/src/typst-outline.mts
@@ -263,7 +263,7 @@ function patchOutlineChildren(ctx: GenContext, prev: Element, next: Element) {
   const [targetView, toPatch] = interpretTargetView<Element>(
     prev.children as unknown as Element[],
     next.children as unknown as Element[],
-    // todo: accurate calcuation
+    // todo: accurate calculation
     false
   );
 

--- a/tools/typst-dom/src/typst-patch.svg.mts
+++ b/tools/typst-dom/src/typst-patch.svg.mts
@@ -115,7 +115,7 @@ function preReplaceNonSVGElements(
 }
 
 function postReplaceNonSVGElements(prev: Element, frozen: FrozenReplacement) {
-  /// Retrive the `<g>` elements from the `prev` element.
+  /// Retrieve the `<g>` elements from the `prev` element.
   const gElements = Array.from(prev.children).filter(isGElem);
   if (gElements.length + 1 !== frozen.inserts.length) {
     throw new Error(`invalid frozen replacement: gElements.length (${gElements.length
@@ -174,7 +174,7 @@ function initOrPatchSvgHeader(svg: SVGElement) {
     resourceHeader.append(svg.firstElementChild!);
   }
 
-  /// Insert resource header to somewhere visble to the svg element.
+  /// Insert resource header to somewhere visible to the svg element.
   document.body.prepend(resourceHeader);
 }
 

--- a/tools/typst-dom/src/typst-patch.test.mts
+++ b/tools/typst-dom/src/typst-patch.test.mts
@@ -240,7 +240,7 @@ describe("interpretView", () => {
     `);
   });
 
-  it("handleReusePreseveOrder", () => {
+  it("handleReusePreserveOrder", () => {
     const result = indexTargetView([0, 1, 2, 1, 2], [1, 2, 1, 2]);
     expect(toSnapshot(result)).toMatchInlineSnapshot(`
       [
@@ -253,7 +253,7 @@ describe("interpretView", () => {
       ]
     `);
   });
-  it("handleReusePreseveOrder_origin", () => {
+  it("handleReusePreserveOrder_origin", () => {
     const result = indexOriginView([0, 1, 2, 1, 2], [1, 2, 1, 2]);
     expect(toSnapshot([result, []])).toMatchInlineSnapshot(`
       [
@@ -261,7 +261,7 @@ describe("interpretView", () => {
       ]
     `);
   });
-  it("handleReusePreseveOrder2", () => {
+  it("handleReusePreserveOrder2", () => {
     const result = indexTargetView(
       [0, 1, 2, 1, 2, 3, 4, 3, 4],
       [1, 2, 3, 4, 3, 4, 1, 2]
@@ -281,7 +281,7 @@ describe("interpretView", () => {
       ]
     `);
   });
-  it("handleReusePreseveOrder2_origin", () => {
+  it("handleReusePreserveOrder2_origin", () => {
     const result = indexOriginView(
       [0, 1, 2, 1, 2, 3, 4, 3, 4],
       [1, 2, 3, 4, 3, 4, 1, 2]

--- a/tools/typst-preview-frontend/src/ws.ts
+++ b/tools/typst-preview-frontend/src/ws.ts
@@ -19,7 +19,7 @@ export { PreviewMode } from 'typst-dom/typst-doc.mjs';
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
-const NOT_AVAIABLE = "current not avalible";
+const NOT_AVAILABLE = "current not available";
 const COMMA = enc.encode(",");
 export interface WsArgs {
     url: string;
@@ -271,7 +271,7 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
 
         function processMessage(data: ArrayBuffer) {
             if (!(data instanceof ArrayBuffer)) {
-                if (data === NOT_AVAIABLE) {
+                if (data === NOT_AVAILABLE) {
                     return;
                 }
 

--- a/typ/templates/tokyo-night.tmTheme
+++ b/typ/templates/tokyo-night.tmTheme
@@ -196,7 +196,7 @@
         <key>name</key>
         <string>Operator, Misc</string>
         <key>scope</key>
-        <string>keyword.operator,keyword.control.as,keyword.other,keyword.operator.bitwise.shift,punctuation,expression.embbeded.vue punctuation.definition.tag,text.html.twig meta.tag.inline.any.html,meta.tag.template.value.twig meta.function.arguments.twig,meta.directive.vue punctuation.separator.key-value.html,punctuation.definition.constant.markdown,punctuation.definition.string,punctuation.support.type.property-name,text.html.vue-html meta.tag,meta.attribute.directive,punctuation.definition.keyword,punctuation.terminator.rule,punctuation.definition.entity,punctuation.separator.inheritance.php,keyword.other.template,keyword.other.substitution,entity.name.operator,meta.property-list punctuation.separator.key-value,meta.at-rule.mixin punctuation.separator.key-value,meta.at-rule.function variable.parameter.url</string>
+        <string>keyword.operator,keyword.control.as,keyword.other,keyword.operator.bitwise.shift,punctuation,expression.embedded.vue punctuation.definition.tag,text.html.twig meta.tag.inline.any.html,meta.tag.template.value.twig meta.function.arguments.twig,meta.directive.vue punctuation.separator.key-value.html,punctuation.definition.constant.markdown,punctuation.definition.string,punctuation.support.type.property-name,text.html.vue-html meta.tag,meta.attribute.directive,punctuation.definition.keyword,punctuation.terminator.rule,punctuation.definition.entity,punctuation.separator.inheritance.php,keyword.other.template,keyword.other.substitution,entity.name.operator,meta.property-list punctuation.separator.key-value,meta.at-rule.mixin punctuation.separator.key-value,meta.at-rule.function variable.parameter.url</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>
@@ -724,7 +724,7 @@
       </dict>
       <dict>
         <key>name</key>
-        <string>CSS psuedo selectors</string>
+        <string>CSS pseudo selectors</string>
         <key>scope</key>
         <string>entity.other.attribute-name.pseudo-class,entity.other.attribute-name.pseudo-element,entity.other.attribute-name.placeholder,meta.property-list meta.property-value</string>
         <key>settings</key>


### PR DESCRIPTION
- **chore: Add typos configuration to manifest for project level spellchecking**

    This commit just sets the stage with tooling configuration for `typos`, conveniently tucked away in the workspace manifest where other lint configurations already are.

- **chore: Fix typos throughout code base (automatic)**

    This commit has fixes for all the typos that `typos` is confident can just be fixed automatically, minus the overrides added to the manifest for the false positives I found.

- **chore: Fix typos throughout code base (manual)**

    This commit has fixes for just the typos that `typos` was not confident on how to fix but these seem like reasonable resolutions to me.
