### PR TITLE
feat: enrich all type completions consistently

### DIFF
--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform3.typ.snap
@@ -17,7 +17,7 @@ snapshot_kind: text
     },
     "sortText": "173",
     "textEdit": {
-     "newText": "raw(${1:})",
+     "newText": " raw(${1:})",
      "range": {
       "end": {
        "character": 10,
@@ -38,7 +38,7 @@ snapshot_kind: text
     },
     "sortText": "174",
     "textEdit": {
-     "newText": "raw.with(${1:})",
+     "newText": " raw.with(${1:})",
      "range": {
       "end": {
        "character": 10,
@@ -59,7 +59,7 @@ snapshot_kind: text
     },
     "sortText": "175",
     "textEdit": {
-     "newText": "read(${1:})",
+     "newText": " read(${1:})",
      "range": {
       "end": {
        "character": 10,
@@ -80,7 +80,7 @@ snapshot_kind: text
     },
     "sortText": "176",
     "textEdit": {
-     "newText": "read.with(${1:})",
+     "newText": " read.with(${1:})",
      "range": {
       "end": {
        "character": 10,
@@ -98,7 +98,7 @@ snapshot_kind: text
     "label": "replacement",
     "sortText": "187",
     "textEdit": {
-     "newText": "[${1:content}]",
+     "newText": " [${1:content}]",
      "range": {
       "end": {
        "character": 10,

--- a/crates/tinymist-query/src/upstream/complete/ext.rs
+++ b/crates/tinymist-query/src/upstream/complete/ext.rs
@@ -1412,10 +1412,6 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
         type_completion(ctx, &ty, None);
     }
 
-    if ctx.before.ends_with(',') || ctx.before.ends_with(':') {
-        ctx.enrich(" ", "");
-    }
-
     let mut completions = std::mem::take(&mut ctx.completions);
     let explicit = ctx.explicit;
     ctx.explicit = true;
@@ -1526,6 +1522,9 @@ pub(crate) fn complete_type(ctx: &mut CompletionContext) -> Option<()> {
         }
     }
 
+    if ctx.before.ends_with(',') || ctx.before.ends_with(':') {
+        ctx.enrich(" ", "");
+    }
     match scope {
         SurroundingSyntax::Regular => {}
         SurroundingSyntax::ImportList => {}


### PR DESCRIPTION
By moving site of enrich completions, snippets are also got enriched with space. For example:

```typ
#show:|
```

and select `transform`, it completes

```typ
#show: it => it
//    ^ added space in this PR
```

