### PR TITLE
fix: use new wasm renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,7 @@ dependencies = [
  "strum",
  "sync-lsp",
  "temp-env",
- "tinymist-assets 0.12.20",
+ "tinymist-assets 0.13.0-rc1",
  "tinymist-core",
  "tinymist-project",
  "tinymist-query",
@@ -4032,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-assets"
-version = "0.12.20"
+version = "0.13.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73b4b64dfed7f28335992d79570ea1dd8828c921883284cf5d9f415f726986a"
+checksum = "c9071f17040942a67fffc0540761928c6e8947807e51c485d345486782d559f1"
 
 [[package]]
 name = "tinymist-assets"
@@ -4769,7 +4769,7 @@ dependencies = [
  "reflexo-vec2svg",
  "serde",
  "serde_json",
- "tinymist-assets 0.12.20",
+ "tinymist-assets 0.13.0-rc1",
  "tinymist-std",
  "tokio",
  "typst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ insta = { version = "1.39", features = ["glob"] }
 # Our Own Crates
 typst-preview = { path = "./crates/typst-preview", version = "0.13.0" }
 typst-shim = { path = "./crates/typst-shim", version = "0.13.0" }
-tinymist-assets = { version = "=0.12.20" }
+tinymist-assets = { version = "=0.13.0-rc1" }
 tinymist = { path = "./crates/tinymist/", version = "0.13.0" }
 tinymist-std = { path = "./crates/tinymist-std/", version = "0.13.0", default-features = false }
 tinymist-vfs = { path = "./crates/tinymist-vfs/", version = "0.13.0", default-features = false }

--- a/editors/vscode/Configuration.md
+++ b/editors/vscode/Configuration.md
@@ -52,7 +52,7 @@ Whether to configure default word separators on startup
 - **Enum**:
   - `enable`: Override the default word separators on startup
   - `disable`: Do not override the default word separators on startup
-- **Default**: `"enable"`
+- **Default**: `"disable"`
 
 ## `tinymist.semanticTokens`
 

--- a/tools/typst-dom/package.json
+++ b/tools/typst-dom/package.json
@@ -13,12 +13,12 @@
     "unlink:local": "yarn unlink @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.5.4",
-    "@myriaddreamin/typst.ts": "=0.5.4"
+    "@myriaddreamin/typst-ts-renderer": "=0.5.5-rc6",
+    "@myriaddreamin/typst.ts": "=0.5.5-rc6"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.5.4",
-    "@myriaddreamin/typst.ts": "=0.5.4",
+    "@myriaddreamin/typst-ts-renderer": "=0.5.5-rc6",
+    "@myriaddreamin/typst.ts": "=0.5.5-rc6",
     "typescript": "^5.0.2"
   },
   "exports": {

--- a/tools/typst-preview-frontend/package.json
+++ b/tools/typst-preview-frontend/package.json
@@ -13,8 +13,8 @@
     "unlink:local": "yarn unlink @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.5.4",
-    "@myriaddreamin/typst.ts": "=0.5.4",
+    "@myriaddreamin/typst-ts-renderer": "=0.5.5-rc6",
+    "@myriaddreamin/typst.ts": "=0.5.5-rc6",
     "typst-dom": "link:../typst-dom",
     "rxjs": "^7.8.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,15 +363,15 @@
   resolved "https://registry.yarnpkg.com/@jspm/core/-/core-2.1.0.tgz#ee21ff64591d68de98b79ca8e4bd6c5249fded53"
   integrity sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==
 
-"@myriaddreamin/typst-ts-renderer@=0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.5.4.tgz#2fdaeb158015511007956fc3530ff76fb23ca052"
-  integrity sha512-Z3wvSv78kWgUdr23EXGXvqa/QeRnPjkmLkpu6Ne8pDWPWjHHL1j+Wy7cTdZos6bhAUQGMkdFbO+ZhHoBepTgcw==
+"@myriaddreamin/typst-ts-renderer@=0.5.5-rc6":
+  version "0.5.5-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.5.5-rc6.tgz#79669e7c4872fb0942cc766d7c16cd1e0c92771e"
+  integrity sha512-AQ7DVHsoZtjQo+xmGPhAMYlEqHo598iokHGRXJHUUXMmkBUuvEhT+dK9VtOOrrQPoqQasodevrkARc1NqWaIsg==
 
-"@myriaddreamin/typst.ts@=0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.5.4.tgz#700cd4e1144119d520484de77f21bed6ceee03d5"
-  integrity sha512-Zn+dwiN+UuhFkl+9vO44fxj1QwHk4yunDrvY48iG3V3pIQsfNVySVOE8wjMSVAh496Mo63BFSIqzZRQj2ShS8g==
+"@myriaddreamin/typst.ts@=0.5.5-rc6":
+  version "0.5.5-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.5.5-rc6.tgz#38cc9077844fadc85204c043f691609a4c83de7f"
+  integrity sha512-KFXvdrDmLvzKJxl7u9+Alzd99ZS1stsg2O19VP5qxalWKgL9y0pf6eHvxXpHx8L435qtWfmk0XpHntt+KGpObA==
   dependencies:
     idb "^7.1.1"
 


### PR DESCRIPTION
The repr of `VecItem` in the backend (compiler, v0.5.5) is imcompatible that in the frontend (renderer, v0.5.4).