### PR TITLE
fix: Prevent malicious websites from connecting to http / websocket server

### DIFF
--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroUsize;
 use std::{collections::HashMap, net::SocketAddr, path::Path, sync::Arc};
 
 use futures::{SinkExt, StreamExt, TryStreamExt};
+use hyper::header::HeaderValue;
 use hyper::service::service_fn;
 use hyper_tungstenite::{tungstenite::Message, HyperWebsocket, HyperWebsocketStream};
 use hyper_util::rt::TokioIo;
@@ -408,33 +409,47 @@ pub async fn make_http_server(
     type Server = hyper_util::server::conn::auto::Builder<hyper_util::rt::TokioExecutor>;
 
     let frontend_html = hyper::body::Bytes::from(frontend_html);
+    let expected_origin = format!("http://{static_file_addr}");
     let make_service = move || {
         let frontend_html = frontend_html.clone();
         let websocket_tx = websocket_tx.clone();
+        let expected_origin = expected_origin.clone();
         service_fn(move |mut req: hyper::Request<Incoming>| {
             let frontend_html = frontend_html.clone();
             let websocket_tx = websocket_tx.clone();
+            let expected_origin = expected_origin.clone();
             async move {
                 // Check if the request is a websocket upgrade request.
-                if hyper_tungstenite::is_upgrade_request(&req) {
-                    let (response, websocket) = hyper_tungstenite::upgrade(&mut req, None)
-                        .map_err(|e| {
-                            log::error!("Error in websocket upgrade: {e}");
-                            // let e = Error::new(e);
-                        })
-                        .unwrap();
+                let response = if hyper_tungstenite::is_upgrade_request(&req) {
+                    // Any website a user visits in a browser can connect to our websocket server on
+                    // 127.0.0.1 because CORS does not work for websockets. Thus, check the `Origin`
+                    // header ourselves. See the comment on CORS below for more details.
+                    if req
+                        .headers()
+                        .get("Origin")
+                        .map_or(false, |h| *h == expected_origin)
+                    {
+                        let (response, websocket) = hyper_tungstenite::upgrade(&mut req, None)
+                            .map_err(|e| {
+                                log::error!("Error in websocket upgrade: {e}");
+                                // let e = Error::new(e);
+                            })
+                            .unwrap();
 
-                    let _ = websocket_tx.send(websocket);
+                        let _ = websocket_tx.send(websocket);
 
-                    // Return the response so the spawned future can continue.
-                    Ok(response)
+                        // Return the response so the spawned future can continue.
+                        Ok(response)
+                    } else {
+                        anyhow::bail!("Websocket connection with unexpected `Origin` header. Closing connection");
+                    }
                 } else if req.uri().path() == "/" {
                     // log::debug!("Serve frontend: {mode:?}");
                     let res = hyper::Response::builder()
                         .header(hyper::header::CONTENT_TYPE, "text/html")
                         .body(Full::<Bytes>::from(frontend_html))
                         .unwrap();
-                    Ok::<_, std::convert::Infallible>(res)
+                    Ok::<_, anyhow::Error>(res)
                 } else {
                     // jump to /
                     let res = hyper::Response::builder()
@@ -443,7 +458,29 @@ pub async fn make_http_server(
                         .body(Full::<Bytes>::default())
                         .unwrap();
                     Ok(res)
-                }
+                };
+
+                // When a user visits a website in a browser, that website can try to connect to our http / websocket
+                // server on `127.0.0.1` which may leak sensitive information. Thus, use CORS to explicitly disallow this.
+                //
+                // However, for Websockets, CORS does not work. Thus, we have additional checks of the `Origin` header
+                // above in the websocket upgrade path.
+                //
+                // Stricly speaking, setting the `Acess-Control-Allow-Origin` header is not required here since browsers
+                // disallow cross origin access also when that header is missing. But I think it's better to be explicit.
+                //
+                // Important: This does _not_ protect against malicious users that share the same computer as us (i.e. multi-
+                // user systems where the users don't trust each other). In this case, malicious attackers can _still_ connect
+                // to our http / websocket servers (using a browser and otherwise). And additionally they can impersonate
+                // a tinymist http / websocket server towards a legitimate frontend/html client.
+                // This requires additional protection that may be added in the future.
+                response.map(|mut response| {
+                    response.headers_mut().insert(
+                        hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                        HeaderValue::from_str(&expected_origin).unwrap(),
+                    );
+                    response
+                })
             }
         })
     };


### PR DESCRIPTION
Simpler alternative to #1093 that does not break any downstream packages.

However, this does _not_ provide protection on multi-user systems where users don't trust each other. It only prevents websites other than `127.0.0.1` from connecting to our servers. So it's a good first step but doesn't cover all scenarios.

One question:

I noticed there's a second `make_http_server` function that explicitly sets `Access-Control-Allow-Origin: *`. What is that server used for? Obviously, the `*` CORS header looks dangerous.

https://github.com/Myriad-Dreamin/tinymist/blob/8e918cb1322c67160a516c7478d6ecd7a444f014/crates/tinymist/src/task/user_action.rs#L227-L264