### PR TITLE
feat: infer types of show rule transformers

### DIFF
--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@set_in_show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@set_in_show.typ.snap
@@ -15,7 +15,7 @@ snapshot_kind: text
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "052",
+    "sortText": "053",
     "textEdit": {
      "newText": "raw(${1:})",
      "range": {

--- a/crates/tinymist-query/src/fixtures/type_check/show.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/show.typ
@@ -1,0 +1,5 @@
+/// contains: text
+
+#show regex(":\S+:"): it => it./* range 0..1 */
+
+:test:

--- a/crates/tinymist-query/src/fixtures/type_check/show_raw.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/show_raw.typ
@@ -1,0 +1,5 @@
+/// contains: text
+
+#show raw: it => it./* range 0..1 */
+
+:test:

--- a/crates/tinymist-query/src/fixtures/type_check/show_raw_where.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/show_raw_where.typ
@@ -1,0 +1,5 @@
+/// contains: text
+
+#show raw.where(block: false): it => it./* range 0..1 */
+
+:test:

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show.typ.snap
@@ -1,0 +1,15 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/show.typ
+snapshot_kind: text
+---
+"" = (Any) => Any.it
+"it" = Element(text)
+=====
+26..31 -> Type(regex)
+26..40 -> Type(regex)
+42..44 -> @it
+42..51 -> @
+48..50 -> @it
+48..51 -> @v"it".it

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw.typ.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/show_raw.typ
+snapshot_kind: text
+---
+"" = (Any) => Any.it
+"it" = Element(raw)
+=====
+26..29 -> Func(raw)
+31..33 -> @it
+31..40 -> @
+37..39 -> @it
+37..40 -> @v"it".it

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw_where.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw_where.typ.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/show_raw_where.typ
+snapshot_kind: text
+---
+"" = (Any) => Any.it
+"it" = Element(raw)
+=====
+26..29 -> Func(raw)
+26..35 -> (Func(raw) | Func(raw).where)
+26..49 -> (Func(raw)).with(..("block": false) => any)
+51..53 -> @it
+51..60 -> @
+57..59 -> @it
+57..60 -> @v"it".it


### PR DESCRIPTION
Inferring `it` variables in following cases:
```typ
#show regex(":\S+:"): it => it
#show raw: it => it
#show raw.where(block: false): it => it
```