### PR TITLE
feat: restart server command in vscode

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1020,7 +1020,7 @@
         },
         {
           "command": "tinymist.restartServer",
-          "when": "editorLangId == typst"
+          "when": "ext.tinymistActivated"
         }
       ],
       "editor/title": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -898,6 +898,11 @@
         "icon": "$(list-flat)"
       },
       {
+        "command": "tinymist.restartServer",
+        "title": "Restart server",
+        "category": "Typst"
+      },
+      {
         "command": "tinymist.clearCache",
         "title": "Clear all Cached Resources",
         "category": "Typst"
@@ -1011,6 +1016,10 @@
         },
         {
           "command": "tinymist.clearCache",
+          "when": "editorLangId == typst"
+        },
+        {
+          "command": "tinymist.restartServer",
           "when": "editorLangId == typst"
         }
       ],

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -315,6 +315,10 @@ async function startClient(client: LanguageClient, context: ExtensionContext): P
     commands.registerCommand("tinymist.showPdf", () => commandShow("Pdf")),
     commands.registerCommand("tinymist.getCurrentDocumentMetrics", commandGetCurrentDocumentMetrics),
     commands.registerCommand("tinymist.clearCache", commandClearCache),
+    commands.registerCommand("tinymist.restartServer", async () => {
+      await deactivate();
+      await doActivate(context);
+    }),
     commands.registerCommand("tinymist.runCodeLens", commandRunCodeLens),
     commands.registerCommand("tinymist.showLog", tinymist.showLog),
     commands.registerCommand("tinymist.copyAnsiHighlight", commandCopyAnsiHighlight),

--- a/editors/vscode/src/features/dev-kit.ts
+++ b/editors/vscode/src/features/dev-kit.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 
 export function devKitFeatureActivate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand("setContext", "ext.tinymistDevKit", true);
+  context.subscriptions.push({
+    dispose: () => {
+      vscode.commands.executeCommand("setContext", "ext.tinymistDevKit", false);
+    },
+  });
 
   const devKitProvider = new DevKitViewProvider();
   context.subscriptions.push(

--- a/editors/vscode/src/features/preview-compat.ts
+++ b/editors/vscode/src/features/preview-compat.ts
@@ -100,6 +100,12 @@ export async function getPreviewHtml(context: vscode.ExtensionContext) {
     _previewHtml = html;
   }
 
+  context.subscriptions.push({
+    dispose: () => {
+      _previewHtml = undefined;
+    },
+  });
+
   return html;
 }
 

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -13,13 +13,9 @@ import {
   LaunchInBrowserTask,
   getPreviewHtml as getPreviewHtmlCompat,
 } from "./preview-compat";
-import {
-  commandKillPreview,
-  commandScrollPreview,
-  commandStartPreview,
-  registerPreviewTaskDispose,
-} from "../extension";
+import { commandKillPreview, commandScrollPreview, commandStartPreview } from "../extension";
 import { isGitpod, translateGitpodURL } from "../gitpod";
