### PR TITLE
fix: simplify types of variables for hover tooltip

### DIFF
--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -305,12 +305,18 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     let ty = type_info.type_of_span(pos)?;
 
     // todo multiple sources
+    // Must use raw result as type aliases contain the source information.
     let mut srcs = ty.sources();
     srcs.sort();
     log::info!("check variable docs of ty: {ty:?} => {srcs:?}");
     let doc_source = srcs.into_iter().next()?;
 
-    let return_ty = format_ty(Some(&ty));
+    // todo people can easily forget to simplify the type which is not good. we
+    // might find a way to ensure them at compile time.
+    //
+    // Must be simplified before formatting, to expand type aliases.
+    let simplified_ty = type_info.simplify(ty, false);
+    let return_ty = format_ty(Some(&simplified_ty));
     match doc_source {
         DocSource::Var(var) => {
             let docs = type_info

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@annotate_dict_param2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@annotate_dict_param2.typ.snap
@@ -5,6 +5,6 @@ input_file: crates/tinymist-query/src/fixtures/hover/annotate_dict_param2.typ
 snapshot_kind: text
 ---
 {
- "contents": "```typc\nlet inherited-scope = any;\n```\n\n---\nDefinitions that are made available to the entire parsed\n         module. This parameter is only used internally.",
+ "contents": "```typc\nlet inherited-scope = dictionary;\n```\n\n---\nDefinitions that are made available to the entire parsed\n         module. This parameter is only used internally.",
  "range": "6:21:6:36"
 }

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@param.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@param.typ.snap
@@ -5,6 +5,6 @@ input_file: crates/tinymist-query/src/fixtures/hover/param.typ
 snapshot_kind: text
 ---
 {
- "contents": "```typc\nlet param = any;\n```\n\n---\nThe `parameter`.",
+ "contents": "```typc\nlet param = int;\n```\n\n---\nThe `parameter`.",
  "range": "3:25:3:30"
 }

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -178,7 +178,21 @@ fn def_tooltip(
 
                         match &sym_docs {
                             Some(DefDocs::Variable(docs)) => {
-                                push_result_ty(def.name(), docs.return_ty.as_ref(), &mut type_doc);
+                                if let Some((_, long, _)) = docs.return_ty.as_ref() {
+                                    if long.as_str() == format!("@{}", def.name()) {
+                                        let ty = ctx
+                                            .literal_type_of_node(leaf)?
+                                            .repr()
+                                            .unwrap_or_else(|| "any".into());
+                                        let _ = write!(type_doc, " = {ty}");
+                                    } else {
+                                        push_result_ty(
+                                            def.name(),
+                                            docs.return_ty.as_ref(),
+                                            &mut type_doc,
+                                        );
+                                    }
+                                }
                             }
                             Some(DefDocs::Function(docs)) => {
                                 let _ = docs.print(&mut type_doc);

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -178,21 +178,7 @@ fn def_tooltip(
 
                         match &sym_docs {
                             Some(DefDocs::Variable(docs)) => {
-                                if let Some((_, long, _)) = docs.return_ty.as_ref() {
-                                    if long.as_str() == format!("@{}", def.name()) {
-                                        let ty = ctx
-                                            .literal_type_of_node(leaf)?
-                                            .repr()
-                                            .unwrap_or_else(|| "any".into());
-                                        let _ = write!(type_doc, " = {ty}");
-                                    } else {
-                                        push_result_ty(
-                                            def.name(),
-                                            docs.return_ty.as_ref(),
-                                            &mut type_doc,
-                                        );
-                                    }
-                                }
+                                push_result_ty(def.name(), docs.return_ty.as_ref(), &mut type_doc);
                             }
                             Some(DefDocs::Function(docs)) => {
                                 let _ = docs.print(&mut type_doc);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:6b94fdf913e670825d2b4daf6ef8c7f5");
+        insta::assert_snapshot!(hash, @"siphash128_13:8cebcc89c1cbdaab64ad54fded330afb");
     }
 
     {
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:afe8f09344dbbd1ff501368282065404");
+        insta::assert_snapshot!(hash, @"siphash128_13:6ee935b352766f1faebe86fac4cb77c1");
     }
 }
 


### PR DESCRIPTION
better hover on var:
```typst
#let d = (:)
       ^
       |
       let d = any; => let d = dictionary;
```