### PR TITLE
feat: track fine-grained revisions of `font`, `registry`, `entry`, and `vfs`

### DIFF
--- a/crates/tinymist-project/src/watch.rs
+++ b/crates/tinymist-project/src/watch.rs
@@ -17,9 +17,9 @@ use tokio::sync::mpsc;
 use typst::diag::FileError;
 
 use crate::vfs::{
-    notify::{FileChangeSet, FileSnapshot, FilesystemEvent, NotifyMessage, UpstreamUpdateEvent},
+    notify::{FilesystemEvent, NotifyMessage, UpstreamUpdateEvent},
     system::SystemAccessModel,
-    PathAccessModel,
+    FileChangeSet, FileSnapshot, PathAccessModel,
 };
 
 type WatcherPair = (RecommendedWatcher, mpsc::UnboundedReceiver<NotifyEvent>);

--- a/crates/tinymist-project/src/world.rs
+++ b/crates/tinymist-project/src/world.rs
@@ -7,7 +7,9 @@ pub use tinymist_world::config::CompileFontOpts;
 use tinymist_world::package::RegistryPathMapper;
 pub use tinymist_world::vfs;
 pub use tinymist_world::{entry::*, EntryOpts, EntryState};
-pub use tinymist_world::{font, package, CompilerUniverse, CompilerWorld, Revising, TaskInputs};
+pub use tinymist_world::{
+    font, package, CompilerUniverse, CompilerWorld, RevisingUniverse, TaskInputs,
+};
 
 use std::path::Path;
 use std::{borrow::Cow, sync::Arc};

--- a/crates/tinymist-query/src/code_context.rs
+++ b/crates/tinymist-query/src/code_context.rs
@@ -106,7 +106,7 @@ impl SemanticRequest for InteractCodeContextRequest {
                         mapped_source.id(),
                         Bytes::from(mapped_source.text().as_bytes()),
                     );
-                    world.take_state();
+                    world.take_db();
 
                     let root = LinkedNode::new(mapped_source.root());
                     let leaf = root.leaf_at_compat(start + offset)?;

--- a/crates/tinymist-query/src/code_context.rs
+++ b/crates/tinymist-query/src/code_context.rs
@@ -106,7 +106,7 @@ impl SemanticRequest for InteractCodeContextRequest {
                         mapped_source.id(),
                         Bytes::from(mapped_source.text().as_bytes()),
                     );
-                    world.source_db.take_state();
+                    world.take_state();
 
                     let root = LinkedNode::new(mapped_source.root());
                     let leaf = root.leaf_at_compat(start + offset)?;

--- a/crates/tinymist-query/src/docs/convert.rs
+++ b/crates/tinymist-query/src/docs/convert.rs
@@ -25,7 +25,7 @@ pub(crate) fn convert_docs(ctx: &SharedContext, content: &str) -> StrResult<EcoS
     });
     w.map_shadow_by_id(w.main(), Bytes::from(content.as_bytes().to_owned()))?;
     // todo: bad performance
-    w.take_state();
+    w.take_db();
 
     let conv = typlite::Typlite::new(Arc::new(w))
         .with_library(DOCS_LIB.clone())

--- a/crates/tinymist-query/src/docs/convert.rs
+++ b/crates/tinymist-query/src/docs/convert.rs
@@ -25,7 +25,7 @@ pub(crate) fn convert_docs(ctx: &SharedContext, content: &str) -> StrResult<EcoS
     });
     w.map_shadow_by_id(w.main(), Bytes::from(content.as_bytes().to_owned()))?;
     // todo: bad performance
-    w.source_db.take_state();
+    w.take_state();
 
     let conv = typlite::Typlite::new(Arc::new(w))
         .with_library(DOCS_LIB.clone())

--- a/crates/tinymist-vfs/src/dummy.rs
+++ b/crates/tinymist-vfs/src/dummy.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use tinymist_std::ImmutPath;
 use typst::diag::{FileError, FileResult};
 
 use crate::{AccessModel, Bytes, PathAccessModel, TypstFileId};
