### PR TITLE
build: bump version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "shlex",
 ]
@@ -2090,9 +2090,9 @@ checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"
@@ -2217,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2850,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -2881,8 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo"
-version = "0.5.5-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?rev=1adab6b0e3b19549def92842b340e3568d5a60ff#1adab6b0e3b19549def92842b340e3568d5a60ff"
+version = "0.5.5-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d731ce225d37fa4ffa46c7319ada98c417fabed570198af29920017ff10ddf"
 dependencies = [
  "base64",
  "bitvec",
@@ -2907,8 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst"
-version = "0.5.5-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?rev=1adab6b0e3b19549def92842b340e3568d5a60ff#1adab6b0e3b19549def92842b340e3568d5a60ff"
+version = "0.5.5-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6986017a82b2a9b4697da1c1c0058a15f220a2e2d25740b96292b4ae91780f"
 dependencies = [
  "codespan-reporting",
  "comemo",
@@ -2939,8 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst2vec"
-version = "0.5.5-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?rev=1adab6b0e3b19549def92842b340e3568d5a60ff#1adab6b0e3b19549def92842b340e3568d5a60ff"
+version = "0.5.5-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48042b09b41f2363825abc628524bb4ab6715b1ce7e6c0e427b775b400a98eb6"
 dependencies = [
  "bitvec",
  "comemo",
@@ -2965,8 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2svg"
-version = "0.5.5-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts/?rev=1adab6b0e3b19549def92842b340e3568d5a60ff#1adab6b0e3b19549def92842b340e3568d5a60ff"
+version = "0.5.5-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2091a02692c310f01fdef03fc677cdf0a68c824043f7e6306cf1288967650962"
 dependencies = [
  "base64",
  "comemo",
@@ -3087,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3562,9 +3566,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d08feb8f695b465baed819b03c128dc23f57a694510ab1f06c77f763975685e"
+checksum = "d9156ebd5870ef293bfb43f91c7a74528d363ec0d424afe24160ed5a4343d08a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3753,9 +3757,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "crityp"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "sync-lsp"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-analysis"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "ecow",
  "insta",
@@ -4024,11 +4024,11 @@ checksum = "f73b4b64dfed7f28335992d79570ea1dd8828c921883284cf5d9f415f726986a"
 
 [[package]]
 name = "tinymist-assets"
-version = "0.13.0-rc1"
+version = "0.13.0"
 
 [[package]]
 name = "tinymist-core"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-derive"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-project"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "log",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-std"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-task"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-vfs"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "comemo",
  "ecow",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-world"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4522,7 +4522,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typlite"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "clap",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "typst-preview"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "clap",
  "comemo",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "typst-shim"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "cfg-if",
  "comemo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,8 +4920,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle-core"
-version = "0.12.15"
-source = "git+https://github.com/ParaN3xus/typstyle/?tag=tinymist-nightly-v0.12.21-rc1#37529defcada013bb4c8342c70968daff8097f24"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdff2f2401154ace9f096686e15bcae7a3c242e3e0af552932b1910004995384"
 dependencies = [
  "ecow",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "An integrated language service for Typst."
 authors = ["Myriad-Dreamin <camiyoru@gmail.com>", "Nathan Varner"]
-version = "0.13.0-rc1"
+version = "0.13.0"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -173,20 +173,20 @@ insta = { version = "1.39", features = ["glob"] }
 
 
 # Our Own Crates
-typst-preview = { path = "./crates/typst-preview", version = "0.13.0-rc1" }
-typst-shim = { path = "./crates/typst-shim", version = "0.13.0-rc1" }
+typst-preview = { path = "./crates/typst-preview", version = "0.13.0" }
+typst-shim = { path = "./crates/typst-shim", version = "0.13.0" }
 tinymist-assets = { version = "=0.12.20" }
-tinymist = { path = "./crates/tinymist/", version = "0.13.0-rc1" }
-tinymist-std = { path = "./crates/tinymist-std/", version = "0.13.0-rc1", default-features = false }
-tinymist-vfs = { path = "./crates/tinymist-vfs/", version = "0.13.0-rc1", default-features = false }
-tinymist-core = { path = "./crates/tinymist-core/", version = "0.13.0-rc1", default-features = false }
-tinymist-world = { path = "./crates/tinymist-world/", version = "0.13.0-rc1", default-features = false }
-tinymist-project = { path = "./crates/tinymist-project/", version = "0.13.0-rc1" }
-tinymist-task = { path = "./crates/tinymist-task/", version = "0.13.0-rc1" }
-tinymist-derive = { path = "./crates/tinymist-derive/", version = "0.13.0-rc1" }
-tinymist-analysis = { path = "./crates/tinymist-analysis/", version = "0.13.0-rc1" }
-tinymist-query = { path = "./crates/tinymist-query/", version = "0.13.0-rc1" }
-tinymist-render = { path = "./crates/tinymist-render/", version = "0.13.0-rc1" }
+tinymist = { path = "./crates/tinymist/", version = "0.13.0" }
+tinymist-std = { path = "./crates/tinymist-std/", version = "0.13.0", default-features = false }
+tinymist-vfs = { path = "./crates/tinymist-vfs/", version = "0.13.0", default-features = false }
+tinymist-core = { path = "./crates/tinymist-core/", version = "0.13.0", default-features = false }
+tinymist-world = { path = "./crates/tinymist-world/", version = "0.13.0", default-features = false }
+tinymist-project = { path = "./crates/tinymist-project/", version = "0.13.0" }
+tinymist-task = { path = "./crates/tinymist-task/", version = "0.13.0" }
+tinymist-derive = { path = "./crates/tinymist-derive/", version = "0.13.0" }
+tinymist-analysis = { path = "./crates/tinymist-analysis/", version = "0.13.0" }
+tinymist-query = { path = "./crates/tinymist-query/", version = "0.13.0" }
+tinymist-render = { path = "./crates/tinymist-render/", version = "0.13.0" }
 
 [profile.dev.package.insta]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ typst-eval = "0.13.0"
 typst-assets = "0.13.0"
 typstfmt = { git = "https://github.com/Myriad-Dreamin/typstfmt", tag = "v0.12.1" }
 typst-ansi-hl = "0.3.0"
-typstyle-core = { version = "=0.12.15", default-features = false }
+typstyle-core = { version = "=0.13.0", default-features = false }
 typlite = { path = "./crates/typlite" }
 
 # LSP
@@ -281,7 +281,7 @@ typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinym
 # reflexo = { path = "../typst.ts/crates/reflexo/" }
 # reflexo-typst = { path = "../typst.ts/crates/reflexo-typst/" }
 # reflexo-vec2svg = { path = "../typst.ts/crates/conversion/vec2svg/" }
-typstyle-core = { git = "https://github.com/ParaN3xus/typstyle/", tag = "tinymist-nightly-v0.12.21-rc1" }
+# typstyle-core = { git = "https://github.com/ParaN3xus/typstyle/", tag = "tinymist-nightly-v0.12.21-rc1" }
 
 typst-shim = { path = "crates/typst-shim" }
 tinymist-analysis = { path = "crates/tinymist-analysis" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,11 +125,11 @@ env_logger = "0.11.3"
 log = "0.4"
 
 # Typst
-reflexo = { version = "=0.5.5-rc5", default-features = false, features = [
+reflexo = { version = "=0.5.5-rc6", default-features = false, features = [
     "flat-vector",
 ] }
-reflexo-typst = { version = "=0.5.5-rc5", default-features = false }
-reflexo-vec2svg = { version = "=0.5.5-rc5" }
+reflexo-typst = { version = "=0.5.5-rc6", default-features = false }
+reflexo-vec2svg = { version = "=0.5.5-rc6" }
 
 typst = "0.13.0"
 typst-html = "0.13.0"
@@ -273,9 +273,9 @@ typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinym
 # These patches use a different version of `reflexo`.
 #
 # A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
-reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
-reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
-reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
+# reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
+# reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
+# reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "1adab6b0e3b19549def92842b340e3568d5a60ff" }
 
 # These patches use local `reflexo` for development.
 # reflexo = { path = "../typst.ts/crates/reflexo/" }
@@ -283,16 +283,6 @@ reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts/", rev = "
 # reflexo-vec2svg = { path = "../typst.ts/crates/conversion/vec2svg/" }
 typstyle-core = { git = "https://github.com/ParaN3xus/typstyle/", tag = "tinymist-nightly-v0.12.21-rc1" }
 
-# typst-shim = { path = "crates/typst-shim" }
-# tinymist-analysis = { path = "crates/tinymist-analysis" }
-# tinymist-std = { path = "crates/tinymist-std" }
-# tinymist-vfs = { path = "crates/tinymist-vfs" }
-# tinymist-world = { path = "crates/tinymist-world" }
-# tinymist-project = { path = "crates/tinymist-project" }
-# tinymist-task = { path = "crates/tinymist-task" }
-
-# If reflexo use the tinymist from git, you should use the following patch.
-[patch."https://github.com/Myriad-Dreamin/tinymist.git"]
 typst-shim = { path = "crates/typst-shim" }
 tinymist-analysis = { path = "crates/tinymist-analysis" }
 tinymist-std = { path = "crates/tinymist-std" }
@@ -300,3 +290,13 @@ tinymist-vfs = { path = "crates/tinymist-vfs" }
 tinymist-world = { path = "crates/tinymist-world" }
 tinymist-project = { path = "crates/tinymist-project" }
 tinymist-task = { path = "crates/tinymist-task" }
+
+# If reflexo use the tinymist from git, you should use the following patch.
+# [patch."https://github.com/Myriad-Dreamin/tinymist.git"]
+# typst-shim = { path = "crates/typst-shim" }
+# tinymist-analysis = { path = "crates/tinymist-analysis" }
+# tinymist-std = { path = "crates/tinymist-std" }
+# tinymist-vfs = { path = "crates/tinymist-vfs" }
+# tinymist-world = { path = "crates/tinymist-world" }
+# tinymist-project = { path = "crates/tinymist-project" }
+# tinymist-task = { path = "crates/tinymist-task" }

--- a/crates/tinymist-core/package.json
+++ b/crates/tinymist-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymist-web",
-  "version": "0.13.0-rc1",
+  "version": "0.13.0",
   "description": "WASM module for running tinymist analyzers in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -30,6 +30,8 @@ The changelog lines unspecified with authors are all written by the @Myriad-Drea
 ### Compiler
 
 * (Fix) Removing diagnostics when removing a project in https://github.com/Myriad-Dreamin/tinymist/pull/1372
+* (Fix) Applying memory changes to dedicate instances in https://github.com/Myriad-Dreamin/tinymist/pull/1371
+  * This fixes the issue that the second preview tab is updated.
 
 ### Preview
 
@@ -39,8 +41,6 @@ The changelog lines unspecified with authors are all written by the @Myriad-Drea
 * (Fix) Fixed broken regular preview affected by the browsing preview feature in https://github.com/Myriad-Dreamin/tinymist/pull/1357 and https://github.com/Myriad-Dreamin/tinymist/pull/1358
 * (Fix) Sharing preview handler among states in https://github.com/Myriad-Dreamin/tinymist/pull/1370
   * This fixes the issue that a user can't open multiple preview tabs at the same time.
-* (Fix) Applying memory changes to dedicate instances in https://github.com/Myriad-Dreamin/tinymist/pull/1371
-  * This fixes the issue that the second preview tab is updated.
 
 **Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.12.20...v0.12.22
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymist",
-  "version": "0.13.0-rc1",
+  "version": "0.13.0",
   "description": "An integrated language service for Typst",
   "keywords": [
     "typst",

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typst-textmate",
-  "version": "0.13.0-rc1",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "compile": "npx tsc && node ./dist/main.mjs",


### PR DESCRIPTION
Small note: v0.13+ use typst v0.13.0, while v0.12+ continue using typst v0.12.0. The v0.12+ will be maintainted until most people move to v0.13+ or it takes too much cost to backport patches.