### PR TITLE
feat: neovim client-side check and configure completion callbacks

### DIFF
--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -26,7 +26,27 @@ return {
             return vim.fn.getcwd()
           end,
           --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/Configuration.md) for references.
-          settings = {}
+          settings = {
+            
+            -- Please don't edit following internal settings if you don't know what you are doing.
+            -- Neovim 0.9.1 supported these builitin commands
+            -- editor.action.triggerSuggest
+            triggerSuggest = vim.fn.has("nvim-0.9.1"),
+            -- editor.action.triggerParameterHints
+            triggerParameterHints = vim.fn.has("nvim-0.9.1"),
+            -- tinymist.triggerSuggestAndParameterHints which combines the above two commands.
+            triggerSuggestAndParameterHints = vim.fn.has("nvim-0.9.1"),
+          },
+          -- todo: this is not a correct implementation
+          commands = {
+            "tinymist.triggerSuggestAndParameterHints" = {
+              function()
+                vscode_neovim.action("editor.action.triggerSuggest")
+                vscode_neovim.action("editor.action.triggerParameterHints")
+              end,
+              desc = "Trigger Suggest and Parameter Hints",
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
This PR shows the ways of set up completion callbacks for the language server to enhance experience of lsp-based completion. As #875 said, these commands cannot be checked at language server side, so the client must take responsibility to check them and push configuration to the server. todo list:

- [ ] check existence of commands,  `triggerSuggest` and `triggerParameterHints`
- [ ] implement command `tinymist.triggerSuggestAndParameterHints` to callback above two commands.
- [ ] find a way to promote the configuration, e.g. add an PR to nvim-lspconfig.
