### PR TITLE
feat: prefer to select the previous token when cursor is before a marker

### DIFF
--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -32,7 +32,7 @@ impl StatefulRequest for GotoDefinitionRequest {
         doc: Option<VersionedDocument>,
     ) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
-        let syntax = ctx.classify_pos(&source, self.position, 1)?;
+        let syntax = ctx.classify_for_decl(&source, self.position)?;
         let origin_selection_range = ctx.to_lsp_range(syntax.node().range(), &source);
 
         let def = ctx.def_of_syntax(&source, doc.as_ref(), syntax)?;

--- a/crates/tinymist-query/src/prepare_rename.rs
+++ b/crates/tinymist-query/src/prepare_rename.rs
@@ -38,7 +38,7 @@ impl StatefulRequest for PrepareRenameRequest {
         doc: Option<VersionedDocument>,
     ) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
-        let syntax = ctx.classify_pos(&source, self.position, 1)?;
+        let syntax = ctx.classify_for_decl(&source, self.position)?;
         if matches!(syntax.node().kind(), SyntaxKind::FieldAccess) {
             // todo: rename field access
             log::info!("prepare_rename: field access is not a definition site");

--- a/crates/tinymist-query/src/references.rs
+++ b/crates/tinymist-query/src/references.rs
@@ -31,7 +31,7 @@ impl StatefulRequest for ReferencesRequest {
         doc: Option<VersionedDocument>,
     ) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
-        let syntax = ctx.classify_pos(&source, self.position, 1)?;
+        let syntax = ctx.classify_for_decl(&source, self.position)?;
 
         let locations = find_references(ctx, &source, doc.as_ref(), syntax)?;
 

--- a/crates/tinymist-query/src/rename.rs
+++ b/crates/tinymist-query/src/rename.rs
@@ -42,7 +42,7 @@ impl StatefulRequest for RenameRequest {
         doc: Option<VersionedDocument>,
     ) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
-        let syntax = ctx.classify_pos(&source, self.position, 1)?;
+        let syntax = ctx.classify_for_decl(&source, self.position)?;
 
         let def = ctx.def_of_syntax(&source, doc.as_ref(), syntax.clone())?;
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:13c8f3b8332d33ca70a079e4a96cc55f");
+        insta::assert_snapshot!(hash, @"siphash128_13:cd193b47cc7db3edf339eb048f34f4e2");
     }
 
     {
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:1d6bc2aac362b883a197487869cddf0e");
+        insta::assert_snapshot!(hash, @"siphash128_13:e9f262b45e59ec0c1f282f36103c419");
     }
 }
 


### PR DESCRIPTION
When a cursor is before a marker and after an identifier, the matcher will prefer to match the identifier instead of the marker.

For example, the following bars select the identifier:

```
#f(|xx)
#f(x|x)
#f(xx|)
```
