### PR TITLE
feat: resolve projects by `lockDatabase`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "reflexo",
  "reflexo-typst",
  "reflexo-vec2svg",
+ "rpds",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -24,6 +24,7 @@ macro_rules! display_possible_values {
     Clone,
     Eq,
     PartialEq,
+    Hash,
     Ord,
     PartialOrd,
     serde::Serialize,
@@ -71,7 +72,9 @@ pub enum OutputFormat {
 display_possible_values!(OutputFormat);
 
 /// A PDF standard that Typst can enforce conformance with.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Hash, ValueEnum, serde::Serialize, serde::Deserialize,
+)]
 #[allow(non_camel_case_types)]
 pub enum PdfStandard {
     /// PDF 1.7.
@@ -91,7 +94,7 @@ display_possible_values!(PdfStandard);
 /// value parser, in order to generate better errors.
 ///
 /// See also: <https://github.com/clap-rs/clap/issues/5065>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Pages(pub RangeInclusive<Option<NonZeroUsize>>);
 
 impl FromStr for Pages {

--- a/crates/tinymist-project/src/entry.rs
+++ b/crates/tinymist-project/src/entry.rs
@@ -67,11 +67,20 @@ impl EntryResolver {
 
     /// Resolves the entry state.
     pub fn resolve(&self, entry: Option<ImmutPath>) -> EntryState {
+        let root_dir = self.root(entry.as_ref());
+        self.resolve_with_root(root_dir, entry)
+    }
+
+    /// Resolves the entry state.
+    pub fn resolve_with_root(
+        &self,
+        root_dir: Option<ImmutPath>,
+        entry: Option<ImmutPath>,
+    ) -> EntryState {
         // todo: formalize untitled path
         // let is_untitled = entry.as_ref().is_some_and(|p| p.starts_with("/untitled"));
         // let root_dir = self.determine_root(if is_untitled { None } else {
         // entry.as_ref() });
-        let root_dir = self.root(entry.as_ref());
 
         let entry = match (entry, root_dir) {
             // (Some(entry), Some(root)) if is_untitled => Some(EntryState::new_rooted(

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -12,7 +12,7 @@ pub use anyhow::Result;
 
 use super::{Pages, PdfStandard, TaskWhen};
 
-const LOCKFILE_PATH: &str = "tinymist.lock";
+pub const LOCK_FILENAME: &str = "tinymist.lock";
 
 const LOCK_VERSION: &str = "0.1.0-beta0";
 
@@ -176,7 +176,7 @@ impl LockFile {
     pub fn update(cwd: &Path, f: impl FnOnce(&mut Self) -> Result<()>) -> Result<()> {
         let fs = tinymist_fs::flock::Filesystem::new(cwd.to_owned());
 
-        let mut lock_file = fs.open_rw_exclusive_create(LOCKFILE_PATH, "project commands")?;
+        let mut lock_file = fs.open_rw_exclusive_create(LOCK_FILENAME, "project commands")?;
 
         let mut data = vec![];
         lock_file.read_to_end(&mut data)?;

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -24,6 +24,7 @@ pub mod signature;
 pub use signature::*;
 pub mod semantic_tokens;
 pub use semantic_tokens::*;
+use tinymist_std::ImmutPath;
 use tinymist_world::vfs::WorkspaceResolver;
 use tinymist_world::WorldDeps;
 use typst::syntax::Source;
@@ -76,6 +77,10 @@ pub trait LspWorldExt {
     /// Get all depended file ids of a compilation, inclusively.
     /// Note: must be called after compilation.
     fn depended_files(&self) -> EcoVec<FileId>;
+
+    /// Get all depended paths in file system of a compilation, inclusively.
+    /// Note: must be called after compilation.
+    fn depended_fs_paths(&self) -> EcoVec<ImmutPath>;
 }
 
 impl LspWorldExt for tinymist_project::LspWorld {
@@ -106,6 +111,16 @@ impl LspWorldExt for tinymist_project::LspWorld {
         let mut deps = EcoVec::new();
         self.iter_dependencies(&mut |file_id| {
             deps.push(file_id);
+        });
+        deps
+    }
+
+    fn depended_fs_paths(&self) -> EcoVec<ImmutPath> {
+        let mut deps = EcoVec::new();
+        self.iter_dependencies(&mut |file_id| {
+            if let Ok(path) = self.path_for_id(file_id) {
+                deps.push(path.as_path().into());
+            }
         });
         deps
     }

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -52,6 +52,7 @@ rayon.workspace = true
 reflexo.workspace = true
 reflexo-typst = { workspace = true, features = ["system"] }
 reflexo-vec2svg.workspace = true
+rpds.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/tinymist/src/lib.rs
+++ b/crates/tinymist/src/lib.rs
@@ -23,6 +23,7 @@ mod cmd;
 mod init;
 pub mod project;
 mod resource;
+pub(crate) mod route;
 mod server;
 mod stats;
 mod task;

--- a/crates/tinymist/src/lib.rs
+++ b/crates/tinymist/src/lib.rs
@@ -23,7 +23,7 @@ mod cmd;
 mod init;
 pub mod project;
 mod resource;
-pub(crate) mod route;
+mod route;
 mod server;
 mod stats;
 mod task;

--- a/crates/tinymist/src/route.rs
+++ b/crates/tinymist/src/route.rs
@@ -1,7 +1,13 @@
 use std::{path::Path, sync::Arc};
 
-use reflexo::{hash::FxHashMap, ImmutPath};
-use tinymist_project::Id;
+use reflexo_typst::{path::unix_slash, typst::prelude::EcoVec, LazyHash};
+use rpds::RedBlackTreeMapSync;
+use tinymist_project::{
+    CompileSnapshot, Id, LockFile, LspCompilerFeat, ProjectPathMaterial, ProjectRoute,
+};
+use tinymist_query::LspWorldExt;
+use tinymist_std::{hash::FxHashMap, ImmutPath};
+use typst::diag::EcoString;
 
 #[derive(Default)]
 pub struct ProjectRouteState {
@@ -14,9 +20,14 @@ pub struct ProjectResolution {
 }
 
 impl ProjectRouteState {
-    pub fn resolve(&self, path: &ImmutPath) -> Option<ProjectResolution> {
-        for path in std::iter::successors(Some(path.as_ref()), |p| p.parent()) {
-            if let Some(resolution) = self.resolve_at(path) {
+    pub fn locate(&self, resolved: &ProjectResolution) -> Option<Arc<LockFile>> {
+        let path_route = self.path_routes.get(&resolved.lock_dir)?;
+        Some(path_route.lock.clone())
+    }
+
+    pub fn resolve(&mut self, leaf: &ImmutPath) -> Option<ProjectResolution> {
+        for path in std::iter::successors(Some(leaf.as_ref()), |p| p.parent()) {
+            if let Some(resolution) = self.resolve_at(path, leaf) {
                 return Some(resolution);
             }
         }
@@ -24,17 +35,163 @@ impl ProjectRouteState {
         None
     }
 
-    fn resolve_at(&self, path: &Path) -> Option<ProjectResolution> {
-        let (key, path_route) = self.path_routes.get_key_value(path)?;
-        let project_id = path_route.routes.get(path)?;
+    fn resolve_at(&mut self, lock_dir: &Path, leaf: &Path) -> Option<ProjectResolution> {
+        log::debug!("resolve: {leaf:?} at {lock_dir:?}");
+        let (lock_dir, project_id) = match self.path_routes.get_key_value(lock_dir) {
+            Some((key, path_route)) => (key.clone(), path_route.routes.get(leaf)?.clone()),
+            None => {
+                let lock_dir: ImmutPath = lock_dir.into();
+                let mut new_route = self.load_lock(&lock_dir).unwrap_or_default();
+
+                let mut materials = RedBlackTreeMapSync::default();
+
+                if let Some(cache_dir) = new_route.cache_dir.as_ref() {
+                    let entries = walkdir::WalkDir::new(cache_dir)
+                        .into_iter()
+                        .filter_map(|entry| entry.ok())
+                        .filter(|entry| entry.file_type().is_file());
+
+                    for entry in entries {
+                        let material = self.read_material(entry.path());
+                        if let Some(material) = material {
+                            let id = material.id.clone();
+                            materials.insert_mut(id.clone(), material);
+                        }
+                    }
+                }
+                let materials = LazyHash::new(materials);
+                new_route.routes = calculate_routes(new_route.lock.route.clone(), &materials);
+                new_route.materials = materials;
+
+                log::debug!("loaded routes at {lock_dir:?}, {:?}", new_route.routes);
+                let project_id = new_route.routes.get(leaf)?.clone();
+
+                self.path_routes.insert(lock_dir.clone(), new_route);
+                (lock_dir, project_id)
+            }
+        };
 
         Some(ProjectResolution {
-            lock_dir: key.clone(),
-            project_id: project_id.clone(),
+            lock_dir,
+            project_id,
         })
+    }
+
+    pub fn update_lock(&mut self, lock_dir: ImmutPath, lock: LockFile) -> Option<()> {
+        let path_route = self.path_routes.get_mut(&lock_dir)?;
+
+        let lock_unchanged = path_route.lock.as_ref() == &lock;
+        if lock_unchanged {
+            return Some(());
+        }
+
+        path_route.lock = Arc::new(lock);
+        path_route.routes = calculate_routes(path_route.lock.route.clone(), &path_route.materials);
+
+        Some(())
+    }
+
+    pub fn update_existing_material(
+        &mut self,
+        lock_dir: ImmutPath,
+        snap: &CompileSnapshot<LspCompilerFeat>,
+    ) -> Option<()> {
+        let path_route = self.path_routes.get_mut(&lock_dir)?;
+
+        let id = Id::from_world(&snap.world)?;
+        let deps = snap.world.depended_fs_paths();
+        let material = ProjectPathMaterial::from_deps(id, deps);
+
+        let old = path_route.materials.get_mut(&material.id)?;
+        if old == &material {
+            return Some(());
+        }
+
+        path_route
+            .materials
+            .insert_mut(material.id.clone(), material);
+        path_route.routes = calculate_routes(path_route.lock.route.clone(), &path_route.materials);
+
+        Some(())
+    }
+
+    fn load_lock(&self, path: &Path) -> Option<RoutePathState> {
+        let lock_data = Arc::new(match LockFile::read(path) {
+            Ok(lock) => lock,
+            Err(e) => {
+                log::debug!("failed to load lock at {path:?}: {e:?}");
+                return None;
+            }
+        });
+        log::info!("loaded lock at {path:?}");
+
+        let root: EcoString = unix_slash(path).into();
+        let root_hash = tinymist_std::hash::hash128(&root);
+        let cache_dir_base = dirs::cache_dir();
+        let mut cache_dir = None;
+        if let Some(cache_dir_base) = cache_dir_base {
+            let root_lo = root_hash & 0xfff;
+            let root_hi = root_hash >> 12;
+
+            // let hash_str = format!("{root:016x}/{id:016x}");
+            let project_state = format!("{root_lo:03x}/{root_hi:013x}");
+
+            cache_dir = Some(
+                cache_dir_base
+                    .join("tinymist/projects")
+                    .join(project_state)
+                    .into(),
+            );
+        }
+
+        Some(RoutePathState {
+            lock: lock_data,
+            materials: LazyHash::default(),
+            routes: Arc::new(FxHashMap::default()),
+            cache_dir,
+        })
+    }
+
+    fn read_material(&self, entry_path: &Path) -> Option<ProjectPathMaterial> {
+        log::info!("check material at {entry_path:?}");
+        let name = entry_path.file_name().unwrap_or(entry_path.as_os_str());
+        if name != "path-material.json" {
+            return None;
+        }
+
+        let data = std::fs::read(entry_path).ok()?;
+
+        let material = serde_json::from_slice::<ProjectPathMaterial>(&data).ok()?;
+        Some(material)
     }
 }
 
+#[comemo::memoize]
+fn calculate_routes(
+    raw_routes: EcoVec<ProjectRoute>,
+    materials: &LazyHash<rpds::RedBlackTreeMapSync<Id, ProjectPathMaterial>>,
+) -> Arc<FxHashMap<ImmutPath, Id>> {
+    let mut routes = FxHashMap::default();
+
+    let mut priorities = FxHashMap::default();
+
+    for route in raw_routes.iter() {
+        if let Some(material) = materials.get(&route.id) {
+            for file in material.files.iter() {
+                routes.insert(file.as_path().into(), route.id.clone());
+            }
+        }
+
+        priorities.insert(route.id.clone(), route.priority);
+    }
+
+    Arc::new(routes)
+}
+
+#[derive(Default)]
 struct RoutePathState {
+    lock: Arc<LockFile>,
+    materials: LazyHash<rpds::RedBlackTreeMapSync<Id, ProjectPathMaterial>>,
     routes: Arc<FxHashMap<ImmutPath, Id>>,
+    cache_dir: Option<ImmutPath>,
 }

--- a/crates/tinymist/src/route.rs
+++ b/crates/tinymist/src/route.rs
@@ -1,0 +1,40 @@
+use std::{path::Path, sync::Arc};
+
+use reflexo::{hash::FxHashMap, ImmutPath};
+use tinymist_project::Id;
+
+#[derive(Default)]
+pub struct ProjectRouteState {
+    path_routes: FxHashMap<ImmutPath, RoutePathState>,
+}
+
+pub struct ProjectResolution {
+    pub lock_dir: ImmutPath,
+    pub project_id: Id,
+}
+
+impl ProjectRouteState {
+    pub fn resolve(&self, path: &ImmutPath) -> Option<ProjectResolution> {
+        for path in std::iter::successors(Some(path.as_ref()), |p| p.parent()) {
+            if let Some(resolution) = self.resolve_at(path) {
+                return Some(resolution);
+            }
+        }
+
+        None
+    }
+
+    fn resolve_at(&self, path: &Path) -> Option<ProjectResolution> {
+        let (key, path_route) = self.path_routes.get_key_value(path)?;
+        let project_id = path_route.routes.get(path)?;
+
+        Some(ProjectResolution {
+            lock_dir: key.clone(),
+            project_id: project_id.clone(),
+        })
+    }
+}
+
+struct RoutePathState {
+    routes: Arc<FxHashMap<ImmutPath, Id>>,
+}

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -19,6 +19,7 @@ use project::{watch_deps, LspPreviewState};
 use project::{CompileHandlerImpl, Project, QuerySnapFut, QuerySnapWithStat, WorldSnapFut};
 use reflexo_typst::Bytes;
 use request::{RegisterCapability, UnregisterCapability};
+use route::ProjectRouteState;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
 use sync_lsp::*;
@@ -66,6 +67,8 @@ fn as_path_pos(inp: TextDocumentPositionParams) -> (PathBuf, Position) {
 pub struct LanguageState {
     /// The lsp client
     pub client: TypedLspClient<Self>,
+    /// The lcok state.
+    pub lock: ProjectRouteState,
     /// The project state.
     pub project: Project,
 
@@ -127,6 +130,7 @@ impl LanguageState {
 
         Self {
             client: client.clone(),
+            lock: ProjectRouteState::default(),
             project: handle,
             editor_tx,
             memory_changes: HashMap::new(),

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -252,6 +252,7 @@ impl ExportConfig {
                     let _ = page;
 
                     let ppi = ppi.unwrap_or(144.) as f32;
+                    let ppi = ppi.try_into().unwrap();
                     ProjectTask::ExportPng(ExportPngTask { export, ppi })
                 }
             };

--- a/crates/tinymist/src/tool/project.rs
+++ b/crates/tinymist/src/tool/project.rs
@@ -23,6 +23,7 @@ impl LockFileExt for LockFile {
             .root
             .as_ref()
             .map(|root| ResourcePath::from_user_sys(Path::new(root)));
+        let main = ResourcePath::from_user_sys(Path::new(&args.id.input));
 
         let font_paths = args
             .font
@@ -46,6 +47,7 @@ impl LockFileExt for LockFile {
         let input = ProjectInput {
             id: id.clone(),
             root,
+            main: Some(main),
             font_paths,
             system_fonts: !args.font.ignore_system_fonts,
             package_path,
@@ -106,7 +108,7 @@ impl LockFileExt for LockFile {
             }),
             OutputFormat::Png => ProjectTask::ExportPng(ExportPngTask {
                 export,
-                ppi: args.ppi,
+                ppi: args.ppi.try_into().unwrap(),
             }),
             OutputFormat::Svg => ProjectTask::ExportSvg(ExportSvgTask { export }),
             OutputFormat::Html => ProjectTask::ExportSvg(ExportSvgTask { export }),


### PR DESCRIPTION
Although we have great multiple-files project support in VS Code, we still experiment a sample implementation in VS Code. The new mechanism is put behind a flag. It isn't enabled by default. You can also only use the `lockDatabase` in some specific workspaces.

- the CLI or server will update the lock file if one invokes compile/preview commands via CLI or LSP.
- the server will see the lock file to see what's the best main file to use:
  - If _a file_ is depended by some unique main file recorded in the lock, the main file is used.
  - If _a file_ is depended by multiple main files, the most recently recorded main file wins.
  - otherwise, the language server sets the main file to _the file_ itself.

Even if there is no any editor-side (client-side) additional support, people should be able to tell such information to the language server by invoking CLI in terminal. 

We might deprecate the pin/unpin commands if this solution receives positive voice after experiment.

