### PR TITLE
feat: optionally make symbol completion stepless

### DIFF
--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -85,6 +85,9 @@ pub struct CompletionFeat {
     #[serde(default)]
     pub trigger_suggest_and_parameter_hints: bool,
 
+    /// The Way to complete symbols.
+    pub symbol: Option<SymbolCompletionWay>,
+
     /// Whether to enable postfix completion.
     pub postfix: Option<bool>,
     /// Whether to enable ufcs completion.
@@ -129,6 +132,22 @@ impl CompletionFeat {
             .as_ref()
             .unwrap_or(&DEFAULT_POSTFIX_SNIPPET)
     }
+
+    pub(crate) fn is_stepless(&self) -> bool {
+        matches!(self.symbol, Some(SymbolCompletionWay::Stepless))
+    }
+}
+
+/// Whether to make symbol completion stepless. For example, `$ar|$` will be
+/// completed to `$arrow.r$`. Hint: Restarting the editor is required to change
+/// this setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SymbolCompletionWay {
+    /// Complete symbols step by step
+    Step,
+    /// Complete symbols steplessly
+    Stepless,
 }
 
 /// The struct describing how a completion worker views the editor's cursor.

--- a/crates/tinymist-query/src/analysis/completion/field_access.rs
+++ b/crates/tinymist-query/src/analysis/completion/field_access.rs
@@ -73,16 +73,7 @@ impl CompletionPair<'_, '_, '_> {
 
         match value {
             Value::Symbol(symbol) => {
-                for modifier in symbol.modifiers() {
-                    if let Ok(modified) = symbol.clone().modified(modifier) {
-                        self.push_completion(Completion {
-                            kind: CompletionKind::Symbol(modified.get()),
-                            label: modifier.into(),
-                            label_details: Some(symbol_label_detail(modified.get())),
-                            ..Completion::default()
-                        });
-                    }
-                }
+                self.symbol_var_completions(&symbol, None);
 
                 if valid_postfix_target {
                     self.ufcs_completions(target);

--- a/crates/tinymist-query/src/analysis/completion/kind.rs
+++ b/crates/tinymist-query/src/analysis/completion/kind.rs
@@ -1,13 +1,15 @@
 //! Completion kind analysis.
 
+use typst::foundations::Symbol;
+
 use super::*;
 
-pub(crate) struct CompletionKindChecker {
-    pub symbols: HashSet<char>,
-    pub functions: HashSet<Ty>,
+pub(crate) struct CompletionKindChecker<'a> {
+    pub symbols: HashSet<&'a Symbol>,
+    pub functions: HashSet<&'a Ty>,
 }
 
-impl CompletionKindChecker {
+impl<'a> CompletionKindChecker<'a> {
     /// Reset the checker status for a fresh checking.
     fn reset(&mut self) {
         self.symbols.clear();
@@ -15,29 +17,29 @@ impl CompletionKindChecker {
     }
 
     /// Check the completion kind of a type.
-    pub fn check(&mut self, ty: &Ty) {
+    pub fn check(&mut self, ty: &'a Ty) {
         self.reset();
         match ty {
             Ty::Value(val) => match &val.val {
                 Value::Type(t) if t.constructor().is_ok() => {
-                    self.functions.insert(ty.clone());
+                    self.functions.insert(ty);
                 }
                 Value::Func(..) => {
-                    self.functions.insert(ty.clone());
+                    self.functions.insert(ty);
                 }
                 Value::Symbol(s) => {
-                    self.symbols.insert(s.get());
+                    self.symbols.insert(s);
                 }
                 _ => {}
             },
             Ty::Func(..) | Ty::With(..) => {
-                self.functions.insert(ty.clone());
+                self.functions.insert(ty);
             }
             Ty::Builtin(BuiltinTy::TypeType(t)) if t.constructor().is_ok() => {
-                self.functions.insert(ty.clone());
+                self.functions.insert(ty);
             }
             Ty::Builtin(BuiltinTy::Element(..)) => {
-                self.functions.insert(ty.clone());
+                self.functions.insert(ty);
             }
             Ty::Let(bounds) => {
                 for bound in bounds.ubs.iter().chain(bounds.lbs.iter()) {

--- a/crates/tinymist-query/src/analysis/completion/snippet.rs
+++ b/crates/tinymist-query/src/analysis/completion/snippet.rs
@@ -213,15 +213,15 @@ impl CompletionPair<'_, '_, '_> {
         let rb = if is_content_block { "" } else { ")" };
 
         // we don't check literal type here for faster completion
-        for (name, ty) in defines.defines {
+        for (name, ty) in &defines.defines {
             // todo: filter ty
             if name.is_empty() {
                 continue;
             }
 
-            kind_checker.check(&ty);
+            kind_checker.check(ty);
 
-            if kind_checker.symbols.iter().min().copied().is_some() {
+            if !kind_checker.symbols.is_empty() {
                 continue;
             }
             if kind_checker.functions.is_empty() {
@@ -242,7 +242,7 @@ impl CompletionPair<'_, '_, '_> {
                     .map(From::from),
                 ..Default::default()
             };
-            let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter());
+            let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter().copied());
 
             crate::log_debug_ct!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
 

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -275,7 +275,7 @@ impl CompletionPair<'_, '_, '_> {
                     None => modifier.into(),
                 };
 
-                self.symbol_completions(label, symbol);
+                self.symbol_completions(label, &modified);
             }
         }
     }

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -271,7 +271,7 @@ impl CompletionPair<'_, '_, '_> {
         for modifier in symbol.modifiers() {
             if let Ok(modified) = symbol.clone().modified(modifier) {
                 let label = match &prefix {
-                    Some(prefix) => eco_format!("{prefix}.{modified}"),
+                    Some(prefix) => eco_format!("{prefix}.{modifier}"),
                     None => modifier.into(),
                 };
 

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -251,20 +251,20 @@ impl CompletionPair<'_, '_, '_> {
     }
 
     pub fn symbol_completions(&mut self, label: EcoString, symbol: &Symbol) {
-        let is_stepless = self.cursor.ctx.analysis.completion_feat.is_stepless();
-        if is_stepless {
-            self.symbol_var_completions(symbol, Some(&label));
-        }
-
         let ch = symbol.get();
         let kind = CompletionKind::Symbol(ch);
         self.push_completion(Completion {
             kind,
-            label,
+            label: label.clone(),
             label_details: Some(symbol_label_detail(ch)),
             detail: Some(symbol_detail(ch)),
             ..Completion::default()
         });
+
+        let is_stepless = self.cursor.ctx.analysis.completion_feat.is_stepless();
+        if is_stepless {
+            self.symbol_var_completions(symbol, Some(&label));
+        }
     }
 
     pub fn symbol_var_completions(&mut self, symbol: &Symbol, prefix: Option<&str>) {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -542,7 +542,7 @@
           "title": "The Way to complete symbols",
           "markdownDescription": "Whether to make symbol completion stepless. For example, `$ar|$` will be completed to `$arrow.r$`. Hint: Restarting the editor is required to change this setting.",
           "type": "string",
-          "default": "enable",
+          "default": "step",
           "enum": [
             "step",
             "stepless"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -538,6 +538,20 @@
           "type": "boolean",
           "default": false
         },
+        "tinymist.completion.symbol": {
+          "title": "The Way to complete symbols",
+          "markdownDescription": "Whether to make symbol completion stepless. For example, `$ar|$` will be completed to `$arrow.r$`. Hint: Restarting the editor is required to change this setting.",
+          "type": "string",
+          "default": "enable",
+          "enum": [
+            "step",
+            "stepless"
+          ],
+          "enumDescriptions": [
+            "Complete symbols step by step",
+            "Complete symbols steplessly"
+          ]
+        },
         "tinymist.completion.postfix": {
           "title": "%extension.tinymist.config.tinymist.completion.postfix.title%",
           "markdownDescription": "%extension.tinymist.config.tinymist.completion.postfix.desc%",


### PR DESCRIPTION
The configuration `tinymist.completion.symbol` is to determine whether to make symbol completion stepless. For example, 
- `$ar|$` could be completed to `$arrow.r$`,
- `$arrow.tbsd|$` could be completed to `$arrow.t.b.stroked$`,
- and `$paseet|$` could be completed to `$parallel.slanted.eq.tilde$`.

This feature is disabled by default.