### PR TITLE
fix: Import Item Completion

### DIFF
--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -548,6 +548,8 @@ fn complete_imports(ctx: &mut CompletionContext) -> bool {
     if_chain! {
         if ctx.leaf.kind() == SyntaxKind::Ident;
         if let Some(parent) = ctx.leaf.parent();
+        if parent.kind() == SyntaxKind::ImportItemPath;
+        if let Some(parent) = parent.parent();
         if parent.kind() == SyntaxKind::ImportItems;
         if let Some(grand) = parent.parent();
         if let Some(ast::Expr::Import(import)) = grand.get().cast();


### PR DESCRIPTION
Part fix for #945 

- Fix: for `import "lib.typ": tes|`, the parent syntax is import item path, then parent is import items