### PR TITLE
build: bump version to 0.12.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "crityp"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "sync-lsp"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-analysis"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "ecow",
  "insta",
@@ -4058,11 +4058,11 @@ checksum = "f73b4b64dfed7f28335992d79570ea1dd8828c921883284cf5d9f415f726986a"
 
 [[package]]
 name = "tinymist-assets"
-version = "0.12.22-rc1"
+version = "0.12.22"
 
 [[package]]
 name = "tinymist-core"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-derive"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-project"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "base64",
  "log",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-std"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-task"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-vfs"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "comemo",
  "ecow",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-world"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4555,7 +4555,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typlite"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "base64",
  "clap",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "typst-preview"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "clap",
  "comemo",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "typst-shim"
-version = "0.12.22-rc1"
+version = "0.12.22"
 dependencies = [
  "cfg-if",
  "comemo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.12.22-rc1"
+version = "0.12.22"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/crates/tinymist-core/package.json
+++ b/crates/tinymist-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tinymist-web",
-    "version": "0.12.22-rc1",
+    "version": "0.12.22",
     "description": "WASM module for running tinymist analyzers in JavaScript environment.",
     "author": "Myriad-Dreamin",
     "license": "Apache-2.0",

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 The changelog lines unspecified with authors are all written by the @Myriad-Dreamin.
 
-## v0.12.22 - [2025-02-21]
+## v0.12.22 - [2025-02-23]
 
 ### Preview
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymist",
-  "version": "0.12.22-rc1",
+  "version": "0.12.22",
   "description": "An integrated language service for Typst",
   "keywords": [
     "typst",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.12.22-rc1",
+  "version": "0.12.22",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.mjs",


### PR DESCRIPTION
Small note: v0.13+ use typst v0.13.0, while v0.12+ continue using typst v0.12.0. The v0.12+ will be maintainted until most people move to v0.13+ or it takes too much cost to backport patches.