### PR TITLE
feat: micro benchmark support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,178 +183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.4.0",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.0",
- "futures-lite",
- "rustix",
- "tracing",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,19 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -821,15 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "confy"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,36 +705,6 @@ dependencies = [
 [[package]]
 name = "criterion"
 version = "0.5.1"
-dependencies = [
- "anes",
- "approx",
- "async-std",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "csv",
- "futures",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "plotters",
- "quickcheck",
- "rand",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "smol",
- "tempfile",
- "tinytemplate",
- "tokio",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
@@ -936,7 +712,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -950,17 +726,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-dependencies = [
- "cast",
- "itertools 0.13.0",
- "itertools-num",
- "num-complex",
- "rand",
 ]
 
 [[package]]
@@ -981,7 +746,7 @@ dependencies = [
  "base64",
  "clap",
  "comemo",
- "criterion 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion",
  "ecow",
  "insta",
  "regex",
@@ -1351,33 +1116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener 5.4.0",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,19 +1276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,18 +1385,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2299,15 +2012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools-num"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,15 +2064,6 @@ checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec 0.7.6",
  "smallvec",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -2452,9 +2147,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lsp-server"
@@ -2599,15 +2291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,12 +2401,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2845,17 +2522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pixglyph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,21 +2582,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3058,15 +2709,6 @@ checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "rand",
 ]
 
 [[package]]
@@ -3905,23 +3547,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "smol"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-net",
- "async-process",
- "blocking",
- "futures-lite",
-]
 
 [[package]]
 name = "socket2"
@@ -5251,12 +4876,6 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
-
-[[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vergen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_colours"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +181,178 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix",
+ "tracing",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -300,6 +478,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +589,12 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -624,6 +821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "confy"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +894,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+dependencies = [
+ "anes",
+ "approx",
+ "async-std",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "csv",
+ "futures",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "quickcheck",
+ "rand",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "smol",
+ "tempfile",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+ "itertools-num",
+ "num-complex",
+ "rand",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crityp"
+version = "0.12.18"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "comemo",
+ "criterion 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecow",
+ "insta",
+ "regex",
+ "tinymist-world",
+ "typst",
+ "typst-syntax",
 ]
 
 [[package]]
@@ -1051,6 +1351,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1538,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1660,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1930,11 +2282,29 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itertools-num"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1990,6 +2360,15 @@ checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec 0.7.6",
  "smallvec",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2073,6 +2452,9 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lsp-server"
@@ -2217,6 +2599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "open"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2718,12 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2442,6 +2845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pixglyph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2878,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2916,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2601,6 +3058,15 @@ checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -3441,6 +3907,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,7 +4341,7 @@ dependencies = [
  "hyper",
  "hyper-tungstenite",
  "hyper-util",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "lsp-server",
  "lsp-types",
@@ -3998,7 +4481,7 @@ dependencies = [
  "if_chain",
  "indexmap 2.7.0",
  "insta",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "lsp-types",
  "once_cell",
@@ -4077,6 +4560,16 @@ dependencies = [
  "displaydoc",
  "serde",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4549,7 +5042,7 @@ source = "git+https://github.com/Myriad-Dreamin/typstfmt?tag=v0.12.1#c1fd45a4594
 dependencies = [
  "confy",
  "globmatch",
- "itertools",
+ "itertools 0.13.0",
  "lexopt",
  "regex",
  "serde",
@@ -4566,7 +5059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab4ca4a1cc62f670b3cf96d37b1d5284ab9137418f476610847d79d5f3a7b8b"
 dependencies = [
  "ecow",
- "itertools",
+ "itertools 0.13.0",
  "pretty",
  "rustc-hash 2.1.0",
  "typst-syntax",
@@ -4758,6 +5251,12 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+
+[[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.82"
 
 [workspace]
 resolver = "2"
-members = ["crates/*", "tests"]
+members = ["crates/*", "tests", "target/criterion.rs"]
 
 [workspace.dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.82"
 
 [workspace]
 resolver = "2"
-members = ["crates/*", "tests", "target/criterion.rs"]
+members = ["crates/*", "tests"]
 
 [workspace.dependencies]
 

--- a/crates/crityp/Cargo.toml
+++ b/crates/crityp/Cargo.toml
@@ -41,5 +41,5 @@ regex.workspace = true
 default = ["cli"]
 cli = ["clap"]
 
-# [lints]
-# workspace = true
+[lints]
+workspace = true

--- a/crates/crityp/Cargo.toml
+++ b/crates/crityp/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "crityp"
+description = "Benchmark support for typst."
+categories = ["compilers", "command-line-utilities"]
+keywords = ["language", "typst"]
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "crityp"
+path = "src/main.rs"
+required-features = ["cli"]
+test = false
+doctest = false
+bench = false
+doc = false
+
+[dependencies]
+base64.workspace = true
+clap = { workspace = true, optional = true }
+comemo.workspace = true
+ecow.workspace = true
+anyhow.workspace = true
+
+typst.workspace = true
+typst-syntax.workspace = true
+tinymist-world.workspace = true
+criterion = "0.5.1"
+# criterion = { path = "../../target/criterion.rs" }
+
+[dev-dependencies]
+insta.workspace = true
+regex.workspace = true
+
+[features]
+default = ["cli"]
+cli = ["clap"]
+
+# [lints]
+# workspace = true

--- a/crates/crityp/README.md
+++ b/crates/crityp/README.md
@@ -4,7 +4,7 @@ Benchmark support for typst.
 
 ## Usage
 
-Use `crityp` to benchmark a typst file. The CLI arguments is compatible with `typst-cli compile`.
+Use `crityp` to benchmark functions whose name starts with "bench" a typst file. The CLI arguments is compatible with `typst-cli compile`.
 
 ```shell
 crityp test-bench.typ
@@ -20,4 +20,13 @@ Found 7 outliers among 100 measurements (7.00%)
   2 (2.00%) low mild
   4 (4.00%) high mild
   1 (1.00%) high severe
+Benchmarking /test-bench.typ@bench-fib2 ...
+```
+
+The example typst file is as follows:
+
+```typ
+#let fib(n) = if n < 2 { n } else { fib(n - 1) + fib(n - 2) }
+#let bench-fib() = fib(20)
+#let bench-fib2() = fib(20)
 ```

--- a/crates/crityp/README.md
+++ b/crates/crityp/README.md
@@ -4,16 +4,20 @@ Benchmark support for typst.
 
 ## Usage
 
+Use `crityp` to benchmark a typst file. The CLI arguments is compatible with `typst-cli compile`.
+
 ```shell
-crityp test-bench.typ@fib-bench
-Benchmarking fib-bench typst
-Benchmarking fib-bench typst: Warming up for 3.0000 s
-Benchmarking fib-bench typst: Collecting 100 samples in estimated 5.2594 s (56k iterations)
-Benchmarking fib-bench typst: Analyzing
-test-bench.typ@fib-bench time:   [93.551 µs 94.220 µs 94.967 µs]    
-                         change: [-91.268% -90.867% -90.520%] (p = 0.00 < 0.05)
-                         Performance has improved.
-Found 4 outliers among 100 measurements (4.00%)
-  3 (3.00%) high mild
+crityp test-bench.typ
+Benchmarking /test-bench.typ@bench-fib
+Benchmarking /test-bench.typ@bench-fib: Warming up for 3.0000 s
+Benchmarking /test-bench.typ@bench-fib: Collecting 100 samples in estimated 5.3151 s (56k iterations)
+Benchmarking /test-bench.typ@bench-fib: Analyzing
+/test-bench.typ@bench-fib
+                        time:   [93.919 µs 94.631 µs 95.459 µs]
+                        change: [-7.2275% -5.2111% -3.4660%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 7 outliers among 100 measurements (7.00%)
+  2 (2.00%) low mild
+  4 (4.00%) high mild
   1 (1.00%) high severe
 ```

--- a/crates/crityp/README.md
+++ b/crates/crityp/README.md
@@ -1,0 +1,19 @@
+# Crityp
+
+Benchmark support for typst.
+
+## Usage
+
+```shell
+crityp test-bench.typ@fib-bench
+Benchmarking fib-bench typst
+Benchmarking fib-bench typst: Warming up for 3.0000 s
+Benchmarking fib-bench typst: Collecting 100 samples in estimated 5.2594 s (56k iterations)
+Benchmarking fib-bench typst: Analyzing
+test-bench.typ@fib-bench time:   [93.551 µs 94.220 µs 94.967 µs]    
+                         change: [-91.268% -90.867% -90.520%] (p = 0.00 < 0.05)
+                         Performance has improved.
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+```

--- a/crates/crityp/dist.toml
+++ b/crates/crityp/dist.toml
@@ -1,0 +1,3 @@
+
+[dist]
+dist = false

--- a/crates/crityp/src/lib.rs
+++ b/crates/crityp/src/lib.rs
@@ -1,16 +1,15 @@
 use anyhow::Context as ContextTrait;
-use clap::Parser;
 use comemo::Track;
 use criterion::Criterion;
 use ecow::{eco_format, EcoString};
 use tinymist_world::reflexo_typst::path::unix_slash;
-use tinymist_world::{CompileOnceArgs, LspWorld};
+use tinymist_world::LspWorld;
 use typst::engine::{Engine, Route, Sink, Traced};
 use typst::foundations::{Context, Func, Value};
 use typst::introspection::Introspector;
 use typst::World;
 
-fn crityp_bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
+pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
     let main_source = world.source(world.main())?;
     let main_path = unix_slash(world.main().vpath().as_rooted_path());
 
@@ -70,38 +69,6 @@ fn crityp_bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
             })
         });
     }
-
-    Ok(())
-}
-
-/// Common arguments of crityp benchmark.
-#[derive(Debug, Clone, Parser, Default)]
-pub struct BenchArgs {
-    /// Arguments for compiling the document once, compatible with `typst-cli
-    /// compile`.
-    #[clap(flatten)]
-    pub compile: CompileOnceArgs,
-
-    /// Path to output file for benchmarks
-    #[clap(long, default_value = "target/crityp")]
-    pub bench_output: String,
-}
-
-pub fn run() -> anyhow::Result<()> {
-    // Parse command line arguments
-    let args = BenchArgs::parse();
-
-    let universe = args.compile.resolve()?;
-    let mut world = universe.snapshot();
-
-    let out_dir = std::env::current_dir()
-        .context("cannot get current working directory")?
-        .join(args.bench_output);
-    let mut crit = criterion::Criterion::default().output_directory(&out_dir);
-
-    crityp_bench(&mut crit, &mut world)?;
-
-    crit.final_summary();
 
     Ok(())
 }

--- a/crates/crityp/src/lib.rs
+++ b/crates/crityp/src/lib.rs
@@ -1,3 +1,15 @@
+//! Crityp is a crate for benchmarking typst code.
+//!
+//! ## Usage
+//!
+//! ```rs
+//! let mut crit = criterion::Criterion::default();
+//! let mut verse = tinymist_world::CompileOnceArgs::parse().resolve()?;
+//! let mut world = verse.snapshot();
+//! crityp::bench(&mut crit, &mut world)?;
+//! crit.final_summary();
+//! ```
+
 use anyhow::Context as ContextTrait;
 use comemo::Track;
 use criterion::Criterion;
@@ -9,7 +21,10 @@ use typst::foundations::{Context, Func, Value};
 use typst::introspection::Introspector;
 use typst::World;
 
+/// Runs benchmarks on the given world. An entry point must be provided in the
+/// world.
 pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
+    // Gets the main source file and its path.
     let main_source = world.source(world.main())?;
     let main_path = unix_slash(world.main().vpath().as_rooted_path());
 
@@ -18,6 +33,7 @@ pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
     let traced = Traced::default();
     let introspector = Introspector::default();
 
+    // Evaluates the main source file.
     let module = typst::eval::eval(
         ((world) as &dyn World).track(),
         traced.track(),
@@ -29,6 +45,7 @@ pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("{e:?}"))
         .context("evaluation error")?;
 
+    // Collects all benchmarks.
     let mut goals: Vec<(EcoString, &Func)> = vec![];
     for (name, value, _) in module.scope().iter() {
         if !name.starts_with("bench") {
@@ -40,6 +57,7 @@ pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
         }
     }
 
+    // Runs benchmarks.
     for (name, func) in goals {
         let route = Route::default();
         let mut sink = Sink::default();
@@ -51,17 +69,22 @@ pub fn bench(c: &mut Criterion, world: &mut LspWorld) -> anyhow::Result<()> {
             route,
         };
 
+        // Runs the benchmark once.
         let mut call_once = move || {
             let context = Context::default();
             let values = Vec::<Value>::default();
             func.call(engine, context.track(), values)
         };
 
+        // Calls the benchmark once to ensure it is correct.
+        // Since all typst functions are pure, we can safely ignore the result
+        // in the benchmark loop then.
         if let Err(err) = call_once() {
             eprintln!("call error in {name}: {err:?}");
             continue;
         }
 
+        // Benchmarks the function
         c.bench_function(&name, move |b| {
             b.iter(|| {
                 comemo::evict(0);

--- a/crates/crityp/src/lib.rs
+++ b/crates/crityp/src/lib.rs
@@ -1,0 +1,101 @@
+use clap::Parser;
+use criterion::Criterion;
+use tinymist_world::CompileOnceArgs;
+use typst::{
+    engine::{Engine, Route, Sink, Traced},
+    foundations::{Context, Value},
+    introspection::Introspector,
+    World,
+};
+use typst_syntax::{FileId, VirtualPath};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 1,
+        1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion, world: &mut tinymist_world::LspWorld) {
+    use comemo::Track;
+
+    let id = FileId::new(None, VirtualPath::new("target/test-bench.typ"));
+
+    let source = world.source(id).unwrap();
+    let route = Route::default();
+    let traced = Traced::default();
+    let mut sink = Sink::default();
+    let introspector = Introspector::default();
+
+    let module = typst::eval::eval(
+        ((world) as &dyn World).track(),
+        traced.track(),
+        sink.track_mut(),
+        route.track(),
+        &source,
+    );
+
+    let engine = &mut Engine {
+        world: ((world) as &dyn World).track(),
+        introspector: introspector.track(),
+        traced: traced.track(),
+        sink: sink.track_mut(),
+        route,
+    };
+
+    let module = module.unwrap();
+
+    let fib_func = module.scope().get("fib-bench").unwrap();
+    let fib_func = match fib_func {
+        Value::Func(f) => f,
+        _ => panic!("Expected function"),
+    };
+
+    let mut call_typst_func_trampoline = || {
+        let context = Context::default();
+        let values = Vec::<Value>::default();
+        let _result = fib_func.call(engine, context.track(), values).unwrap();
+    };
+
+    c.bench_function("fib typst", |b| {
+        b.iter(|| {
+            comemo::evict(0);
+            call_typst_func_trampoline();
+        })
+    });
+    c.bench_function("fib rust", |b| {
+        b.iter(|| fibonacci(std::hint::black_box(20)))
+    });
+}
+
+/// Common arguments of compile, watch, and query.
+#[derive(Debug, Clone, Parser, Default)]
+pub struct CompileArgs {
+    #[clap(flatten)]
+    pub compile: CompileOnceArgs,
+
+    /// Path to output file
+    #[clap(value_name = "OUTPUT")]
+    pub output: Option<String>,
+}
+
+pub fn run() -> anyhow::Result<()> {
+    let crityp_path = std::env::current_dir().unwrap().join("target/crityp");
+
+    // Parse command line arguments
+    let mut args = CompileArgs::parse();
+
+    args.compile.input = Some("target/test-bench.typ".to_string());
+
+    let universe = args.compile.resolve()?;
+    let mut world = universe.snapshot();
+
+    let mut crit = criterion::Criterion::default().output_directory(&crityp_path);
+
+    criterion_benchmark(&mut crit, &mut world);
+
+    crit.final_summary();
+
+    Ok(())
+}

--- a/crates/crityp/src/main.rs
+++ b/crates/crityp/src/main.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    crityp::run()
+}

--- a/crates/crityp/src/main.rs
+++ b/crates/crityp/src/main.rs
@@ -1,3 +1,35 @@
-fn main() -> anyhow::Result<()> {
-    crityp::run()
+use anyhow::Context;
+use clap::Parser;
+use tinymist_world::CompileOnceArgs;
+
+/// Common arguments of crityp benchmark.
+#[derive(Debug, Clone, Parser, Default)]
+pub struct BenchArgs {
+    /// Arguments for compiling the document once, compatible with `typst-cli
+    /// compile`.
+    #[clap(flatten)]
+    pub compile: CompileOnceArgs,
+
+    /// Path to output file for benchmarks
+    #[clap(long, default_value = "target/crityp")]
+    pub bench_output: String,
+}
+
+pub fn main() -> anyhow::Result<()> {
+    // Parse command line arguments
+    let args = BenchArgs::parse();
+
+    let universe = args.compile.resolve()?;
+    let mut world = universe.snapshot();
+
+    let out_dir = std::env::current_dir()
+        .context("cannot get current working directory")?
+        .join(args.bench_output);
+    let mut crit = criterion::Criterion::default().output_directory(&out_dir);
+
+    crityp::bench(&mut crit, &mut world)?;
+
+    crit.final_summary();
+
+    Ok(())
 }

--- a/crates/crityp/src/main.rs
+++ b/crates/crityp/src/main.rs
@@ -1,3 +1,5 @@
+//! Crityp is a standalone benchmark tool for typst.
+
 use anyhow::Context;
 use clap::Parser;
 use tinymist_world::CompileOnceArgs;
@@ -15,7 +17,7 @@ pub struct BenchArgs {
     pub bench_output: String,
 }
 
-pub fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     // Parse command line arguments
     let args = BenchArgs::parse();
 


### PR DESCRIPTION
Using the criterion.rs as the backend, it is pretty simple to create a bench tool. The PoC shows cold execution of the `fib(20)` in typst.

Example of execution:

```shell
crityp test-bench.typ
Benchmarking fib-bench typst
Benchmarking fib-bench typst: Warming up for 3.0000 s
Benchmarking fib-bench typst: Collecting 100 samples in estimated 5.2594 s (56k iterations)
Benchmarking fib-bench typst: Analyzing
test-bench.typ@fib-bench time:   [93.551 µs 94.220 µs 94.967 µs]    
                         change: [-91.268% -90.867% -90.520%] (p = 0.00 < 0.05)
                         Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

Proposed design:
- can accept all arguments of `typst-cli compile`
- matches the exported function of the given main file. If the name of a function starts with `bench`, it is assumed to be a bench case. We can also have an extra glob `--filter` flag to match functions in future, e.g. `^my-bench*`.

More thoughts:
- An IDE can provide codelens over the matched functions to launch the benchmark quickly.
- We should estimate the binary size of the criterion.rs. If it bloats much, we might not integrate it by default. 