### PR TITLE
ci: build universe target vscode extension for other platforms

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -114,6 +114,7 @@ jobs:
       isRelease: ${{ (startsWith(github.ref, 'refs/tags/') && (!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8')))) }}
       isNightly: ${{ ((startsWith(github.ref, 'refs/tags/') && !((!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8'))))) || (!startsWith(github.ref, 'refs/tags/') && matrix.regular_build == 'true')) }}
       isTest: ${{ matrix.rust-target == 'x86_64-unknown-linux-gnu' || matrix.rust-target == 'x86_64-pc-windows-msvc' }}
+      isNoServer: ${{ matrix.rust-target == 'x86_64-unknown-linux-gnu' }}
     steps:
       - name: "Print Env"
         run: |
@@ -121,6 +122,8 @@ jobs:
           echo "Target: ${{ env.target }}"
           echo "Is Release: ${{ fromJson(env.isRelease) }}"
           echo "Is Nightly: ${{ fromJson(env.isNightly) }}"
+          echo "Is Test: ${{ fromJson(env.isTest) }}"
+          echo "Is NoServer: ${{ fromJson(env.isNoServer) }}"
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -263,6 +266,25 @@ jobs:
         with:
           name: tinymist-${{ env.target }}.vsix
           path: editors/vscode/tinymist-${{ env.target }}.vsix
+
+      - name: Remove server binary
+        if: fromJson(env.isNoServer)
+        run: rm "editors/vscode/out/tinymist"
+      - name: Package extension (No Server)
+        if: fromJson(env.isRelease) && fromJson(env.isNoServer)
+        run: yarn run package -- -o tinymist-no-server.vsix
+        working-directory: ./editors/vscode
+      - name: Package extension (No Server, Nightly)
+        if: fromJson(env.isNightly) && fromJson(env.isNoServer)
+        run: yarn run package -- -o tinymist-no-server.vsix --pre-release
+        working-directory: ./editors/vscode
+      - name: Upload tinymist VSIX artifact (No Server)
+        if: (fromJson(env.isRelease) || fromJson(env.isNightly)) && fromJson(env.isNoServer)
+        uses: actions/upload-artifact@v4
+        with:
+          name: tinymist-no-server.vsix
+          path: editors/vscode/tinymist-no-server.vsix
+
       - name: Upload Tinymist E2E Test Snapshot 
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -114,7 +114,7 @@ jobs:
       isRelease: ${{ (startsWith(github.ref, 'refs/tags/') && (!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8')))) }}
       isNightly: ${{ ((startsWith(github.ref, 'refs/tags/') && !((!contains(github.ref, 'rc') && (endsWith(github.ref, '0') || endsWith(github.ref, '2') || endsWith(github.ref, '4') || endsWith(github.ref, '6') || endsWith(github.ref, '8'))))) || (!startsWith(github.ref, 'refs/tags/') && matrix.regular_build == 'true')) }}
       isTest: ${{ matrix.rust-target == 'x86_64-unknown-linux-gnu' || matrix.rust-target == 'x86_64-pc-windows-msvc' }}
-      isNoServer: ${{ matrix.rust-target == 'x86_64-unknown-linux-gnu' }}
+      isUniverse: ${{ matrix.rust-target == 'x86_64-unknown-linux-gnu' }}
     steps:
       - name: "Print Env"
         run: |
@@ -123,7 +123,7 @@ jobs:
           echo "Is Release: ${{ fromJson(env.isRelease) }}"
           echo "Is Nightly: ${{ fromJson(env.isNightly) }}"
           echo "Is Test: ${{ fromJson(env.isTest) }}"
-          echo "Is NoServer: ${{ fromJson(env.isNoServer) }}"
+          echo "Is Universe (No Server): ${{ fromJson(env.isUniverse) }}"
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -267,23 +267,25 @@ jobs:
           name: tinymist-${{ env.target }}.vsix
           path: editors/vscode/tinymist-${{ env.target }}.vsix
 
+      # The universe target doesn't bundle the binary. Users of that must install
+      # tinymist by themselves.
       - name: Remove server binary
-        if: fromJson(env.isNoServer)
+        if: fromJson(env.isUniverse)
         run: rm "editors/vscode/out/tinymist"
-      - name: Package extension (No Server)
-        if: fromJson(env.isRelease) && fromJson(env.isNoServer)
-        run: yarn run package -- -o tinymist-no-server.vsix
+      - name: Package extension (Universe)
+        if: fromJson(env.isRelease) && fromJson(env.isUniverse)
+        run: yarn run package -- -o tinymist-universe.vsix
         working-directory: ./editors/vscode
-      - name: Package extension (No Server, Nightly)
-        if: fromJson(env.isNightly) && fromJson(env.isNoServer)
-        run: yarn run package -- -o tinymist-no-server.vsix --pre-release
+      - name: Package extension (Universe, Nightly)
+        if: fromJson(env.isNightly) && fromJson(env.isUniverse)
+        run: yarn run package -- -o tinymist-universe.vsix --pre-release
         working-directory: ./editors/vscode
-      - name: Upload tinymist VSIX artifact (No Server)
-        if: (fromJson(env.isRelease) || fromJson(env.isNightly)) && fromJson(env.isNoServer)
+      - name: Upload tinymist VSIX artifact (Universe)
+        if: (fromJson(env.isRelease) || fromJson(env.isNightly)) && fromJson(env.isUniverse)
         uses: actions/upload-artifact@v4
         with:
-          name: tinymist-no-server.vsix
-          path: editors/vscode/tinymist-no-server.vsix
+          name: tinymist-universe.vsix
+          path: editors/vscode/tinymist-universe.vsix
 
       - name: Upload Tinymist E2E Test Snapshot 
         if: always()


### PR DESCRIPTION
The universe target doesn't bundle the binary. This is suitable for other platforms like riscv64 or loongarch64. Users of that must install tinymist by themselves. Note it introduces risk to use unaligned version of the extension and the binary, but we can mitigate it in future.