### PR TITLE
feat: support convert to typst table from xlsx file

### DIFF
--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -86,7 +86,7 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
         codeSnippet = `grayscale-image(read(${strPath}))`;
         break;
       case ResourceKind.Xlsx:
-        additionalPkgs.push(["@preview/rexllent", "0.2.1", "xlsx-parser"]);
+        additionalPkgs.push(["@preview/rexllent", "0.2.2", "xlsx-parser"]);
         codeSnippet = `xlsx-parser(read(${strPath}, encoding: none))`;
         break;
       case ResourceKind.Source:

--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -85,7 +85,7 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
         additionalPkgs.push(["@preview/grayness", "0.1.0", "grayscale-image"]);
         codeSnippet = `grayscale-image(read(${strPath}))`;
         break;
-      case ResourceKind.Webp:
+      case ResourceKind.Xlsx:
         additionalPkgs.push(["@preview/rexllent", "0.2.0", "xlsx-parser"]);
         codeSnippet = `xlsx-parser(read(${strPath}, encoding: none)`;
         break;

--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -19,6 +19,7 @@ enum ResourceKind {
   Csv,
   Yaml,
   Bib,
+  Xlsx,
 }
 
 const resourceKinds: Record<string, ResourceKind> = {
@@ -42,6 +43,7 @@ const resourceKinds: Record<string, ResourceKind> = {
   ".yaml": ResourceKind.Yaml,
   ".yml": ResourceKind.Yaml,
   ".bib": ResourceKind.Bib,
+  ".xlsx": ResourceKind.Xlsx,
 };
 
 export class TextProvider implements vscode.DocumentDropEditProvider {
@@ -82,6 +84,10 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
       case ResourceKind.Webp:
         additionalPkgs.push(["@preview/grayness", "0.1.0", "grayscale-image"]);
         codeSnippet = `grayscale-image(read(${strPath}))`;
+        break;
+      case ResourceKind.Webp:
+        additionalPkgs.push(["@preview/rexllent", "0.2.0", "xlsx-parser"]);
+        codeSnippet = `xlsx-parser(read(${strPath}, encoding: none)`;
         break;
       case ResourceKind.Source:
         codeSnippet = `include ${strPath}`;

--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -87,7 +87,7 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
         break;
       case ResourceKind.Xlsx:
         additionalPkgs.push(["@preview/rexllent", "0.2.1", "xlsx-parser"]);
-        codeSnippet = `xlsx-parser(read(${strPath}, encoding: none)`;
+        codeSnippet = `xlsx-parser(read(${strPath}, encoding: none))`;
         break;
       case ResourceKind.Source:
         codeSnippet = `include ${strPath}`;

--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -86,7 +86,7 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
         codeSnippet = `grayscale-image(read(${strPath}))`;
         break;
       case ResourceKind.Xlsx:
-        additionalPkgs.push(["@preview/rexllent", "0.2.0", "xlsx-parser"]);
+        additionalPkgs.push(["@preview/rexllent", "0.2.1", "xlsx-parser"]);
         codeSnippet = `xlsx-parser(read(${strPath}, encoding: none)`;
         break;
       case ResourceKind.Source:


### PR DESCRIPTION
Hi! This pr inherits the implementation of [excel-to-typst repo](https://github.com/hongjr03/excel-to-typst) into tinymist. Due to the limitations of the vscode API, I was only able to read the user's clipboard in HTML format via a shell call from the platform.

I have tested this on my MacBook (by developing a vscode extension), the Linux platform is not yet tested. On Windows platforms there may be problems with character encoding (UTF8 -> GBK -> UTF8) due to calls to powershell, not yet solved.