### PR TITLE
fix(vscode): make label view work when there's exactly one label

### DIFF
--- a/editors/vscode/e2e-workspaces/issue-1158/label-test.typ
+++ b/editors/vscode/e2e-workspaces/issue-1158/label-test.typ
@@ -1,0 +1,1 @@
+#figure[test] <fig:dingens>

--- a/editors/vscode/src/features/label.ts
+++ b/editors/vscode/src/features/label.ts
@@ -104,7 +104,10 @@ function makeLabelTree(labels: LabelViewItem[]): LabelViewItem[] {
     (currentTrie.refs ||= []).push(label);
   }
 
-  const items = mergeLabelTree(trie).children!;
+  const merged  = mergeLabelTree(trie);
+  // If there's only one label in the document, the result of `mergeLabelTree` is that label
+  // and has no children. So make make a list out of that by hand here.
+  const items = merged.children ?? [merged];
 
   assignDescription(items, "");
   return items;


### PR DESCRIPTION
The labels tool view in vscode didn't work for documents with exactly one label. The error "items is not an iterable" was shown. This PR fixes that.

Before:

![image](https://github.com/user-attachments/assets/0925cded-8e73-4f36-80a8-f14e3684e709)

After:

![image](https://github.com/user-attachments/assets/b0df1fc9-3056-4e71-b385-241ae152a73e)


