### PR TITLE
chore: bump typstyle to v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,13 +5000,15 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e065ac369d7703504b4c5d7ec849ab033f2c55fb616739ef62c67af2f8050c50"
+checksum = "9f0e6fb3386b1068f073d846b71d24ae3cbccb358b8d79f0a9fdd34d16dfe97c"
 dependencies = [
  "anyhow",
+ "ecow 0.2.3",
  "itertools 0.13.0",
  "pretty",
+ "rustc-hash 2.0.0",
  "typst-syntax 0.12.0",
  "vergen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907c3a7195f2e8d421089aab94f79e320400ce20f95e5d035a0ae5ad1c881f13"
+checksum = "e065ac369d7703504b4c5d7ec849ab033f2c55fb616739ef62c67af2f8050c50"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ typst-pdf = "0.12.0"
 typst-syntax = "0.12.0"
 typst-assets = "0.12.0"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
-typstyle = { version = "0.12.2", default-features = false }
+typstyle = { version = "0.12.3", default-features = false }
 typlite = { path = "./crates/typlite" }
 typst-shim = { path = "./crates/typst-shim", features = ["nightly"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ typst-pdf = "0.12.0"
 typst-syntax = "0.12.0"
 typst-assets = "0.12.0"
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt", tag = "0.2.7" }
-typstyle = { version = "0.12.1", default-features = false }
+typstyle = { version = "0.12.2", default-features = false }
 typlite = { path = "./crates/typlite" }
 typst-shim = { path = "./crates/typst-shim", features = ["nightly"] }
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "tinymist" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+* Bumped typstyle to v0.12.3 by @Enter-tainer in https://github.com/Myriad-Dreamin/tinymist/pull/893
+  * Comment formatting and code block formatting is improved. For details, see https://enter-tainer.github.io/typstyle/changelog/#v0122---2024-11-23
+  * Performance is greatly improved. For details, see https://enter-tainer.github.io/typstyle/changelog/#v0124---2024-11-26
+
 ## v0.12.4 - [2024-11-22]
 
 * Updated roadmap (typst v0.13.0+) in https://github.com/Myriad-Dreamin/tinymist/pull/876


### PR DESCRIPTION
This is a massive update. See https://enter-tainer.github.io/typstyle/changelog/#v0122---2024-11-23 . Many thanks for @QuadnucYard !