### PR TITLE
feat: check surrounding syntax when performing type completion

### DIFF
--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@string_pos_arg.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@string_pos_arg.typ.snap
@@ -1,0 +1,13 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on \" (35..36)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/string_pos_arg.typ
+snapshot_kind: text
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/string_pos_arg.typ
+++ b/crates/tinymist-query/src/fixtures/completion/string_pos_arg.typ
@@ -1,0 +1,3 @@
+/// contains: dir, content
+
+#text(""/* range -1..0 */)

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -942,12 +942,7 @@ impl<'a> CompletionContext<'a> {
     }
 
     /// Add a snippet completion.
-    fn snippet_completion(
-        &mut self,
-        label: &'static str,
-        snippet: &'static str,
-        docs: &'static str,
-    ) {
+    fn snippet_completion(&mut self, label: &str, snippet: &str, docs: &str) {
         self.completions.push(Completion {
             kind: CompletionKind::Syntax,
             label: label.into(),


### PR DESCRIPTION
Previously, type completion doesn't check surrounding syntax, e.g. whether it is inside of some string, thus completes some invalid results.