### PR TITLE
feat: print type representation of anonymous modules

### DIFF
--- a/crates/tinymist-query/src/ty/describe.rs
+++ b/crates/tinymist-query/src/ty/describe.rs
@@ -1,5 +1,6 @@
 use ecow::{eco_format, EcoString};
 use tinymist_std::hash::hash128;
+use tinymist_world::vfs::WorkspaceResolver;
 use typst::foundations::Repr;
 
 use crate::{
@@ -196,7 +197,13 @@ impl TypeDescriber {
                 let Value::Module(m) = &v.val else {
                     return "module".into();
                 };
-                return eco_format!("module({})", m.name().unwrap());
+
+                return match (m.name(), m.file_id()) {
+                    (Some(name), ..) => eco_format!("module({name:?})"),
+                    (None, file_id) => {
+                        eco_format!("module({:?})", WorkspaceResolver::display(file_id))
+                    }
+                };
             }
             Ty::Value(v) if !is_plain_value(&v.val) => return self.describe(&term_value(&v.val)),
             Ty::Value(v) if self.value => return truncated_repr_::<181>(&v.val),

--- a/crates/tinymist-vfs/src/path_mapper.rs
+++ b/crates/tinymist-vfs/src/path_mapper.rs
@@ -262,7 +262,7 @@ impl fmt::Debug for Resolving {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use WorkspaceResolution::*;
         let Some(id) = self.id else {
-            return write!(f, "None");
+            return write!(f, "unresolved-path");
         };
 
         let path = match WorkspaceResolver::resolve(id) {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -374,7 +374,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:4eac03a63490eece9188d477f427de10");
+        insta::assert_snapshot!(hash, @"siphash128_13:58f4fd36e0995aab72b742c72a0e8e26");
     }
 
     {
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:5b6780811ad069bada68fe0b170867e8");
+        insta::assert_snapshot!(hash, @"siphash128_13:c55a687e43434c943b248b8b04d928d2");
     }
 }
 


### PR DESCRIPTION
typst v0.13.0 can have module objects that don't have a name or even a file path:
- plugins are modules now.
- in future, there might be some in-place created modules `let m = module { let x = 1 }`.