### PR TITLE
fix: typst language words should not contain dollars

### DIFF
--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -395,7 +395,7 @@ class LanguageState {
     }
 
     const wordPattern =
-      /(-?\d*.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.<\>\/\?\s]+)/;
+      /(-?\d*.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.<\>\/\?\s]+)/;
 
     console.log("Setting up language configuration", typingContinueCommentsOnNewline);
     this.configureLang = vscode.languages.setLanguageConfiguration("typst", {


### PR DESCRIPTION
The word pattern was copied from some GitHub issue but it is not suitable for typst, at least we see a bug in #1053. That is we should not match dollar to identify a typst word. Bug cases:

Before fix:

```
$R
^^ word
$ R
  ^ word
$R$
^^^ word
```

After fix:

```
$R
 ^ word
$ R
  ^ word
$R$
 ^ word
```


