### PR TITLE
feat: better contextual render

### DIFF
--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -421,15 +421,9 @@ impl TypliteWorker {
             ""
         };
 
-        let write_error = |content: &mut EcoString, align: &str, err: &str, inline: bool| {
-            if !inline {
-                let _ = write!(content, r#"<p align="{align}">"#);
-            }
+        let write_error = |content: &mut EcoString, err: &str| {
             let err = err.replace("`", r#"\`"#);
             let _ = write!(content, "```\nRender Error\n{err}\n```");
-            if !inline {
-                content.push_str("</p>");
-            }
         };
 
         let write_image = |content: &mut EcoString,
@@ -480,7 +474,7 @@ impl TypliteWorker {
                 let data = match render(theme) {
                     Ok(data) => data,
                     Err(err) if self.feat.soft_error => {
-                        write_error(&mut content, align, &err.to_string(), inline);
+                        write_error(&mut content, &err.to_string());
                         return Ok(Value::Content(content));
                     }
                     Err(err) => return Err(err),
@@ -516,7 +510,7 @@ impl TypliteWorker {
                 let dark = match render(ColorTheme::Dark) {
                     Ok(d) => d,
                     Err(err) if self.feat.soft_error => {
-                        write_error(&mut content, align, &err.to_string(), inline);
+                        write_error(&mut content, &err.to_string());
                         return Ok(Value::Content(content));
                     }
                     Err(err) => return Err(err),
@@ -524,7 +518,7 @@ impl TypliteWorker {
                 let light = match render(ColorTheme::Light) {
                     Ok(l) => l,
                     Err(err) if self.feat.soft_error => {
-                        write_error(&mut content, align, &err.to_string(), inline);
+                        write_error(&mut content, &err.to_string());
                         return Ok(Value::Content(content));
                     }
                     Err(err) => return Err(err),

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -310,7 +310,12 @@ impl TypliteWorker {
             LineComment => Ok(Value::None),
             BlockComment => Ok(Value::None),
         };
-        if res.clone()? == Value::None && !matches!(node.kind(), Hash | Ident) {
+        if res.clone()? == Value::None
+            && !matches!(
+                node.kind(),
+                Hash | Ident | Bool | Int | Float | Numeric | Str | Array | Dict
+            )
+        {
             self.pref += node.clone().into_text();
             self.pref += "\n";
         }

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -114,6 +114,7 @@ impl Typlite {
             current,
             feat: self.feat,
             list_depth: 0,
+            pref: EcoString::new(),
             scopes: self
                 .library
                 .as_ref()
@@ -133,6 +134,7 @@ pub struct TypliteWorker {
     scopes: Arc<Scopes<Value>>,
     world: Arc<LspWorld>,
     list_depth: usize,
+    pref: EcoString,
     /// Features for the conversion.
     pub feat: TypliteFeat,
 }
@@ -146,7 +148,7 @@ impl TypliteWorker {
     /// Eval the content
     pub fn eval(&mut self, node: &SyntaxNode) -> Result<Value> {
         use SyntaxKind::*;
-        match node.kind() {
+        let res = match node.kind() {
             RawLang | RawDelim | RawTrimmed => Err("converting clause")?,
 
             Math | MathIdent | MathAlignPoint | MathDelimited | MathAttach | MathPrimes
@@ -307,7 +309,12 @@ impl TypliteWorker {
             // Ignored comments
             LineComment => Ok(Value::None),
             BlockComment => Ok(Value::None),
+        };
+        if res.clone()? == Value::None && !matches!(node.kind(), Hash | Ident) {
+            self.pref += node.clone().into_text();
+            self.pref += "\n";
         }
+        res
     }
 
     fn reduce(&mut self, node: &SyntaxNode) -> Result<Value> {
@@ -702,7 +709,10 @@ impl TypliteWorker {
         if self.feat.remove_html {
             return self.to_raw_block(node, false);
         }
-        self.render(node, false)
+        self.render(
+            &SyntaxNode::leaf(node.kind(), self.pref.clone() + node.clone().into_text()),
+            false,
+        )
     }
 
     fn include(&self, node: &SyntaxNode) -> Result<Value> {

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -6,7 +6,7 @@ pub mod scopes;
 pub mod value;
 
 use core::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt::Write, sync::LazyLock};
 
@@ -50,8 +50,12 @@ pub enum ColorTheme {
 
 #[derive(Debug, Default, Clone)]
 pub struct TypliteFeat {
-    /// The preferred color theme
+    /// The preferred color theme.
     pub color_theme: Option<ColorTheme>,
+    /// The path of external assets directory.
+    pub assets_path: Option<PathBuf>,
+    /// The path of external assets' source code directory.
+    pub assets_src_path: Option<PathBuf>,
     /// Allows GFM (GitHub Flavored Markdown) markups.
     pub gfm: bool,
     /// Annotate the elements for identification.
@@ -115,6 +119,7 @@ impl Typlite {
             feat: self.feat,
             list_depth: 0,
             pref: EcoString::new(),
+            assets_numbering: 0,
             scopes: self
                 .library
                 .as_ref()
@@ -135,6 +140,7 @@ pub struct TypliteWorker {
     world: Arc<LspWorld>,
     list_depth: usize,
     pref: EcoString,
+    assets_numbering: usize,
     /// Features for the conversion.
     pub feat: TypliteFeat,
 }
@@ -361,9 +367,27 @@ impl TypliteWorker {
         Ok(Value::Content(s))
     }
 
-    pub fn render(&mut self, node: &SyntaxNode, inline: bool) -> Result<Value> {
+    pub fn render(
+        &mut self,
+        pref_node: &SyntaxNode,
+        node: &SyntaxNode,
+        inline: bool,
+    ) -> Result<Value> {
+        self.assets_numbering += 1;
+        let pref_code = pref_node.clone().into_text();
         let code = node.clone().into_text();
-        self.render_code(&code, false, "center", "", inline)
+        if let Some(assets_src_path) = &self.feat.assets_src_path {
+            let file_name = format!(
+                "{}/{}.typ",
+                assets_src_path.display(),
+                self.assets_numbering,
+            );
+            if let Err(e) = std::fs::write(&file_name, format!("#{{\n// render_code\n{}\n}}", code))
+            {
+                return Err(format!("Failed to write code to file: {}", e).into());
+            }
+        }
+        self.render_code(&(pref_code + code), false, "center", "", inline)
     }
 
     pub fn render_code(
@@ -375,6 +399,17 @@ impl TypliteWorker {
         inline: bool,
     ) -> Result<Value> {
         let theme = self.feat.color_theme;
+
+        let code_file_name = if let Some(assets_src_path) = &self.feat.assets_src_path {
+            Some(format!(
+                "{}/{}.typ",
+                assets_src_path.display(),
+                self.assets_numbering,
+            ))
+        } else {
+            None
+        };
+
         let mut render = |theme| self.render_inner(code, is_markup, theme);
 
         let mut content = EcoString::new();
@@ -384,20 +419,58 @@ impl TypliteWorker {
         } else {
             ""
         };
+
         match theme {
             Some(theme) => {
                 let data = render(theme);
                 match data {
                     Ok(data) => {
-                        if !inline {
-                            let _ = write!(content, r#"<p align="{align}">"#);
-                        }
-                        let _ = write!(
-                            content,
-                            r#"<img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{data}" {extra_attrs}/>"#,
-                        );
-                        if !inline {
-                            content.push_str("</p>");
+                        if let Some(assets_path) = &self.feat.assets_path {
+                            let file_name = format!(
+                                "{}/{}_{:?}.svg",
+                                assets_path.display(),
+                                self.assets_numbering,
+                                theme
+                            );
+                            if let Err(e) = std::fs::write(&file_name, &data) {
+                                return Err(format!("Failed to write SVG to file: {}", e).into());
+                            }
+
+                            if let Some(code_file_name) = &code_file_name {
+                                if !inline {
+                                    let _ = write!(content, r#"<p align="{align}">"#);
+                                }
+                                let _ = write!(
+                                    content,
+                                    r#"<a href="{code_file_name}"><img{inline_attrs} alt="typst-block" src="{file_name}" {extra_attrs}/></a>"#,
+                                );
+                                if !inline {
+                                    content.push_str("</p>");
+                                }
+                            } else {
+                                if !inline {
+                                    let _ = write!(content, r#"<p align="{align}">"#);
+                                }
+                                let _ = write!(
+                                    content,
+                                    r#"<img{inline_attrs} alt="typst-block" src="{file_name}" {extra_attrs}/>"#,
+                                );
+                                if !inline {
+                                    content.push_str("</p>");
+                                }
+                            }
+                        } else {
+                            // Fallback to Base64-encoded data URL if assets_path is None
+                            if !inline {
+                                let _ = write!(content, r#"<p align="{align}">"#);
+                            }
+                            let _ = write!(
+                                content,
+                                r#"<img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{data}" {extra_attrs}/>"#,
+                            );
+                            if !inline {
+                                content.push_str("</p>");
+                            }
                         }
                     }
                     Err(err) if self.feat.soft_error => {
@@ -414,15 +487,54 @@ impl TypliteWorker {
 
                 match (dark, light) {
                     (Ok(dark), Ok(light)) => {
-                        if !inline {
-                            let _ = write!(content, r#"<p align="{align}">"#);
-                        }
-                        let _ = write!(
-                            content,
-                            r#"<picture><source media="(prefers-color-scheme: dark)" srcset="data:image/svg+xml;base64,{dark}"><img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{light}" {extra_attrs}/></picture>"#,
-                        );
-                        if !inline {
-                            content.push_str("</p>");
+                        if let Some(assets_path) = &self.feat.assets_path {
+                            let dark_file_name = format!(
+                                "{}/{}_{:?}.svg",
+                                assets_path.display(),
+                                self.assets_numbering,
+                                ColorTheme::Dark
+                            );
+                            let light_file_name = format!(
+                                "{}/{}_{:?}.svg",
+                                assets_path.display(),
+                                self.assets_numbering,
+                                ColorTheme::Light
+                            );
+
+                            if let Some(code_file_name) = &code_file_name {
+                                if !inline {
+                                    let _ = write!(content, r#"<p align="{align}">"#);
+                                }
+                                let _ = write!(
+                                    content,
+                                    r#"<a href="{code_file_name}"><picture><source media="(prefers-color-scheme: dark)" srcset="{dark_file_name}"><img{inline_attrs} alt="typst-block" src="{light_file_name}" {extra_attrs}/></picture></a>"#,
+                                );
+                                if !inline {
+                                    content.push_str("</p>");
+                                }
+                            } else {
+                                if !inline {
+                                    let _ = write!(content, r#"<p align="{align}">"#);
+                                }
+                                let _ = write!(
+                                    content,
+                                    r#"<picture><source media="(prefers-color-scheme: dark)" srcset="{dark_file_name}"><img{inline_attrs} alt="typst-block" src="{light_file_name}" {extra_attrs}/></picture>"#,
+                                );
+                                if !inline {
+                                    content.push_str("</p>");
+                                }
+                            }
+                        } else {
+                            if !inline {
+                                let _ = write!(content, r#"<p align="{align}">"#);
+                            }
+                            let _ = write!(
+                                content,
+                                r#"<picture><source media="(prefers-color-scheme: dark)" srcset="data:image/svg+xml;base64,{dark}"><img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{light}" {extra_attrs}/></picture>"#,
+                            );
+                            if !inline {
+                                content.push_str("</p>");
+                            }
                         }
                     }
                     (Err(err), _) | (_, Err(err)) if self.feat.soft_error => {
@@ -528,7 +640,21 @@ impl TypliteWorker {
         })?;
 
         let svg_payload = typst_svg::svg_merged(&document, Abs::zero());
-        Ok(base64::engine::general_purpose::STANDARD.encode(svg_payload))
+
+        if let Some(assets_path) = &self.feat.assets_path {
+            let file_name = format!(
+                "{}/{}_{:?}.svg",
+                assets_path.display(),
+                self.assets_numbering,
+                theme
+            );
+            if let Err(e) = std::fs::write(&file_name, &svg_payload) {
+                return Err(format!("Failed to write SVG to file: {}", e).into());
+            }
+            Ok(file_name)
+        } else {
+            Ok(base64::engine::general_purpose::STANDARD.encode(svg_payload))
+        }
     }
 
     fn char(arg: char) -> Result<Value> {
@@ -679,7 +805,7 @@ impl TypliteWorker {
             return self.to_raw_block(node, !equation.block());
         }
 
-        self.render(node, !equation.block())
+        self.render(&SyntaxNode::default(), node, !equation.block())
     }
 
     fn let_binding(&self, node: &SyntaxNode) -> Result<Value> {
@@ -715,7 +841,8 @@ impl TypliteWorker {
             return self.to_raw_block(node, false);
         }
         self.render(
-            &SyntaxNode::leaf(node.kind(), self.pref.clone() + node.clone().into_text()),
+            &SyntaxNode::leaf(node.kind(), self.pref.clone()),
+            node,
             false,
         )
     }

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -27,6 +27,7 @@ use typst::{
 };
 use value::{Args, Value};
 
+use crate::SyntaxKind::Text;
 use ecow::{eco_format, EcoString};
 use typst_syntax::{
     ast::{self, AstNode},
@@ -401,7 +402,7 @@ impl TypliteWorker {
         let theme = self.feat.color_theme;
 
         let code_file_name = if let Some(assets_src_path) = &self.feat.assets_src_path {
-            Some(format!(
+            Some(eco_format!(
                 "{}/{}.typ",
                 assets_src_path.display(),
                 self.assets_numbering,
@@ -420,136 +421,148 @@ impl TypliteWorker {
             ""
         };
 
+        let write_error = |content: &mut EcoString, align: &str, err: &str, inline: bool| {
+            if !inline {
+                let _ = write!(content, r#"<p align="{align}">"#);
+            }
+            let err = err.replace("`", r#"\`"#);
+            let _ = write!(content, "```\nRender Error\n{err}\n```");
+            if !inline {
+                content.push_str("</p>");
+            }
+        };
+
+        let write_image = |content: &mut EcoString,
+                           file_name: &std::path::Path,
+                           code_file_name: Option<&EcoString>,
+                           inline_attrs: &str,
+                           extra_attrs: &str| {
+            if let Some(code_file_name) = code_file_name {
+                let _ = write!(
+                    content,
+                    r#"<a href="{code_file_name}"><img{inline_attrs} alt="typst-block" src="{}" {extra_attrs}/></a>"#,
+                    file_name.display()
+                );
+            } else {
+                let _ = write!(
+                    content,
+                    r#"<img{inline_attrs} alt="typst-block" src="{}" {extra_attrs}/>"#,
+                    file_name.display()
+                );
+            }
+        };
+
+        let write_picture = |content: &mut EcoString,
+                             dark_file_name: &std::path::Path,
+                             light_file_name: &std::path::Path,
+                             code_file_name: Option<&EcoString>,
+                             inline_attrs: &str,
+                             extra_attrs: &str| {
+            if let Some(code_file_name) = code_file_name {
+                let _ = write!(
+                    content,
+                    r#"<a href="{code_file_name}"><picture><source media="(prefers-color-scheme: dark)" srcset="{}"><img{inline_attrs} alt="typst-block" src="{}" {extra_attrs}/></picture></a>"#,
+                    dark_file_name.display(),
+                    light_file_name.display()
+                );
+            } else {
+                let _ = write!(
+                    content,
+                    r#"<picture><source media="(prefers-color-scheme: dark)" srcset="{}"><img{inline_attrs} alt="typst-block" src="{}" {extra_attrs}/></picture>"#,
+                    dark_file_name.display(),
+                    light_file_name.display()
+                );
+            }
+        };
+
+        if !inline {
+            let _ = write!(content, r#"<p align="{align}">"#);
+        }
+
         match theme {
             Some(theme) => {
-                let data = render(theme);
-                match data {
-                    Ok(data) => {
-                        if let Some(assets_path) = &self.feat.assets_path {
-                            let file_name = format!(
-                                "{}/{}_{:?}.svg",
-                                assets_path.display(),
-                                self.assets_numbering,
-                                theme
-                            );
-                            if let Err(e) = std::fs::write(&file_name, &data) {
-                                return Err(format!("Failed to write SVG to file: {}", e).into());
-                            }
-
-                            if let Some(code_file_name) = &code_file_name {
-                                if !inline {
-                                    let _ = write!(content, r#"<p align="{align}">"#);
-                                }
-                                let _ = write!(
-                                    content,
-                                    r#"<a href="{code_file_name}"><img{inline_attrs} alt="typst-block" src="{file_name}" {extra_attrs}/></a>"#,
-                                );
-                                if !inline {
-                                    content.push_str("</p>");
-                                }
-                            } else {
-                                if !inline {
-                                    let _ = write!(content, r#"<p align="{align}">"#);
-                                }
-                                let _ = write!(
-                                    content,
-                                    r#"<img{inline_attrs} alt="typst-block" src="{file_name}" {extra_attrs}/>"#,
-                                );
-                                if !inline {
-                                    content.push_str("</p>");
-                                }
-                            }
-                        } else {
-                            // Fallback to Base64-encoded data URL if assets_path is None
-                            if !inline {
-                                let _ = write!(content, r#"<p align="{align}">"#);
-                            }
-                            let _ = write!(
-                                content,
-                                r#"<img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{data}" {extra_attrs}/>"#,
-                            );
-                            if !inline {
-                                content.push_str("</p>");
-                            }
-                        }
-                    }
+                let data = match render(theme) {
+                    Ok(data) => data,
                     Err(err) if self.feat.soft_error => {
-                        // wrap the error in a fenced code block
-                        let err = err.to_string().replace("`", r#"\`"#);
-                        let _ = write!(content, "```\nRender Error\n{err}\n```");
+                        write_error(&mut content, align, &err.to_string(), inline);
+                        return Ok(Value::Content(content));
                     }
                     Err(err) => return Err(err),
+                };
+
+                if let Some(assets_path) = &self.feat.assets_path {
+                    let file_name =
+                        assets_path.join(format!("{}_{:?}.svg", self.assets_numbering, theme));
+                    std::fs::write(&file_name, &data)
+                        .map_err(|e| format!("failed to write SVG to file: {}", e))?;
+
+                    write_image(
+                        &mut content,
+                        &file_name,
+                        code_file_name.as_ref(),
+                        inline_attrs,
+                        extra_attrs,
+                    );
+                } else {
+                    let _ = write!(
+                        content,
+                        r#"<img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{data}" {extra_attrs}/>"#
+                    );
                 }
             }
             None => {
-                let dark = render(ColorTheme::Dark);
-                let light = render(ColorTheme::Light);
-
-                match (dark, light) {
-                    (Ok(dark), Ok(light)) => {
-                        if let Some(assets_path) = &self.feat.assets_path {
-                            let dark_file_name = format!(
-                                "{}/{}_{:?}.svg",
-                                assets_path.display(),
-                                self.assets_numbering,
-                                ColorTheme::Dark
-                            );
-                            let light_file_name = format!(
-                                "{}/{}_{:?}.svg",
-                                assets_path.display(),
-                                self.assets_numbering,
-                                ColorTheme::Light
-                            );
-
-                            if let Some(code_file_name) = &code_file_name {
-                                if !inline {
-                                    let _ = write!(content, r#"<p align="{align}">"#);
-                                }
-                                let _ = write!(
-                                    content,
-                                    r#"<a href="{code_file_name}"><picture><source media="(prefers-color-scheme: dark)" srcset="{dark_file_name}"><img{inline_attrs} alt="typst-block" src="{light_file_name}" {extra_attrs}/></picture></a>"#,
-                                );
-                                if !inline {
-                                    content.push_str("</p>");
-                                }
-                            } else {
-                                if !inline {
-                                    let _ = write!(content, r#"<p align="{align}">"#);
-                                }
-                                let _ = write!(
-                                    content,
-                                    r#"<picture><source media="(prefers-color-scheme: dark)" srcset="{dark_file_name}"><img{inline_attrs} alt="typst-block" src="{light_file_name}" {extra_attrs}/></picture>"#,
-                                );
-                                if !inline {
-                                    content.push_str("</p>");
-                                }
-                            }
-                        } else {
-                            if !inline {
-                                let _ = write!(content, r#"<p align="{align}">"#);
-                            }
-                            let _ = write!(
-                                content,
-                                r#"<picture><source media="(prefers-color-scheme: dark)" srcset="data:image/svg+xml;base64,{dark}"><img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{light}" {extra_attrs}/></picture>"#,
-                            );
-                            if !inline {
-                                content.push_str("</p>");
-                            }
-                        }
+                let dark = match render(ColorTheme::Dark) {
+                    Ok(d) => d,
+                    Err(err) if self.feat.soft_error => {
+                        write_error(&mut content, align, &err.to_string(), inline);
+                        return Ok(Value::Content(content));
                     }
-                    (Err(err), _) | (_, Err(err)) if self.feat.soft_error => {
-                        // wrap the error in a fenced code block
-                        let err = err.to_string().replace("`", r#"\`"#);
-                        let _ = write!(content, "```\nRendering Error\n{err}\n```");
+                    Err(err) => return Err(err),
+                };
+                let light = match render(ColorTheme::Light) {
+                    Ok(l) => l,
+                    Err(err) if self.feat.soft_error => {
+                        write_error(&mut content, align, &err.to_string(), inline);
+                        return Ok(Value::Content(content));
                     }
-                    (Err(err), _) | (_, Err(err)) => return Err(err),
+                    Err(err) => return Err(err),
+                };
+
+                if let Some(assets_path) = &self.feat.assets_path {
+                    let dark_file_name = assets_path.join(format!(
+                        "{}_{:?}.svg",
+                        self.assets_numbering,
+                        ColorTheme::Dark
+                    ));
+                    let light_file_name = assets_path.join(format!(
+                        "{}_{:?}.svg",
+                        self.assets_numbering,
+                        ColorTheme::Light
+                    ));
+
+                    write_picture(
+                        &mut content,
+                        &dark_file_name,
+                        &light_file_name,
+                        code_file_name.as_ref(),
+                        inline_attrs,
+                        extra_attrs,
+                    );
+                } else {
+                    let _ = write!(
+                        content,
+                        r#"<picture><source media="(prefers-color-scheme: dark)" srcset="data:image/svg+xml;base64,{dark}"><img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{light}" {extra_attrs}/></picture>"#
+                    );
                 }
             }
         }
 
+        if !inline {
+            content.push_str("</p>");
+        }
+
         Ok(Value::Content(content))
     }
-
     fn render_inner(&mut self, code: &str, is_markup: bool, theme: ColorTheme) -> Result<String> {
         static DARK_THEME_INPUT: LazyLock<Arc<LazyHash<Dict>>> = LazyLock::new(|| {
             Arc::new(LazyHash::new(Dict::from_iter(std::iter::once((
@@ -805,7 +818,7 @@ impl TypliteWorker {
             return self.to_raw_block(node, !equation.block());
         }
 
-        self.render(&SyntaxNode::default(), node, !equation.block())
+        self.render(&SyntaxNode::leaf(Text, ""), node, !equation.block())
     }
 
     fn let_binding(&self, node: &SyntaxNode) -> Result<Value> {

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -475,10 +475,6 @@ impl TypliteWorker {
             }
         };
 
-        if !inline {
-            let _ = write!(content, r#"<p align="{align}">"#);
-        }
-
         match theme {
             Some(theme) => {
                 let data = match render(theme) {
@@ -490,6 +486,9 @@ impl TypliteWorker {
                     Err(err) => return Err(err),
                 };
 
+                if !inline {
+                    let _ = write!(content, r#"<p align="{align}">"#);
+                }
                 if let Some(assets_path) = &self.feat.assets_path {
                     let file_name =
                         assets_path.join(format!("{}_{:?}.svg", self.assets_numbering, theme));
@@ -508,6 +507,9 @@ impl TypliteWorker {
                         content,
                         r#"<img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{data}" {extra_attrs}/>"#
                     );
+                }
+                if !inline {
+                    content.push_str("</p>");
                 }
             }
             None => {
@@ -528,6 +530,9 @@ impl TypliteWorker {
                     Err(err) => return Err(err),
                 };
 
+                if !inline {
+                    let _ = write!(content, r#"<p align="{align}">"#);
+                }
                 if let Some(assets_path) = &self.feat.assets_path {
                     let dark_file_name = assets_path.join(format!(
                         "{}_{:?}.svg",
@@ -554,15 +559,15 @@ impl TypliteWorker {
                         r#"<picture><source media="(prefers-color-scheme: dark)" srcset="data:image/svg+xml;base64,{dark}"><img{inline_attrs} alt="typst-block" src="data:image/svg+xml;base64,{light}" {extra_attrs}/></picture>"#
                     );
                 }
+                if !inline {
+                    content.push_str("</p>");
+                }
             }
-        }
-
-        if !inline {
-            content.push_str("</p>");
         }
 
         Ok(Value::Content(content))
     }
+
     fn render_inner(&mut self, code: &str, is_markup: bool, theme: ColorTheme) -> Result<String> {
         static DARK_THEME_INPUT: LazyLock<Arc<LazyHash<Dict>>> = LazyLock::new(|| {
             Arc::new(LazyHash::new(Dict::from_iter(std::iter::once((

--- a/crates/typlite/src/main.rs
+++ b/crates/typlite/src/main.rs
@@ -77,8 +77,8 @@ fn main() -> typlite::Result<()> {
     let converter = Typlite::new(Arc::new(world))
         .with_library(lib())
         .with_feature(TypliteFeat {
-            assets_path: assets_path,
-            assets_src_path: assets_src_path,
+            assets_path,
+            assets_src_path,
             ..Default::default()
         });
     let conv = converter.convert();

--- a/crates/typlite/src/main.rs
+++ b/crates/typlite/src/main.rs
@@ -25,7 +25,7 @@ pub struct CompileArgs {
     #[clap(long, default_value = None, value_name = "ASSETS_PATH")]
     pub assets_path: Option<String>,
 
-    /// Configures the path of assets' source code directory
+    /// Configure the path to the assets' corresponding source code directory. When the path is specified, typlite adds a href to jump to the source code in the exported asset.
     #[clap(long, default_value = None, value_name = "ASSETS_SRC_PATH")]
     pub assets_src_path: Option<String>,
 }
@@ -49,8 +49,7 @@ fn main() -> typlite::Result<()> {
             let path = PathBuf::from(assets_path);
             if !path.exists() {
                 if let Err(e) = std::fs::create_dir_all(&path) {
-                    eprintln!("Failed to create assets directory: {}", e);
-                    return Err(format!("Failed to create assets directory: {}", e).into());
+                    return Err(format!("failed to create assets directory: {}", e).into());
                 }
             }
             Some(path)
@@ -62,8 +61,7 @@ fn main() -> typlite::Result<()> {
             let path = PathBuf::from(assets_src_path);
             if !path.exists() {
                 if let Err(e) = std::fs::create_dir_all(&path) {
-                    eprintln!("Failed to create assets' src directory: {}", e);
-                    return Err(format!("Failed to create assets' src directory: {}", e).into());
+                    return Err(format!("failed to create assets' src directory: {}", e).into());
                 }
             }
             Some(path)


### PR DESCRIPTION
- Better contexual render

    I introduced an `EcoString` to store the codes of nodes that result in `Value::None` (excluding `Hash | Ident | Bool | Int | Float | Numeric | Str | Array | Dict`) that appear before a `Contextual` node. Then prepend the buffer to the `Contextual` node to render in right environment.
    
    Add assets_path and assets_src_path to args and TypliteFeat, support render contexual code to external svg file.

Variable names were chosen quickly and are not ideal apparently, sorry for that :(