### PR TITLE
fix: push resolved span to editor

### DIFF
--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -91,7 +91,7 @@ impl RenderActor {
                 log::debug!("RenderActor: resolved WebviewResolveSpan: {spans:?}");
                 // end position is used
                 if let Some(spans) = spans {
-                    self.resolve_span_range(spans.0..spans.1);
+                    self.editor_resolve_span_range(spans.0..spans.1);
                 }
             }
             RenderActorRequest::ResolveSourceLoc(req) => {


### PR DESCRIPTION
This was broken by #1156, same as #1159. @Enter-tainer 