### PR TITLE
fix: log error on channel closed

### DIFF
--- a/crates/typst-preview/src/actor/editor.rs
+++ b/crates/typst-preview/src/actor/editor.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use reflexo_typst::debug_loc::DocumentPosition;
 use serde::{Deserialize, Serialize};
+use tinymist_std::error::IgnoreLogging;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
@@ -206,15 +207,15 @@ impl<T: EditorServer> EditorActor<T> {
                     match msg {
                         ControlPlaneMessage::ChangeCursorPosition(cursor_info) => {
                             log::debug!("EditorActor: received message from editor: {:?}", cursor_info);
-                            self.renderer_sender.send(RenderActorRequest::ChangeCursorPosition(cursor_info)).unwrap();
+                            self.renderer_sender.send(RenderActorRequest::ChangeCursorPosition(cursor_info)).log_error("EditorActor");
                         }
                         ControlPlaneMessage::ResolveSourceLoc(jump_info) => {
                             log::debug!("EditorActor: received message from editor: {:?}", jump_info);
-                            self.renderer_sender.send(RenderActorRequest::ResolveSourceLoc(jump_info)).unwrap();
+                            self.renderer_sender.send(RenderActorRequest::ResolveSourceLoc(jump_info)).log_error("EditorActor");
                         }
                         ControlPlaneMessage::PanelScrollByPosition(jump_info) => {
                             log::debug!("EditorActor: received message from editor: {:?}", jump_info);
-                            self.webview_sender.send(WebviewActorRequest::ViewportPosition(jump_info.position)).unwrap();
+                            self.webview_sender.send(WebviewActorRequest::ViewportPosition(jump_info.position)).log_error("EditorActor");
                         }
                         ControlPlaneMessage::DocToSrcJumpResolve(jump_info) => {
                             log::debug!("EditorActor: received message from editor: {:?}", jump_info);
@@ -278,7 +279,7 @@ impl<T: EditorServer> EditorActor<T> {
                 .send(RenderActorRequest::EditorResolveSpanRange(
                     span_and_offset..span_and_offset,
                 ))
-                .unwrap();
+                .log_error("EditorActor");
         };
     }
 }

--- a/crates/typst-preview/src/actor/webview.rs
+++ b/crates/typst-preview/src/actor/webview.rs
@@ -1,5 +1,6 @@
 use futures::{SinkExt, StreamExt};
 use reflexo_typst::debug_loc::{DocumentPosition, ElementPoint};
+use tinymist_std::error::IgnoreLogging;
 use tokio::sync::{broadcast, mpsc};
 
 use crate::{
@@ -93,29 +94,29 @@ impl<
                         WebviewActorRequest::SrcToDocJump(jump_info) => {
                             let msg = positions_req("jump", jump_info);
                             self.webview_websocket_conn.send(Message::Binary(msg.into_bytes()))
-                            .await.unwrap();
+                              .await.log_error("WebViewActor");
                         }
                         WebviewActorRequest::ViewportPosition(jump_info) => {
                             let msg = position_req("viewport", jump_info);
                             self.webview_websocket_conn.send(Message::Binary(msg.into_bytes()))
-                            .await.unwrap();
+                              .await.log_error("WebViewActor");
                         }
                         // WebviewActorRequest::CursorPosition(jump_info) => {
                         //     let msg = position_req("cursor", jump_info);
-                        //     self.webview_websocket_conn.send(WsMessage::Binary(msg.into_bytes())).await.unwrap();
+                        //     self.webview_websocket_conn.send(WsMessage::Binary(msg.into_bytes())).await.log_error("WebViewActor");
                         // }
                         WebviewActorRequest::CursorPaths(jump_info) => {
                             let json = serde_json::to_string(&jump_info).unwrap();
                             let msg = format!("cursor-paths,{json}");
                             self.webview_websocket_conn.send(Message::Binary(msg.into_bytes()))
-                            .await.unwrap();
+                              .await.log_error("WebViewActor");
                         }
                     }
                 }
                 Some(svg) = self.svg_receiver.recv() => {
                     log::trace!("WebviewActor: received svg from renderer");
                     self.webview_websocket_conn.send(Message::Binary(svg))
-                    .await.unwrap();
+                    .await.log_error("WebViewActor");
                 }
                 Some(msg) = self.webview_websocket_conn.next() => {
                     log::trace!("WebviewActor: received message from websocket: {:?}", msg);
@@ -130,14 +131,14 @@ impl<
                         break;
                     };
                     if msg == "current" {
-                        self.render_sender.send(RenderActorRequest::RenderFullLatest).unwrap();
+                        self.render_sender.send(RenderActorRequest::RenderFullLatest).log_error("WebViewActor");
                     } else if msg.starts_with("srclocation") {
                         let location = msg.split(' ').nth(1).unwrap();
                         self.editor_sender.send(EditorActorRequest::DocToSrcJumpResolve(
                             DocToSrcJumpResolveRequest {
                                 span: location.trim().to_owned(),
                             },
-                        )).unwrap();
+                        )).log_error("WebViewActor");
                     } else if msg.starts_with("outline-sync") {
                         let location = msg.split(',').nth(1).unwrap();
                         let location = location.split(' ').collect::<Vec::<&str>>();
@@ -146,14 +147,14 @@ impl<
                         let y = location.get(2).map(|s| s.parse().unwrap()).unwrap_or(0.);
                         let pos = DocumentPosition { page_no, x, y };
 
-                        self.broadcast_sender.send(WebviewActorRequest::ViewportPosition(pos)).unwrap();
+                        self.broadcast_sender.send(WebviewActorRequest::ViewportPosition(pos)).log_error("WebViewActor");
                     } else if msg.starts_with("srcpath") {
                         let path = msg.split(' ').nth(1).unwrap();
                         let path = serde_json::from_str(path);
                         if let Ok(path) = path {
                             let path: Vec<(u32, u32, String)> = path;
                             let path = path.into_iter().map(ElementPoint::from).collect::<Vec<_>>();
-                            self.render_sender.send(RenderActorRequest::WebviewResolveSpan(ResolveSpanRequest(path))).unwrap();
+                            self.render_sender.send(RenderActorRequest::WebviewResolveSpan(ResolveSpanRequest(path))).log_error("WebViewActor");
                         };
                     } else {
                         let err = self.webview_websocket_conn.send(Message::Text(format!("error, received unknown message: {}", msg))).await;

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -8,6 +8,7 @@ pub use actor::editor::{
 };
 pub use args::*;
 pub use outline::Outline;
+use tinymist_std::error::IgnoreLogging;
 
 use std::{collections::HashMap, future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
@@ -101,14 +102,14 @@ impl Previewer {
                 if h.enable_partial_rendering {
                     conn.send(WsMessage::Binary("partial-rendering,true".into()))
                         .await
-                        .unwrap();
+                        .log_error("SendPartialRendering");
                 }
                 if !h.invert_colors.is_empty() {
                     conn.send(WsMessage::Binary(
                         format!("invert-colors,{}", h.invert_colors).into(),
                     ))
                     .await
-                    .unwrap();
+                    .log_error("SendInvertColor");
                 }
                 let actor::webview::Channels { svg } =
                     actor::webview::WebviewActor::<'_, C>::set_up_channels();


### PR DESCRIPTION
The broadcast channels can return error when the editor or the browser hasn't created connection with the preview server.