@@ -13,8 +14,8 @@ use crate::{AccessModel, Bytes, PathAccessModel, TypstFileId};
 pub struct DummyAccessModel;
 
 impl AccessModel for DummyAccessModel {
-    fn content(&self, _src: TypstFileId) -> FileResult<Bytes> {
-        Err(FileError::AccessDenied)
+    fn content(&self, _src: TypstFileId) -> (Option<ImmutPath>, FileResult<Bytes>) {
+        (None, Err(FileError::AccessDenied))
     }
 }
 

--- a/crates/tinymist-vfs/src/lib.rs
+++ b/crates/tinymist-vfs/src/lib.rs
@@ -206,8 +206,8 @@ impl<M: PathAccessModel + Clone + Sized> Vfs<M> {
         }
     }
 
-    pub fn take_state(&self) -> SourceCache {
-        self.source_cache.clone()
+    pub fn take_state(&mut self) -> SourceCache {
+        std::mem::take(&mut self.source_cache)
     }
 }
 

--- a/crates/tinymist-vfs/src/lib.rs
+++ b/crates/tinymist-vfs/src/lib.rs
@@ -205,10 +205,6 @@ impl<M: PathAccessModel + Clone + Sized> Vfs<M> {
             access_model: self.access_model.clone(),
         }
     }
-
-    pub fn take_state(&mut self) -> SourceCache {
-        std::mem::take(&mut self.source_cache)
-    }
 }
 
 impl<M: PathAccessModel + Sized> Vfs<M> {
@@ -250,6 +246,7 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
     pub fn reset_all(&mut self) {
         self.reset_access_model();
         self.reset_cache();
+        self.take_state();
     }
 
     /// Reset access model.
@@ -272,6 +269,10 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
                 m.entries.remove_mut(id);
             }
         }
+    }
+
+    pub fn take_state(&mut self) -> SourceCache {
+        std::mem::take(&mut self.source_cache)
     }
 
     /// Resolve the real path for a file id.

