### PR TITLE
feat: execute export and query on the task model

### DIFF
--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -182,25 +182,29 @@ impl TaskCompileArgs {
         }
 
         let export = ExportTask {
-            document: doc_id,
-            id: task_id.clone(),
             when,
             transform: transforms,
         };
 
-        Ok(match output_format {
-            OutputFormat::Pdf => ProjectTask::ExportPdf(ExportPdfTask {
+        let config = match output_format {
+            OutputFormat::Pdf => ProjectTaskConfig::ExportPdf(ExportPdfTask {
                 export,
                 pdf_standards: self.pdf_standard.clone(),
                 creation_timestamp: None,
             }),
-            OutputFormat::Png => ProjectTask::ExportPng(ExportPngTask {
+            OutputFormat::Png => ProjectTaskConfig::ExportPng(ExportPngTask {
                 export,
                 ppi: self.ppi.try_into().unwrap(),
                 fill: None,
             }),
-            OutputFormat::Svg => ProjectTask::ExportSvg(ExportSvgTask { export }),
-            OutputFormat::Html => ProjectTask::ExportSvg(ExportSvgTask { export }),
+            OutputFormat::Svg => ProjectTaskConfig::ExportSvg(ExportSvgTask { export }),
+            OutputFormat::Html => ProjectTaskConfig::ExportSvg(ExportSvgTask { export }),
+        };
+
+        Ok(ProjectTask {
+            id: task_id.clone(),
+            document: doc_id,
+            config,
         })
     }
 }

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -148,7 +148,7 @@ pub struct TaskCompileArgs {
 
 impl TaskCompileArgs {
     /// Convert the arguments to a project task.
-    pub fn to_task(self, doc_id: Id) -> Result<ProjectTask> {
+    pub fn to_task(self, doc_id: Id) -> Result<ApplyProjectTask> {
         let new_task_id = self.task_name.map(Id::new);
         let task_id = new_task_id.unwrap_or(doc_id.clone());
 
@@ -188,24 +188,24 @@ impl TaskCompileArgs {
         };
 
         let config = match output_format {
-            OutputFormat::Pdf => ProjectTaskConfig::ExportPdf(ExportPdfTask {
+            OutputFormat::Pdf => ProjectTask::ExportPdf(ExportPdfTask {
                 export,
                 pdf_standards: self.pdf_standard.clone(),
                 creation_timestamp: None,
             }),
-            OutputFormat::Png => ProjectTaskConfig::ExportPng(ExportPngTask {
+            OutputFormat::Png => ProjectTask::ExportPng(ExportPngTask {
                 export,
                 ppi: self.ppi.try_into().unwrap(),
                 fill: None,
             }),
-            OutputFormat::Svg => ProjectTaskConfig::ExportSvg(ExportSvgTask { export }),
-            OutputFormat::Html => ProjectTaskConfig::ExportSvg(ExportSvgTask { export }),
+            OutputFormat::Svg => ProjectTask::ExportSvg(ExportSvgTask { export }),
+            OutputFormat::Html => ProjectTask::ExportSvg(ExportSvgTask { export }),
         };
 
-        Ok(ProjectTask {
+        Ok(ApplyProjectTask {
             id: task_id.clone(),
             document: doc_id,
-            config,
+            task: config,
         })
     }
 }

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -183,6 +183,7 @@ impl TaskCompileArgs {
 
         let export = ExportTask {
             when,
+            output: None,
             transform: transforms,
         };
 

--- a/crates/tinymist-project/src/lock.rs
+++ b/crates/tinymist-project/src/lock.rs
@@ -11,7 +11,7 @@ use tinymist_std::{bail, ImmutPath};
 use typst::diag::EcoString;
 use typst::World;
 
-use crate::model::{Id, ProjectInput, ProjectRoute, ProjectTask, ResourcePath};
+use crate::model::{ApplyProjectTask, Id, ProjectInput, ProjectRoute, ResourcePath};
 use crate::{LockFile, LockFileCompat, LspWorld, ProjectPathMaterial, LOCK_VERSION};
 
 pub const LOCK_FILENAME: &str = "tinymist.lock";
@@ -33,7 +33,7 @@ impl LockFile {
         }
     }
 
-    pub fn replace_task(&mut self, task: ProjectTask) {
+    pub fn replace_task(&mut self, task: ApplyProjectTask) {
         let id = task.id().clone();
         let index = self.task.iter().position(|i| *i.id() == id);
         if let Some(index) = index {
@@ -225,7 +225,7 @@ pub fn update_lock(root: ImmutPath) -> LockFileUpdate {
 
 enum LockUpdate {
     Input(ProjectInput),
-    Task(ProjectTask),
+    Task(ApplyProjectTask),
     Material(ProjectPathMaterial),
     Route(ProjectRoute),
 }
@@ -278,7 +278,7 @@ impl LockFileUpdate {
         Some(id)
     }
 
-    pub fn task(&mut self, task: ProjectTask) {
+    pub fn task(&mut self, task: ApplyProjectTask) {
         self.updates.push(LockUpdate::Task(task));
     }
 

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -9,9 +9,10 @@ use clap::ValueEnum;
 use ecow::EcoVec;
 use serde::{Deserialize, Serialize};
 use tinymist_std::error::prelude::*;
-use tinymist_std::path::unix_slash;
+use tinymist_std::path::{unix_slash, PathClean};
 use tinymist_std::{bail, ImmutPath};
-use tinymist_world::EntryReader;
+use tinymist_world::vfs::WorkspaceResolver;
+use tinymist_world::{EntryReader, EntryState};
 use typst::diag::EcoString;
 use typst::syntax::FileId;
 
@@ -118,17 +119,16 @@ macro_rules! display_possible_values {
 /// alias typst="tinymist compile --when=onSave"
 /// typst compile main.typ
 /// ```
-#[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, ValueEnum, Serialize, Deserialize,
-)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, ValueEnum, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[clap(rename_all = "camelCase")]
 pub enum TaskWhen {
     /// Never watch to run task.
+    #[default]
     Never,
-    /// Run task on save.
+    /// Run task on saving the document, i.e. on `textDocument/didSave` events.
     OnSave,
-    /// Run task on type.
+    /// Run task on typing, i.e. on `textDocument/didChange` events.
     OnType,
     /// *DEPRECATED* Run task when a document has a title and on saved, which is
     /// useful to filter out template files.
@@ -160,6 +160,71 @@ pub enum OutputFormat {
 }
 
 display_possible_values!(OutputFormat);
+
+/// The path pattern that could be substituted.
+///
+/// # Examples
+/// - `$root` is the root of the project.
+/// - `$root/$dir` is the parent directory of the input (main) file.
+/// - `$root/main` will help store pdf file to `$root/main.pdf` constantly.
+/// - (default) `$root/$dir/$name` will help store pdf file along with the input
+///   file.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PathPattern(pub String);
+
+impl PathPattern {
+    /// Creates a new path pattern.
+    pub fn new(pattern: &str) -> Self {
+        Self(pattern.to_owned())
+    }
+
+    /// Substitutes the path pattern with `$root`, and `$dir/$name`.
+    pub fn substitute(&self, entry: &EntryState) -> Option<ImmutPath> {
+        self.substitute_impl(entry.root(), entry.main())
+    }
+
+    #[comemo::memoize]
+    fn substitute_impl(&self, root: Option<ImmutPath>, main: Option<FileId>) -> Option<ImmutPath> {
+        log::info!("Check path {main:?} and root {root:?} with output directory {self:?}");
+
+        let (root, main) = root.zip(main)?;
+
+        // Files in packages are not exported
+        if WorkspaceResolver::is_package_file(main) {
+            return None;
+        }
+        // Files without a path are not exported
+        let path = main.vpath().resolve(&root)?;
+
+        // todo: handle untitled path
+        if let Ok(path) = path.strip_prefix("/untitled") {
+            let tmp = std::env::temp_dir();
+            let path = tmp.join("typst").join(path);
+            return Some(path.as_path().into());
+        }
+
+        if self.0.is_empty() {
+            return Some(path.to_path_buf().clean().into());
+        }
+
+        let path = path.strip_prefix(&root).ok()?;
+        let dir = path.parent();
+        let file_name = path.file_name().unwrap_or_default();
+
+        let w = root.to_string_lossy();
+        let f = file_name.to_string_lossy();
+
+        // replace all $root
+        let mut path = self.0.replace("$root", &w);
+        if let Some(dir) = dir {
+            let d = dir.to_string_lossy();
+            path = path.replace("$dir", &d);
+        }
+        path = path.replace("$name", &f);
+
+        Some(PathBuf::from(path).clean().into())
+    }
+}
 
 /// A PDF standard that Typst can enforce conformance with.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, ValueEnum, Serialize, Deserialize)]
@@ -471,4 +536,34 @@ pub struct ProjectRoute {
     pub id: Id,
     /// The priority of the project. (lower numbers are higher priority).
     pub priority: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use typst::syntax::VirtualPath;
+
+    #[test]
+    fn test_substitute_path() {
+        let root = Path::new("/root");
+        let entry =
+            EntryState::new_rooted(root.into(), Some(VirtualPath::new("/dir1/dir2/file.txt")));
+
+        assert_eq!(
+            PathPattern::new("/substitute/$dir/$name").substitute(&entry),
+            Some(PathBuf::from("/substitute/dir1/dir2/file.txt").into())
+        );
+        assert_eq!(
+            PathPattern::new("/substitute/$dir/../$name").substitute(&entry),
+            Some(PathBuf::from("/substitute/dir1/file.txt").into())
+        );
+        assert_eq!(
+            PathPattern::new("/substitute/$name").substitute(&entry),
+            Some(PathBuf::from("/substitute/file.txt").into())
+        );
+        assert_eq!(
+            PathPattern::new("/substitute/target/$dir/$name").substitute(&entry),
+            Some(PathBuf::from("/substitute/target/dir1/dir2/file.txt").into())
+        );
+    }
 }

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -257,6 +257,11 @@ display_possible_values!(PdfStandard);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Pages(pub RangeInclusive<Option<NonZeroUsize>>);
 
+impl Pages {
+    /// Selects the first page.
+    pub const FIRST: Pages = Pages(NonZeroUsize::new(1)..=None);
+}
+
 impl FromStr for Pages {
     type Err = &'static str;
 

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -25,7 +25,7 @@ use crate::LspWorld;
 pub const LOCK_VERSION: &str = "0.1.0-beta0";
 
 /// A scalar that is not NaN.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Scalar(f32);
 
 impl TryFrom<f32> for Scalar {
@@ -37,6 +37,13 @@ impl TryFrom<f32> for Scalar {
         } else {
             Ok(Scalar(value))
         }
+    }
+}
+
+impl Scalar {
+    /// Converts the scalar to an f32.
+    pub fn to_f32(self) -> f32 {
+        self.0
     }
 }
 

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -464,7 +464,7 @@ pub struct LockFile {
     pub document: Vec<ProjectInput>,
     /// The project's task (output).
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub task: Vec<ProjectTask>,
+    pub task: Vec<ApplyProjectTask>,
     /// The project's task route.
     #[serde(skip_serializing_if = "EcoVec::is_empty", default)]
     pub route: EcoVec<ProjectRoute>,

--- a/crates/tinymist-project/src/model/task.rs
+++ b/crates/tinymist-project/src/model/task.rs
@@ -32,7 +32,20 @@ use super::{Id, Pages, PdfStandard, Scalar, TaskWhen};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
-pub enum ProjectTask {
+pub struct ProjectTask {
+    /// The task's ID.
+    pub id: Id,
+    /// The document's ID.
+    pub document: Id,
+    /// The task's configuration.
+    #[serde(flatten)]
+    pub config: ProjectTaskConfig,
+}
+
+/// A project task configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "type")]
+pub enum ProjectTaskConfig {
     /// A preview task.
     Preview(PreviewTask),
     /// An export PDF task.
@@ -57,32 +70,12 @@ pub enum ProjectTask {
 impl ProjectTask {
     /// Returns the task's ID.
     pub fn doc_id(&self) -> &Id {
-        match self {
-            ProjectTask::Preview(task) => &task.document,
-            ProjectTask::ExportPdf(task) => &task.export.document,
-            ProjectTask::ExportPng(task) => &task.export.document,
-            ProjectTask::ExportSvg(task) => &task.export.document,
-            ProjectTask::ExportHtml(task) => &task.export.document,
-            ProjectTask::ExportMarkdown(task) => &task.export.document,
-            ProjectTask::ExportText(task) => &task.export.document,
-            ProjectTask::Query(task) => &task.export.document,
-            // ProjectTask::Other(_) => return None,
-        }
+        &self.document
     }
 
     /// Returns the document's ID.
     pub fn id(&self) -> &Id {
-        match self {
-            ProjectTask::Preview(task) => &task.id,
-            ProjectTask::ExportPdf(task) => &task.export.id,
-            ProjectTask::ExportPng(task) => &task.export.id,
-            ProjectTask::ExportSvg(task) => &task.export.id,
-            ProjectTask::ExportHtml(task) => &task.export.id,
-            ProjectTask::ExportMarkdown(task) => &task.export.id,
-            ProjectTask::ExportText(task) => &task.export.id,
-            ProjectTask::Query(task) => &task.export.id,
-            // ProjectTask::Other(_) => return None,
-        }
+        &self.id
     }
 }
 
@@ -90,10 +83,6 @@ impl ProjectTask {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct PreviewTask {
-    /// The task's ID.
-    pub id: Id,
-    /// The document's ID.
-    pub document: Id,
     /// When to run the task. See [`TaskWhen`] for more
     /// information.
     pub when: TaskWhen,
@@ -103,15 +92,21 @@ pub struct PreviewTask {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ExportTask {
-    /// The task's ID.
-    pub id: Id,
-    /// The document's ID.
-    pub document: Id,
     /// When to run the task
     pub when: TaskWhen,
     /// The task's transforms.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub transform: Vec<ExportTransform>,
+}
+
+impl ExportTask {
+    /// Creates a new unmounted export task.
+    pub fn new(when: TaskWhen) -> Self {
+        Self {
+            when,
+            transform: Vec::new(),
+        }
+    }
 }
 
 /// A project export transform specifier.

--- a/crates/tinymist-project/src/model/task.rs
+++ b/crates/tinymist-project/src/model/task.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{Id, Pages, PathPattern, PdfStandard, Scalar, TaskWhen};
 
-/// A project task specifier. This is used for specifying tasks in a project.
-/// When the language service notifies an update event of the project, it will
-/// check whether any associated tasks need to be run.
+/// A project task application specifier. This is used for specifying tasks to
+/// run in a project. When the language service notifies an update event of the
+/// project, it will check whether any associated tasks need to be run.
 ///
 /// Each task can have different timing and conditions for running. See
 /// [`TaskWhen`] for more information.
@@ -32,20 +32,32 @@ use super::{Id, Pages, PathPattern, PdfStandard, Scalar, TaskWhen};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
-pub struct ProjectTask {
+pub struct ApplyProjectTask {
     /// The task's ID.
     pub id: Id,
     /// The document's ID.
     pub document: Id,
-    /// The task's configuration.
+    /// The task to run.
     #[serde(flatten)]
-    pub config: ProjectTaskConfig,
+    pub task: ProjectTask,
 }
 
-/// A project task configuration.
+impl ApplyProjectTask {
+    /// Returns the document's ID.
+    pub fn doc_id(&self) -> &Id {
+        &self.document
+    }
+
+    /// Returns the task's ID.
+    pub fn id(&self) -> &Id {
+        &self.id
+    }
+}
+
+/// A project task specifier. This structure specifies the arguments for a task.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
-pub enum ProjectTaskConfig {
+pub enum ProjectTask {
     /// A preview task.
     Preview(PreviewTask),
     /// An export PDF task.
@@ -68,18 +80,6 @@ pub enum ProjectTaskConfig {
 }
 
 impl ProjectTask {
-    /// Returns the task's ID.
-    pub fn doc_id(&self) -> &Id {
-        &self.document
-    }
-
-    /// Returns the document's ID.
-    pub fn id(&self) -> &Id {
-        &self.id
-    }
-}
-
-impl ProjectTaskConfig {
     /// Returns the timing of executing the task.
     pub fn when(&self) -> Option<TaskWhen> {
         Some(match self {

--- a/crates/tinymist-project/src/model/task.rs
+++ b/crates/tinymist-project/src/model/task.rs
@@ -2,9 +2,7 @@
 
 use std::hash::Hash;
 
-use reflexo_typst::TypstAbs;
 use serde::{Deserialize, Serialize};
-use tinymist_std::error::prelude::*;
 
 use super::{Id, Pages, PathPattern, PdfStandard, Scalar, TaskWhen};
 
@@ -165,24 +163,6 @@ impl ExportTask {
         self.transform
             .push(ExportTransform::Pretty { script: None });
     }
-
-    /// Gets legacy page selection
-    pub fn get_page_selection(&self) -> Result<(bool, TypstAbs)> {
-        let is_first = self.transform.iter().any(
-            |t| matches!(t, ExportTransform::Pages { ranges, .. } if ranges == &[Pages::FIRST]),
-        );
-
-        let mut gap_res = TypstAbs::default();
-        if !is_first {
-            for trans in &self.transform {
-                if let ExportTransform::Merge { gap } = trans {
-                    gap_res = TypstAbs::pt(gap.to_f32() as f64);
-                }
-            }
-        }
-
-        Ok((is_first, gap_res))
-    }
 }
 
 /// The legacy page selection specifier.
@@ -210,8 +190,8 @@ pub enum ExportTransform {
     },
     /// Merge pages into a single page.
     Merge {
-        /// The gap between pages (in pt).
-        gap: Scalar,
+        /// The gap between pages (typst code expression, e.g. `1pt`).
+        gap: Option<String>,
     },
     /// Execute a transform script.
     Script {

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -155,80 +155,18 @@ mod polymorphic {
     use completion::CompletionList;
     use lsp_types::TextEdit;
     use serde::{Deserialize, Serialize};
+    use tinymist_project::ProjectTask;
     use typst::foundations::Dict;
 
     use super::prelude::*;
     use super::*;
 
-    #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub enum PageSelection {
-        #[default]
-        First,
-        Merged {
-            gap: Option<String>,
-        },
-    }
-
-    #[derive(Debug, Clone)]
-    pub enum ExportKind {
-        Pdf {
-            creation_timestamp: Option<chrono::DateTime<chrono::Utc>>,
-        },
-        Html {},
-        Markdown {},
-        Text {},
-        Query {
-            format: String,
-            output_extension: Option<String>,
-            strict: bool,
-            selector: String,
-            field: Option<String>,
-            one: bool,
-            pretty: bool,
-        },
-        Svg {
-            page: PageSelection,
-        },
-        Png {
-            ppi: Option<f64>,
-            fill: Option<String>,
-            page: PageSelection,
-        },
-    }
-
-    impl Default for ExportKind {
-        fn default() -> Self {
-            Self::Pdf {
-                creation_timestamp: None,
-            }
-        }
-    }
-
-    impl ExportKind {
-        pub fn extension(&self) -> &str {
-            match self {
-                Self::Pdf { .. } => "pdf",
-                Self::Html { .. } => "html",
-                Self::Markdown { .. } => "md",
-                Self::Text { .. } => "txt",
-                Self::Svg { .. } => "svg",
-                Self::Png { .. } => "png",
-                Self::Query {
-                    format,
-                    output_extension,
-                    ..
-                } => output_extension.as_deref().unwrap_or(format),
-            }
-        }
-    }
-
     #[derive(Debug, Clone)]
     pub struct OnExportRequest {
         /// The path of the document to export.
         pub path: PathBuf,
-        /// The kind of the export.
-        pub kind: ExportKind,
+        /// The export task to run.
+        pub task: ProjectTask,
         /// Whether to open the exported file(s) after the export is done.
         pub open: bool,
     }

--- a/crates/tinymist-world/src/args.rs
+++ b/crates/tinymist-world/src/args.rs
@@ -70,7 +70,7 @@ pub struct CompileOnceArgs {
     #[clap(flatten)]
     pub package: CompilePackageArgs,
 
-    /// The document's creation date formatted as a UNIX timestamp.
+    /// The document's creation date formatted as a UNIX timestamp (in seconds).
     ///
     /// For more information, see <https://reproducible-builds.org/specs/source-date-epoch/>.
     #[clap(
@@ -80,7 +80,7 @@ pub struct CompileOnceArgs {
         value_parser = parse_source_date_epoch,
         hide(true),
     )]
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<i64>,
 
     /// Path to CA certificate file for network access, especially for
     /// downloading typst packages.
@@ -105,9 +105,12 @@ fn parse_input_pair(raw: &str) -> Result<(String, String), String> {
 }
 
 /// Parses a UNIX timestamp according to <https://reproducible-builds.org/specs/source-date-epoch/>
-pub fn parse_source_date_epoch(raw: &str) -> Result<DateTime<Utc>, String> {
-    let timestamp: i64 = raw
-        .parse()
-        .map_err(|err| format!("timestamp must be decimal integer ({err})"))?;
-    DateTime::from_timestamp(timestamp, 0).ok_or_else(|| "timestamp out of range".to_string())
+pub fn parse_source_date_epoch(raw: &str) -> Result<i64, String> {
+    raw.parse()
+        .map_err(|err| format!("timestamp must be decimal integer ({err})"))
+}
+
+/// Parses a UNIX timestamp according to <https://reproducible-builds.org/specs/source-date-epoch/>
+pub fn convert_source_date_epoch(seconds: i64) -> Result<chrono::DateTime<Utc>, String> {
+    DateTime::from_timestamp(seconds, 0).ok_or_else(|| "timestamp out of range".to_string())
 }

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -3,21 +3,24 @@
 use std::ops::Deref;
 use std::path::PathBuf;
 
+use anyhow::bail;
 use lsp_server::RequestId;
 use lsp_types::*;
+use reflexo_typst::TypstAbs;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use task::TraceParams;
 use tinymist_assets::TYPST_PREVIEW_HTML;
 use tinymist_project::{
     ExportHtmlTask, ExportMarkdownTask, ExportPdfTask, ExportPngTask, ExportSvgTask, ExportTask,
-    ExportTextTask, PageSelection, ProjectTask, QueryTask,
+    ExportTextTask, ExportTransform, PageSelection, Pages, ProjectTask, QueryTask,
 };
 use tinymist_query::package::PackageInfo;
 use tinymist_query::LocalContextGuard;
 use tinymist_std::error::prelude::*;
 use typst::diag::{eco_format, EcoString, StrResult};
 use typst::syntax::package::{PackageSpec, VersionlessPackageSpec};
+use typst::syntax::{ast, SyntaxNode};
 use world::TaskInputs;
 
 use super::state::*;
@@ -159,7 +162,7 @@ impl ServerState {
         let opts = get_arg_or_default!(args[1] as ExportOpts);
 
         let mut export = ExportTask::default();
-        export.select_page(opts.page).map_err(invalid_params)?;
+        select_page(&mut export, opts.page).map_err(invalid_params)?;
 
         self.export(
             req_id,
@@ -180,7 +183,7 @@ impl ServerState {
             .map_err(invalid_params)?;
 
         let mut export = ExportTask::default();
-        export.select_page(opts.page).map_err(invalid_params)?;
+        select_page(&mut export, opts.page).map_err(invalid_params)?;
 
         self.export(
             req_id,
@@ -712,5 +715,77 @@ impl ServerState {
 
             snap.run_analysis(f).map_err(internal_error)?
         })
+    }
+}
+
+/// Applies page selection to the export task.
+fn select_page(task: &mut ExportTask, selection: PageSelection) -> Result<()> {
+    match selection {
+        PageSelection::First => task.transform.push(ExportTransform::Pages {
+            ranges: vec![Pages::FIRST],
+        }),
+        PageSelection::Merged { gap } => {
+            let gap = gap
+                .map(parse_length)
+                .transpose()
+                .context_ut("failed to parse gap")?
+                .map(|abs| abs.to_pt() as f32)
+                .unwrap_or_default()
+                .try_into()
+                .context("invalid gap (e.g. NaN)")?;
+
+            task.transform.push(ExportTransform::Merge { gap });
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_length(gap: String) -> anyhow::Result<TypstAbs> {
+    let length = typst::syntax::parse_code(&gap);
+    if length.erroneous() {
+        bail!("invalid length: {gap}, errors: {:?}", length.errors());
+    }
+
+    let length: Option<ast::Numeric> = descendants(&length).into_iter().find_map(SyntaxNode::cast);
+
+    let Some(length) = length else {
+        bail!("not a length: {gap}");
+    };
+
+    let (value, unit) = length.get();
+    match unit {
+        ast::Unit::Pt => Ok(TypstAbs::pt(value)),
+        ast::Unit::Mm => Ok(TypstAbs::mm(value)),
+        ast::Unit::Cm => Ok(TypstAbs::cm(value)),
+        ast::Unit::In => Ok(TypstAbs::inches(value)),
+        _ => bail!("invalid unit: {unit:?} in {gap}"),
+    }
+}
+
+/// Low performance but simple recursive iterator.
+fn descendants(node: &SyntaxNode) -> impl IntoIterator<Item = &SyntaxNode> + '_ {
+    let mut res = vec![];
+    for child in node.children() {
+        res.push(child);
+        res.extend(descendants(child));
+    }
+
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use TypstAbs as Abs;
+
+    #[test]
+    fn test_parse_length() {
+        assert_eq!(parse_length("1pt".to_owned()).unwrap(), Abs::pt(1.));
+        assert_eq!(parse_length("1mm".to_owned()).unwrap(), Abs::mm(1.));
+        assert_eq!(parse_length("1cm".to_owned()).unwrap(), Abs::cm(1.));
+        assert_eq!(parse_length("1in".to_owned()).unwrap(), Abs::inches(1.));
+        assert!(parse_length("1".to_owned()).is_err());
+        assert!(parse_length("1px".to_owned()).is_err());
     }
 }

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -56,6 +56,55 @@ struct HighlightRangeOpts {
 
 /// Here are implemented the handlers for each command.
 impl ServerState {
+    // let when = self.config.when;
+
+    // // todo: page transforms
+    // let transforms = vec![];
+
+    // use tinymist_project::ExportTask as ProjectExportTask;
+
+    // let export = ProjectExportTask {
+    //     when,
+    //     transform: transforms,
+    // };
+
+    // let config = match kind {
+    //     Pdf { creation_timestamp } => {
+    //         let _ = creation_timestamp;
+    //         ProjectTaskConfig::ExportPdf(ExportPdfTask {
+    //             export,
+    //             pdf_standards: Default::default(),
+    //             creation_timestamp: None,
+    //         })
+    //     }
+    //     Html {} => ProjectTaskConfig::ExportHtml(ExportHtmlTask { export }),
+    //     Markdown {} => ProjectTaskConfig::ExportMarkdown(ExportMarkdownTask {
+    // export }),     Text {} => ProjectTaskConfig::ExportText(ExportTextTask {
+    // export }),     Query { .. } => {
+    //         // todo: ignoring query task.
+    //         return None;
+    //     }
+    //     Svg { page } => {
+    //         // todo: ignoring page selection.
+    //         let _ = page;
+    //         return None;
+    //     }
+    //     Png { ppi, fill, page } => {
+    //         // todo: ignoring page fill.
+    //         let _ = fill;
+    //         // todo: ignoring page selection.
+    //         let _ = page;
+
+    //         let ppi = ppi.unwrap_or(144.) as f32;
+    //         let ppi = ppi.try_into().unwrap();
+    //         ProjectTaskConfig::ExportPng(ExportPngTask {
+    //             export,
+    //             ppi,
+    //             fill: None,
+    //         })
+    //     }
+    // };
+
     /// Export the current document as PDF file(s).
     pub fn export_pdf(&mut self, req_id: RequestId, mut args: Vec<JsonValue>) -> ScheduledResult {
         let opts = get_arg_or_default!(args[1] as ExportOpts);

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -708,7 +708,7 @@ impl CompileConfig {
     }
 
     /// Determines the creation timestamp.
-    pub fn determine_creation_timestamp(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+    pub fn determine_creation_timestamp(&self) -> Option<i64> {
         self.typst_extra_args.as_ref()?.creation_timestamp
     }
 
@@ -806,8 +806,8 @@ pub struct CompileExtraOpts {
     pub font: CompileFontArgs,
     /// Package related arguments.
     pub package: CompilePackageArgs,
-    /// The creation timestamp for various output.
-    pub creation_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    /// The creation timestamp for various output (in seconds).
+    pub creation_timestamp: Option<i64>,
     /// Path to certification file
     pub cert: Option<ImmutPath>,
 }
@@ -885,7 +885,7 @@ mod tests {
 
     #[test]
     fn test_config_creation_timestamp() {
-        type Timestamp = Option<chrono::DateTime<chrono::Utc>>;
+        type Timestamp = Option<i64>;
 
         fn timestamp(f: impl FnOnce(&mut Config)) -> Timestamp {
             let mut config = Config::default();

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -11,8 +11,11 @@ use reflexo_typst::{ImmutPath, TypstDict};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value as JsonValue};
 use strum::IntoEnumIterator;
-use task::{FormatUserConfig, FormatterConfig};
-use tinymist_project::{EntryResolver, PathPattern, ProjectResolutionKind, TaskWhen};
+use task::{ExportUserConfig, FormatUserConfig, FormatterConfig};
+use tinymist_project::{
+    EntryResolver, ExportPdfTask, ExportTask, PathPattern, ProjectResolutionKind, ProjectTask,
+    TaskWhen,
+};
 use tinymist_query::analysis::{Modifier, TokenType};
 use tinymist_query::{CompletionFeat, PositionEncoding};
 use tinymist_render::PeriscopeArgs;
@@ -396,7 +399,7 @@ impl Config {
         self.compile.validate()
     }
 
-    /// Get the formatter configuration.
+    /// Gets the formatter configuration.
     pub fn formatter(&self) -> FormatUserConfig {
         let formatter_print_width = self.formatter_print_width.unwrap_or(120) as usize;
 
@@ -412,6 +415,24 @@ impl Config {
                 FormatterMode::Disable => FormatterConfig::Disable,
             },
             position_encoding: self.const_config.position_encoding,
+        }
+    }
+
+    /// Gets the export configuration.
+    pub(crate) fn export(&self) -> ExportUserConfig {
+        let compile_config = &self.compile;
+
+        ExportUserConfig {
+            task: ProjectTask::ExportPdf(ExportPdfTask {
+                export: ExportTask {
+                    output: Some(compile_config.output_path.clone()),
+                    when: compile_config.export_pdf,
+                    transform: vec![],
+                },
+                pdf_standards: vec![],
+                creation_timestamp: compile_config.determine_creation_timestamp(),
+            }),
+            count_words: self.compile.notify_status,
         }
     }
 }

--- a/crates/tinymist/src/state/input.rs
+++ b/crates/tinymist/src/state/input.rs
@@ -78,7 +78,7 @@ impl ServerState {
         {
             let config = ExportUserConfig {
                 output: self.config.compile.output_path.clone(),
-                mode: self.config.compile.export_pdf,
+                when: self.config.compile.export_pdf,
             };
 
             self.change_export_config(config.clone());

--- a/crates/tinymist/src/state/input.rs
+++ b/crates/tinymist/src/state/input.rs
@@ -76,12 +76,14 @@ impl ServerState {
         if config.compile.output_path != self.config.compile.output_path
             || config.compile.export_pdf != self.config.compile.export_pdf
         {
-            let config = ExportUserConfig {
-                output: self.config.compile.output_path.clone(),
-                when: self.config.compile.export_pdf,
-            };
+            // let config = ExportUserConfig {
+            //     output: self.config.compile.output_path.clone(),
+            //     when: self.config.compile.export_pdf,
+            // };
 
-            self.change_export_config(config.clone());
+            let config = todo!();
+
+            self.change_export_config(config);
         }
 
         if config.compile.primary_opts() != self.config.compile.primary_opts() {

--- a/crates/tinymist/src/state/input.rs
+++ b/crates/tinymist/src/state/input.rs
@@ -16,7 +16,7 @@ use tinymist_std::ImmutPath;
 use typst::{diag::FileResult, syntax::Source};
 
 use crate::route::ProjectResolution;
-use crate::task::{ExportUserConfig, FormatterConfig};
+use crate::task::FormatterConfig;
 use crate::world::vfs::{notify::MemoryEvent, FileChangeSet};
 use crate::world::TaskInputs;
 use crate::{init::*, *};
@@ -61,11 +61,11 @@ impl ServerState {
         &mut self,
         values: Map<String, JsonValue>,
     ) -> LspResult<()> {
-        let config = self.config.clone();
+        let old_config = self.config.clone();
         match self.config.update_by_map(&values) {
             Ok(()) => {}
             Err(err) => {
-                self.config = config;
+                self.config = old_config;
                 error!("error applying new settings: {err}");
                 return Err(invalid_params(format!(
                     "error applying new settings: {err}"
@@ -73,20 +73,12 @@ impl ServerState {
             }
         }
 
-        if config.compile.output_path != self.config.compile.output_path
-            || config.compile.export_pdf != self.config.compile.export_pdf
-        {
-            // let config = ExportUserConfig {
-            //     output: self.config.compile.output_path.clone(),
-            //     when: self.config.compile.export_pdf,
-            // };
-
-            let config = todo!();
-
-            self.change_export_config(config);
+        let new_export_config = self.config.export();
+        if old_config.export() != new_export_config {
+            self.change_export_config(new_export_config);
         }
 
-        if config.compile.primary_opts() != self.config.compile.primary_opts() {
+        if old_config.compile.primary_opts() != self.config.compile.primary_opts() {
             self.config.compile.fonts = OnceCell::new(); // todo: don't reload fonts if not changed
             let err = self.restart_primary();
             if let Err(err) = err {
@@ -94,7 +86,7 @@ impl ServerState {
             }
         }
 
-        if config.semantic_tokens != self.config.semantic_tokens {
+        if old_config.semantic_tokens != self.config.semantic_tokens {
             let err = self
                 .enable_sema_token_caps(self.config.semantic_tokens == SemanticTokensMode::Enable);
             if let Err(err) = err {
@@ -103,7 +95,7 @@ impl ServerState {
         }
 
         let new_formatter_config = self.config.formatter();
-        if !config.formatter().eq(&new_formatter_config) {
+        if !old_config.formatter().eq(&new_formatter_config) {
             let enabled = !matches!(new_formatter_config.config, FormatterConfig::Disable);
             let err = self.enable_formatter_caps(enabled);
             if let Err(err) = err {

--- a/crates/tinymist/src/state/project.rs
+++ b/crates/tinymist/src/state/project.rs
@@ -316,7 +316,7 @@ impl CompileHandler<LspCompilerFeat, ProjectInsStateExt> for CompileHandlerImpl 
         );
 
         self.client.send_event(LspInterrupt::Compiled(snap.clone()));
-        self.export.signal(snap, snap.signal);
+        self.export.signal(snap);
 
         self.editor_tx
             .send(EditorRequest::Status(CompileStatus {

--- a/crates/tinymist/src/state/server.rs
+++ b/crates/tinymist/src/state/server.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use log::{error, info};
 use lsp_types::*;
-use serde::{Deserialize, Serialize};
 use sync_lsp::*;
+use task::ExportUserConfig;
 use tinymist_project::{EntryResolver, LspCompileSnapshot, ProjectInsId};
 use tinymist_query::analysis::{Analysis, PeriscopeProvider};
 use tinymist_query::{
@@ -32,7 +32,7 @@ use crate::project::{
 use crate::route::ProjectRouteState;
 use crate::state::query::OnEnter;
 use crate::stats::CompilerQueryStats;
-use crate::task::{ExportConfig, ExportTask, ExportUserConfig, FormatTask, UserActionTask};
+use crate::task::{ExportTask, FormatTask, UserActionTask};
 use crate::world::{ImmutDict, LspUniverseBuilder, TaskInputs};
 use crate::{init::*, *};
 
@@ -406,25 +406,12 @@ impl ServerState {
     ) -> ProjectState {
         let compile_config = &config.compile;
         let const_config = &config.const_config;
-
-        // use codespan_reporting::term::Config;
         // Run Export actors before preparing cluster to avoid loss of events
-        let export_config = ExportConfig {
-            // config: ExportUserConfig {
-            //     output: compile_config.output_path.clone(),
-            //     when: compile_config.export_pdf,
-            //     kind: ExportKind::Pdf {
-            //         creation_timestamp: config.compile.determine_creation_timestamp(),
-            //     },
-            // },
-            config: todo!(),
-            count_words: config.compile.notify_status,
-        };
         let export = ExportTask::new(
             client.handle.clone(),
             diag_group.clone(),
             Some(editor_tx.clone()),
-            export_config,
+            config.export(),
         );
 
         log::info!(

--- a/crates/tinymist/src/state/server.rs
+++ b/crates/tinymist/src/state/server.rs
@@ -414,7 +414,7 @@ impl ServerState {
             editor_tx: Some(editor_tx.clone()),
             config: ExportUserConfig {
                 output: compile_config.output_path.clone(),
-                mode: compile_config.export_pdf,
+                when: compile_config.export_pdf,
             },
             kind: ExportKind::Pdf {
                 creation_timestamp: config.compile.determine_creation_timestamp(),

--- a/crates/tinymist/src/state/server.rs
+++ b/crates/tinymist/src/state/server.rs
@@ -533,15 +533,14 @@ impl ServerState {
         });
 
         let snap = self.snapshot()?;
-        // todo: merge all
-        let task_base = self.project.export.clone();
         just_future(async move {
             let snap = snap.task(TaskInputs {
                 entry: Some(entry),
                 ..Default::default()
             });
-            // kind
-            let res = task_base.oneshot(snap.clone(), task, lock_dir).await?;
+
+            let artifact = snap.clone().compile();
+            let res = ExportTask::do_export(task, artifact, lock_dir).await?;
             if let Some(update_dep) = update_dep {
                 tokio::spawn(update_dep(snap));
             }

--- a/crates/tinymist/src/state/server.rs
+++ b/crates/tinymist/src/state/server.rs
@@ -410,18 +410,22 @@ impl ServerState {
         // use codespan_reporting::term::Config;
         // Run Export actors before preparing cluster to avoid loss of events
         let export_config = ExportConfig {
-            group: diag_group.clone(),
-            editor_tx: Some(editor_tx.clone()),
-            config: ExportUserConfig {
-                output: compile_config.output_path.clone(),
-                when: compile_config.export_pdf,
-            },
-            kind: ExportKind::Pdf {
-                creation_timestamp: config.compile.determine_creation_timestamp(),
-            },
+            // config: ExportUserConfig {
+            //     output: compile_config.output_path.clone(),
+            //     when: compile_config.export_pdf,
+            //     kind: ExportKind::Pdf {
+            //         creation_timestamp: config.compile.determine_creation_timestamp(),
+            //     },
+            // },
+            config: todo!(),
             count_words: config.compile.notify_status,
         };
-        let export = ExportTask::new(client.handle.clone(), export_config);
+        let export = ExportTask::new(
+            client.handle.clone(),
+            diag_group.clone(),
+            Some(editor_tx.clone()),
+            export_config,
+        );
 
         log::info!(
             "TypstActor: creating server for {diag_group}, entry: {entry:?}, inputs: {inputs:?}"
@@ -542,13 +546,15 @@ impl ServerState {
         });
 
         let snap = self.snapshot()?;
-        let task = self.project.export.factory.task();
+        // todo: clone all
+        let task = self.project.export.clone();
         just_future(async move {
             let snap = snap.task(TaskInputs {
                 entry: Some(entry),
                 ..Default::default()
             });
-            let res = task.oneshot(snap.clone(), kind, lock_dir).await?;
+            // kind
+            let res = task.oneshot(snap.clone(), todo!(), lock_dir).await?;
             if let Some(update_dep) = update_dep {
                 tokio::spawn(update_dep(snap));
             }

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -15,7 +15,6 @@ use tinymist_project::{
     EntryReader, ExportTask as ProjectExportTask, LspCompileSnapshot, LspCompiledArtifact,
     PathPattern, ProjectTask, QueryTask,
 };
-use tinymist_query::{ExportKind, PageSelection};
 use tokio::sync::mpsc;
 use typlite::Typlite;
 use typst::foundations::IntoValue;
@@ -222,7 +221,6 @@ impl ExportTask {
 
     async fn do_export(task: ExportOnceTask) -> anyhow::Result<Option<PathBuf>> {
         use reflexo_vec2svg::DefaultExportFeature;
-        use PageSelection::*;
         use ProjectTask::*;
 
         let ExportOnceTask {

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -8,11 +8,12 @@ use crate::project::{
     ExportTextTask, ProjectTask, TaskWhen,
 };
 use anyhow::{bail, Context};
+use chrono::DateTime;
 use reflexo::ImmutPath;
 use reflexo_typst::TypstDatetime;
 use tinymist_project::{
     EntryReader, ExportTask as ProjectExportTask, LspCompileSnapshot, LspCompiledArtifact,
-    PathPattern, ProjectTaskConfig,
+    PathPattern, ProjectTaskConfig, QueryTask,
 };
 use tinymist_query::{ExportKind, PageSelection};
 use tokio::sync::mpsc;
@@ -104,15 +105,24 @@ impl Default for ExportUserConfig {
 #[derive(Clone)]
 pub struct ExportTask {
     pub handle: tokio::runtime::Handle,
+    pub group: String,
+    pub editor_tx: Option<mpsc::UnboundedSender<EditorRequest>>,
     pub factory: SyncTaskFactory<ExportConfig>,
     export_folder: FutureFolder,
     count_word_folder: FutureFolder,
 }
 
 impl ExportTask {
-    pub fn new(handle: tokio::runtime::Handle, data: ExportConfig) -> Self {
+    pub fn new(
+        handle: tokio::runtime::Handle,
+        group: String,
+        editor_tx: Option<mpsc::UnboundedSender<EditorRequest>>,
+        data: ExportConfig,
+    ) -> Self {
         Self {
             handle,
+            group,
+            editor_tx,
             factory: SyncTaskFactory::new(data),
             export_folder: FutureFolder::default(),
             count_word_folder: FutureFolder::default(),
@@ -124,41 +134,25 @@ impl ExportTask {
     }
 
     pub fn signal(&self, snap: &LspCompiledArtifact) {
-        self.factory.task().signal(snap, self);
-    }
-}
+        //     self.factory.task().signal(snap, self);
+        // }
 
-pub struct ExportOnceTask {
-    pub task: ProjectTaskConfig,
-    pub artifact: LspCompiledArtifact,
-    pub lock_path: Option<ImmutPath>,
-}
+        // fn signal(self: Arc<Self>, snap: &LspCompiledArtifact, t: &ExportTask) {
+        let config = self.factory.task();
 
-#[derive(Clone, Default)]
-pub struct ExportConfig {
-    pub group: String,
-    pub editor_tx: Option<mpsc::UnboundedSender<EditorRequest>>,
-    pub config: ExportUserConfig,
-    // pub kind: ExportKind,
-    // pub config: ProjectTaskConfig,
-    pub count_words: bool,
-}
-
-impl ExportConfig {
-    fn signal(self: Arc<Self>, snap: &LspCompiledArtifact, t: &ExportTask) {
-        self.signal_export(snap, t);
-        self.signal_count_word(snap, t);
+        self.signal_export(snap, &config);
+        self.signal_count_word(snap, &config);
     }
 
     fn signal_export(
-        self: &Arc<Self>,
+        &self,
         artifact: &LspCompiledArtifact,
-        t: &ExportTask,
+        config: &Arc<ExportConfig>,
     ) -> Option<()> {
         let doc = artifact.doc.as_ref().ok()?;
         let s = artifact.signal;
 
-        let when = self.config.task.when().unwrap_or_default();
+        let when = config.config.task.when().unwrap_or_default();
         let need_export = (!matches!(when, TaskWhen::Never) && s.by_entry_update)
             || match when {
                 TaskWhen::Never => false,
@@ -171,8 +165,9 @@ impl ExportConfig {
             return None;
         }
 
-        let fut = t.export_folder.spawn(artifact.world.revision().get(), || {
-            let task = self.config.task.clone();
+        let rev = artifact.world.revision().get();
+        let fut = self.export_folder.spawn(rev, || {
+            let task = config.config.task.clone();
             let artifact = artifact.clone();
             Box::pin(async move {
                 log_err(
@@ -187,27 +182,30 @@ impl ExportConfig {
             })
         })?;
 
-        t.handle.spawn(fut);
+        self.handle.spawn(fut);
 
         Some(())
     }
 
-    fn signal_count_word(&self, artifact: &LspCompiledArtifact, t: &ExportTask) -> Option<()> {
-        if !self.count_words {
+    fn signal_count_word(
+        &self,
+        artifact: &LspCompiledArtifact,
+        config: &Arc<ExportConfig>,
+    ) -> Option<()> {
+        if !config.count_words {
             return None;
         }
 
         let editor_tx = self.editor_tx.clone()?;
-        let revision = artifact.world.revision().get();
-
-        let fut = t.count_word_folder.spawn(revision, || {
+        let rev = artifact.world.revision().get();
+        let fut = self.count_word_folder.spawn(rev, || {
             let artifact = artifact.clone();
             let group = self.group.clone();
             Box::pin(async move {
                 let doc = artifact.doc.ok()?;
                 let wc =
                     log_err(FutureFolder::compute(move |_| word_count::word_count(&doc)).await);
-                log::debug!("WordCount({group}:{revision}): {wc:?}");
+                log::debug!("WordCount({group}:{rev}): {wc:?}");
 
                 if let Some(wc) = wc {
                     let _ = editor_tx.send(EditorRequest::WordCount(group, wc));
@@ -217,41 +215,41 @@ impl ExportConfig {
             })
         })?;
 
-        t.handle.spawn(fut);
+        self.handle.spawn(fut);
 
         Some(())
     }
 
-    async fn do_export(task: ExportOnceTask<'_>) -> anyhow::Result<Option<PathBuf>> {
+    async fn do_export(task: ExportOnceTask) -> anyhow::Result<Option<PathBuf>> {
         use reflexo_vec2svg::DefaultExportFeature;
-        use ExportKind::*;
         use PageSelection::*;
+        use ProjectTaskConfig::*;
 
         let ExportOnceTask {
-            task: kind,
+            task,
             artifact: CompiledArtifact { snap, doc, .. },
             lock_path: lock_dir,
         } = task;
 
         // Prepare the output path.
         let entry = snap.world.entry_state();
-        let config = task.task.as_export().unwrap();
-        let output = config.output.unwrap_or_default();
+        let config = task.as_export().unwrap();
+        let output = config.output.clone().unwrap_or_default();
         let Some(to) = output.substitute(&entry) else {
             return Ok(None);
         };
         if to.is_relative() {
-            bail!("RenderActor({kind:?}): path is relative: {to:?}");
+            bail!("RenderActor({task:?}): path is relative: {to:?}");
         }
         if to.is_dir() {
-            bail!("RenderActor({kind:?}): path is a directory: {to:?}");
+            bail!("RenderActor({task:?}): path is a directory: {to:?}");
         }
-        let to = to.with_extension(kind.extension());
-        log::info!("RenderActor({kind:?}): exporting {entry:?} to {to:?}");
+        let to = to.with_extension(task.extension());
+        log::info!("RenderActor({task:?}): exporting {entry:?} to {to:?}");
         if let Some(e) = to.parent() {
             if !e.exists() {
                 std::fs::create_dir_all(e).with_context(|| {
-                    format!("RenderActor({kind:?}): failed to create directory")
+                    format!("RenderActor({task:?}): failed to create directory")
                 })?;
             }
         }
@@ -262,60 +260,61 @@ impl ExportConfig {
             let doc_id = updater.compiled(&snap.world)?;
             let task_id = doc_id.clone();
 
-            let when = self.config.when;
+            // let when = self.config.when;
 
             // todo: page transforms
-            let transforms = vec![];
+            // let transforms = vec![];
 
-            use tinymist_project::ExportTask as ProjectExportTask;
+            // use tinymist_project::ExportTask as ProjectExportTask;
 
-            let export = ProjectExportTask {
-                when,
-                output: Some(self.config.output.clone()),
-                transform: transforms,
-            };
+            // let export = ProjectExportTask {
+            //     when,
+            //     output: Some(self.config.output.clone()),
+            //     transform: transforms,
+            // };
 
-            let config = match kind {
-                Pdf { creation_timestamp } => {
-                    let _ = creation_timestamp;
-                    ProjectTaskConfig::ExportPdf(ExportPdfTask {
-                        export,
-                        pdf_standards: Default::default(),
-                        creation_timestamp: None,
-                    })
-                }
-                Html {} => ProjectTaskConfig::ExportHtml(ExportHtmlTask { export }),
-                Markdown {} => ProjectTaskConfig::ExportMarkdown(ExportMarkdownTask { export }),
-                Text {} => ProjectTaskConfig::ExportText(ExportTextTask { export }),
-                Query { .. } => {
-                    // todo: ignoring query task.
-                    return None;
-                }
-                Svg { page } => {
-                    // todo: ignoring page selection.
-                    let _ = page;
-                    return None;
-                }
-                Png { ppi, fill, page } => {
-                    // todo: ignoring page fill.
-                    let _ = fill;
-                    // todo: ignoring page selection.
-                    let _ = page;
+            // let config = match kind {
+            //     Pdf { creation_timestamp } => {
+            //         let _ = creation_timestamp;
+            //         ProjectTaskConfig::ExportPdf(ExportPdfTask {
+            //             export,
+            //             pdf_standards: Default::default(),
+            //             creation_timestamp: None,
+            //         })
+            //     }
+            //     Html {} => ProjectTaskConfig::ExportHtml(ExportHtmlTask { export }),
+            //     Markdown {} => ProjectTaskConfig::ExportMarkdown(ExportMarkdownTask {
+            // export }),     Text {} =>
+            // ProjectTaskConfig::ExportText(ExportTextTask { export }),
+            //     Query { .. } => {
+            //         // todo: ignoring query task.
+            //         return None;
+            //     }
+            //     Svg { page } => {
+            //         // todo: ignoring page selection.
+            //         let _ = page;
+            //         return None;
+            //     }
+            //     Png { ppi, fill, page } => {
+            //         // todo: ignoring page fill.
+            //         let _ = fill;
+            //         // todo: ignoring page selection.
+            //         let _ = page;
 
-                    let ppi = ppi.unwrap_or(144.) as f32;
-                    let ppi = ppi.try_into().unwrap();
-                    ProjectTaskConfig::ExportPng(ExportPngTask {
-                        export,
-                        ppi,
-                        fill: None,
-                    })
-                }
-            };
+            //         let ppi = ppi.unwrap_or(144.) as f32;
+            //         let ppi = ppi.try_into().unwrap();
+            //         ProjectTaskConfig::ExportPng(ExportPngTask {
+            //             export,
+            //             ppi,
+            //             fill: None,
+            //         })
+            //     }
+            // };
 
             let task = ProjectTask {
                 id: task_id,
                 document: doc_id,
-                config,
+                config: task.clone(),
             };
 
             updater.task(task);
@@ -328,14 +327,21 @@ impl ExportConfig {
         let doc = doc.map_err(|_| anyhow::anyhow!("no document"))?;
 
         // Prepare data.
-        let kind2 = kind.clone();
+        let kind2 = task.clone();
         let data = FutureFolder::compute(move |_| -> anyhow::Result<Vec<u8>> {
             let doc = &doc;
 
             // static BLANK: Lazy<Page> = Lazy::new(Page::default);
             let first_page = doc.pages.first().unwrap();
             Ok(match kind2 {
-                Pdf { creation_timestamp } => {
+                Preview(..) => vec![],
+                // todo: more pdf flags
+                ExportPdf(ExportPdfTask {
+                    creation_timestamp, ..
+                }) => {
+                    let creation_timestamp = creation_timestamp.map(|timestamp|   DateTime::from_timestamp(timestamp, 0).ok_or_else(|| anyhow::anyhow!("timestamp out of range")))
+                    .transpose()?;
+                 
                     let timestamp =
                         convert_datetime(creation_timestamp.unwrap_or_else(chrono::Utc::now));
                     // todo: Some(pdf_uri.as_str())
@@ -349,15 +355,17 @@ impl ExportConfig {
                     )
                     .map_err(|e| anyhow::anyhow!("failed to convert to pdf: {e:?}"))?
                 }
-                Query {
+                Query(QueryTask {
+                    export: _,
                     format,
                     output_extension: _,
-                    strict,
+                    // strict,
                     selector,
                     field,
                     one,
-                    pretty,
-                } => {
+                    // pretty,
+                }) => {
+                    let pretty = false;
                     let elements = reflexo_typst::query::retrieve(&snap.world, &selector, doc)
                         .map_err(|e| anyhow::anyhow!("failed to retrieve: {e}"))?;
                     if one && elements.len() != 1 {
@@ -376,46 +384,50 @@ impl ExportConfig {
                         let Some(value) = mapped.first() else {
                             bail!("no such field found for element");
                         };
-                        serialize(value, &format, strict, pretty).map(String::into_bytes)?
+                        serialize(value, &format, pretty).map(String::into_bytes)?
                     } else {
-                        serialize(&mapped, &format, strict, pretty).map(String::into_bytes)?
+                        serialize(&mapped, &format,  pretty).map(String::into_bytes)?
                     }
                 }
-                Html {} => {
+                ExportHtml { .. } => {
                     reflexo_vec2svg::render_svg_html::<DefaultExportFeature>(doc).into_bytes()
                 }
-                Text {} => format!("{}", FullTextDigest(doc.clone())).into_bytes(),
-                Markdown {} => {
+                ExportText { .. } => format!("{}", FullTextDigest(doc.clone())).into_bytes(),
+                ExportMarkdown { .. } => {
                     let conv = Typlite::new(Arc::new(snap.world))
                         .convert()
                         .map_err(|e| anyhow::anyhow!("failed to convert to markdown: {e}"))?;
 
                     conv.as_bytes().to_owned()
                 }
-                Svg { page: First } => typst_svg::svg(first_page).into_bytes(),
-                Svg {
-                    page: Merged { .. },
+                ExportSvg {
+                    // page: Merged { .. },
+                    ..
                 } => typst_svg::svg_merged(doc, Abs::zero()).into_bytes(),
-                Png {
-                    ppi,
-                    fill: _,
-                    page: First,
-                } => {
-                    let ppi = ppi.unwrap_or(144.) as f32;
-                    if ppi <= 1e-6 {
-                        bail!("invalid ppi: {ppi}");
-                    }
+                // page: First
+                ExportSvg { .. } => typst_svg::svg(first_page).into_bytes(),
+                // ExportPng {
+                //     ppi,
+                //     fill: _,
+                //     page: First,
+                // } => {
+                //     let ppi = ppi.unwrap_or(144.) as f32;
+                //     if ppi <= 1e-6 {
+                //         bail!("invalid ppi: {ppi}");
+                //     }
 
-                    typst_render::render(first_page, ppi / 72.)
-                        .encode_png()
-                        .map_err(|err| anyhow::anyhow!("failed to encode PNG ({err})"))?
-                }
-                Png {
+                //     typst_render::render(first_page, ppi / 72.)
+                //         .encode_png()
+                //         .map_err(|err| anyhow::anyhow!("failed to encode PNG ({err})"))?
+                // }
+                ExportPng(ExportPngTask {
+                    export: _,
                     ppi,
                     fill,
-                    page: Merged { gap },
-                } => {
-                    let ppi = ppi.unwrap_or(144.) as f32;
+                    // page: Merged { gap },
+                }) => {
+                    // .unwrap_or(144.) 
+                    let ppi = ppi.to_f32();
                     if ppi <= 1e-6 {
                         bail!("invalid ppi: {ppi}");
                     }
@@ -426,11 +438,13 @@ impl ExportConfig {
                         Color::WHITE
                     };
 
-                    let gap = if let Some(gap) = gap {
-                        parse_length(gap).map_err(|err| anyhow::anyhow!("invalid gap ({err})"))?
-                    } else {
-                        Abs::zero()
-                    };
+                    // let gap = if let Some(gap) = gap {
+                    //     parse_length(gap).map_err(|err| anyhow::anyhow!("invalid gap ({err})"))?
+                    // } else {
+                    //     Abs::zero()
+                    // };
+
+                    let gap = Abs::zero();
 
                     typst_render::render_merged(doc, ppi / 72., gap, Some(fill))
                         .encode_png()
@@ -441,27 +455,43 @@ impl ExportConfig {
 
         tokio::fs::write(&to, data.await??)
             .await
-            .with_context(|| format!("RenderActor({kind:?}): failed to export"))?;
+            .with_context(|| format!("RenderActor({task:?}): failed to export"))?;
 
-        log::info!("RenderActor({kind:?}): export complete");
+        log::info!("RenderActor({task:?}): export complete");
         Ok(Some(to))
     }
 
     pub async fn oneshot(
         &self,
         snap: LspCompileSnapshot,
-        kind: ExportKind,
+        task: ProjectTaskConfig,
         lock_path: Option<ImmutPath>,
     ) -> anyhow::Result<Option<PathBuf>> {
         let artifact = snap.compile();
-        self.do_export(ExportOnceTask {
-            task: &kind,
+        Self::do_export(ExportOnceTask {
+            task,
             artifact,
             lock_path,
         })
         .await
     }
 }
+
+pub struct ExportOnceTask {
+    pub task: ProjectTaskConfig,
+    pub artifact: LspCompiledArtifact,
+    pub lock_path: Option<ImmutPath>,
+}
+
+#[derive(Clone, Default)]
+pub struct ExportConfig {
+    pub config: ExportUserConfig,
+    // pub kind: ExportKind,
+    // pub config: ProjectTaskConfig,
+    pub count_words: bool,
+}
+
+impl ExportConfig {}
 
 fn parse_color(fill: String) -> anyhow::Result<Color> {
     match fill.as_str() {
@@ -534,17 +564,12 @@ fn convert_datetime(date_time: chrono::DateTime<chrono::Utc>) -> Option<TypstDat
 }
 
 /// Serialize data to the output format.
-fn serialize(
-    data: &impl serde::Serialize,
-    format: &str,
-    strict: bool,
-    pretty: bool,
-) -> anyhow::Result<String> {
+fn serialize(data: &impl serde::Serialize, format: &str, pretty: bool) -> anyhow::Result<String> {
     Ok(match format {
         "json" if pretty => serde_json::to_string_pretty(data)?,
         "json" => serde_json::to_string(data)?,
         "yaml" => serde_yaml::to_string(&data)?,
-        format if format == "txt" || !strict => {
+        "txt" => {
             use serde_json::Value::*;
             let value = serde_json::to_value(data)?;
             match value {
@@ -574,7 +599,8 @@ mod tests {
     fn test_default_never() {
         let conf = ExportConfig::default();
         assert!(!conf.count_words);
-        assert_eq!(conf.config.when, TaskWhen::Never);
+        assert_eq!(conf.config.task.when(), None);
+        assert_eq!(conf.config.task.when().unwrap_or_default(), TaskWhen::Never);
     }
 
     #[test]

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -457,8 +457,7 @@ mod tests {
     fn test_default_never() {
         let conf = ExportUserConfig::default();
         assert!(!conf.count_words);
-        assert_eq!(conf.task.when(), None);
-        assert_eq!(conf.task.when().unwrap_or_default(), TaskWhen::Never);
+        assert_eq!(conf.task.when(), Some(TaskWhen::Never));
     }
 
     #[test]

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -107,10 +107,6 @@ impl ExportTask {
     }
 
     pub fn signal(&self, snap: &LspCompiledArtifact) {
-        //     self.factory.task().signal(snap, self);
-        // }
-
-        // fn signal(self: Arc<Self>, snap: &LspCompiledArtifact, t: &ExportTask) {
         let config = self.factory.task();
 
         self.signal_export(snap, &config);

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -595,7 +595,12 @@ pub async fn preview_main(args: PreviewCliArgs) -> Result<()> {
         let compile_handle = Arc::new(CompileHandlerImpl {
             preview: preview_state.clone(),
             diag_group: "main".to_owned(),
-            export: crate::task::ExportTask::new(handle, Default::default()),
+            export: crate::task::ExportTask::new(
+                handle,
+                String::default(),
+                None,
+                Default::default(),
+            ),
             editor_tx,
             client: Box::new(intr_tx.clone()),
             analysis: Arc::default(),

--- a/crates/tinymist/src/tool/project.rs
+++ b/crates/tinymist/src/tool/project.rs
@@ -79,11 +79,12 @@ impl LockFileExt for LockFile {
             .unwrap_or(doc_id.clone());
 
         let when = args.when.unwrap_or(TaskWhen::OnType);
-        let task = ProjectTask::Preview(PreviewTask {
+        let task = ProjectTaskConfig::Preview(PreviewTask { when });
+        let task = ProjectTask {
             id: task_id.clone(),
             document: doc_id,
-            when,
-        });
+            config: task,
+        };
 
         self.replace_task(task);
 

--- a/crates/tinymist/src/tool/project.rs
+++ b/crates/tinymist/src/tool/project.rs
@@ -79,11 +79,11 @@ impl LockFileExt for LockFile {
             .unwrap_or(doc_id.clone());
 
         let when = args.when.unwrap_or(TaskWhen::OnType);
-        let task = ProjectTaskConfig::Preview(PreviewTask { when });
-        let task = ProjectTask {
+        let task = ProjectTask::Preview(PreviewTask { when });
+        let task = ApplyProjectTask {
             id: task_id.clone(),
             document: doc_id,
-            config: task,
+            task,
         };
 
         self.replace_task(task);


### PR DESCRIPTION
A task is serializable, which is locked in the lock file. A task consists of the `input` id, `output` pattern, `when` to execute, and the task-specific configuration (parameters). The export function is refactored and execute on the task's configuration.