### PR TITLE
fix: cleanup CORS checks

### DIFF
--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -491,11 +491,9 @@ pub async fn make_http_server(
                 // `Origin` starting with `vscode-webview://` as well. I think that's okay from a security
                 // point of view, because I think malicious websites can't trick browsers into sending
                 // `vscode-webview://...` as `Origin`.
-                if req
-                    .headers()
-                    .get("Origin")
-                    .is_some_and(|h| *h != expected_origin)
-                {
+                if req.headers().get("Origin").is_some_and(|h| {
+                    *h != expected_origin && !h.as_bytes().starts_with(b"vscode-webview://")
+                }) {
                     anyhow::bail!(
                         "Connection with unexpected `Origin` header. Closing connection."
                     );


### PR DESCRIPTION
cc @Myriad-Dreamin I've tried to cleanup the code from https://github.com/Myriad-Dreamin/tinymist/pull/1295 . I don't think we need to allow `ws` and `wss`, so I removed that. Two questions:

- Do we need to support `https` here?
- In this version, I'm only allowing `localhost`/`127.0.0.1`. Was your idea to parse the `static_file_addr`, extract the host from that, and use that host to match against the `Origin` header?