### PR TITLE
fix: complete type of type having constructors

### DIFF
--- a/crates/tinymist-query/src/analysis/completion/type.rs
+++ b/crates/tinymist-query/src/analysis/completion/type.rs
@@ -300,12 +300,21 @@ impl TypeCompletionWorker<'_, '_, '_, '_> {
                         "(${params}) => ${output}",
                         "A custom function.",
                     );
+                } else if let Ok(cons) = ty.constructor() {
+                    let docs = docs.or(cons.docs()).unwrap_or(ty.docs());
+                    self.base.value_completion(
+                        Some(ty.short_name().into()),
+                        &Value::Func(cons),
+                        true,
+                        Some(docs),
+                    );
                 } else {
+                    let docs = docs.unwrap_or(ty.docs());
                     self.base.push_completion(Completion {
                         kind: CompletionKind::Syntax,
                         label: ty.short_name().into(),
                         apply: Some(eco_format!("${{{ty}}}")),
-                        detail: Some(eco_format!("A value of type {ty}.")),
+                        detail: Some(docs.into()),
                         ..Completion::default()
                     });
                 }

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-current-heading.typ-2.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-current-heading.typ-2.snap
@@ -9,11 +9,11 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-current-headin
   "isIncomplete": false,
   "items": [
    {
-    "kind": 15,
+    "kind": 3,
     "label": "int",
     "sortText": "001",
     "textEdit": {
-     "newText": "${1:integer}",
+     "newText": "int(${1:})",
      "range": {
       "end": {
        "character": 24,

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-markup-text.typ.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-markup-text.typ.snap
@@ -45,11 +45,11 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-markup-text.ty
     }
    },
    {
-    "kind": 15,
+    "kind": 3,
     "label": "str",
     "sortText": "002",
     "textEdit": {
-     "newText": "${1:string}",
+     "newText": "str(${1:})",
      "range": {
       "end": {
        "character": 19,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -385,7 +385,7 @@ fn e2e() {
         });
 
         let hash = replay_log(&tinymist_binary, &root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:f3c3792e0e3a79652689fa02e0c33515");
+        insta::assert_snapshot!(hash, @"siphash128_13:e5477864b705e9810077be3560c3049b");
     }
 }
 


### PR DESCRIPTION
completes `regex` to `regex(${1})` instead of `${1:regex}`