### PR TITLE
feat: Rescaling with Ctrl+=/- in browser (in addition to ctrl+wheel)

### DIFF
--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -262,8 +262,9 @@ export class TypstDocumentContext<O = any> {
     };
 
     // Ctrl+= or Ctrl+- rescaling
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') !== -1;
     const keydownEventHandler = (event: KeyboardEvent) => {
-      if(event.ctrlKey) {
+      if((!isMac && event.ctrlKey) || (isMac && event.metaKey)) {
         if(event.key === "=") {
           event.preventDefault();
           doRescale(-1, undefined, undefined);

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -325,7 +325,7 @@ export function provideSvgDoc<
         this.hookedElem.style.transform = transformAttr;
       }
 
-      // change height of the container back from `installCtrlWheelHandler` hack
+      // change height of the container back from `installRescaleHandler` hack
       if (this.hookedElem.style.height) {
         this.hookedElem.style.removeProperty("height");
       }


### PR DESCRIPTION
In normal browsers, one can zoom in and out by `ctrl`+`wheel` and also by `ctrl`+`=` or `ctrl`+`-` . tinymist so far only supports the former. This pr adds support for the latter.