### PR TITLE
feat: embed Markdown codes

### DIFF
--- a/crates/typlite/README.md
+++ b/crates/typlite/README.md
@@ -10,3 +10,7 @@ typlite main.typ
 # specify output
 typlite main.typ output.md
 ```
+
+## Feature
+
+- **Raw Output**: Raw codes with `typlite` language will be directly output into the Markdown result.

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -582,6 +582,15 @@ impl TypliteWorker {
     fn raw(node: &SyntaxNode) -> Result<Value> {
         let mut s = EcoString::new();
         let raw = node.cast::<ast::Raw>().unwrap();
+        if let Some(lang) = raw.lang() {
+            if &EcoString::from("typlite") == lang.get() {
+                for line in raw.lines() {
+                    s.push_str(&Self::value(Self::str(line.to_untyped())?));
+                    s.push('\n');
+                }
+                return Ok(Value::Content(s));
+            }
+        }
         if raw.block() {
             s.push_str(&Self::value(Self::str(node)?));
             return Ok(Value::Content(s));

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -582,6 +582,8 @@ impl TypliteWorker {
     fn raw(node: &SyntaxNode) -> Result<Value> {
         let mut s = EcoString::new();
         let raw = node.cast::<ast::Raw>().unwrap();
+
+        // Raw codes with typlite language will not be treated as a code block but directly output into the Markdown result.
         if let Some(lang) = raw.lang() {
             if &EcoString::from("typlite") == lang.get() {
                 for line in raw.lines() {
@@ -591,6 +593,7 @@ impl TypliteWorker {
                 return Ok(Value::Content(s));
             }
         }
+
         if raw.block() {
             s.push_str(&Self::value(Self::str(node)?));
             return Ok(Value::Content(s));


### PR DESCRIPTION
- Embed Markdown codes

    Raw codes with `typlite` language will not be treated as a code block but directly output into the Markdown result.