### PR TITLE
docs: state `shiroa` as a requirement

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -55,7 +55,7 @@ yarn docs:rs --open
 ```
 
 > [!Tip]
-> You must install [Shiroa](https://myriad-dreamin.github.io/shiroa/guide/installation.html) to build the docs with `yarn`, see the `shiroa` command for more information.
+> Please install [Shiroa](https://myriad-dreamin.github.io/shiroa/guide/installation.html) to build the docs with `yarn`.
 
 If you find missing or incomplete documentation, please feel free to open an issue or pull request. There is also a tracking issue to improve the documentation, see [Request for Documentation (RFD)](https://github.com/Myriad-Dreamin/tinymist/issues/931).
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -55,9 +55,9 @@ yarn docs:rs --open
 ```
 
 > [!Tip]
-> Check [Shiroa](https://myriad-dreamin.github.io/shiroa/guide/installation.html) to install the `shiroa` command for documentation generation.
+> You must install [Shiroa](https://myriad-dreamin.github.io/shiroa/guide/installation.html) to build the docs with `yarn`, see the `shiroa` command for more information.
 
-If you find something are not documented, please feel free to open an issue or pull request. There is also a tracking issue to improve the documentation, see [Request for Documentation (RFD)](https://github.com/Myriad-Dreamin/tinymist/issues/931).
+If you find missing or incomplete documentation, please feel free to open an issue or pull request. There is also a tracking issue to improve the documentation, see [Request for Documentation (RFD)](https://github.com/Myriad-Dreamin/tinymist/issues/931).
 
 ## Contribute to tinymist-assets or tools/typst-preview-frontend
 


### PR DESCRIPTION
Building the docs via `yarn docs` wraps `shiroa`, I could not build them without first installing `shiroa` which should be stated clearly in the development guide.