+import { registerPreviewTaskDispose } from "../lsp";
 
 function translateExternalURL(urlstr: string): string {
   if (isGitpod()) {

--- a/editors/vscode/src/lsp.on-enter.ts
+++ b/editors/vscode/src/lsp.on-enter.ts
@@ -1,9 +1,9 @@
 import * as lc from "vscode-languageclient";
 import * as vscode from "vscode";
-import { client } from "./lsp";
 import { applySnippetTextEdits } from "./snippets";
 import { activeTypstEditor } from "./util";
 import { extensionState } from "./state";
+import { tinymist } from "./lsp";
 
 /**
  * A parameter literal used in requests to pass a text document and a range inside that
@@ -39,6 +39,7 @@ async function handleKeypress() {
 
   const editor = activeTypstEditor();
 
+  const client = tinymist.client;
   if (!editor || !client) return false;
 
   const lcEdits = await client

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -1,35 +1,21 @@
-import * as vscode from "vscode";
-import { LanguageClient, SymbolInformation } from "vscode-languageclient/node";
 import { spawnSync } from "child_process";
 import { resolve } from "path";
 
-export let client: LanguageClient | undefined = undefined;
+import * as vscode from "vscode";
+import { ExtensionMode } from "vscode";
+import {
+  LanguageClient,
+  SymbolInformation,
+  type LanguageClientOptions,
+  type ServerOptions,
+} from "vscode-languageclient/node";
 
-export function setClient(newClient: LanguageClient) {
-  client = newClient;
-  clientPromiseResolve(newClient);
-}
-
-let clientPromiseResolve = (_client: LanguageClient) => {};
-let clientPromise: Promise<LanguageClient> = new Promise((resolve) => {
-  clientPromiseResolve = resolve;
-});
-export async function getClient(): Promise<LanguageClient> {
-  return clientPromise;
-}
-
-export interface PackageInfo {
-  path: string;
-  namespace: string;
-  name: string;
-  version: string;
-}
-
-export interface SymbolInfo {
-  name: string;
-  kind: string;
-  children: SymbolInfo[];
-}
+import { HoverDummyStorage, HoverTmpStorage } from "./features/hover-storage";
+import { extensionState } from "./state";
+import { DisposeList, getSensibleTextEditorColumn, typstDocumentSelector } from "./util";
+import { substVscodeVarsInConfig } from "./config";
+import { wordCountItemProcess } from "./ui-extends";
+import { previewProcessOutline } from "./features/preview";
 
 interface ResourceRoutes {
   "/symbols": any;
@@ -41,37 +27,255 @@ interface ResourceRoutes {
   "/package/docs": string;
 }
 
-export const tinymist = {
-  getClient,
-  probeEnvPath,
-  probePaths,
-  exportPdf: exportCommand("tinymist.exportPdf"),
-  exportSvg: exportCommand("tinymist.exportSvg"),
-  exportPng: exportCommand("tinymist.exportPng"),
-  exportHtml: exportCommand("tinymist.exportHtml"),
-  exportMarkdown: exportCommand("tinymist.exportMarkdown"),
-  exportText: exportCommand("tinymist.exportText"),
-  exportQuery: exportCommand("tinymist.exportQuery"),
-  exportAnsiHighlight: exportCommand("tinymist.exportAnsiHighlight"),
+/// kill the probe task after 60s
+const PROBE_TIMEOUT = 60_000;
+
+class LanguageState {
+  outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel("Tinymist Typst", "log");
+  context: vscode.ExtensionContext = undefined!;
+  client: LanguageClient | undefined = undefined;
+  clientPromiseResolve = (_client: LanguageClient) => {};
+  clientPromise: Promise<LanguageClient> = new Promise((resolve) => {
+    this.clientPromiseResolve = resolve;
+  });
+
+  async stop() {
+    this.clientPromiseResolve = (_client: LanguageClient) => {};
+    this.clientPromise = new Promise((resolve) => {
+      this.clientPromiseResolve = resolve;
+    });
+
+    if (this.client) {
+      await this.client.stop();
+      this.client = undefined;
+    }
+  }
+
+  getClient() {
+    return this.clientPromise;
+  }
+
+  probeEnvPath(configName: string, configPath?: string): string {
+    const isWindows = process.platform === "win32";
+    const binarySuffix = isWindows ? ".exe" : "";
+    const binaryName = "tinymist" + binarySuffix;
+
+    const serverPaths: [string, string][] = configPath
+      ? [[`\`${configName}\` (${configPath})`, configPath as string]]
+      : [
+          ["Bundled", resolve(__dirname, binaryName)],
+          ["In PATH", binaryName],
+        ];
+
+    return tinymist.probePaths(serverPaths);
+  }
+
+  probePaths(paths: [string, string][]): string {
+    const messages = [];
+    for (const [loc, path] of paths) {
+      let messageSuffix;
+      try {
+        const result = spawnSync(path, ["probe"], { timeout: PROBE_TIMEOUT });
+        if (result.status === 0) {
+          return path;
+        }
+
+        const statusMessage = result.status !== null ? [`return status: ${result.status}`] : [];
+        const errorMessage =
+          result.error?.message !== undefined ? [`error: ${result.error.message}`] : [];
+        const messages = [statusMessage, errorMessage];
+        messageSuffix = messages.length !== 0 ? `:\n\t${messages.flat().join("\n\t")}` : "";
+      } catch (e) {
+        if (e instanceof Error) {
+          messageSuffix = `: ${e.message}`;
+        } else {
+          messageSuffix = `: ${JSON.stringify(e)}`;
+        }
+      }
+
+      messages.push([loc, path, `failed to probe${messageSuffix}`]);
+    }
+
+    const infos = messages
+      .map(([loc, path, message]) => `${loc} ('${path}'): ${message}`)
+      .join("\n");
+    throw new Error(`Could not find a valid tinymist binary.\n${infos}`);
+  }
+
+  initClient(config: Record<string, any>) {
+    const context = this.context;
+    const isProdMode = context.extensionMode === ExtensionMode.Production;
+
+    const run = {
+      command: tinymist.probeEnvPath("tinymist.serverPath", config.serverPath),
+      args: [
+        "lsp",
+        /// The `--mirror` flag is only used in development/test mode for testing
+        ...(isProdMode ? [] : ["--mirror", "tinymist-lsp.log"]),
+      ],
+      options: { env: Object.assign({}, process.env, { RUST_BACKTRACE: "1" }) },
+    };
+    // console.log("use arguments", run);
+    const serverOptions: ServerOptions = {
+      run,
+      debug: run,
+    };
+
+    const trustedCommands = {
+      enabledCommands: ["tinymist.openInternal", "tinymist.openExternal"],
+    };
+    const hoverStorage = extensionState.features.renderDocs
+      ? new HoverTmpStorage(context)
+      : new HoverDummyStorage();
+
+    const clientOptions: LanguageClientOptions = {
+      documentSelector: typstDocumentSelector,
+      initializationOptions: config,
+      outputChannel: this.outputChannel,
+      middleware: {
+        workspace: {
+          async configuration(params, token, next) {
+            const items = params.items.map((item) => item.section);
+            const result = await next(params, token);
+            if (!Array.isArray(result)) {
+              return result;
+            }
+            return substVscodeVarsInConfig(items, result);
+          },
+        },
+        provideHover: async (document, position, token, next) => {
+          const hover = await next(document, position, token);
+          if (!hover) {
+            return hover;
+          }
+
+          const hoverHandler = await hoverStorage.startHover();
+
+          for (const content of hover.contents) {
+            if (content instanceof vscode.MarkdownString) {
+              content.isTrusted = trustedCommands;
+              content.supportHtml = true;
+
+              if (context.storageUri) {
+                content.baseUri = vscode.Uri.joinPath(context.storageUri, "tmp/");
+              }
+
+              // outline all data "data:image/svg+xml;base64," to render huge image correctly
+              content.value = content.value.replace(
+                /\"data\:image\/svg\+xml\;base64,([^\"]*)\"/g,
+                (_, content) => hoverHandler.storeImage(content),
+              );
+            }
+          }
+
+          await hoverHandler.finish();
+          return hover;
+        },
+      },
+    };
+
+    const client = (this.client = new LanguageClient(
+      "tinymist",
+      "Tinymist Typst Language Server",
+      serverOptions,
+      clientOptions,
+    ));
+
+    this.clientPromiseResolve(client);
+    return client;
+  }
+
+  async startClient(): Promise<void> {
+    const client = this.client;
+    if (!client) {
+      throw new Error("Language client is not set");
+    }
+
+    client.onNotification("tinymist/compileStatus", (params) => {
+      wordCountItemProcess(params);
+    });
+
+    interface JumpInfo {
+      filepath: string;
+      start: [number, number] | null;
+      end: [number, number] | null;
+    }
+    client.onNotification("tinymist/preview/scrollSource", async (jump: JumpInfo) => {
+      console.log(
+        "recv editorScrollTo request",
+        jump,
+        "active",
+        vscode.window.activeTextEditor !== undefined,
+        "documents",
+        vscode.workspace.textDocuments.map((doc) => doc.uri.fsPath),
+      );
+
+      if (jump.start === null || jump.end === null) {
+        return;
+      }
+
+      // open this file and show in editor
+      const doc =
+        vscode.workspace.textDocuments.find((doc) => doc.uri.fsPath === jump.filepath) ||
+        (await vscode.workspace.openTextDocument(jump.filepath));
+      const editor = await vscode.window.showTextDocument(doc, getSensibleTextEditorColumn());
+      const startPosition = new vscode.Position(jump.start[0], jump.start[1]);
+      const endPosition = new vscode.Position(jump.end[0], jump.end[1]);
+      const range = new vscode.Range(startPosition, endPosition);
+      editor.selection = new vscode.Selection(range.start, range.end);
+      editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+    });
+
+    client.onNotification("tinymist/documentOutline", async (data: any) => {
+      previewProcessOutline(data);
+    });
+
+    client.onNotification("tinymist/preview/dispose", ({ taskId }) => {
+      const dispose = previewDisposes[taskId];
+      if (dispose) {
+        dispose();
+        delete previewDisposes[taskId];
+      } else {
+        console.warn("No dispose function found for task", taskId);
+      }
+    });
+
+    await client.start();
+
+    return;
+  }
+
   async executeCommand<R>(command: string, args: any[]) {
     return await (
-      await getClient()
+      await this.getClient()
     ).sendRequest<R>("workspace/executeCommand", {
       command,
       arguments: args,
     });
-  },
+  }
+
+  exportPdf = exportCommand("tinymist.exportPdf");
+  exportSvg = exportCommand("tinymist.exportSvg");
+  exportPng = exportCommand("tinymist.exportPng");
+  exportHtml = exportCommand("tinymist.exportHtml");
+  exportMarkdown = exportCommand("tinymist.exportMarkdown");
+  exportText = exportCommand("tinymist.exportText");
+  exportQuery = exportCommand("tinymist.exportQuery");
+  exportAnsiHighlight = exportCommand("tinymist.exportAnsiHighlight");
+
   getResource<T extends keyof ResourceRoutes>(path: T, ...args: any[]) {
     return tinymist.executeCommand<ResourceRoutes[T]>("tinymist.getResources", [path, ...args]);
-  },
+  }
+
   getWorkspaceLabels() {
     return tinymist.executeCommand<SymbolInformation[]>("tinymist.getWorkspaceLabels", []);
-  },
+  }
+
   showLog() {
-    if (client) {
-      client.outputChannel.show();
+    if (this.client) {
+      this.client.outputChannel.show();
     }
-  },
+  }
 
   /**
    * The code is borrowed from https://github.com/rust-lang/rust-analyzer/blob/fc98e0657abf3ce07eed513e38274c89bbb2f8ad/editors/code/src/config.ts#L98
@@ -82,7 +286,7 @@ export const tinymist = {
    *
    * [1]: https://github.com/Microsoft/vscode/issues/11514#issuecomment-244707076
    */
-  configureLang: undefined as vscode.Disposable | undefined,
+  configureLang = undefined as vscode.Disposable | undefined;
   configureLanguage(typingContinueCommentsOnNewline: boolean) {
     // Only need to dispose of the config if there's a change
     if (this.configureLang) {
@@ -164,59 +368,37 @@ export const tinymist = {
     this.configureLang = vscode.languages.setLanguageConfiguration("typst", {
       onEnterRules,
     });
-  },
-};
-
-/// kill the probe task after 60s
-const PROBE_TIMEOUT = 60_000;
-
-function probeEnvPath(configName: string, configPath?: string): string {
-  const isWindows = process.platform === "win32";
-  const binarySuffix = isWindows ? ".exe" : "";
-  const binaryName = "tinymist" + binarySuffix;
-
-  const serverPaths: [string, string][] = configPath
-    ? [[`\`${configName}\` (${configPath})`, configPath as string]]
-    : [
-        ["Bundled", resolve(__dirname, binaryName)],
-        ["In PATH", binaryName],
-      ];
-
-  return tinymist.probePaths(serverPaths);
-}
-
-function probePaths(paths: [string, string][]): string {
-  const messages = [];
-  for (const [loc, path] of paths) {
-    let messageSuffix;
-    try {
-      const result = spawnSync(path, ["probe"], { timeout: PROBE_TIMEOUT });
-      if (result.status === 0) {
-        return path;
-      }
-
-      const statusMessage = result.status !== null ? [`return status: ${result.status}`] : [];
-      const errorMessage =
-        result.error?.message !== undefined ? [`error: ${result.error.message}`] : [];
-      const messages = [statusMessage, errorMessage];
-      messageSuffix = messages.length !== 0 ? `:\n\t${messages.flat().join("\n\t")}` : "";
-    } catch (e) {
-      if (e instanceof Error) {
-        messageSuffix = `: ${e.message}`;
-      } else {
-        messageSuffix = `: ${JSON.stringify(e)}`;
-      }
-    }
-
-    messages.push([loc, path, `failed to probe${messageSuffix}`]);
   }
-
-  const infos = messages.map(([loc, path, message]) => `${loc} ('${path}'): ${message}`).join("\n");
-  throw new Error(`Could not find a valid tinymist binary.\n${infos}`);
 }
+
+export const tinymist = new LanguageState();
 
 function exportCommand(command: string) {
   return (uri: string, extraOpts?: any) => {
     return tinymist.executeCommand<string>(command, [uri, ...(extraOpts ? [extraOpts] : [])]);
   };
+}
+
+const previewDisposes: Record<string, () => void> = {};
+export function registerPreviewTaskDispose(taskId: string, dl: DisposeList): void {
+  if (previewDisposes[taskId]) {
+    throw new Error(`Task ${taskId} already exists`);
+  }
+  dl.add(() => {
+    delete previewDisposes[taskId];
+  });
+  previewDisposes[taskId] = () => dl.dispose();
+}
+
+export interface PackageInfo {
+  path: string;
+  namespace: string;
+  name: string;
+  version: string;
+}
+
+export interface SymbolInfo {
+  name: string;
+  kind: string;
+  children: SymbolInfo[];
 }


### PR DESCRIPTION
The upstream bugs might crash the language server in many cases, I feel it a requirement to have an explicit way to restart the language server client in such case.