### PR TITLE
feat: add support to preview typst targeting html

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,6 @@ dependencies = [
 [[package]]
 name = "reflexo"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "base64",
  "bitvec",
@@ -2887,7 +2886,6 @@ dependencies = [
 [[package]]
 name = "reflexo-typst"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "codespan-reporting",
  "comemo 0.4.0",
@@ -2916,7 +2914,6 @@ dependencies = [
 [[package]]
 name = "reflexo-typst-shim"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "cfg-if",
  "typst",
@@ -2926,7 +2923,6 @@ dependencies = [
 [[package]]
 name = "reflexo-typst2vec"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "bitvec",
  "comemo 0.4.0",
@@ -2951,7 +2947,6 @@ dependencies = [
 [[package]]
 name = "reflexo-vec2svg"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "base64",
  "comemo 0.4.0",
@@ -2964,7 +2959,6 @@ dependencies = [
 [[package]]
 name = "reflexo-vfs"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "indexmap 2.7.0",
  "log",
@@ -2978,7 +2972,6 @@ dependencies = [
 [[package]]
 name = "reflexo-world"
 version = "0.5.1"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?branch=nightly%2Fv0.5.3#94f9064117cfd130a7afcd87424315a54d9468cd"
 dependencies = [
  "chrono",
  "codespan-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,17 +210,17 @@ typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "ti
 # typst-render = { path = "../typst/crates/typst-render" }
 # typst-syntax = { path = "../typst/crates/typst-syntax" }
 
-reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
-reflexo-world = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
-reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
-reflexo-typst2vec = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
-reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
-reflexo-typst-shim = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo-world = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo-typst2vec = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
+# reflexo-typst-shim = { git = "https://github.com/Myriad-Dreamin/typst.ts/", branch = "nightly/v0.5.3" }
 
-# reflexo = { path = "../typst.ts/crates/reflexo/" }
-# reflexo-world = { path = "../typst.ts/crates/reflexo-world/" }
-# reflexo-typst = { path = "../typst.ts/crates/reflexo-typst/" }
-# reflexo-typst2vec = { path = "../typst.ts/crates/conversion/typst2vec/" }
-# reflexo-vec2svg = { path = "../typst.ts/crates/conversion/vec2svg/" }
-# reflexo-typst-shim = { path = "../typst.ts/crates/reflexo-typst-shim/" }
+reflexo = { path = "../typst.ts/crates/reflexo/" }
+reflexo-world = { path = "../typst.ts/crates/reflexo-world/" }
+reflexo-typst = { path = "../typst.ts/crates/reflexo-typst/" }
+reflexo-typst2vec = { path = "../typst.ts/crates/conversion/typst2vec/" }
+reflexo-vec2svg = { path = "../typst.ts/crates/conversion/vec2svg/" }
+reflexo-typst-shim = { path = "../typst.ts/crates/reflexo-typst-shim/" }
 # typstyle = { path = "../typstyle" }

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -9,7 +9,7 @@ use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use reflexo::debug_loc::DataSource;
 use reflexo::hash::{hash128, FxDashMap};
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use reflexo_typst::{EntryReader, WorldDeps};
 use rustc_hash::FxHashMap;
 use tinymist_world::LspWorld;
@@ -882,7 +882,7 @@ impl SharedContext {
     /// only generated when the document is available.
     pub fn tooltip(
         &self,
-        document: Option<&TypstDocument>,
+        document: Option<&TypstPagedDocument>,
         source: &Source,
         cursor: usize,
     ) -> Option<Tooltip> {

--- a/crates/tinymist-query/src/analysis/track_values.rs
+++ b/crates/tinymist-query/src/analysis/track_values.rs
@@ -2,7 +2,7 @@
 
 use comemo::Track;
 use ecow::*;
-use reflexo::typst::TypstDocument;
+use reflexo::typst::TypstPagedDocument;
 use typst::engine::{Engine, Route, Sink, Traced};
 use typst::foundations::{Label, Styles, Value};
 use typst::introspection::Introspector;
@@ -42,7 +42,7 @@ pub fn analyze_expr_(world: &dyn World, node: &SyntaxNode) -> EcoVec<(Value, Opt
                 }
             }
 
-            return typst::trace::<TypstDocument>(world, node.span());
+            return typst::trace::<TypstPagedDocument>(world, node.span());
         }
     };
 
@@ -100,7 +100,7 @@ pub struct DynLabel {
 /// - All labels and descriptions for them, if available
 /// - A split offset: All labels before this offset belong to nodes, all after
 ///   belong to a bibliography.
-pub fn analyze_labels(document: &TypstDocument) -> (Vec<DynLabel>, usize) {
+pub fn analyze_labels(document: &TypstPagedDocument) -> (Vec<DynLabel>, usize) {
     let mut output = vec![];
 
     // Labels in the document.

--- a/crates/tinymist-query/src/document_metrics.rs
+++ b/crates/tinymist-query/src/document_metrics.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
 use reflexo::debug_loc::DataSource;
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use serde::{Deserialize, Serialize};
 use typst::text::{Font, FontStretch, FontStyle, FontWeight};
 use typst::{
@@ -142,7 +142,7 @@ struct DocumentMetricsWorker<'a> {
 }
 
 impl DocumentMetricsWorker<'_> {
-    fn work(&mut self, doc: &TypstDocument) -> Option<()> {
+    fn work(&mut self, doc: &TypstPagedDocument) -> Option<()> {
         for page in &doc.pages {
             self.work_frame(&page.frame)?;
         }

--- a/crates/tinymist-query/src/jump.rs
+++ b/crates/tinymist-query/src/jump.rs
@@ -4,7 +4,7 @@
 
 use std::num::NonZeroUsize;
 
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use typst::{
     layout::{Frame, FrameItem, Point, Position},
     syntax::{LinkedNode, Source, Span, SyntaxKind},
@@ -13,7 +13,7 @@ use typst_shim::syntax::LinkedNodeExt;
 
 /// Find the output location in the document for a cursor position.
 pub fn jump_from_cursor(
-    document: &TypstDocument,
+    document: &TypstPagedDocument,
     source: &Source,
     cursor: usize,
 ) -> Option<Position> {

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -84,7 +84,7 @@ mod prelude;
 
 use std::sync::Arc;
 
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use typst::syntax::Source;
 
 /// The physical position in a document.
@@ -98,7 +98,7 @@ pub struct VersionedDocument {
     /// The version of the document.
     pub version: usize,
     /// The compiled document.
-    pub document: Arc<TypstDocument>,
+    pub document: Arc<TypstPagedDocument>,
 }
 
 /// A request handler with given syntax information.

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use ecow::{eco_format, EcoString};
 use if_chain::if_chain;
 use lsp_types::TextEdit;
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use serde::{Deserialize, Serialize};
 use typst::foundations::{fields_on, format_str, repr, Repr, StyleChain, Styles, Value};
 use typst::syntax::{ast, is_id_continue, is_id_start, is_ident, LinkedNode, Source, SyntaxKind};
@@ -801,7 +801,7 @@ fn code_completions(ctx: &mut CompletionContext, hash: bool) {
 /// Context for autocompletion.
 pub struct CompletionContext<'a> {
     pub ctx: &'a mut LocalContext,
-    pub document: Option<&'a TypstDocument>,
+    pub document: Option<&'a TypstPagedDocument>,
     pub text: &'a str,
     pub before: &'a str,
     pub after: &'a str,
@@ -825,7 +825,7 @@ impl<'a> CompletionContext<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: &'a mut LocalContext,
-        document: Option<&'a TypstDocument>,
+        document: Option<&'a TypstPagedDocument>,
         source: &'a Source,
         cursor: usize,
         explicit: bool,

--- a/crates/tinymist-query/src/upstream/tooltip.rs
+++ b/crates/tinymist-query/src/upstream/tooltip.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use ecow::{eco_format, EcoString};
 use if_chain::if_chain;
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use typst::engine::Sink;
 use typst::foundations::{repr, Capturer, CastInfo, Value};
 use typst::layout::Length;
@@ -23,7 +23,7 @@ use crate::analysis::{analyze_expr, analyze_labels, DynLabel};
 /// when the document is available.
 pub fn tooltip_(
     world: &dyn World,
-    document: Option<&TypstDocument>,
+    document: Option<&TypstPagedDocument>,
     source: &Source,
     cursor: usize,
 ) -> Option<Tooltip> {
@@ -157,7 +157,7 @@ fn length_tooltip(length: Length) -> Option<Tooltip> {
 }
 
 /// Tooltip for a hovered reference or label.
-fn label_tooltip(document: &TypstDocument, leaf: &LinkedNode) -> Option<Tooltip> {
+fn label_tooltip(document: &TypstPagedDocument, leaf: &LinkedNode) -> Option<Tooltip> {
     let target = match leaf.kind() {
         SyntaxKind::RefMarker => leaf.text().trim_start_matches('@'),
         SyntaxKind::Label => leaf.text().trim_start_matches('<').trim_end_matches('>'),

--- a/crates/tinymist/src/resource/symbols.rs
+++ b/crates/tinymist/src/resource/symbols.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 // use reflexo_typst::font::GlyphId;
 use reflexo_typst::{
-    vector::font::GlyphId, world::EntryState, ShadowApi, TaskInputs, TypstDocument, TypstFont,
+    vector::font::GlyphId, world::EntryState, ShadowApi, TaskInputs, TypstFont, TypstPagedDocument,
 };
 use sync_lsp::LspResult;
 
@@ -1106,7 +1106,7 @@ impl LanguageState {
 }
 
 fn trait_symbol_fonts(
-    doc: &TypstDocument,
+    doc: &TypstPagedDocument,
     symbols: &[String],
 ) -> HashMap<String, (TypstFont, GlyphId)> {
     use typst::layout::Frame;
@@ -1127,7 +1127,7 @@ fn trait_symbol_fonts(
     }
 
     impl Worker<'_> {
-        fn work(&mut self, doc: &TypstDocument) {
+        fn work(&mut self, doc: &TypstPagedDocument) {
             for (pg, s) in doc.pages.iter().zip(self.symbols.iter()) {
                 self.active = s;
                 self.work_frame(&pg.frame);

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -11,7 +11,7 @@ use hyper_util::server::graceful::GracefulShutdown;
 use lsp_types::notification::Notification;
 use reflexo_typst::debug_loc::SourceSpanOffset;
 use reflexo_typst::vfs::notify::{FileChangeSet, MemoryEvent};
-use reflexo_typst::{error::prelude::*, EntryReader, Error, TypstDocument, TypstFileId};
+use reflexo_typst::{error::prelude::*, EntryReader, Error, TypstFileId, TypstPagedDocument};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use sync_lsp::just_ok;
@@ -675,7 +675,11 @@ impl Notification for NotifDocumentOutline {
 }
 
 /// Find the output location in the document for a cursor position.
-fn jump_from_cursor(document: &TypstDocument, source: &Source, cursor: usize) -> Option<Position> {
+fn jump_from_cursor(
+    document: &TypstPagedDocument,
+    source: &Source,
+    cursor: usize,
+) -> Option<Position> {
     let node = LinkedNode::new(source.root()).leaf_at_compat(cursor)?;
     if node.kind() != SyntaxKind::Text {
         return None;

--- a/crates/tinymist/src/tool/text.rs
+++ b/crates/tinymist/src/tool/text.rs
@@ -1,11 +1,11 @@
 //! Text export utilities.
 
 use core::fmt;
-use reflexo_typst::TypstDocument;
+use reflexo_typst::TypstPagedDocument;
 use std::sync::Arc;
 
 /// A full text digest of a document.
-pub struct FullTextDigest(pub Arc<TypstDocument>);
+pub struct FullTextDigest(pub Arc<TypstPagedDocument>);
 
 impl FullTextDigest {
     fn export_frame(f: &mut fmt::Formatter<'_>, doc: &typst::layout::Frame) -> fmt::Result {

--- a/crates/tinymist/src/tool/word_count.rs
+++ b/crates/tinymist/src/tool/word_count.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::ops::Range;
 use std::sync::Arc;
 
-use reflexo_typst::{debug_loc::SourceSpanOffset, exporter_utils::map_err, TypstDocument};
+use reflexo_typst::{debug_loc::SourceSpanOffset, exporter_utils::map_err, TypstPagedDocument};
 use serde::{Deserialize, Serialize};
 use typst::{syntax::Span, text::TextItem};
 use unicode_script::{Script, UnicodeScript};
@@ -25,7 +25,7 @@ pub struct WordsCount {
 }
 
 /// Count words in a document.
-pub fn word_count(doc: &TypstDocument) -> WordsCount {
+pub fn word_count(doc: &TypstPagedDocument) -> WordsCount {
     // the mapping is still not use, so we prevent the warning here
     let _ = TextContent::map_back_spans;
 
@@ -97,7 +97,7 @@ pub struct TextExporter {}
 
 impl TextExporter {
     /// Collect text content from a document.
-    pub fn collect(&self, output: &TypstDocument) -> typst::diag::SourceResult<String> {
+    pub fn collect(&self, output: &TypstPagedDocument) -> typst::diag::SourceResult<String> {
         let w = std::io::BufWriter::new(Vec::new());
 
         let mut d = TextExportWorker { w };
@@ -113,7 +113,7 @@ struct TextExportWorker {
 }
 
 impl TextExportWorker {
-    fn doc(&mut self, doc: &TypstDocument) -> io::Result<()> {
+    fn doc(&mut self, doc: &TypstPagedDocument) -> io::Result<()> {
         for page in doc.pages.iter() {
             self.frame(&page.frame)?;
         }
@@ -159,7 +159,7 @@ pub struct TextContent {
     /// A string of the content for slicing.
     pub content: String,
     /// annotating document.
-    pub doc: Arc<TypstDocument>,
+    pub doc: Arc<TypstPagedDocument>,
 }
 
 impl TextContent {
@@ -197,7 +197,7 @@ struct SpanMapper {
 }
 
 impl SpanMapper {
-    fn doc(&mut self, doc: &TypstDocument) {
+    fn doc(&mut self, doc: &TypstPagedDocument) {
         for page in doc.pages.iter() {
             self.frame(&page.frame);
         }

--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -34,7 +34,7 @@ impl RenderActorRequest {
 
 pub struct RenderActor {
     mailbox: broadcast::Receiver<RenderActorRequest>,
-    document: Arc<std::sync::RwLock<Option<Arc<TypstDocument>>>>,
+    document: Arc<std::sync::RwLock<Option<TypstDocument>>>,
     renderer: IncrSvgDocServer,
     resolve_sender: mpsc::UnboundedSender<TypstActorRequest>,
     svg_sender: mpsc::UnboundedSender<Vec<u8>>,
@@ -44,7 +44,7 @@ pub struct RenderActor {
 impl RenderActor {
     pub fn new(
         mailbox: broadcast::Receiver<RenderActorRequest>,
-        document: Arc<std::sync::RwLock<Option<Arc<TypstDocument>>>>,
+        document: Arc<std::sync::RwLock<Option<TypstDocument>>>,
         resolve_sender: mpsc::UnboundedSender<TypstActorRequest>,
         svg_sender: mpsc::UnboundedSender<Vec<u8>>,
         webview_sender: broadcast::Sender<WebviewActorRequest>,
@@ -155,7 +155,7 @@ impl RenderActor {
 
 pub struct OutlineRenderActor {
     signal: broadcast::Receiver<RenderActorRequest>,
-    document: Arc<std::sync::RwLock<Option<Arc<TypstDocument>>>>,
+    document: Arc<std::sync::RwLock<Option<TypstDocument>>>,
     editor_tx: mpsc::UnboundedSender<EditorActorRequest>,
 
     span_interner: SpanInterner,
@@ -164,7 +164,7 @@ pub struct OutlineRenderActor {
 impl OutlineRenderActor {
     pub fn new(
         signal: broadcast::Receiver<RenderActorRequest>,
-        document: Arc<std::sync::RwLock<Option<Arc<TypstDocument>>>>,
+        document: Arc<std::sync::RwLock<Option<TypstDocument>>>,
         editor_tx: mpsc::UnboundedSender<EditorActorRequest>,
         span_interner: SpanInterner,
     ) -> Self {

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -8,6 +8,7 @@ pub use actor::editor::{
 };
 pub use args::*;
 pub use outline::Outline;
+use reflexo_typst::TypstDocument;
 
 use std::{collections::HashMap, future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
@@ -15,7 +16,6 @@ use futures::sink::SinkExt;
 use once_cell::sync::OnceCell;
 use reflexo_typst::debug_loc::SourceSpanOffset;
 use reflexo_typst::Error;
-use reflexo_typst::TypstDocument as Document;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc};
 use typst::{layout::Position, syntax::Span};
@@ -197,7 +197,7 @@ pub struct PreviewBuilder {
     renderer_mailbox: BroadcastChannel<RenderActorRequest>,
     editor_conn: MpScChannel<EditorActorRequest>,
     webview_conn: BroadcastChannel<WebviewActorRequest>,
-    doc_sender: Arc<std::sync::RwLock<Option<Arc<Document>>>>,
+    doc_sender: Arc<std::sync::RwLock<Option<TypstDocument>>>,
 
     compile_watcher: OnceCell<Arc<CompileWatcher>>,
 }
@@ -400,7 +400,7 @@ pub struct MemoryFilesShort {
 pub struct CompileWatcher {
     task_id: String,
     refresh_style: RefreshStyle,
-    doc_sender: Arc<std::sync::RwLock<Option<Arc<Document>>>>,
+    doc_sender: Arc<std::sync::RwLock<Option<TypstDocument>>>,
     editor_tx: mpsc::UnboundedSender<EditorActorRequest>,
     render_tx: broadcast::Sender<RenderActorRequest>,
 }
@@ -418,7 +418,7 @@ impl CompileWatcher {
 
     pub fn notify_compile(
         &self,
-        res: Result<Arc<Document>, CompileStatus>,
+        res: Result<TypstDocument, CompileStatus>,
         is_on_saved: bool,
         is_by_entry_update: bool,
     ) {
@@ -455,5 +455,5 @@ struct DataPlane {
     enable_partial_rendering: bool,
     invert_colors: String,
     renderer_tx: broadcast::Sender<RenderActorRequest>,
-    doc_sender: Arc<std::sync::RwLock<Option<Arc<Document>>>>,
+    doc_sender: Arc<std::sync::RwLock<Option<TypstDocument>>>,
 }

--- a/crates/typst-preview/src/outline.rs
+++ b/crates/typst-preview/src/outline.rs
@@ -140,7 +140,7 @@ struct OutlineItem {
 }
 
 pub fn outline(interner: &mut SpanInternerImpl, document: &TypstDocument) -> Outline {
-    let outline = get_outline(&document.introspector);
+    let outline = get_outline(document.introspector());
     let mut items = Vec::with_capacity(outline.as_ref().map_or(0, Vec::len));
 
     for heading in outline.iter().flatten() {


### PR DESCRIPTION
Adding support to previewing typst document in HTML target, i.e. `typst compile main.typ main.html`. Only PoC works, but the arch is already set up.

![image](https://github.com/user-attachments/assets/c2dca1f0-1df1-4aa9-bd14-8552bf05e3d9)

Although different targets share a same main source file, when targeting `html`, typst interpreter runs on completely different control flow from the one targeting `paged`. For example, the following document has content `html.div(y)` when targeting `html`, and has content `box(width: 10em, x)` when targeting `paged`:
```typ
#context if page.target == paged {
  box(width: 10em, x)
} else {
  html.div(y)
}
```

A main question is throwed at once: how do we inform the language server to run code targeting `html`? Or whether we should run both targets to get diagnostics on both targets as many as possible.


