### PR TITLE
feat: let `tinymist::Config` pull environment variables on start of server

### DIFF
--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -91,9 +91,7 @@ impl Initializer for RegularInit {
             ConstConfig::from(&params),
             roots,
             std::mem::take(&mut self.font_opts),
-        )
-        .log_error("cannot assign Config defaults")
-        .unwrap_or_default();
+        );
 
         let err = params.initialization_options.and_then(|init| {
             config
@@ -324,7 +322,7 @@ impl Config {
         const_config: ConstConfig,
         roots: Vec<ImmutPath>,
         font_opts: CompileFontArgs,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let mut config = Self {
             const_config,
             compile: CompileConfig {
@@ -337,8 +335,10 @@ impl Config {
             },
             ..Self::default()
         };
-        config.update_by_map(&Map::default())?;
-        Ok(config)
+        config
+            .update_by_map(&Map::default())
+            .log_error("failed to assign Config defaults");
+        config
     }
 
     /// Gets items for serialization.

--- a/crates/tinymist/src/init.rs
+++ b/crates/tinymist/src/init.rs
@@ -291,9 +291,11 @@ const CONFIG_ITEMS: &[&str] = &[
 ];
 // endregion Configuration Items
 
-// todo: Config::default() doesn't initialize arguments from environment
-// variables
 /// The user configuration read from the editor.
+///
+/// Note: `Config::default` is intentionally to be "pure" and not to be
+/// affected by system environment variables.
+/// To get the configuration with system defaults, use [`Config::new`] intead.
 #[derive(Debug, Default, Clone)]
 pub struct Config {
     /// The resolution kind of the project.
@@ -320,6 +322,13 @@ pub struct Config {
 }
 
 impl Config {
+    /// Creates a new configuration with system defaults.
+    pub fn new() -> anyhow::Result<Self> {
+        let mut config = Self::default();
+        config.update_by_map(&Map::default())?;
+        Ok(config)
+    }
+
     /// Gets items for serialization.
     pub fn get_items() -> Vec<ConfigurationItem> {
         let sections = CONFIG_ITEMS


### PR DESCRIPTION
Use `Config::new` instead of `Config::default` to create a config on start of server.

> Note: `Config::default` is intentionally to be "pure" and not to be affected by system environment variables. To get the configuration with system defaults, use [`Config::new`] intead.