### PR TITLE
dev: disable all runtime check to `log::debug!`

### DIFF
--- a/crates/tinymist-query/src/analysis/bib.rs
+++ b/crates/tinymist-query/src/analysis/bib.rs
@@ -24,13 +24,13 @@ impl MarkedEventReceiver for YamlBibLoader {
         match event {
             Event::MappingStart(..) => {
                 if self.depth == 1 {
-                    log::debug!("mapping start: {:?} {:?}", self.key, mark.index());
+                    crate::log_debug_ct!("mapping start: {:?} {:?}", self.key, mark.index());
                     self.start = self.key.take();
                 }
                 self.depth += 1;
             }
             Event::Scalar(s, ..) => {
-                log::debug!("scalar: {:?} {:?}", s, mark.index());
+                crate::log_debug_ct!("scalar: {:?} {:?}", s, mark.index());
                 if self.depth == 1 {
                     self.key = Some(BibSpanned {
                         value: s.to_owned(),
@@ -48,7 +48,7 @@ impl MarkedEventReceiver for YamlBibLoader {
                     };
                     let span = start.span.start..end;
                     self.content.push((start, span));
-                    log::debug!("mapping end: {:?} {:?}", self.key, mark.index());
+                    crate::log_debug_ct!("mapping end: {:?} {:?}", self.key, mark.index());
                 }
             }
             _ => {}
@@ -141,7 +141,7 @@ pub(crate) fn analyze_bib(paths: EcoVec<(TypstFileId, Bytes)>) -> Option<Arc<Bib
         worker.analyze_path(path, content);
     }
 
-    log::debug!(
+    crate::log_debug_ct!(
         "bib analysis: {paths:?} -> {entries:?}",
         entries = worker.info.entries
     );

--- a/crates/tinymist-query/src/analysis/definition.rs
+++ b/crates/tinymist-query/src/analysis/definition.rs
@@ -98,7 +98,7 @@ fn find_ident_definition(
         ast::Expr::MathIdent(e) => e.span(),
         ast::Expr::FieldAccess(s) => return find_field_definition(ctx, s),
         _ => {
-            log::debug!("unsupported kind {kind:?}", kind = use_site.kind());
+            crate::log_debug_ct!("unsupported kind {kind:?}", kind = use_site.kind());
             Span::detached()
         }
     };
@@ -109,16 +109,16 @@ fn find_ident_definition(
 fn find_field_definition(ctx: &Arc<SharedContext>, fa: ast::FieldAccess<'_>) -> Option<Definition> {
     let span = fa.span();
     let ty = ctx.type_of_span(span)?;
-    log::debug!("find_field_definition[{span:?}]: {ty:?}");
+    crate::log_debug_ct!("find_field_definition[{span:?}]: {ty:?}");
 
     // todo multiple sources
     let mut srcs = ty.sources();
     srcs.sort();
-    log::debug!("check type signature of ty: {ty:?} => {srcs:?}");
+    crate::log_debug_ct!("check type signature of ty: {ty:?} => {srcs:?}");
     let type_var = srcs.into_iter().next()?;
     match type_var {
         DocSource::Var(v) => {
-            log::debug!("field var: {:?} {:?}", v.def, v.def.span());
+            crate::log_debug_ct!("field var: {:?} {:?}", v.def, v.def.span());
             Some(Definition::new(v.def.clone(), None))
         }
         DocSource::Ins(v) if !v.span().is_detached() => {
@@ -144,7 +144,7 @@ fn find_bib_definition(
     let bib_info = ctx.analyze_bib(bib_elem.span(), bib_paths)?;
 
     let entry = bib_info.entries.get(key)?;
-    log::debug!("find_bib_definition: {key} => {entry:?}");
+    crate::log_debug_ct!("find_bib_definition: {key} => {entry:?}");
 
     // todo: rename with regard to string format: yaml-key/bib etc.
     let decl = Decl::bib_entry(key.into(), entry.file_id, entry.span.clone());
@@ -357,7 +357,7 @@ impl DefResolver {
     }
 
     fn of_expr(&mut self, expr: &Expr, term: Option<&Ty>) -> Option<Definition> {
-        log::debug!("of_expr: {expr:?}");
+        crate::log_debug_ct!("of_expr: {expr:?}");
 
         match expr {
             Expr::Decl(decl) => self.of_decl(decl, term),
@@ -367,7 +367,7 @@ impl DefResolver {
     }
 
     fn of_term(&mut self, term: &Ty) -> Option<Definition> {
-        log::debug!("of_term: {term:?}");
+        crate::log_debug_ct!("of_term: {term:?}");
 
         // Get the type of the type node
         let better_def = match term {
@@ -385,7 +385,7 @@ impl DefResolver {
     }
 
     fn of_decl(&mut self, decl: &Interned<Decl>, term: Option<&Ty>) -> Option<Definition> {
-        log::debug!("of_decl: {decl:?}");
+        crate::log_debug_ct!("of_decl: {decl:?}");
 
         // todo:
         match decl.as_ref() {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -754,12 +754,12 @@ impl SharedContext {
     }
 
     pub(crate) fn type_of_func(self: &Arc<Self>, func: Func) -> Signature {
-        log::debug!("convert runtime func {func:?}");
+        crate::log_debug_ct!("convert runtime func {func:?}");
         analyze_signature(self, SignatureTarget::Convert(func)).unwrap()
     }
 
     pub(crate) fn type_of_value(self: &Arc<Self>, val: &Value) -> Ty {
-        log::debug!("convert runtime value {val:?}");
+        crate::log_debug_ct!("convert runtime value {val:?}");
 
         // todo: check performance on peeking signature source frequently
         let cache_key = val;
@@ -832,7 +832,7 @@ impl SharedContext {
     }
 
     pub(crate) fn sig_of_def(self: &Arc<Self>, def: Definition) -> Option<Signature> {
-        log::debug!("check definition func {def:?}");
+        crate::log_debug_ct!("check definition func {def:?}");
         let source = def.decl.file_id().and_then(|f| self.source_by_id(f).ok());
         analyze_signature(self, SignatureTarget::Def(source, def))
     }
@@ -961,19 +961,19 @@ impl SharedContext {
     /// Check on a module before really needing them. But we likely use them
     /// after a while.
     pub(crate) fn prefetch_type_check(self: &Arc<Self>, _fid: TypstFileId) {
-        // log::debug!("prefetch type check {fid:?}");
+        // crate::log_debug_ct!("prefetch type check {fid:?}");
         // let this = self.clone();
         // rayon::spawn(move || {
         //     let Some(source) = this.world.source(fid).ok() else {
         //         return;
         //     };
         //     this.type_check(&source);
-        //     // log::debug!("prefetch type check end {fid:?}");
+        //     // crate::log_debug_ct!("prefetch type check end {fid:?}");
         // });
     }
 
     pub(crate) fn preload_package(self: Arc<Self>, entry_point: TypstFileId) {
-        log::debug!("preload package start {entry_point:?}");
+        crate::log_debug_ct!("preload package start {entry_point:?}");
 
         #[derive(Clone)]
         struct Preloader {
@@ -983,7 +983,7 @@ impl SharedContext {
 
         impl Preloader {
             fn work(&self, fid: TypstFileId) {
-                log::debug!("preload package {fid:?}");
+                crate::log_debug_ct!("preload package {fid:?}");
                 let source = self.shared.source_by_id(fid).ok().unwrap();
                 let expr = self.shared.expr_stage(&source);
                 self.shared.type_check(&source);

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -31,7 +31,7 @@ struct SignatureReceiver {
 
 impl SignatureReceiver {
     fn insert(&mut self, ty: Ty, pol: bool) {
-        log::debug!("post check receive: {ty:?}");
+        crate::log_debug_ct!("post check receive: {ty:?}");
         if !pol {
             if self.lbs_dedup.insert(ty.clone()) {
                 self.bounds.lbs.push(ty);
@@ -172,7 +172,7 @@ impl<'a> PostTypeChecker<'a> {
 
     fn check_(&mut self, node: &LinkedNode) -> Option<Ty> {
         let context = node.parent()?;
-        log::debug!("post check: {:?}::{:?}", context.kind(), node.kind());
+        crate::log_debug_ct!("post check: {:?}::{:?}", context.kind(), node.kind());
 
         let context_ty = self.check_context(context, node);
         let self_ty = if !matches!(node.kind(), SyntaxKind::Label | SyntaxKind::Ref) {
@@ -182,7 +182,7 @@ impl<'a> PostTypeChecker<'a> {
         };
 
         let contextual_self_ty = self.check_target(get_check_target(node.clone()), context_ty);
-        log::debug!(
+        crate::log_debug_ct!(
             "post check(res): {:?}::{:?} -> {self_ty:?}, {contextual_self_ty:?}",
             context.kind(),
             node.kind(),
@@ -207,7 +207,7 @@ impl<'a> PostTypeChecker<'a> {
         let Some(node) = node else {
             return context_ty;
         };
-        log::debug!("post check target: {node:?}");
+        crate::log_debug_ct!("post check target: {node:?}");
 
         match node {
             CheckTarget::Param {
@@ -217,10 +217,12 @@ impl<'a> PostTypeChecker<'a> {
                 is_set,
             } => {
                 let callee = self.check_context_or(&callee, context_ty)?;
-                log::debug!("post check call target: ({callee:?})::{target:?} is_set: {is_set}");
+                crate::log_debug_ct!(
+                    "post check call target: ({callee:?})::{target:?} is_set: {is_set}"
+                );
 
                 let sig = self.ctx.sig_of_type(self.info, callee)?;
-                log::debug!("post check call sig: {target:?} {sig:?}");
+                crate::log_debug_ct!("post check call sig: {target:?} {sig:?}");
                 let mut resp = SignatureReceiver::default();
 
                 match &target {
@@ -261,12 +263,12 @@ impl<'a> PostTypeChecker<'a> {
                     }
                 }
 
-                log::debug!("post check target iterated: {:?}", resp.bounds);
+                crate::log_debug_ct!("post check target iterated: {:?}", resp.bounds);
                 Some(resp.finalize())
             }
             CheckTarget::Element { container, target } => {
                 let container_ty = self.check_context_or(&container, context_ty)?;
-                log::debug!("post check element target: ({container_ty:?})::{target:?}");
+                crate::log_debug_ct!("post check element target: ({container_ty:?})::{target:?}");
 
                 let mut resp = SignatureReceiver::default();
 
@@ -277,7 +279,7 @@ impl<'a> PostTypeChecker<'a> {
                     &mut check_signature(&mut resp, &target),
                 );
 
-                log::debug!("post check target iterated: {:?}", resp.bounds);
+                crate::log_debug_ct!("post check target iterated: {:?}", resp.bounds);
                 Some(resp.finalize())
             }
             CheckTarget::Paren {
@@ -285,7 +287,7 @@ impl<'a> PostTypeChecker<'a> {
                 is_before,
             } => {
                 let container_ty = self.check_context_or(&container, context_ty)?;
-                log::debug!("post check paren target: {container_ty:?}::{is_before:?}");
+                crate::log_debug_ct!("post check paren target: {container_ty:?}::{is_before:?}");
 
                 let mut resp = SignatureReceiver::default();
                 // todo: this is legal, but it makes it sometimes complete itself.
@@ -300,12 +302,12 @@ impl<'a> PostTypeChecker<'a> {
                     &mut check_signature(&mut resp, &target),
                 );
 
-                log::debug!("post check target iterated: {:?}", resp.bounds);
+                crate::log_debug_ct!("post check target iterated: {:?}", resp.bounds);
                 Some(resp.finalize())
             }
             CheckTarget::Normal(target) => {
                 let ty = self.check_context_or(&target, context_ty)?;
-                log::debug!("post check target normal: {ty:?}");
+                crate::log_debug_ct!("post check target normal: {ty:?}");
                 Some(ty)
             }
         }

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -179,7 +179,7 @@ pub(crate) fn analyze_signature(
     callee_node: SignatureTarget,
 ) -> Option<Signature> {
     ctx.compute_signature(callee_node.clone(), move |ctx| {
-        log::debug!("analyzing signature for {callee_node:?}");
+        crate::log_debug_ct!("analyzing signature for {callee_node:?}");
         analyze_type_signature(ctx, &callee_node)
             .or_else(|| analyze_dyn_signature(ctx, &callee_node))
     })
@@ -223,7 +223,7 @@ pub(crate) fn sig_of_type(
     // todo multiple sources
     let mut srcs = ty.sources();
     srcs.sort();
-    log::debug!("check type signature of ty: {ty:?} => {srcs:?}");
+    crate::log_debug_ct!("check type signature of ty: {ty:?} => {srcs:?}");
     let type_var = srcs.into_iter().next()?;
     match type_var {
         DocSource::Var(v) => {
@@ -384,7 +384,7 @@ struct AliasStackChecker<'a, 'b> {
 
 impl BoundChecker for AliasStackChecker<'_, '_> {
     fn check_var(&mut self, u: &Interned<TypeVar>, pol: bool) {
-        log::debug!("collecting var {u:?} {pol:?}");
+        crate::log_debug_ct!("collecting var {u:?} {pol:?}");
         if self.res.is_some() {
             return;
         }
@@ -396,7 +396,7 @@ impl BoundChecker for AliasStackChecker<'_, '_> {
 
         let docs = self.ctx.info.var_docs.get(&u.def).map(|x| x.as_ref());
 
-        log::debug!("collecting var {u:?} {pol:?} => {docs:?}");
+        crate::log_debug_ct!("collecting var {u:?} {pol:?} => {docs:?}");
         // todo: bind builtin functions
         match docs {
             Some(UntypedDefDocs::Function(sig)) => {
@@ -420,7 +420,7 @@ impl BoundChecker for AliasStackChecker<'_, '_> {
 
         match (self.checking_with, ty) {
             (true, Ty::With(w)) => {
-                log::debug!("collecting with {ty:?} {pol:?}");
+                crate::log_debug_ct!("collecting with {ty:?} {pol:?}");
                 self.stack.last_mut().unwrap().1 = Some(w.clone());
                 self.checking_with = false;
                 w.sig.bounds(pol, self);

--- a/crates/tinymist-query/src/analysis/tyck.rs
+++ b/crates/tinymist-query/src/analysis/tyck.rs
@@ -10,7 +10,6 @@ use super::{
     TypeVarBounds,
 };
 use crate::{
-    log_never,
     syntax::{Decl, DeclExpr, Expr, ExprInfo, UnaryOp},
     ty::*,
 };
@@ -70,7 +69,7 @@ pub(crate) fn type_check(
     checker.info.exports = exports;
 
     let elapsed = type_check_start.elapsed();
-    log::debug!("Type checking on {:?} took {elapsed:?}", checker.ei.fid);
+    crate::log_debug_ct!("Type checking on {:?} took {elapsed:?}", checker.ei.fid);
 
     checker.env.visiting.remove(&checker.ei.fid);
 
@@ -161,7 +160,7 @@ impl TypeChecker<'_> {
         let mut gen_var = var.as_ref().clone();
         let encoded = Interned::new(Decl::docs(base.clone(), var.clone()));
         gen_var.def = encoded.clone();
-        log::debug!("copy var {fr:?} as {encoded:?}");
+        crate::log_debug_ct!("copy var {fr:?} as {encoded:?}");
         let bounds = TypeVarBounds::new(gen_var, fr.bounds.bounds().read().clone());
         let var = bounds.as_type();
         self.info.vars.insert(encoded, bounds);
@@ -169,7 +168,7 @@ impl TypeChecker<'_> {
     }
 
     fn get_var(&mut self, decl: &DeclExpr) -> Interned<TypeVar> {
-        log::debug!("get_var {decl:?}");
+        crate::log_debug_ct!("get_var {decl:?}");
         let entry = self.info.vars.entry(decl.clone()).or_insert_with(|| {
             let name = decl.name().clone();
             let decl = decl.clone();
@@ -180,7 +179,7 @@ impl TypeChecker<'_> {
                     return None;
                 }
 
-                log::debug!("import_ty {name} from {fid:?}");
+                crate::log_debug_ct!("import_ty {name} from {fid:?}");
 
                 let ext_def_use_info = self.ctx.expr_stage_by_id(fid)?;
                 let source = &ext_def_use_info.source;
@@ -279,7 +278,7 @@ impl TypeChecker<'_> {
                 let _ = w.def;
             }
             (Ty::Var(v), rhs) => {
-                log_never!("constrain var {v:?} ⪯ {rhs:?}");
+                crate::log_debug_ct!("constrain var {v:?} ⪯ {rhs:?}");
                 let w = self.info.vars.get_mut(&v.def).unwrap();
                 // strict constraint on upper bound
                 let bound = rhs.clone();
@@ -293,7 +292,7 @@ impl TypeChecker<'_> {
             (lhs, Ty::Var(v)) => {
                 let w = self.info.vars.get(&v.def).unwrap();
                 let bound = self.weaken_constraint(lhs, &w.bounds);
-                log_never!("constrain var {v:?} ⪰ {bound:?}");
+                crate::log_debug_ct!("constrain var {v:?} ⪰ {bound:?}");
                 match &w.bounds {
                     FlowVarKind::Strong(v) | FlowVarKind::Weak(v) => {
                         let mut v = v.write();
@@ -365,7 +364,7 @@ impl TypeChecker<'_> {
             }
             (Ty::Dict(lhs), Ty::Dict(rhs)) => {
                 for (key, lhs, rhs) in lhs.common_iface_fields(rhs) {
-                    log_never!("constrain record item {key} {lhs:?} ⪯ {rhs:?}");
+                    crate::log_debug_ct!("constrain record item {key} {lhs:?} ⪯ {rhs:?}");
                     self.constrain(lhs, rhs);
                     // if !sl.is_detached() {
                     //     self.info.witness_at_most(*sl, rhs.clone());
@@ -381,32 +380,32 @@ impl TypeChecker<'_> {
                 self.constrain(&lhs.lhs, &rhs.lhs);
             }
             (Ty::Unary(lhs), rhs) if lhs.op == UnaryOp::TypeOf && is_ty(rhs) => {
-                log_never!("constrain type of {lhs:?} ⪯ {rhs:?}");
+                crate::log_debug_ct!("constrain type of {lhs:?} ⪯ {rhs:?}");
 
                 self.constrain(&lhs.lhs, rhs);
             }
             (lhs, Ty::Unary(rhs)) if rhs.op == UnaryOp::TypeOf && is_ty(lhs) => {
-                log_never!(
+                crate::log_debug_ct!(
                     "constrain type of {lhs:?} ⪯ {rhs:?} {:?}",
-                    matches!(lhs, Ty::Builtin(..))
+                    matches!(lhs, Ty::Builtin(..)),
                 );
                 self.constrain(lhs, &rhs.lhs);
             }
             (Ty::Value(lhs), rhs) => {
-                log_never!("constrain value {lhs:?} ⪯ {rhs:?}");
+                crate::log_debug_ct!("constrain value {lhs:?} ⪯ {rhs:?}");
                 let _ = TypeScheme::witness_at_most;
                 // if !lhs.1.is_detached() {
                 //     self.info.witness_at_most(lhs.1, rhs.clone());
                 // }
             }
             (lhs, Ty::Value(rhs)) => {
-                log_never!("constrain value {lhs:?} ⪯ {rhs:?}");
+                crate::log_debug_ct!("constrain value {lhs:?} ⪯ {rhs:?}");
                 // if !rhs.1.is_detached() {
                 //     self.info.witness_at_least(rhs.1, lhs.clone());
                 // }
             }
             _ => {
-                log_never!("constrain {lhs:?} ⪯ {rhs:?}");
+                crate::log_debug_ct!("constrain {lhs:?} ⪯ {rhs:?}");
             }
         }
     }
@@ -531,7 +530,7 @@ struct Joiner {
 }
 impl Joiner {
     fn finalize(self) -> Ty {
-        log::debug!("join: {:?} {:?}", self.possibles, self.definite);
+        crate::log_debug_ct!("join: {:?} {:?}", self.possibles, self.definite);
         if self.possibles.is_empty() {
             return self.definite;
         }
@@ -544,7 +543,7 @@ impl Joiner {
         //     definite = definite.join(p);
         // }
 
-        // log::debug!("possibles: {:?} {:?}", self.definite, self.possibles);
+        // crate::log_debug_ct!("possibles: {:?} {:?}", self.definite, self.possibles);
 
         Ty::Any
     }

--- a/crates/tinymist-query/src/analysis/tyck/apply.rs
+++ b/crates/tinymist-query/src/analysis/tyck/apply.rs
@@ -40,7 +40,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
             Sig::Builtin(BuiltinSig::TupleMap(this)) => {
                 if let Some(p0) = args.pos(0) {
                     let mut resultants = vec![];
-                    log::debug!("syntax check tuple map {this:?} {p0:?}");
+                    crate::log_debug_ct!("syntax check tuple map {this:?} {p0:?}");
                     let mut mapper = |base: &mut TypeChecker, sig: Sig<'_>, _pol| {
                         resultants.push(Ty::Any);
 
@@ -49,7 +49,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                                 let res = cons
                                     .iter()
                                     .map(|elem| {
-                                        log::debug!(
+                                        crate::log_debug_ct!(
                                             "tuple map check on tuple elem: {elem:?} {p0:?}"
                                         );
                                         let args = ArgsTy::unary(elem.clone(), Ty::Any);
@@ -66,7 +66,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                                 self.resultant.push(Ty::Tuple(res.into()));
                             }
                             Sig::ArrayCons(elem) => {
-                                log::debug!("array map check on array: {elem:?} {p0:?}");
+                                crate::log_debug_ct!("array map check on array: {elem:?} {p0:?}");
                                 let args = ArgsTy::unary(elem.as_ref().clone(), Ty::Any);
                                 let mut mapper = ApplyTypeChecker {
                                     base,
@@ -86,13 +86,13 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                         driver: &mut mapper,
                     };
                     this.tuple_element_of(pol, &mut worker);
-                    log::debug!("resultant: {resultants:?}");
+                    crate::log_debug_ct!("resultant: {resultants:?}");
                 }
             }
             Sig::Builtin(BuiltinSig::TupleAt(this)) => {
                 if let Some(p0) = args.pos(0) {
                     let mut resultants = vec![];
-                    log::debug!("syntax check tuple at {this:?} {p0:?}");
+                    crate::log_debug_ct!("syntax check tuple at {this:?} {p0:?}");
 
                     // todo: caster
                     let selector = match p0 {
@@ -109,7 +109,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
 
                         match sig {
                             Sig::TupleCons(cons) => {
-                                log::debug!("tuple at check on tuple elem: {cons:?} {p0:?}");
+                                crate::log_debug_ct!("tuple at check on tuple elem: {cons:?} {p0:?}");
                                 let sel = match selector {
                                     Ok(i) => cons.get(i).cloned(),
                                     Err(_) => None,
@@ -120,7 +120,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                                 self.resultant.push(res);
                             }
                             Sig::ArrayCons(elem) => {
-                                log::debug!("array at check on array: {elem:?} {p0:?}");
+                                crate::log_debug_ct!("array at check on array: {elem:?} {p0:?}");
                                 self.resultant.push(elem.as_ref().clone());
                             }
                             _ => {}
@@ -131,7 +131,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                         driver: &mut mapper,
                     };
                     this.tuple_element_of(pol, &mut worker);
-                    log::debug!("resultant: {resultants:?}");
+                    crate::log_debug_ct!("resultant: {resultants:?}");
                 }
             }
             _ => {}
@@ -149,7 +149,7 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
         }
 
         if is_partialize {
-            log::debug!("Partialize location {sig:?} a.k.a {callee:?}");
+            crate::log_debug_ct!("Partialize location {sig:?} a.k.a {callee:?}");
             if let Some(Ty::Select(call_raw_for_with)) = self.call_raw_for_with.take() {
                 self.resultant.push(Ty::With(SigWithTy::new(
                     call_raw_for_with.ty.clone(),

--- a/crates/tinymist-query/src/analysis/tyck/select.rs
+++ b/crates/tinymist-query/src/analysis/tyck/select.rs
@@ -12,14 +12,14 @@ pub struct SelectFieldChecker<'a, 'b> {
 
 impl SelectChecker for SelectFieldChecker<'_, '_> {
     fn select(&mut self, iface: Iface, key: &Interned<str>, pol: bool) {
-        log::debug!("selecting field: {iface:?} {key:?}");
+        crate::log_debug_ct!("selecting field: {iface:?} {key:?}");
         let _ = pol;
 
         let Some(res) = iface.select(self.base, key) else {
             return;
         };
 
-        log::debug!("selecting field real: {key:?} -> {res:?}");
+        crate::log_debug_ct!("selecting field real: {key:?} -> {res:?}");
         self.resultant.push(res.clone());
     }
 }

--- a/crates/tinymist-query/src/analysis/tyck/syntax.rs
+++ b/crates/tinymist-query/src/analysis/tyck/syntax.rs
@@ -334,7 +334,7 @@ impl TypeChecker<'_> {
         let select_site = select.span;
         let ty = self.check(&select.lhs);
         let field = select.key.name().clone();
-        log::debug!("field access: {select:?}[{select_site:?}] => {ty:?}.{field:?}");
+        crate::log_debug_ct!("field access: {select:?}[{select_site:?}] => {ty:?}.{field:?}");
 
         // todo: move this to base
         let base = Ty::Select(SelectTy::new(ty.clone().into(), field.clone()));
@@ -352,7 +352,7 @@ impl TypeChecker<'_> {
         let args = self.check(&apply.args);
         let callee = self.check(&apply.callee);
 
-        log::debug!("func_call: {callee:?} with {args:?}");
+        crate::log_debug_ct!("func_call: {callee:?} with {args:?}");
 
         if let Ty::Args(args) = args {
             let mut worker = ApplyTypeChecker {
@@ -377,7 +377,7 @@ impl TypeChecker<'_> {
         let docstring = self.check_docstring(&def_id);
         let docstring = docstring.as_deref().unwrap_or(&EMPTY_DOCSTRING);
 
-        log::debug!("check closure: {func:?} with docs {docstring:#?}");
+        crate::log_debug_ct!("check closure: {func:?} with docs {docstring:#?}");
 
         let (sig, defaults) = self.check_pattern_sig(Some(&def_id), &func.params, docstring);
 
@@ -447,7 +447,7 @@ impl TypeChecker<'_> {
         let args = self.check(&set.args);
         let _cond = set.cond.as_ref().map(|cond| self.check(cond));
 
-        log::debug!("set rule: {callee:?} with {args:?}");
+        crate::log_debug_ct!("set rule: {callee:?} with {args:?}");
 
         if let Ty::Args(args) = args {
             let mut worker = ApplyTypeChecker {

--- a/crates/tinymist-query/src/completion.rs
+++ b/crates/tinymist-query/src/completion.rs
@@ -150,7 +150,7 @@ impl StatefulRequest for CompletionRequest {
                     let ty_chk = ctx.type_check(&source);
 
                     let ty = ty_chk.type_of_span(cano_expr.span());
-                    log::debug!("check string ty: {ty:?}");
+                    crate::log_debug_ct!("check string ty: {ty:?}");
                     if let Some(Ty::Builtin(BuiltinTy::Path(path_filter))) = ty {
                         completion_result =
                             complete_path(ctx, Some(cano_expr), &source, cursor, &path_filter);

--- a/crates/tinymist-query/src/docs/module.rs
+++ b/crates/tinymist-query/src/docs/module.rs
@@ -54,7 +54,7 @@ pub fn module_docs(ctx: &mut LocalContext, entry_point: FileId) -> StrResult<Pac
         })
         .collect();
 
-    log::debug!("module_uses: {module_uses:#?}",);
+    crate::log_debug_ct!("module_uses: {module_uses:#?}",);
 
     defs.children.extend(extras);
 
@@ -184,11 +184,11 @@ impl ScanDefCtx<'_> {
                 aliases_vec.push(path.iter().join("."));
 
                 if !is_fresh {
-                    log::debug!("found module: {path:?} (reexport)");
+                    crate::log_debug_ct!("found module: {path:?} (reexport)");
                     return None;
                 }
 
-                log::debug!("found module: {path:?}");
+                crate::log_debug_ct!("found module: {path:?}");
 
                 let ei = self.ctx.expr_stage_by_id(fid)?;
 
@@ -239,7 +239,7 @@ impl ScanDefCtx<'_> {
                     path.push("-");
                     path.push(key);
 
-                    log::debug!("found internal module: {path:?}");
+                    crate::log_debug_ct!("found internal module: {path:?}");
                     if let Some(m) = src {
                         let msym = self.defs(path, m);
                         self.extras.push(msym)

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -28,7 +28,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Str
 
     let PackageDefInfo { root, module_uses } = module_docs(ctx, entry_point)?;
 
-    log::debug!("module_uses: {module_uses:#?}");
+    crate::log_debug_ct!("module_uses: {module_uses:#?}");
 
     let title = for_spec.to_string();
 
@@ -86,7 +86,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Str
                 let _ = writeln!(md, "---\n## Module: {primary}");
             }
 
-            log::debug!("module: {primary} -- {parent_ident}");
+            crate::log_debug_ct!("module: {primary} -- {parent_ident}");
 
             let persist_fid = fid.map(|f| file_ids.insert_full(f).0);
 
@@ -228,7 +228,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Str
                 }
 
                 if !child_children.is_empty() {
-                    log::debug!("sub_fid: {child_fid:?}");
+                    crate::log_debug_ct!("sub_fid: {child_fid:?}");
                     match child_fid {
                         Some(fid) => {
                             let aka = akas(fid);

--- a/crates/tinymist-query/src/document_highlight.rs
+++ b/crates/tinymist-query/src/document_highlight.rs
@@ -132,7 +132,7 @@ impl<'a> DocumentHighlightWorker<'a> {
         self.check_children(loop_node);
         self.check(Self::check_loop);
 
-        log::debug!("highlights: {:?}", self.highlights);
+        crate::log_debug_ct!("highlights: {:?}", self.highlights);
         self.finish()
     }
 }

--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -48,7 +48,7 @@ impl StatefulRequest for GotoDefinitionRequest {
             target_selection_range: range,
         }]));
 
-        log::debug!("goto_definition: {fid:?} {res:?}");
+        crate::log_debug_ct!("goto_definition: {fid:?} {res:?}");
         res
     }
 }

--- a/crates/tinymist-query/src/inlay_hint.rs
+++ b/crates/tinymist-query/src/inlay_hint.rs
@@ -65,14 +65,14 @@ impl SemanticRequest for InlayHintRequest {
         let range = ctx.to_typst_range(self.range, &source)?;
 
         let hints = inlay_hint(ctx, &source, range, ctx.position_encoding()).ok()?;
-        log::debug!(
+        crate::log_debug_ct!(
             "got inlay hints on {source:?} => {hints:?}",
             source = source.id(),
             hints = hints.len()
         );
         if hints.is_empty() {
             let root = LinkedNode::new(source.root());
-            log::debug!("debug root {root:#?}");
+            crate::log_debug_ct!("debug root {root:#?}");
         }
 
         Some(hints)
@@ -132,7 +132,7 @@ fn inlay_hint(
                 SyntaxKind::FuncCall => {
                     log::trace!("func call found: {:?}", node);
                     let call_info = analyze_call(self.ctx, self.source.clone(), node.clone())?;
-                    log::debug!("got call_info {call_info:?}");
+                    crate::log_debug_ct!("got call_info {call_info:?}");
 
                     let f = node.cast::<ast::FuncCall>().unwrap();
                     let args = f.args();

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -136,7 +136,7 @@ pub trait StatefulRequest {
 
 /// Completely disabled log
 #[macro_export]
-macro_rules! log_never {
+macro_rules! log_debug_ct {
     // debug!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // debug!(target: "my_target", "a {} event", "log")
     (target: $target:expr, $($arg:tt)+) => {

--- a/crates/tinymist-query/src/prepare_rename.rs
+++ b/crates/tinymist-query/src/prepare_rename.rs
@@ -3,7 +3,6 @@ use crate::{
     prelude::*,
     syntax::{Decl, DerefTarget},
 };
-use log::debug;
 
 /// The [`textDocument/prepareRename`] request is sent from the client to the
 /// server to setup and test the validity of a rename operation at a given
@@ -67,16 +66,16 @@ pub(crate) fn prepare_renaming(
     let (def_fid, _def_range) = def.def_at(ctx.shared()).clone()?;
 
     if def_fid.package().is_some() {
-        debug!(
+        crate::log_debug_ct!(
             "prepare_rename: {name} is in a package {pkg:?}",
-            pkg = def_fid.package()
+            pkg = def_fid.package(),
         );
         return None;
     }
 
     let var_rename = || Some((name.to_string(), None));
 
-    log::debug!("prepare_rename: {name}");
+    crate::log_debug_ct!("prepare_rename: {name}");
     use Decl::*;
     match def.decl.as_ref() {
         // Cannot rename headings or blocks

--- a/crates/tinymist-query/src/references.rs
+++ b/crates/tinymist-query/src/references.rs
@@ -1,6 +1,5 @@
 use std::sync::OnceLock;
 
-use log::debug;
 use typst::syntax::Span;
 
 use crate::{
@@ -36,7 +35,7 @@ impl StatefulRequest for ReferencesRequest {
 
         let locations = find_references(ctx, &source, doc.as_ref(), deref_target)?;
 
-        debug!("references: {locations:?}");
+        crate::log_debug_ct!("references: {locations:?}");
         Some(locations)
     }
 }

--- a/crates/tinymist-query/src/rename.rs
+++ b/crates/tinymist-query/src/rename.rs
@@ -239,7 +239,7 @@ impl RenameFileWorker<'_> {
         if importing.map_or(true, |i| i != self.def_fid) {
             return None;
         }
-        log::debug!("import: {span:?} -> {importing:?} v.s. {:?}", self.def_fid);
+        crate::log_debug_ct!("import: {span:?} -> {importing:?} v.s. {:?}", self.def_fid);
         // rename_importer(self.ctx, &ref_src, *span, &self.diff, edits);
 
         let root = LinkedNode::new(src.root());

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -41,7 +41,7 @@ impl SemanticRequest for SignatureHelpRequest {
         let deref_target = get_deref_target(callee, cursor)?;
         let def = ctx.def_of_syntax(&source, None, deref_target)?;
         let sig = ctx.sig_of_def(def.clone())?;
-        log::debug!("got signature {sig:?}");
+        crate::log_debug_ct!("got signature {sig:?}");
 
         let param_shift = sig.param_shift();
         let mut active_parameter = None;

--- a/crates/tinymist-query/src/syntax/comment.rs
+++ b/crates/tinymist-query/src/syntax/comment.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 pub fn find_module_level_docs(src: &Source) -> Option<String> {
-    log::debug!("finding docs at: {id:?}", id = src.id());
+    crate::log_debug_ct!("finding docs at: {id:?}", id = src.id());
 
     let root = LinkedNode::new(src.root());
     for n in root.children() {
@@ -34,7 +34,7 @@ fn extract_mod_docs_between(
             break 'scan_comments;
         }
 
-        log::debug!("found comment for docs: {:?}: {:?}", n.kind(), n.text());
+        crate::log_debug_ct!("found comment for docs: {:?}: {:?}", n.kind(), n.text());
         if matcher.process(n.get()) {
             if first_group {
                 break 'scan_comments;

--- a/crates/tinymist-query/src/syntax/def.rs
+++ b/crates/tinymist-query/src/syntax/def.rs
@@ -120,7 +120,7 @@ impl ExprScope {
     pub fn get(&self, name: &Interned<str>) -> (Option<Expr>, Option<Ty>) {
         let (of, val) = match self {
             ExprScope::Lexical(scope) => {
-                log::debug!("evaluating: {name:?} in {scope:?}");
+                crate::log_debug_ct!("evaluating: {name:?} in {scope:?}");
                 (scope.get(name).cloned(), None)
             }
             ExprScope::Module(module) => {
@@ -148,7 +148,7 @@ impl ExprScope {
                 }
             }
             ExprScope::Module(module) => {
-                log::debug!("imported: {module:?}");
+                crate::log_debug_ct!("imported: {module:?}");
                 let v = Interned::new(Ty::Value(InsTy::new(Value::Module(module.clone()))));
                 for (name, _, _) in module.scope().iter() {
                     let name: Interned<str> = name.into();

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -192,7 +192,7 @@ impl DocsChecker<'_> {
     fn generate_var(&mut self, name: StrRef) -> Ty {
         self.next_id += 1;
         let encoded = Interned::new(Decl::generated(DefId(self.next_id as u64)));
-        log::debug!("generate var {name:?} {encoded:?}");
+        crate::log_debug_ct!("generate var {name:?} {encoded:?}");
         let var = TypeVar {
             name,
             def: encoded.clone(),
@@ -283,7 +283,7 @@ impl DocsChecker<'_> {
         }
 
         let v = m.scope().get(name)?;
-        log::debug!("check doc type annotation: {name:?}");
+        crate::log_debug_ct!("check doc type annotation: {name:?}");
         if let Value::Content(c) = v {
             let annotated = c.clone().unpack::<typst::text::RawElem>().ok()?;
             let text = annotated.text().clone().into_value().cast::<Str>().ok()?;
@@ -298,7 +298,7 @@ impl DocsChecker<'_> {
     }
 
     fn check_type_expr(&mut self, m: &Module, s: ast::Expr) -> Option<Ty> {
-        log::debug!("check doc type expr: {s:?}");
+        crate::log_debug_ct!("check doc type expr: {s:?}");
         match s {
             ast::Expr::Ident(i) => self.check_type_ident(m, i.get().as_str()),
             ast::Expr::None(_)
@@ -352,7 +352,7 @@ impl DocsChecker<'_> {
                 _ => None,
             },
             ast::Expr::Closure(c) => {
-                log::debug!("check doc closure annotation: {c:?}");
+                crate::log_debug_ct!("check doc closure annotation: {c:?}");
                 let mut pos = vec![];
                 let mut named = BTreeMap::new();
                 let mut rest = None;
@@ -397,7 +397,7 @@ impl DocsChecker<'_> {
                 sig
             }
             ast::Expr::Dict(d) => {
-                log::debug!("check doc dict annotation: {d:?}");
+                crate::log_debug_ct!("check doc dict annotation: {d:?}");
                 None
             }
             _ => None,

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -41,7 +41,7 @@ pub(crate) fn get_lexical_hierarchy(
         worker.symbreak();
     }
 
-    log::debug!("lexical hierarchy analysis took {:?}", b.elapsed());
+    crate::log_debug_ct!("lexical hierarchy analysis took {:?}", b.elapsed());
     res.map(|_| worker.stack.pop().unwrap().1)
 }
 

--- a/crates/tinymist-query/src/syntax/matcher.rs
+++ b/crates/tinymist-query/src/syntax/matcher.rs
@@ -288,7 +288,7 @@ pub(crate) fn interpret_mode_at_kind(k: SyntaxKind) -> Option<InterpretMode> {
 
 pub(crate) fn interpret_mode_at(mut leaf: Option<&LinkedNode>) -> InterpretMode {
     loop {
-        log::debug!("leaf for context: {leaf:?}");
+        crate::log_debug_ct!("leaf for context: {leaf:?}");
         if let Some(t) = leaf {
             if let Some(mode) = interpret_mode_at_kind(t.kind()) {
                 break mode;
@@ -357,11 +357,11 @@ pub fn get_deref_target(node: LinkedNode, cursor: usize) -> Option<DerefTarget<'
 
     // Move to the first ancestor that is an expression.
     let ancestor = deref_expr(node)?;
-    log::debug!("deref expr: {ancestor:?}");
+    crate::log_debug_ct!("deref expr: {ancestor:?}");
 
     // Unwrap all parentheses to get the actual expression.
     let cano_expr = deref_lvalue(ancestor)?;
-    log::debug!("deref lvalue: {cano_expr:?}");
+    crate::log_debug_ct!("deref lvalue: {cano_expr:?}");
 
     // Identify convenient expression kinds.
     let expr = cano_expr.cast::<ast::Expr>()?;
@@ -452,9 +452,9 @@ fn get_def_target_(node: LinkedNode, strict: bool) -> Option<DefTarget<'_>> {
     while !ancestor.is::<ast::Expr>() {
         ancestor = ancestor.parent()?.clone();
     }
-    log::debug!("def expr: {ancestor:?}");
+    crate::log_debug_ct!("def expr: {ancestor:?}");
     let ancestor = deref_lvalue(ancestor)?;
-    log::debug!("def lvalue: {ancestor:?}");
+    crate::log_debug_ct!("def lvalue: {ancestor:?}");
 
     let may_ident = ancestor.cast::<ast::Expr>()?;
     if strict && !may_ident.hash() && !matches!(may_ident, ast::Expr::MathIdent(_)) {
@@ -491,7 +491,7 @@ fn get_def_target_(node: LinkedNode, strict: bool) -> Option<DefTarget<'_>> {
         }
         _ if may_ident.hash() => return None,
         _ => {
-            log::debug!("unsupported kind {kind:?}", kind = ancestor.kind());
+            crate::log_debug_ct!("unsupported kind {kind:?}", kind = ancestor.kind());
             return None;
         }
     })

--- a/crates/tinymist-query/src/ty/iface.rs
+++ b/crates/tinymist-query/src/ty/iface.rs
@@ -32,7 +32,7 @@ pub enum Iface<'a> {
 impl Iface<'_> {
     // IfaceShape { iface }
     pub fn select(self, ctx: &mut impl TyCtxMut, key: &StrRef) -> Option<Ty> {
-        log::debug!("iface shape: {self:?}");
+        crate::log_debug_ct!("iface shape: {self:?}");
 
         match self {
             // Iface::ArrayCons(a) => SigTy::array_cons(a.as_ref().clone(), false),
@@ -102,7 +102,7 @@ impl IfaceCheckDriver<'_> {
     }
 
     fn ty(&mut self, ty: &Ty, pol: bool) {
-        log::debug!("check iface ty: {ty:?}");
+        crate::log_debug_ct!("check iface ty: {ty:?}");
 
         match ty {
             Ty::Builtin(BuiltinTy::Stroke) if self.dict_as_iface() => {

--- a/crates/tinymist-query/src/ty/sig.rs
+++ b/crates/tinymist-query/src/ty/sig.rs
@@ -167,7 +167,7 @@ impl SigCheckDriver<'_> {
     }
 
     fn ty(&mut self, ty: &Ty, pol: bool) {
-        log::debug!("check sig: {ty:?}");
+        crate::log_debug_ct!("check sig: {ty:?}");
         match ty {
             Ty::Builtin(BuiltinTy::Stroke) if self.dict_as_sig() => {
                 self.checker
@@ -254,7 +254,7 @@ impl SigCheckDriver<'_> {
 
 impl BoundChecker for SigCheckDriver<'_> {
     fn collect(&mut self, ty: &Ty, pol: bool) {
-        log::debug!("sig bounds: {ty:?}");
+        crate::log_debug_ct!("sig bounds: {ty:?}");
         self.ty(ty, pol);
     }
 }
@@ -282,7 +282,7 @@ impl MethodDriver<'_, '_> {
 
 impl BoundChecker for MethodDriver<'_, '_> {
     fn collect(&mut self, ty: &Ty, pol: bool) {
-        log::debug!("check method: {ty:?}.{}", self.1.as_ref());
+        crate::log_debug_ct!("check method: {ty:?}.{}", self.1.as_ref());
         match ty {
             // todo: deduplicate checking early
             Ty::Value(v) => {

--- a/crates/tinymist-query/src/ty/simplify.rs
+++ b/crates/tinymist-query/src/ty/simplify.rs
@@ -255,7 +255,7 @@ impl TypeSimplifier<'_, '_> {
         let mut lbs = HashSet::with_capacity(w.lbs.len());
         let mut ubs = HashSet::with_capacity(w.ubs.len());
 
-        log::debug!("transform let [principal={}] with {w:?}", self.principal);
+        crate::log_debug_ct!("transform let [principal={}] with {w:?}", self.principal);
 
         if !self.principal || ((pol) && !def_id.is_some_and(|i| self.negatives.contains(i))) {
             for lb in w.lbs.iter() {

--- a/crates/tinymist-query/src/ty/subst.rs
+++ b/crates/tinymist-query/src/ty/subst.rs
@@ -3,7 +3,7 @@ use crate::ty::prelude::*;
 
 impl Sig<'_> {
     pub fn call(&self, args: &Interned<ArgsTy>, pol: bool, ctx: &mut impl TyCtxMut) -> Option<Ty> {
-        log::debug!("call {self:?} {args:?} {pol:?}");
+        crate::log_debug_ct!("call {self:?} {args:?} {pol:?}");
         ctx.with_scope(|ctx| {
             let body = self.check_bind(args, ctx)?;
 
@@ -21,7 +21,7 @@ impl Sig<'_> {
 
         for (arg_recv, arg_ins) in sig.matches(args, withs) {
             if let Ty::Var(arg_recv) = arg_recv {
-                log::debug!("bind {arg_recv:?} {arg_ins:?}");
+                crate::log_debug_ct!("bind {arg_recv:?} {arg_ins:?}");
                 ctx.bind_local(arg_recv, arg_ins.clone());
             }
         }

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -38,7 +38,7 @@ pub fn autocomplete(
 ) -> Option<(usize, bool, Vec<Completion>, Vec<lsp_types::CompletionItem>)> {
     let _ = complete_comments(&mut ctx)
         || complete_type(&mut ctx).is_none() && {
-            log::debug!("continue after completing type");
+            crate::log_debug_ct!("continue after completing type");
             complete_labels(&mut ctx)
                 || complete_field_accesses(&mut ctx)
                 || complete_imports(&mut ctx)

--- a/crates/tinymist-query/src/upstream/complete/ext.rs
+++ b/crates/tinymist-query/src/upstream/complete/ext.rs
@@ -192,7 +192,7 @@ impl CompletionContext<'_> {
         let cursor_mode = interpret_mode_at(Some(node));
         let is_content = value.ty() == Type::of::<Content>()
             || value.ty() == Type::of::<typst::symbols::Symbol>();
-        log::debug!("post snippet is_content: {is_content}");
+        crate::log_debug_ct!("post snippet is_content: {is_content}");
 
         let rng = node.range();
         for snippet in self.ctx.analysis.completion_feat.postfix_snippets() {
@@ -207,7 +207,7 @@ impl CompletionContext<'_> {
             if !scope {
                 continue;
             }
-            log::debug!("post snippet: {}", snippet.label);
+            crate::log_debug_ct!("post snippet: {}", snippet.label);
 
             static TYPST_SNIPPET_PLACEHOLDER_RE: LazyLock<Regex> =
                 LazyLock::new(|| Regex::new(r"\$\{(.*?)\}").unwrap());
@@ -238,7 +238,7 @@ impl CompletionContext<'_> {
                     })
                 }
             });
-            log::debug!("post snippet: {} on {:?}", snippet.label, parsed_snippet);
+            crate::log_debug_ct!("post snippet: {} on {:?}", snippet.label, parsed_snippet);
             let Some(ParsedSnippet {
                 node_before,
                 node_before_before_cursor,
@@ -304,7 +304,7 @@ impl CompletionContext<'_> {
             return;
         };
 
-        log::debug!("defines: {:?}", defines.defines.len());
+        crate::log_debug_ct!("defines: {:?}", defines.defines.len());
         let mut kind_checker = CompletionKindChecker {
             symbols: HashSet::default(),
             functions: HashSet::default(),
@@ -344,12 +344,12 @@ impl CompletionContext<'_> {
             };
             let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter());
 
-            log::debug!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
+            crate::log_debug_ct!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
 
             if fn_feat.min_pos() < 1 || !fn_feat.next_arg_is_content {
                 continue;
             }
-            log::debug!("checked ufcs: {ty:?}");
+            crate::log_debug_ct!("checked ufcs: {ty:?}");
             if self.ctx.analysis.completion_feat.ufcs() && fn_feat.min_pos() == 1 {
                 let before = TextEdit {
                     range: self.ctx.to_lsp_range(rng.start..rng.start, &src),
@@ -475,7 +475,7 @@ impl CompletionContext<'_> {
 
             let label_detail = ty.describe().map(From::from).or_else(|| Some("any".into()));
 
-            log::debug!("scope completions!: {name} {ty:?} {label_detail:?}");
+            crate::log_debug_ct!("scope completions!: {name} {ty:?} {label_detail:?}");
             let detail = label_detail.clone();
 
             if !kind_checker.functions.is_empty() {
@@ -488,7 +488,7 @@ impl CompletionContext<'_> {
 
                 let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter());
 
-                log::debug!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
+                crate::log_debug_ct!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
 
                 if matches!(surrounding_syntax, SurroundingSyntax::ShowTransform)
                     && (fn_feat.min_pos() > 0 || fn_feat.min_named() > 0)
@@ -571,7 +571,7 @@ fn check_surrounding_syntax(mut leaf: &LinkedNode) -> Option<SurroundingSyntax> 
     use SurroundingSyntax::*;
     let mut met_args = false;
     while let Some(parent) = leaf.parent() {
-        log::debug!(
+        crate::log_debug_ct!(
             "check_surrounding_syntax: {:?}::{:?}",
             parent.kind(),
             leaf.kind()
@@ -1057,7 +1057,7 @@ fn type_completion(
         return Some(());
     }
 
-    log::debug!("type_completion: {infer_type:?}");
+    crate::log_debug_ct!("type_completion: {infer_type:?}");
 
     match infer_type {
         Ty::Any => return None,
@@ -1325,7 +1325,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
     use crate::syntax::get_check_target;
 
     let check_target = get_check_target(ctx.leaf.clone());
-    log::debug!("complete_type: pos {:?} -> {check_target:#?}", ctx.leaf);
+    crate::log_debug_ct!("complete_type: pos {:?} -> {check_target:#?}", ctx.leaf);
     let mut args_node = None;
 
     match check_target {
@@ -1360,7 +1360,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
         Some(CheckTarget::Paren { .. } | CheckTarget::Normal(..)) | None => {}
     }
 
-    log::debug!("ctx.leaf {:?}", ctx.leaf.clone());
+    crate::log_debug_ct!("ctx.leaf {:?}", ctx.leaf.clone());
 
     let ty = ctx
         .ctx
@@ -1369,7 +1369,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
 
     let scope = ctx.surrounding_syntax();
 
-    log::debug!("complete_type: {:?} -> ({scope:?}, {ty:#?})", ctx.leaf);
+    crate::log_debug_ct!("complete_type: {:?} -> ({scope:?}, {ty:#?})", ctx.leaf);
     if matches!((scope, &ty), (SurroundingSyntax::Regular, None)) {
         return None;
     }
@@ -1441,7 +1441,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
     // let ty = Type::of::<Dir>();
     // ctx.strict_scope_completions(false, |value| value.ty() == ty);
 
-    log::debug!(
+    crate::log_debug_ct!(
         "sort_and_explicit_code_completion: {completions:#?} {:#?}",
         ctx.completions
     );
@@ -1474,7 +1474,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
         compl.sort_text = Some(eco_format!("{i:03}", i = i + sort_base));
     }
 
-    log::debug!(
+    crate::log_debug_ct!(
         "sort_and_explicit_code_completion after: {completions:#?} {:#?}",
         ctx.completions
     );
@@ -1482,7 +1482,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
     ctx.completions.append(&mut completions);
 
     if let Some(c) = args_node {
-        log::debug!("content block compl: args {c:?}");
+        crate::log_debug_ct!("content block compl: args {c:?}");
         let is_unclosed = matches!(c.kind(), SyntaxKind::Args)
             && c.children().fold(0i32, |acc, node| match node.kind() {
                 SyntaxKind::LeftParen => acc + 1,
@@ -1505,7 +1505,7 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
         SurroundingSyntax::SetRule => {}
     }
 
-    log::debug!("sort_and_explicit_code_completion: {:?}", ctx.completions);
+    crate::log_debug_ct!("sort_and_explicit_code_completion: {:?}", ctx.completions);
 
     Some(())
 }
@@ -1532,7 +1532,7 @@ pub fn complete_path(
 
         let vr = v.range();
         rng = vr.start + 1..vr.end - 1;
-        log::debug!("path_of: {rng:?} {cursor}");
+        crate::log_debug_ct!("path_of: {rng:?} {cursor}");
         if rng.start > rng.end || (cursor != rng.end && !rng.contains(&cursor)) {
             return None;
         }
@@ -1542,7 +1542,7 @@ pub fn complete_path(
         w.push_str(&source.text()[rng.start..cursor]);
         w.push('"');
         let partial_str = SyntaxNode::leaf(SyntaxKind::Str, w);
-        log::debug!("path_of: {rng:?} {partial_str:?}");
+        crate::log_debug_ct!("path_of: {rng:?} {partial_str:?}");
 
         text = partial_str.cast::<ast::Str>()?.get();
         is_in_text = true;
@@ -1551,7 +1551,7 @@ pub fn complete_path(
         rng = cursor..cursor;
         is_in_text = false;
     }
-    log::debug!("complete_path: is_in_text: {is_in_text:?}");
+    crate::log_debug_ct!("complete_path: is_in_text: {is_in_text:?}");
     let path = Path::new(text.as_str());
     let has_root = path.has_root();
 
@@ -1562,7 +1562,7 @@ pub fn complete_path(
     if !compl_path.is_dir() {
         compl_path = compl_path.parent().unwrap_or(Path::new(""));
     }
-    log::debug!("compl_path: {src_path:?} + {path:?} -> {compl_path:?}");
+    crate::log_debug_ct!("compl_path: {src_path:?} + {path:?} -> {compl_path:?}");
 
     if compl_path.is_absolute() {
         log::warn!("absolute path completion is not supported for security consideration {path:?}");
@@ -1574,7 +1574,7 @@ pub fn complete_path(
     let mut module_completions = vec![];
     // todo: test it correctly
     for path in ctx.completion_files(p) {
-        log::debug!("compl_check_path: {path:?}");
+        crate::log_debug_ct!("compl_check_path: {path:?}");
 
         // Skip self smartly
         if *path == base {
@@ -1594,7 +1594,7 @@ pub fn complete_path(
             let w = pathdiff::diff_paths(path, base)?;
             unix_slash(&w)
         };
-        log::debug!("compl_label: {label:?}");
+        crate::log_debug_ct!("compl_label: {label:?}");
 
         module_completions.push((label, CompletionKind::File));
 
@@ -1656,7 +1656,7 @@ pub fn complete_path(
                     ..Default::default()
                 };
 
-                log::debug!("compl_res: {res:?}");
+                crate::log_debug_ct!("compl_res: {res:?}");
 
                 res
             })

--- a/crates/tinymist-query/src/upstream/mod.rs
+++ b/crates/tinymist-query/src/upstream/mod.rs
@@ -23,7 +23,7 @@ pub use complete::*;
 ///
 /// Removes Markdown formatting.
 pub fn plain_docs_sentence(docs: &str) -> EcoString {
-    log::debug!("plain docs {docs:?}");
+    crate::log_debug_ct!("plain docs {docs:?}");
     let docs = docs.replace("```example", "```typ");
     let mut s = unscanny::Scanner::new(&docs);
     let mut output = EcoString::new();
@@ -55,7 +55,7 @@ pub fn plain_docs_sentence(docs: &str) -> EcoString {
                     let link_content = s.from(c + 1);
                     s.eat();
 
-                    log::debug!("Intra Link: {link_content}");
+                    crate::log_debug_ct!("Intra Link: {link_content}");
                     let link = resolve(link_content, "https://typst.app/docs/").ok();
                     let link = link.unwrap_or_else(|| {
                         log::warn!("Failed to resolve link: {link_content}");
@@ -308,7 +308,7 @@ static ROUTE_MAPS: Lazy<HashMap<CatKey, String>> = Lazy::new(|| {
                             continue;
                         }
 
-                        log::debug!("func: {f:?} -> {cat:?}");
+                        crate::log_debug_ct!("func: {f:?} -> {cat:?}");
 
                         let route = if let Some(parent_name) = &parent_name {
                             format!("reference/{}/{parent_name}/#definitions-{name}", cat.name())
@@ -324,7 +324,7 @@ static ROUTE_MAPS: Lazy<HashMap<CatKey, String>> = Lazy::new(|| {
                 }
                 Value::Type(t) => {
                     if let Some(cat) = cat {
-                        log::debug!("type: {t:?} -> {cat:?}");
+                        crate::log_debug_ct!("type: {t:?} -> {cat:?}");
 
                         let route = if let Some(parent_name) = &parent_name {
                             format!("reference/{}/{parent_name}/#definitions-{name}", cat.name())


### PR DESCRIPTION
With completely removing checks in these log macros, time to type checking of `@preview/subpar:0.2.0` goes from 122 seconds to 49 seconds.