### PR TITLE
[WIP] Websocket authentication for preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "open",
  "parking_lot",
  "paste",
+ "rand",
  "rayon",
  "reflexo",
  "reflexo-typst",
@@ -3844,9 +3845,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "strum",
  "sync-lsp",
- "tinymist-assets 0.12.16-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets",
  "tinymist-query",
  "tinymist-render",
  "tinymist-world",
@@ -3891,12 +3893,6 @@ dependencies = [
 [[package]]
 name = "tinymist-assets"
 version = "0.12.16-rc1"
-
-[[package]]
-name = "tinymist-assets"
-version = "0.12.16-rc1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d5678f6753b3adda671a428842f1ada25ded7ce78dcfe83bb152120eb7b3fc"
 
 [[package]]
 name = "tinymist-derive"
@@ -3989,7 +3985,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "tinymist-assets 0.12.16-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets",
  "typst",
  "typst-assets",
 ]
@@ -4376,7 +4372,7 @@ dependencies = [
  "reflexo-vec2svg",
  "serde",
  "serde_json",
- "tinymist-assets 0.12.16-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinymist-assets",
  "tokio",
  "typst",
  "typst-assets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ strum = { version = "0.26.2", features = ["derive"] }
 quote = "1"
 syn = "2"
 triomphe = { version = "0.1.10", default-features = false, features = ["std"] }
+rand = "0.8.5"
+sha2 = "0.10.8"
 
 # Asynchoronous and Multi-threading
 async-trait = "0.1.77"
@@ -146,7 +148,9 @@ insta = { version = "1.39", features = ["glob"] }
 
 # Our Own Crates
 typst-preview = { path = "./crates/typst-preview" }
-tinymist-assets = { version = "0.12.16-rc1" }
+# TODO: temporarily for dev
+# tinymist-assets = { version = "0.12.16-rc1" }
+tinymist-assets = { path = "./crates/tinymist-assets" }
 tinymist = { path = "./crates/tinymist/" }
 tinymist-derive = { path = "./crates/tinymist-derive/" }
 tinymist-analysis = { path = "./crates/tinymist-analysis/" }

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -84,6 +84,8 @@ open = { workspace = true, optional = true }
 dirs.workspace = true
 base64.workspace = true
 rayon.workspace = true
+rand.workspace = true
+sha2.workspace = true
 
 [features]
 default = ["cli", "embed-fonts", "no-content-hint", "preview"]

--- a/crates/tinymist/src/tool/preview/auth.rs
+++ b/crates/tinymist/src/tool/preview/auth.rs
@@ -80,10 +80,11 @@ pub async fn try_auth_websocket_client(
         .context("auth response 1 missing")??;
     let response: AuthMsgResponseClient = serde_json::from_str(response.to_text()?)?;
 
-    if sha512hex(format!("{}{}{}", secret, challenge, response.cnonce).as_str()) == response.hash {
+    if sha512hex(format!("{}:{}:{}", secret, challenge, response.cnonce).as_str()) == response.hash
+    {
         // ... then we authenticate to the client
         let snonce = generate_token();
-        let hash = sha512hex(format!("{}{}{}", secret, response.challenge, snonce).as_str());
+        let hash = sha512hex(format!("{}:{}:{}", secret, response.challenge, snonce).as_str());
         let json = serde_json::to_string(&AuthMsgResponseServer {
             snonce: &snonce,
             hash: &hash,

--- a/crates/tinymist/src/tool/preview/auth.rs
+++ b/crates/tinymist/src/tool/preview/auth.rs
@@ -1,0 +1,100 @@
+use anyhow::{Context, Result};
+use futures::SinkExt;
+use futures::StreamExt;
+use hyper_tungstenite::{tungstenite::Message, HyperWebsocketStream};
+use rand::distributions::{Alphanumeric, DistString};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+const TOKEN_LENGTH: usize = 50;
+
+pub fn generate_token() -> String {
+    Alphanumeric.sample_string(&mut rand::thread_rng(), TOKEN_LENGTH)
+}
+
+fn sha512hex(text: &str) -> String {
+    let hash = Sha512::digest(text);
+    format!("{:x}", hash)
+}
+
+#[derive(Serialize, Debug)]
+struct AuthMsgChallenge<'a> {
+    challenge: &'a str,
+}
+
+#[derive(Deserialize, Debug)]
+struct AuthMsgResponseClient<'a> {
+    hash: &'a str,
+    challenge: &'a str,
+    cnonce: &'a str,
+}
+
+#[derive(Serialize, Debug)]
+struct AuthMsgResponseServer<'a> {
+    hash: &'a str,
+    snonce: &'a str,
+}
+
+#[derive(Serialize, Debug)]
+struct AuthFailResponseServer {
+    auth: bool,
+}
+
+#[derive(Debug, Clone)]
+struct AuthError;
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Authentication failed")
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Websocket Authentication
+///
+/// This a) authenticates the client to us and b) we (the server) authenticate ourselves to the client.
+///
+/// a) is important so that we don't send any sensitive information to clients that are not supposed to know that information.
+///    For example, this protects against the fact that browsers allow any website to connect to websockets on 127.0.0.1
+/// b) is important because on multi-user systems another user can potentially impersonate us (the server) and trick the client
+///    into sending private information to that other server instead of to us.
+///
+/// This function takes an owned `HyperWebsocketStream` to avoid accidental misuse elsewhere before authentication.
+///
+/// TODO: This is a basic challenge response authentication with nonces. Is there something more standard we could use?
+pub async fn try_auth_websocket_client(
+    mut websocket: HyperWebsocketStream,
+    secret: &str,
+) -> Result<HyperWebsocketStream> {
+    // First we send the client a challenge to authenticate the client to us ...
+    let challenge = generate_token();
+    let json = serde_json::to_string(&AuthMsgChallenge {
+        challenge: &challenge,
+    })?;
+    websocket.send(Message::Binary(json.into())).await?;
+
+    let response = websocket
+        .next()
+        .await
+        .context("auth response 1 missing")??;
+    let response: AuthMsgResponseClient = serde_json::from_str(response.to_text()?)?;
+
+    if sha512hex(format!("{}{}{}", secret, challenge, response.cnonce).as_str()) == response.hash {
+        // ... then we authenticate to the client
+        let snonce = generate_token();
+        let hash = sha512hex(format!("{}{}{}", secret, response.challenge, snonce).as_str());
+        let json = serde_json::to_string(&AuthMsgResponseServer {
+            snonce: &snonce,
+            hash: &hash,
+        })?;
+        websocket.send(Message::Binary(json.into())).await?;
+
+        Ok(websocket)
+    } else {
+        log::info!("Websocket client authentication failed.");
+        let json = serde_json::to_string(&AuthFailResponseServer { auth: false })?;
+        websocket.send(Message::Binary(json.into())).await?;
+        Err(AuthError.into())
+    }
+}

--- a/editors/vscode/src/features/preview-compat.ts
+++ b/editors/vscode/src/features/preview-compat.ts
@@ -287,11 +287,10 @@ export const launchPreviewCompat = async (task: LaunchInBrowserTask | LaunchInWe
   const enableCursor =
     vscode.workspace.getConfiguration().get<boolean>("typst-preview.cursorIndicator") || false;
   await watchEditorFiles();
-  const { serverProcess, controlPlanePort, dataPlanePort, staticFilePort } = await launchCli(
+  const { serverProcess, controlPlanePort, dataPlanePort, secret, staticFilePort } = await launchCli(
     task.kind === "browser",
   );
 
-  const secret = '__no_secret_because_typst-preview_doesnt_support_it__';
 
   const addonΠserver = new Addon2Server(
     controlPlanePort,
@@ -415,11 +414,12 @@ export const launchPreviewCompat = async (task: LaunchInBrowserTask | LaunchInWe
     console.log(
       `Launched server, data plane port:${dataPlanePort}, control plane port:${controlPlanePort}, static file port:${staticFilePort}`,
     );
+    const secret = '__no_secret_because_typst-preview_doesnt_support_it__';
     if (openInBrowser) {
       const wsUrl =  `ws://127.0.0.1:${dataPlanePort}`;
       const queryString = (new URLSearchParams({
         previewMode: task.mode === "doc" ? "Doc" : "Slide",
-        secret: '__no_secret_because_typst-preview_doesnt_support_it__',
+        secret,
         wsUrl,
       })).toString();
       vscode.env.openExternal(vscode.Uri.parse(`http://127.0.0.1:${staticFilePort}/#${queryString}`));
@@ -429,6 +429,7 @@ export const launchPreviewCompat = async (task: LaunchInBrowserTask | LaunchInWe
       serverProcess,
       dataPlanePort,
       controlPlanePort,
+      secret,
       staticFilePort,
     };
   }

--- a/editors/vscode/src/features/preview-compat.ts
+++ b/editors/vscode/src/features/preview-compat.ts
@@ -414,7 +414,7 @@ export const launchPreviewCompat = async (task: LaunchInBrowserTask | LaunchInWe
     console.log(
       `Launched server, data plane port:${dataPlanePort}, control plane port:${controlPlanePort}, static file port:${staticFilePort}`,
     );
-    const secret = '__no_secret_because_typst-preview_doesnt_support_it__';
+    const secret = '__unsafe-disable__';
     if (openInBrowser) {
       const wsUrl =  `ws://127.0.0.1:${dataPlanePort}`;
       const queryString = (new URLSearchParams({

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -573,7 +573,8 @@ class ContentPreviewProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken,
   ) {
     this._view = webviewView; // 将已经准备好的 HTML 设置为 Webview 内容
-
+    
+    // TODO: Can this `typst-webview-assets` thing be removed?
     const fontendPath = path.resolve(this.context.extensionPath, "out/frontend");
     let html = this.htmlContent.replace(
       /\/typst-webview-assets/g,
@@ -581,8 +582,6 @@ class ContentPreviewProvider implements vscode.WebviewViewProvider {
         .asWebviewUri(vscode.Uri.file(fontendPath))
         .toString()}/typst-webview-assets`,
     );
-
-    html = html.replace("ws://127.0.0.1:23625", ``);
 
     webviewView.webview.options = {
       // Allow scripts in the webview

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -48,6 +48,10 @@ export interface PreviewResult {
    */
   dataPlanePort?: number;
   /**
+   * The secret used for websocket authentication
+   */
+  secret: string,
+  /**
    * Whether the preview content is provided by the primary compiler instance. This must be indicate by the CLI argument `--not-primary`
    * when starts a preview task by *LSP Command*.
    *

--- a/tools/typst-preview-frontend/index.html
+++ b/tools/typst-preview-frontend/index.html
@@ -18,36 +18,9 @@
 
       /// We're sending this html to un-authenticated clients. So no potentially sensitive data should
       /// be in the html itself. We pass all needed parameters in the # part of the URL
-      /// However: VSCode webview panels don't support this I think? So provide an escape hatch for VSCode.
-      ///          to set a special variable. This is ok since VSCode webviews cannot be reached by anyone
-      ///          outside VSCode.
-      const __VSCODE_SECRET_PARAMETERS = undefined;
-      const ARGS = new URLSearchParams(
-          // Check for `acquireVsCodeApi` to help avoid accidental misuse of this outside vscode
-          (__VSCODE_SECRET_PARAMETERS !== undefined && typeof acquireVsCodeApi !== "undefined") ?
-          __VSCODE_SECRET_PARAMETERS :
-          window.location.hash.slice(1)
-      );
-
-      if (typeof acquireVsCodeApi !== "undefined") {
-        const bytes2utf8 = new TextDecoder("utf-8");
-        /**
-         * Base64 to UTF-8
-         * @param encoded Base64 encoded string
-         * @returns UTF-8 string
-         */
-        const base64Decode = (encoded) =>
-          bytes2utf8.decode(
-            Uint8Array.from(atob(encoded), (m) => m.charCodeAt(0))
-          );
-        let state = ARGS.get('state');
-        console.log("state", state);
-        if (state !== "") {
-          /// Set it later when acquiring the VSCode API
-          window.vscode_state = JSON.parse(base64Decode(state));
-          console.log("vscode_state", window.vscode_state);
-        }
-      }
+      /// Note: In VSCode, the parameters are _not_ passed in throuh the URL but through a message using
+      ///       `acquireVsCodeApi()`. See `setupVscodeChannel()`
+      const ARGS = new URLSearchParams(window.location.hash.slice(1));
 
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js
       function deltaE(rgbA, rgbB) {

--- a/tools/typst-preview-frontend/index.html
+++ b/tools/typst-preview-frontend/index.html
@@ -23,7 +23,8 @@
       ///          outside VSCode.
       const __VSCODE_SECRET_PARAMETERS = undefined;
       const ARGS = new URLSearchParams(
-          __VSCODE_SECRET_PARAMETERS !== undefined ?
+          // Check for `acquireVsCodeApi` to help avoid accidental misuse of this outside vscode
+          (__VSCODE_SECRET_PARAMETERS !== undefined && typeof acquireVsCodeApi !== "undefined") ?
           __VSCODE_SECRET_PARAMETERS :
           window.location.hash.slice(1)
       );

--- a/tools/typst-preview-frontend/index.html
+++ b/tools/typst-preview-frontend/index.html
@@ -15,6 +15,19 @@
     <style id="preview-theme-styles"></style>
     <!-- before all of code to avoid rerender by style replacement -->
     <script>
+
+      /// We're sending this html to un-authenticated clients. So no potentially sensitive data should
+      /// be in the html itself. We pass all needed parameters in the # part of the URL
+      /// However: VSCode webview panels don't support this I think? So provide an escape hatch for VSCode.
+      ///          to set a special variable. This is ok since VSCode webviews cannot be reached by anyone
+      ///          outside VSCode.
+      const __VSCODE_SECRET_PARAMETERS = undefined;
+      const ARGS = new URLSearchParams(
+          __VSCODE_SECRET_PARAMETERS !== undefined ?
+          __VSCODE_SECRET_PARAMETERS :
+          window.location.hash.slice(1)
+      );
+
       if (typeof acquireVsCodeApi !== "undefined") {
         const bytes2utf8 = new TextDecoder("utf-8");
         /**
@@ -26,10 +39,7 @@
           bytes2utf8.decode(
             Uint8Array.from(atob(encoded), (m) => m.charCodeAt(0))
           );
-        /// The string here is a placeholder
-        /// It will be replaced by the actual preview mode.
-        let state = `preview-arg:state:`;
-        state = state.replace("preview-arg:state:", "");
+        let state = ARGS.get('state');
         console.log("state", state);
         if (state !== "") {
           /// Set it later when acquiring the VSCode API

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -14,9 +14,11 @@ import { setupDrag } from './drag';
 main();
 
 function main() {
-    const wsArgs = retrieveWsArgs();
     const { nextWs } = buildWs();
-    window.onload = () => nextWs(wsArgs);
+    const wsArgs = retrieveWsArgs();
+    // For the vscode `ContentPreviewProvider`, we initially don't have any info where to connect, so don't try.
+    if(wsArgs.secret) 
+        window.onload = () => nextWs(wsArgs);
     setupVscodeChannel(nextWs);
     setupDrag();
 }

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -21,27 +21,19 @@ function main() {
     setupDrag();
 }
 
-/// Placeholders for typst-preview program initializing frontend
-/// arguments.
+/// Typst-preview program initializing frontend arguments.
 function retrieveWsArgs() {
-    /// The string `preview-arg:previewMode:Doc` is a placeholder
-    /// It will be replaced by the actual preview mode.
-    /// ```rs
-    ///   let frontend_html = frontend_html.replace(
-    ///     "preview-arg:previewMode:Doc", ...);
-    /// ```
-    let mode = 'preview-arg:previewMode:Doc';
-    /// Remove the placeholder prefix.
-    mode = mode.replace('preview-arg:previewMode:', '');
+
+    let url = ARGS.get('wsUrl') ?? '/';
+    let secret = ARGS.get('secret');
+    let mode = ARGS.get('previewMode');
     let previewMode = PreviewMode[mode];
 
-    /// The string `ws://127.0.0.1:23625` is a placeholder
-    /// Also, it is the default url to connect to.
     /// Note that we must resolve the url to an absolute url as
     /// the websocket connection requires an absolute url.
     ///
     /// See [WebSocket and relative URLs](https://github.com/whatwg/websockets/issues/20)
-    let urlObject = new URL("ws://127.0.0.1:23625", window.location.href);
+    let urlObject = new URL(url, window.location.href);
     /// Rewrite the protocol to websocket.
     urlObject.protocol = urlObject.protocol.replace('https:', 'wss:').replace('http:', 'ws:');
     if (location.href.startsWith("https://")) {
@@ -49,7 +41,7 @@ function retrieveWsArgs() {
     }
 
     /// Return a `WsArgs` object.
-    return { url: urlObject.href, previewMode, isContentPreview: false };
+    return { url: urlObject.href, previewMode, isContentPreview: false, secret };
 }
 
 /// `buildWs` returns a object, which keeps track of websocket
@@ -114,6 +106,7 @@ function setupVscodeChannel(nextWs) {
                 console.log('reconnect', message);
                 nextWs({
                     url: message.url,
+                    secret: message.secret,
                     previewMode: PreviewMode[message.mode],
                     isContentPreview: message.isContentPreview,
                 });

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -26,7 +26,7 @@ function retrieveWsArgs() {
 
     let url = ARGS.get('wsUrl') ?? '/';
     let secret = ARGS.get('secret');
-    let mode = ARGS.get('previewMode');
+    let mode = ARGS.get('previewMode') ?? 'Doc';
     let previewMode = PreviewMode[mode];
 
     /// Note that we must resolve the url to an absolute url as

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -16,7 +16,7 @@ main();
 function main() {
     const { nextWs } = buildWs();
     const wsArgs = retrieveWsArgs();
-    // For the vscode `ContentPreviewProvider`, we initially don't have any info where to connect, so don't try.
+    // For vscode, we initially don't have any info where to connect, so don't try.
     if(wsArgs.secret) 
         window.onload = () => nextWs(wsArgs);
     setupVscodeChannel(nextWs);
@@ -95,10 +95,6 @@ function setupVscodeChannel(nextWs) {
     if (vscodeAPI?.postMessage) {
         vscodeAPI.postMessage({ type: 'started' });
     }
-    if (vscodeAPI?.setState && window.vscode_state) {
-        vscodeAPI.setState(window.vscode_state);
-    }
-
 
     // Handle messages sent from the extension to the webview
     window.addEventListener('message', event => {
@@ -106,6 +102,12 @@ function setupVscodeChannel(nextWs) {
         switch (message.type) {
             case 'reconnect': {
                 console.log('reconnect', message);
+
+                if(typeof message.state !== "undefined" && vscodeAPI?.setState) {
+                    console.log("vscode_state", message.state);
+                    vscodeAPI.setState(message.state);
+                }
+
                 nextWs({
                     url: message.url,
                     secret: message.secret,

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -16,7 +16,8 @@ main();
 function main() {
     const { nextWs } = buildWs();
     const wsArgs = retrieveWsArgs();
-    // For vscode, we initially don't have any info where to connect, so don't try.
+    // If a `wsArgs.secret` is not set, we cannot establish the connection on loading. This usually happens when the preview
+    // is opened inside VS Code. For VS Code, we'll finally establish it in {@link setupVscodeChannel}.
     if(wsArgs.secret) 
         window.onload = () => nextWs(wsArgs);
     setupVscodeChannel(nextWs);

--- a/tools/typst-preview-frontend/src/ws/auth.ts
+++ b/tools/typst-preview-frontend/src/ws/auth.ts
@@ -89,7 +89,7 @@ export function getAuthenticatedSocket(url: string, secret: string, dec: TextDec
                 const cnonce = generateCryptoRandom(32);
                 prews.next(enc.encode(JSON.stringify({
                     'cnonce': cnonce,
-                    'hash': await digestHex(secret + message.challenge + cnonce),
+                    'hash': await digestHex(secret + ":" + message.challenge + ":" + cnonce),
                     'challenge': challengeForServer
                 })));
 
@@ -122,7 +122,7 @@ export function getAuthenticatedSocket(url: string, secret: string, dec: TextDec
                 // Server liked our 'hash'. Now we check if the server is malicious or not
                 if(message.snonce === undefined || message.hash === undefined)
                     throw new Error("Missing snonce or hash.");
-                if(message.hash !== await digestHex(secret + challengeForServer + message.snonce))
+                if(message.hash !== await digestHex(secret + ":" + challengeForServer + ":" + message.snonce))
                     throw new Error("Malicious server detected?!");
 
                 // Authentication succeeded!

--- a/tools/typst-preview-frontend/src/ws/auth.ts
+++ b/tools/typst-preview-frontend/src/ws/auth.ts
@@ -49,7 +49,7 @@ function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
 export function getAuthenticatedSocket(url: string, secret: string, dec: TextDecoder, enc: TextEncoder): Promise<WebSocketAndSubject> {
     // Typst-preview doesn't support authentication. For now, we then skip authentication.
     // FIXME: Remove this once we no longer support compatibility with external typst-preview.
-    if('__no_secret_because_typst-preview_doesnt_support_it__' === secret) {
+    if('__unsafe-disable__' === secret) {
         return getUnsafeSocketCompat(url);
     }
 

--- a/tools/typst-preview-frontend/src/ws/auth.ts
+++ b/tools/typst-preview-frontend/src/ws/auth.ts
@@ -42,7 +42,7 @@ function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
             error: () => {},
         }); 
 
-        console.log("Authentication skipped (for compat with typst-preview, triggered by special value of `secret`)");
+        console.error("Authentication skipped (for compat with typst-preview, triggered by special value of `secret`)");
     });
 }
 
@@ -83,10 +83,10 @@ export function getAuthenticatedSocket(url: string, secret: string, dec: TextDec
                 if(message.challenge === undefined)
                     throw new Error("Missing challenge.");
 
-                const cnonce = generateCryptoRandom(32);
+                const client_nonce = generateCryptoRandom(32);
                 prews.next(enc.encode(JSON.stringify({
-                    'cnonce': cnonce,
-                    'hash': await digestHex(secret + ":" + message.challenge + ":" + cnonce),
+                    'client_nonce': client_nonce,
+                    'hash': await digestHex(secret + ":" + message.challenge + ":" + client_nonce),
                     'challenge': challengeForServer
                 })));
 
@@ -117,10 +117,10 @@ export function getAuthenticatedSocket(url: string, secret: string, dec: TextDec
                 }
 
                 // Server liked our 'hash'. Now we check if the server is malicious or not
-                if(message.snonce === undefined || message.hash === undefined)
-                    throw new Error("Missing snonce or hash.");
-                if(message.hash !== await digestHex(secret + ":" + challengeForServer + ":" + message.snonce))
-                    throw new Error("Malicious server detected?!");
+                if(message.server_nonce === undefined || message.hash === undefined)
+                    throw new Error("Missing server_nonce or hash.");
+                if(message.hash !== await digestHex(secret + ":" + challengeForServer + ":" + message.server_nonce))
+                    throw new Error("Mismatched hash computed by digestHex(secret + \":\" + challengeForServer + \":\" + message.server_nonce)");
 
                 // Authentication succeeded!
                 console.log("Authentication succeeded");

--- a/tools/typst-preview-frontend/src/ws/auth.ts
+++ b/tools/typst-preview-frontend/src/ws/auth.ts
@@ -1,0 +1,138 @@
+import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
+
+async function digestHex(message: string) {
+    const hashBuffer = await crypto.subtle.digest('SHA-512', new TextEncoder().encode(message));
+    return Array.from(
+        new Uint8Array(hashBuffer),
+        x => x.toString(16).padStart(2, '0')
+    ).join('');
+}
+
+
+function generateCryptoRandom(length: number)
+{
+    return Array.from(
+        window.crypto.getRandomValues(new Uint8Array(length)),
+        x => x.toString(16).padStart(2, '0')
+    ).join('');
+}
+
+interface WebSocketAndSubject {
+    websocketSubject: WebSocketSubject<ArrayBuffer>;
+    websocket: WebSocket | undefined;
+}
+
+function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
+{
+    return new Promise((wsresolve) => {
+        let _sock: WebSocket | undefined = undefined;
+
+        let prews = webSocket<ArrayBuffer>({
+            url,
+            binaryType: "arraybuffer",
+            serializer: t => t,
+            deserializer: (event) => event.data,
+            openObserver: {
+                next: (e) => {
+                    console.log('WebSocket connection opened', e.target);
+                    _sock = e.target as any;
+                }
+            },
+        });
+
+        prews.subscribe({
+            error: () => {},
+        }); 
+
+        console.log("Authentication skipped (for compat with typst-preview, triggered by special value of `secret`)");
+        wsresolve({ websocketSubject: prews, websocket: _sock });
+    });
+}
+
+export function getAuthenticatedSocket(url: string, secret: string, dec: TextDecoder, enc: TextEncoder): Promise<WebSocketAndSubject> {
+    // Typst-preview doesn't support authentication. For now, we then skip authentication.
+    // Remove this once we no longer support compatibility with external typst-preview.
+    if('__no_secret_because_typst-preview_doesnt_support_it__' === secret) {
+        return getUnsafeSocketCompat(url);
+    }
+
+    return new Promise((wsresolve) => {
+        let _sock: WebSocket | undefined = undefined;
+
+        let prews = webSocket<ArrayBuffer>({
+            url,
+            binaryType: "arraybuffer",
+            serializer: t => t,
+            deserializer: (event) => event.data,
+            openObserver: {
+                next: (e) => {
+                    console.log('WebSocket connection opened', e.target);
+                    _sock = e.target as any;
+                }
+            },
+        });
+
+        // Dummy to keep websocket alive :)
+        prews.subscribe({
+            error: () => {}, // Ignore errors for this subscriber
+        }); 
+
+        const challengeForServer = generateCryptoRandom(32);
+
+        // Auth stage 1: We authenticate to the server
+        const stage1Subscription = {
+            next: async (data: ArrayBuffer) => {
+                const message = JSON.parse(dec.decode(data));
+                if(message.challenge === undefined)
+                    throw new Error("Missing challenge.");
+
+                const cnonce = generateCryptoRandom(32);
+                prews.next(enc.encode(JSON.stringify({
+                    'cnonce': cnonce,
+                    'hash': await digestHex(secret + message.challenge + cnonce),
+                    'challenge': challengeForServer
+                })));
+
+                // Continue to stage 2
+                subscription.unsubscribe();
+                subscription = prews.subscribe(stage2Subscription);
+
+            },
+            error: () => {
+                // TODO: Is it really good to retry here?
+                console.log("WebSocket err during auth stage 1, will retry");
+                setTimeout(() => {
+                    getAuthenticatedSocket(url, secret, dec, enc).then(x => wsresolve(x))
+                }, 1000);
+            },
+        };
+
+        // Auth stage 2: The server authenticates to us
+        const stage2Subscription = {
+            next: async (data: ArrayBuffer) => {
+                const message = JSON.parse(dec.decode(data));
+
+                if(message.auth !== undefined) {
+                    // Server didn't like our 'hash'
+                    // Probably we have an outdated secret (when tinymist preview was restarted)
+                    // TODO: How to make this a nice user-facing error?
+                    throw new Error("Wrong or outdated secret");
+                }
+
+                // Server liked our 'hash'. Now we check if the server is malicious or not
+                if(message.snonce === undefined || message.hash === undefined)
+                    throw new Error("Missing snonce or hash.");
+                if(message.hash !== await digestHex(secret + challengeForServer + message.snonce))
+                    throw new Error("Malicious server detected?!");
+
+                // Authentication succeeded!
+                console.log("Authentication succeeded");
+                subscription.unsubscribe();
+                wsresolve({ websocketSubject: prews, websocket: _sock });
+            }
+        }
+
+        // We start with stage 1
+        let subscription = prews.subscribe(stage1Subscription);
+    });
+}

--- a/tools/typst-preview-frontend/src/ws/auth.ts
+++ b/tools/typst-preview-frontend/src/ws/auth.ts
@@ -25,8 +25,6 @@ interface WebSocketAndSubject {
 function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
 {
     return new Promise((wsresolve) => {
-        let _sock: WebSocket | undefined = undefined;
-
         let prews = webSocket<ArrayBuffer>({
             url,
             binaryType: "arraybuffer",
@@ -35,7 +33,7 @@ function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
             openObserver: {
                 next: (e) => {
                     console.log('WebSocket connection opened', e.target);
-                    _sock = e.target as any;
+                    wsresolve({ websocketSubject: prews, websocket: e.target as any});
                 }
             },
         });
@@ -45,13 +43,12 @@ function getUnsafeSocketCompat(url: string): Promise<WebSocketAndSubject>
         }); 
 
         console.log("Authentication skipped (for compat with typst-preview, triggered by special value of `secret`)");
-        wsresolve({ websocketSubject: prews, websocket: _sock });
     });
 }
 
 export function getAuthenticatedSocket(url: string, secret: string, dec: TextDecoder, enc: TextEncoder): Promise<WebSocketAndSubject> {
     // Typst-preview doesn't support authentication. For now, we then skip authentication.
-    // Remove this once we no longer support compatibility with external typst-preview.
+    // FIXME: Remove this once we no longer support compatibility with external typst-preview.
     if('__no_secret_because_typst-preview_doesnt_support_it__' === secret) {
         return getUnsafeSocketCompat(url);
     }


### PR DESCRIPTION
This adds authentication so that users don't have to worry about a) third parties being able to connect to the tinymist servers on 127.0.0.1 (browsers allow any website to do that) and b) third parties impersonating the tinymist server, potentially making the frontend html/javascript leak information (e.g. on multi-user systems).

This is not ready yet. But I thought I'd post it so you can comment on the overall approach.

This seems to work for me but I haven't tested everything. Especially the VSCode extension I have tested only very superficially. And I have not at all tested the "compat" integration with `typst-preview`.

Some random notes and questions:

- I guess `typst-preview` will not be updated to add support for authentication? For now, I've built in an escape hatch to avoid authentication for the "compat" preview mode (completely untested!). How do you think this should be handled? It would be easiest to just not support the `typst-preview` compat mode but I guess you don't want to do that yet?
- For now I've used a somewhat non-standard challenge response authentication. As you said, @Myriad-Dreamin , it may be good to look into more standard alternatives.
- How would one actually test the "control plane" server? Where is it used? This is not clear to me.
- I've added authentication only to the websocket part, not to the static html server. So any website can load the preview forntend's html. That's probably okay if the frontend html does not contain anything interesting to an attacker. So I've restructured the code a bit to avoid `replace(...)`ing ports and user settings directly into the html. These settings are now passed in as part of  URL that's opened in the browser (like `http://127.0.0.1:23625/#param=value`).  That code restructuring makes it more immediately obvoius that there's nothing interesting in the html for an attacker.
(~~Unfortunately, the vscode webview panel doesn't seem to support setting a location hash (or maybe it does and I didn't figure out how?), so I've built in an escape hatch for the VSCode webview panel where the settings _are_ now `replace(...)`ed into the html. That's somewhat unfortunate, but not a problem from a security point of view because the vscode webview panel cannot be accessed from outside vscode I think.~~ Found a better way, by using the `acquireVsCodeApi` message passing mechanism)
- Maybe off-topic: I noticed that the vscode extension replaces occurences of `typst-webview-assets/` in the frontend html. That didn't seem to have any effect in my tests. Does this code ever do anything?

cc @Myriad-Dreamin 