### PR TITLE
feat: add command to profile the entire server

### DIFF
--- a/crates/tinymist-std/src/error.rs
+++ b/crates/tinymist-std/src/error.rs
@@ -281,6 +281,22 @@ impl<T, E: std::fmt::Display> IgnoreLogging<T> for Result<T, E> {
     }
 }
 
+impl<T> IgnoreLogging<T> for Option<T> {
+    fn log_error(self, msg: &str) -> Option<T> {
+        self.or_else(|| {
+            log::error!("{msg}");
+            None
+        })
+    }
+
+    fn log_error_with(self, f: impl FnOnce() -> String) -> Option<T> {
+        self.or_else(|| {
+            log::error!("{}", f());
+            None
+        })
+    }
+}
+
 /// A trait to add context to a result.
 pub trait WithContext<T>: Sized {
     /// Add a context to the result.

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -16,7 +16,7 @@ use crate::actor::editor::{EditorActor, EditorRequest};
 use crate::lsp_query::OnEnter;
 use crate::project::{update_lock, LspInterrupt, ProjectState, PROJECT_ROUTE_USER_ACTION_PRIORITY};
 use crate::route::ProjectRouteState;
-use crate::task::{ExportTask, FormatTask, UserActionTask};
+use crate::task::{ExportTask, FormatTask, ServerTraceTask, UserActionTask};
 use crate::world::TaskInputs;
 use crate::{init::*, *};
 
@@ -73,6 +73,8 @@ pub struct ServerState {
     pub ever_focusing_by_activities: bool,
     /// The client ever sent manual focusing request.
     pub ever_manual_focusing: bool,
+    /// The running server trace.
+    pub server_trace: Option<ServerTraceTask>,
 
     // Configurations
     /// User configuration from the editor.
@@ -115,6 +117,7 @@ impl ServerState {
             ever_manual_focusing: false,
             sema_tokens_registered: false,
             formatter_registered: false,
+            server_trace: None,
             config,
 
             pinning_by_user: false,
@@ -255,6 +258,8 @@ impl ServerState {
             .with_command("tinymist.doGetTemplateEntry", State::get_template_entry)
             .with_command_("tinymist.interactCodeContext", State::interact_code_context)
             .with_command("tinymist.getDocumentTrace", State::get_document_trace)
+            .with_command("tinymist.startServerProfiling", State::start_server_trace)
+            .with_command("tinymist.stopServerProfiling", State::stop_server_trace)
             .with_command_("tinymist.getDocumentMetrics", State::get_document_metrics)
             .with_command_("tinymist.getWorkspaceLabels", State::get_workspace_labels)
             .with_command_("tinymist.getServerInfo", State::get_server_info)

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1037,6 +1037,11 @@
         "category": "Typst"
       },
       {
+        "command": "tinymist.profileServer",
+        "title": "Profile the entire language server",
+        "category": "Typst"
+      },
+      {
         "command": "tinymist.syncLabel",
         "title": "Scan workspace and collect all labels again",
         "icon": "$(extensions-sync-enabled)",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -561,7 +561,8 @@ async function commandRunCodeLens(...args: string[]): Promise<void> {
     const kBrowsing = "Browsing Preview Documents" as const;
     const kPreviewIn = "Preview in .." as const;
     const kExportAs = "Export as .." as const;
-    const moreCodeLens = [kBrowsing, kPreviewIn, kExportAs] as const;
+    const kProfileServer = "Profile Server" as const;
+    const moreCodeLens = [kBrowsing, kPreviewIn, kExportAs, kProfileServer] as const;
 
     const moreAction = (await vscode.window.showQuickPick(moreCodeLens, {
       title: "More Actions",
@@ -630,6 +631,10 @@ async function commandRunCodeLens(...args: string[]): Promise<void> {
             return;
         }
 
+        return;
+      }
+      case kProfileServer: {
+        void vscode.commands.executeCommand(`tinymist.profileServer`);
         return;
       }
     }


### PR DESCRIPTION
1. [x] Starts the profiling by invoking the command or click the codelens.
1. [ ] Stops the profiling by a button in the panel.
1. [ ] Stops the timings after cliclking the button.
1. [ ] Http server to receive data.
1. [ ] Kill the trace task if it uses too much memory.