### PR TITLE
ci: static link musl on alpine build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,6 @@ jobs:
     env:
       target: alpine-x64
       RUST_TARGET: x86_64-unknown-linux-musl
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
       isRelease: ${{ (startsWith(github.ref, 'refs/tags/') && (!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8')))) }}
       isNightly: ${{ ((startsWith(github.ref, 'refs/tags/') && !((!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8'))))) || (!startsWith(github.ref, 'refs/tags/') && matrix.regular_build == 'true')) }}
     steps:


### PR DESCRIPTION
See https://github.com/Enter-tainer/typstyle/pull/177

Although, it might not be a bug if the `-alpine` binary is design to be running on alpine linux. But generally `-musl` binary is designed to be universal binary for systems with ancient glibc. So we should static link musl here.