--- a/crates/tinymist-vfs/src/notify.rs
+++ b/crates/tinymist-vfs/src/notify.rs
@@ -15,7 +15,7 @@ pub enum MemoryEvent {
     /// this:
     ///
     /// ```
-    /// use tinymist_vfs::notify::{MemoryEvent, FileChangeSet};
+    /// use tinymist_vfs::{FileChangeSet, notify::MemoryEvent};
     /// let event = MemoryEvent::Sync(FileChangeSet::default());
     /// ```
     Sync(FileChangeSet),

--- a/crates/tinymist-vfs/src/notify.rs
+++ b/crates/tinymist-vfs/src/notify.rs
@@ -1,118 +1,12 @@
-use core::fmt;
 use std::path::Path;
 
 use rpds::RedBlackTreeMapSync;
-use typst::diag::{FileError, FileResult};
+use typst::diag::FileResult;
 
-use crate::{Bytes, ImmutPath, PathAccessModel};
-
-/// A file snapshot that is notified by some external source
-///
-/// Note: The error is boxed to avoid large stack size
-#[derive(Clone, PartialEq, Eq)]
-pub struct FileSnapshot(Result<Bytes, Box<FileError>>);
-
-impl fmt::Debug for FileSnapshot {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0.as_ref() {
-            Ok(v) => f
-                .debug_struct("FileSnapshot")
-                .field("content", &FileContent { len: v.len() })
-                .finish(),
-            Err(e) => f.debug_struct("FileSnapshot").field("error", &e).finish(),
-        }
-    }
-}
-
-impl FileSnapshot {
-    /// content of the file
-    #[inline]
-    #[track_caller]
-    pub fn content(&self) -> FileResult<&Bytes> {
-        self.0.as_ref().map_err(|e| *e.clone())
-    }
-
-    /// Whether the related file is a file
-    #[inline]
-    #[track_caller]
-    pub fn is_file(&self) -> FileResult<bool> {
-        self.content().map(|_| true)
-    }
-}
-
-impl std::ops::Deref for FileSnapshot {
-    type Target = Result<Bytes, Box<FileError>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for FileSnapshot {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-/// Convenient function to create a [`FileSnapshot`] from tuple
-impl From<FileResult<Bytes>> for FileSnapshot {
-    fn from(result: FileResult<Bytes>) -> Self {
-        Self(result.map_err(Box::new))
-    }
-}
-
-/// A set of changes to the filesystem.
-///
-/// The correct order of applying changes is:
-/// 1. Remove files
-/// 2. Upsert (Insert or Update) files
-#[derive(Debug, Clone, Default)]
-pub struct FileChangeSet {
-    /// Files to remove
-    pub removes: Vec<ImmutPath>,
-    /// Files to insert or update
-    pub inserts: Vec<(ImmutPath, FileSnapshot)>,
-}
-
-impl FileChangeSet {
-    /// Create a new empty changeset
-    pub fn is_empty(&self) -> bool {
-        self.inserts.is_empty() && self.removes.is_empty()
-    }
-
-    /// Create a new changeset with removing files
-    pub fn new_removes(removes: Vec<ImmutPath>) -> Self {
-        Self {
-            removes,
-            inserts: vec![],
-        }
-    }
-
-    /// Create a new changeset with inserting files
-    pub fn new_inserts(inserts: Vec<(ImmutPath, FileSnapshot)>) -> Self {
-        Self {
-            removes: vec![],
-            inserts,
-        }
-    }
-
-    /// Utility function to insert a possible file to insert or update
-    pub fn may_insert(&mut self, v: Option<(ImmutPath, FileSnapshot)>) {
-        if let Some(v) = v {
-            self.inserts.push(v);
-        }
-    }
-
-    /// Utility function to insert multiple possible files to insert or update
-    pub fn may_extend(&mut self, v: Option<impl Iterator<Item = (ImmutPath, FileSnapshot)>>) {
-        if let Some(v) = v {
-            self.inserts.extend(v);
-        }
-    }
-}
+use crate::{Bytes, FileChangeSet, FileSnapshot, ImmutPath, PathAccessModel};
 
 /// A memory event that is notified by some external source
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MemoryEvent {
     /// Reset all dependencies and update according to the given changeset
     ///
@@ -154,6 +48,18 @@ pub enum FilesystemEvent {
         /// The upstream event that causes the invalidation
         upstream_event: Option<UpstreamUpdateEvent>,
     },
+}
+
+impl FilesystemEvent {
+    pub fn split(self) -> (FileChangeSet, Option<UpstreamUpdateEvent>) {
+        match self {
+            FilesystemEvent::UpstreamUpdate {
+                changeset,
+                upstream_event,
+            } => (changeset, upstream_event),
+            FilesystemEvent::Update(changeset) => (changeset, None),
+        }
+    }
 }
 
 /// A message that is sent to some file watcher
@@ -211,23 +117,23 @@ impl<M: PathAccessModel> NotifyAccessModel<M> {
     }
 
     /// Notify the access model with a filesystem event
-    pub fn notify(&mut self, event: FilesystemEvent) {
-        match event {
-            FilesystemEvent::UpstreamUpdate { changeset, .. }
-            | FilesystemEvent::Update(changeset) => {
-                for path in changeset.removes {
-                    self.files.remove_mut(&path);
-                }
+    pub fn notify(&mut self, changeset: FileChangeSet) {
+        for path in changeset.removes {
+            self.files.remove_mut(&path);
+        }
 
-                for (path, contents) in changeset.inserts {
-                    self.files.insert_mut(path, contents);
-                }
-            }
+        for (path, contents) in changeset.inserts {
+            self.files.insert_mut(path, contents);
         }
     }
 }
 
 impl<M: PathAccessModel> PathAccessModel for NotifyAccessModel<M> {
+    #[inline]
+    fn reset(&mut self) {
+        self.inner.reset();
+    }
+
     fn content(&self, src: &Path) -> FileResult<Bytes> {
         if let Some(entry) = self.files.get(src) {
             return entry.content().cloned();
@@ -235,10 +141,4 @@ impl<M: PathAccessModel> PathAccessModel for NotifyAccessModel<M> {
 
         self.inner.content(src)
     }
-}
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct FileContent {
-    len: usize,
 }

--- a/crates/tinymist-vfs/src/snapshot.rs
+++ b/crates/tinymist-vfs/src/snapshot.rs
@@ -1,0 +1,116 @@
+use core::fmt;
+
+use typst::diag::{FileError, FileResult};
+
+use crate::{Bytes, ImmutPath};
+
+/// A file snapshot that is notified by some external source
+///
+/// Note: The error is boxed to avoid large stack size
+#[derive(Clone, PartialEq, Eq)]
+pub struct FileSnapshot(Result<Bytes, Box<FileError>>);
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct FileContent {
+    len: usize,
+}
+
+impl fmt::Debug for FileSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.as_ref() {
+            Ok(v) => f
+                .debug_struct("FileSnapshot")
+                .field("content", &FileContent { len: v.len() })
+                .finish(),
+            Err(e) => f.debug_struct("FileSnapshot").field("error", &e).finish(),
+        }
+    }
+}
+
+impl FileSnapshot {
+    /// content of the file
+    #[inline]
+    #[track_caller]
+    pub fn content(&self) -> FileResult<&Bytes> {
+        self.0.as_ref().map_err(|e| *e.clone())
+    }
+
+    /// Whether the related file is a file
+    #[inline]
+    #[track_caller]
+    pub fn is_file(&self) -> FileResult<bool> {
+        self.content().map(|_| true)
+    }
+}
+
+impl std::ops::Deref for FileSnapshot {
+    type Target = Result<Bytes, Box<FileError>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FileSnapshot {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Convenient function to create a [`FileSnapshot`] from tuple
+impl From<FileResult<Bytes>> for FileSnapshot {
+    fn from(result: FileResult<Bytes>) -> Self {
+        Self(result.map_err(Box::new))
+    }
+}
+
+/// A set of changes to the filesystem.
+///
+/// The correct order of applying changes is:
+/// 1. Remove files
+/// 2. Upsert (Insert or Update) files
+#[derive(Debug, Clone, Default)]
+pub struct FileChangeSet {
+    /// Files to remove
+    pub removes: Vec<ImmutPath>,
+    /// Files to insert or update
+    pub inserts: Vec<(ImmutPath, FileSnapshot)>,
+}
+
+impl FileChangeSet {
+    /// Create a new empty changeset
+    pub fn is_empty(&self) -> bool {
+        self.inserts.is_empty() && self.removes.is_empty()
+    }
+
+    /// Create a new changeset with removing files
+    pub fn new_removes(removes: Vec<ImmutPath>) -> Self {
+        Self {
+            removes,
+            inserts: vec![],
+        }
+    }
+
+    /// Create a new changeset with inserting files
+    pub fn new_inserts(inserts: Vec<(ImmutPath, FileSnapshot)>) -> Self {
+        Self {
+            removes: vec![],
+            inserts,
+        }
+    }
+
+    /// Utility function to insert a possible file to insert or update
+    pub fn may_insert(&mut self, v: Option<(ImmutPath, FileSnapshot)>) {
+        if let Some(v) = v {
+            self.inserts.push(v);
+        }
+    }
+
+    /// Utility function to insert multiple possible files to insert or update
+    pub fn may_extend(&mut self, v: Option<impl Iterator<Item = (ImmutPath, FileSnapshot)>>) {
+        if let Some(v) = v {
+            self.inserts.extend(v);
+        }
+    }
+}

--- a/crates/tinymist-vfs/src/trace.rs
+++ b/crates/tinymist-vfs/src/trace.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicU64;
 
+use tinymist_std::ImmutPath;
 use typst::diag::FileResult;
 
 use crate::{AccessModel, Bytes, TypstFileId};
@@ -25,11 +26,12 @@ impl<M: AccessModel + Sized> TraceAccessModel<M> {
 }
 
 impl<M: AccessModel + Sized> AccessModel for TraceAccessModel<M> {
-    fn clear(&mut self) {
-        self.inner.clear();
+    #[inline]
+    fn reset(&mut self) {
+        self.inner.reset();
     }
 
-    fn content(&self, src: TypstFileId) -> FileResult<Bytes> {
+    fn content(&self, src: TypstFileId) -> (Option<ImmutPath>, FileResult<Bytes>) {
         let instant = tinymist_std::time::Instant::now();
         let res = self.inner.content(src);
         let elapsed = instant.elapsed();

--- a/crates/tinymist-world/src/entry.rs
+++ b/crates/tinymist-world/src/entry.rs
@@ -16,10 +16,6 @@ pub trait EntryReader {
 }
 
 pub trait EntryManager: EntryReader {
-    fn reset(&mut self) -> SourceResult<()> {
-        Ok(())
-    }
-
     fn mutate_entry(&mut self, state: EntryState) -> SourceResult<EntryState>;
 }
 

--- a/crates/tinymist-world/src/font/resolver.rs
+++ b/crates/tinymist-world/src/font/resolver.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::{
     collections::HashMap,
+    num::NonZeroUsize,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -16,6 +17,10 @@ use crate::Bytes;
 /// It also reuse FontBook for font-related query.
 /// The index is the index of the font in the `FontBook.infos`.
 pub trait FontResolver {
+    fn revision(&self) -> Option<NonZeroUsize> {
+        None
+    }
+
     fn font_book(&self) -> &LazyHash<FontBook>;
     fn font(&self, idx: usize) -> Option<Font>;
 

--- a/crates/tinymist-world/src/lib.rs
+++ b/crates/tinymist-world/src/lib.rs
@@ -133,7 +133,7 @@ pub trait WorldDeps {
 }
 
 /// type trait interface of [`CompilerWorld`].
-pub trait CompilerFeat {
+pub trait CompilerFeat: Send + Sync + 'static {
     /// Specify the font resolver for typst compiler.
     type FontResolver: FontResolver + Send + Sync + Sized;
     /// Specify the access model for VFS.

--- a/crates/tinymist-world/src/package/mod.rs
+++ b/crates/tinymist-world/src/package/mod.rs
@@ -1,4 +1,5 @@
 impl Notifier for DummyNotifier {}
+use std::num::NonZeroUsize;
 use std::{path::Path, sync::Arc};
 
 use ecow::EcoString;
@@ -17,6 +18,10 @@ pub mod http;
 
 pub trait PackageRegistry {
     fn reset(&mut self) {}
+
+    fn revision(&self) -> Option<NonZeroUsize> {
+        None
+    }
 
     fn resolve(&self, spec: &PackageSpec) -> Result<Arc<Path>, PackageError>;
 

--- a/crates/tinymist-world/src/source.rs
+++ b/crates/tinymist-world/src/source.rs
@@ -140,6 +140,15 @@ impl SourceDb {
             entry
         })
     }
+
+    pub(crate) fn take_state(&mut self) -> SourceDb {
+        let slots = std::mem::take(&mut self.slots);
+
+        SourceDb {
+            is_compiling: self.is_compiling,
+            slots,
+        }
+    }
 }
 
 pub trait MergeCache: Sized {

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -431,8 +431,12 @@ impl<F: CompilerFeat> CompilerWorld<F> {
         world
     }
 
-    pub fn take_state(&mut self) -> SourceCache {
+    pub fn take_cache(&mut self) -> SourceCache {
         self.vfs.take_state()
+    }
+
+    pub fn take_db(&mut self) -> SourceDb {
+        self.source_db.take_state()
     }
 
     /// Sets flag to indicate whether the compiler is currently compiling.

--- a/crates/tinymist/src/actor/mod.rs
+++ b/crates/tinymist/src/actor/mod.rs
@@ -8,7 +8,7 @@ pub mod typ_server;
 
 use std::sync::Arc;
 
-use crate::world::vfs::notify::{FileChangeSet, MemoryEvent};
+use crate::world::vfs::{notify::MemoryEvent, FileChangeSet};
 use crate::world::EntryState;
 use reflexo::ImmutPath;
 use tinymist_query::analysis::{Analysis, PeriscopeProvider};

--- a/crates/tinymist/src/actor/typ_server.rs
+++ b/crates/tinymist/src/actor/typ_server.rs
@@ -558,7 +558,7 @@ impl<F: CompilerFeat + Send + Sync + 'static> CompileServerActor<F> {
         )));
 
         // Trigger an evict task.
-        self.cache.evict(world.revision(), world.take_state());
+        self.cache.evict(world.revision(), world.take_cache());
     }
 
     /// Process some interrupt. Return whether it needs compilation.

--- a/crates/tinymist/src/actor/typ_server.rs
+++ b/crates/tinymist/src/actor/typ_server.rs
@@ -532,7 +532,7 @@ impl<F: CompilerFeat + Send + Sync + 'static> CompileServerActor<F> {
     fn process_compile(&mut self, artifact: CompiledArtifact<F>, send: impl Fn(CompilerResponse)) {
         self.compiling = false;
 
-        let world = &artifact.snap.world;
+        let mut world = artifact.snap.world;
         let compiled_revision = world.revision().get();
         if self.committed_revision >= compiled_revision {
             return;
@@ -558,7 +558,7 @@ impl<F: CompilerFeat + Send + Sync + 'static> CompileServerActor<F> {
         )));
 
         // Trigger an evict task.
-        self.cache.evict();
+        self.cache.evict(world.revision(), world.take_state());
     }
 
     /// Process some interrupt. Return whether it needs compilation.

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::world::vfs::notify::{FileChangeSet, MemoryEvent};
+use crate::world::vfs::{notify::MemoryEvent, FileChangeSet};
 use actor::editor::EditorActor;
 use anyhow::anyhow;
 use anyhow::Context;

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -3,7 +3,7 @@
 use std::num::NonZeroUsize;
 use std::{collections::HashMap, net::SocketAddr, path::Path, sync::Arc};
 
-use crate::world::vfs::notify::{FileChangeSet, MemoryEvent};
+use crate::world::vfs::{notify::MemoryEvent, FileChangeSet};
 use futures::{SinkExt, StreamExt, TryStreamExt};
 use hyper::service::service_fn;
 use hyper_tungstenite::{tungstenite::Message, HyperWebsocket, HyperWebsocketStream};

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -454,7 +454,7 @@ impl TypliteWorker {
             entry: Some(entry),
             inputs,
         });
-        world.source_db.take_state();
+        world.take_state();
         world.map_shadow_by_id(world.main(), main).unwrap();
 
         let document = typst::compile(&world).output;

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -454,7 +454,7 @@ impl TypliteWorker {
             entry: Some(entry),
             inputs,
         });
-        world.take_state();
+        world.take_db();
         world.map_shadow_by_id(world.main(), main).unwrap();
 
         let document = typst::compile(&world).output;


### PR DESCRIPTION
- will close #763 in later PR
- close #336
- The world's revision is increased by VFS changed only if any compilation-related content is changed.
  - This was not operatable because both analyzers and the compiler will access the world and touch the files. We were not able to distinguish whether an content is ever accessed by the compiler and not only accessed by the analyzers *after some vfs changes*.
- Each file (`VfsEntry`) has a revision. `Vfs` starts to cache and respond same content on an entry unless the associated cache is explicitly invalidated. This strategy is used by the ruff-lsp.
  - `invalidate_file_id`: The entry corresponds to the `file_id` is invalidated. An entry may have no path if it is an in-memory nameless buffer.
  - `invalidate_path`: Mulitple `file_id`s can be mapped to a same path, for example, a file can be accessed with both `/path/to/workspace/the-package/lib.typ` and `data-dir/local/the-package/0.1.0/lib.typ` by symlink.
- The `entry` is a pair `("root/", "main.typ")`. If `"root/"` is changed, `Vfs` invalidates all caches and increases its revision.
- Both `FontResolver` (fonts) and a `Registry` (packages) can have an optionally implemented `fn revision(&self) -> Option<Revision>` function.
  - If either `previous_revision` or `next_revision` is `None`, the world's revision is always increased.
  - Otherwise, the world's revision is increased if a changed revision is observed.
  - If the revision of packages is changed, `Vfs` invalidates all caches and increases its revision.

