### PR TITLE
feat: explicitly trigger suggest after completed import/include snippets

### DIFF
--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -145,7 +145,7 @@ impl Analysis {
         AllocStats::report(self)
     }
 
-    /// Get configured trigger parameter hints command.
+    /// Get configured trigger suggest command.
     pub fn trigger_suggest(&self, context: bool) -> Option<&'static str> {
         (self.completion_feat.trigger_suggest && context).then_some("editor.action.triggerSuggest")
     }
@@ -156,7 +156,7 @@ impl Analysis {
             .then_some("editor.action.triggerParameterHints")
     }
 
-    /// Get configured trigger after snippet command.
+    /// Get configured trigger suggest after snippet command.
     ///
     /// > VS Code doesn't do that... Auto triggering suggestion only happens on
     /// > typing (word starts or trigger characters). However, you can use

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -146,6 +146,11 @@ impl Analysis {
     }
 
     /// Get configured trigger parameter hints command.
+    pub fn trigger_suggest(&self, context: bool) -> Option<&'static str> {
+        (self.completion_feat.trigger_suggest && context).then_some("editor.action.triggerSuggest")
+    }
+
+    /// Get configured trigger parameter hints command.
     pub fn trigger_parameter_hints(&self, context: bool) -> Option<&'static str> {
         (self.completion_feat.trigger_parameter_hints && context)
             .then_some("editor.action.triggerParameterHints")
@@ -162,7 +167,7 @@ impl Analysis {
             return None;
         }
 
-        (self.completion_feat.trigger_suggest && context).then_some("editor.action.triggerSuggest")
+        self.trigger_suggest(context)
     }
 
     /// Get configured trigger on positional parameter hints command.

--- a/crates/tinymist-query/src/upstream/complete.rs
+++ b/crates/tinymist-query/src/upstream/complete.rs
@@ -19,7 +19,8 @@ use super::{plain_docs_sentence, summarize_font_family};
 use crate::adt::interner::Interned;
 use crate::analysis::{analyze_labels, DynLabel, LocalContext, Ty};
 use crate::snippet::{
-    CompletionContextKey, PrefixSnippet, SurroundingSyntax, DEFAULT_PREFIX_SNIPPET,
+    CompletionCommand, CompletionContextKey, PrefixSnippet, SurroundingSyntax,
+    DEFAULT_PREFIX_SNIPPET,
 };
 use crate::syntax::InterpretMode;
 
@@ -670,15 +671,18 @@ impl<'a> CompletionContext<'a> {
                 continue;
             }
 
+            let analysis = &self.ctx.analysis;
+            let command = match snippet.command {
+                Some(CompletionCommand::TriggerSuggest) => analysis.trigger_suggest(true),
+                None => analysis.trigger_on_snippet(snippet.snippet.contains("${")),
+            };
+
             self.completions.push(Completion {
                 kind: CompletionKind::Syntax,
                 label: snippet.label.as_ref().into(),
                 apply: Some(snippet.snippet.as_ref().into()),
                 detail: Some(snippet.description.as_ref().into()),
-                command: self
-                    .ctx
-                    .analysis
-                    .trigger_on_snippet(snippet.snippet.contains("${")),
+                command,
                 ..Completion::default()
             });
         }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:8cebcc89c1cbdaab64ad54fded330afb");
+        insta::assert_snapshot!(hash, @"siphash128_13:3305840819ce4ac8adbbc73890288188");
     }
 
     {
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:6ee935b352766f1faebe86fac4cb77c1");
+        insta::assert_snapshot!(hash, @"siphash128_13:68d3c231276b454db893af55139d9cad");
     }
 }
 


### PR DESCRIPTION
Almost all people may love to get a list of package completion items after completed import/include snippets, but this was prevented by auto decision by `tinymist.completion.triggerOnSnippetPlaceholders`.