### PR TITLE
refactor: improving names of matched structs and documenting matchers

### DIFF
--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -104,7 +104,7 @@ mod matcher_tests {
     use typst::syntax::LinkedNode;
     use typst_shim::syntax::LinkedNodeExt;
 
-    use crate::{syntax::get_def_target, tests::*};
+    use crate::{syntax::classify_def, tests::*};
 
     #[test]
     fn test() {
@@ -118,7 +118,7 @@ mod matcher_tests {
             let root = LinkedNode::new(source.root());
             let node = root.leaf_at_compat(pos).unwrap();
 
-            let result = get_def_target(node).map(|e| format!("{:?}", e.node().range()));
+            let result = classify_def(node).map(|e| format!("{:?}", e.node().range()));
             let result = result.as_deref().unwrap_or("<nil>");
 
             assert_snapshot!(result);
@@ -436,7 +436,7 @@ mod signature_tests {
     use typst_shim::syntax::LinkedNodeExt;
 
     use crate::analysis::{analyze_signature, Signature, SignatureTarget};
-    use crate::syntax::get_deref_target;
+    use crate::syntax::classify_syntax;
     use crate::tests::*;
 
     #[test]
@@ -450,7 +450,7 @@ mod signature_tests {
 
             let root = LinkedNode::new(source.root());
             let callee_node = root.leaf_at_compat(pos).unwrap();
-            let callee_node = get_deref_target(callee_node, pos).unwrap();
+            let callee_node = classify_syntax(callee_node, pos).unwrap();
             let callee_node = callee_node.node();
 
             let result = analyze_signature(

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::analysis::PostTypeChecker;
 use crate::docs::{UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
-use crate::syntax::get_non_strict_def_target;
+use crate::syntax::classify_def_loosely;
 use crate::ty::{DynTypeBounds, ParamAttrs};
 use crate::ty::{InsTy, TyCtx};
 use crate::upstream::truncated_repr;
@@ -205,7 +205,7 @@ fn analyze_type_signature(
         SignatureTarget::Runtime(f) => {
             let source = ctx.source_by_id(f.span().id()?).ok()?;
             let node = source.find(f.span())?;
-            let def = get_non_strict_def_target(node.parent()?.clone())?;
+            let def = classify_def_loosely(node.parent()?.clone())?;
             let type_info = ctx.type_check(&source);
             let ty = type_info.type_of_span(def.name()?.span())?;
             Some((type_info, ty))

--- a/crates/tinymist-query/src/goto_declaration.rs
+++ b/crates/tinymist-query/src/goto_declaration.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use crate::{prelude::*, syntax::DerefTarget, SemanticRequest};
+use crate::{prelude::*, syntax::SyntaxClass, SemanticRequest};
 
 /// The [`textDocument/declaration`] request asks the server for the declaration
 /// location of a symbol at a given text document position.
@@ -39,7 +39,7 @@ impl SemanticRequest for GotoDeclarationRequest {
 fn find_declarations(
     _ctx: &LocalContext,
     _expr_info: Arc<crate::syntax::ExprInfo>,
-    _deref_target: DerefTarget<'_>,
+    _syntax: SyntaxClass<'_>,
 ) -> Option<Vec<Range<usize>>> {
     todo!()
 }

--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -32,10 +32,10 @@ impl StatefulRequest for GotoDefinitionRequest {
         doc: Option<VersionedDocument>,
     ) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
-        let deref_target = ctx.deref_syntax_at(&source, self.position, 1)?;
-        let origin_selection_range = ctx.to_lsp_range(deref_target.node().range(), &source);
+        let syntax = ctx.classify_pos(&source, self.position, 1)?;
+        let origin_selection_range = ctx.to_lsp_range(syntax.node().range(), &source);
 
-        let def = ctx.def_of_syntax(&source, doc.as_ref(), deref_target)?;
+        let def = ctx.def_of_syntax(&source, doc.as_ref(), syntax)?;
 
         let (fid, def_range) = def.def_at(ctx.shared())?;
         let uri = ctx.uri_for_id(fid).ok()?;

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -117,8 +117,8 @@ fn def_tooltip(
     cursor: usize,
 ) -> Option<HoverContents> {
     let leaf = LinkedNode::new(source.root()).leaf_at_compat(cursor)?;
-    let deref_target = get_deref_target(leaf.clone(), cursor)?;
-    let def = ctx.def_of_syntax(source, document, deref_target.clone())?;
+    let syntax = classify_syntax(leaf.clone(), cursor)?;
+    let def = ctx.def_of_syntax(source, document, syntax.clone())?;
 
     let mut results = vec![];
     let mut actions = vec![];
@@ -147,7 +147,7 @@ fn def_tooltip(
 
             if matches!(def.decl.kind(), DefKind::Variable | DefKind::Constant) {
                 // todo: check sensible length, value highlighting
-                if let Some(values) = expr_tooltip(ctx.world(), deref_target.node()) {
+                if let Some(values) = expr_tooltip(ctx.world(), syntax.node()) {
                     match values {
                         Tooltip::Text(values) => {
                             results.push(MarkedString::String(values.into()));

--- a/crates/tinymist-query/src/prelude.rs
+++ b/crates/tinymist-query/src/prelude.rs
@@ -33,6 +33,6 @@ pub use crate::lsp_typst_boundary::{
     lsp_to_typst, path_to_url, typst_to_lsp, LspDiagnostic, LspRange, LspSeverity,
     PositionEncoding, TypstDiagnostic, TypstSeverity, TypstSpan,
 };
-pub use crate::syntax::{get_deref_target, Decl, DefKind};
+pub use crate::syntax::{classify_syntax, Decl, DefKind};
 pub(crate) use crate::ty::PathPreference;
 pub use crate::{SemanticRequest, StatefulRequest, VersionedDocument};


### PR DESCRIPTION
made some bikeshedding on names of matchers. The main changes are that the useless verb `get` is replaced by `classify`, which is commonly used by compilers checking some special syntax structures, and the noun `Target` is replaced by the corresponding noun of `classify`, i.e. `Class`. Among them, the core struct for ide functions is named as `SyntaxClass`, to refer the classes of syntax structure to be checked by ide functions. 
After naming, it should improve the readability, e.g. :
```patch
-   let deref_target = get_deref_target(leaf.clone(), cursor)?;
-   let def = ctx.def_of_syntax(source, document, deref_target.clone())?;
+   let syntax = classify_syntax(leaf.clone(), cursor)?;
+   let def = ctx.def_of_syntax(source, document, syntax.clone())?;
```