### PR TITLE
fix: update xlsx-parser package version to 0.2.3

### DIFF
--- a/editors/vscode/src/features/drag-and-drop.ts
+++ b/editors/vscode/src/features/drag-and-drop.ts
@@ -86,7 +86,7 @@ export class TextProvider implements vscode.DocumentDropEditProvider {
         codeSnippet = `grayscale-image(read(${strPath}))`;
         break;
       case ResourceKind.Xlsx:
-        additionalPkgs.push(["@preview/rexllent", "0.2.2", "xlsx-parser"]);
+        additionalPkgs.push(["@preview/rexllent", "0.2.3", "xlsx-parser"]);
         codeSnippet = `xlsx-parser(read(${strPath}, encoding: none))`;
         break;
       case ResourceKind.Source:


### PR DESCRIPTION
Hi! 0.2.3 treat 0pt column width and row height as auto instead, and will parse table with dimensions as default.