### PR TITLE
feat: resolve constant references in import at syntax level

### DIFF
--- a/crates/tinymist-query/src/fixtures/hover/module_star_shadow.typ
+++ b/crates/tinymist-query/src/fixtures/hover/module_star_shadow.typ
@@ -1,0 +1,13 @@
+/// path: draw.typ
+
+/// The draw line.
+#let line() = 1;
+-----
+/// path: lib.typ
+
+#import "draw.typ"
+-----
+
+#import "lib.typ"
+#import lib.draw: *
+#(/* position after */ line);

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star_shadow.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star_shadow.typ.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tinymist-query/src/hover.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/hover/module_star_shadow.typ
+snapshot_kind: text
+---
+{
+ "contents": "```typc\nlet line() = int;\n```\n\n---\nThe draw line.",
+ "range": "2:23:2:27"
+}


### PR DESCRIPTION
In the example, `lib.draw` should be constant evaluated to know which symbols to import by wildcard (`*`).

```typ
/// path: draw.typ

/// The draw line.
#let line() = 1;
-----
/// path: lib.typ

#import "draw.typ"
-----

#import "lib.typ"
#import lib.draw: *
#(/* position after */ line);
```