### PR TITLE
feat: add profile-server prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "typst"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "comemo",
  "ecow",
@@ -4593,7 +4593,7 @@ checksum = "1051c56bbbf74d31ea6c6b1661e62fa0ebb8104403ee53f6dcd321600426e0b6"
 [[package]]
 name = "typst-eval"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "comemo",
  "ecow",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "typst-html"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "comemo",
  "ecow",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "typst-layout"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "az",
  "bumpalo",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "typst-library"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "az",
  "bitflags 2.8.0",
@@ -4718,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "typst-macros"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "typst-pdf"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "arrayvec 0.7.6",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "typst-realize"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "arrayvec 0.7.6",
  "bumpalo",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "typst-render"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "bytemuck",
  "comemo",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "typst-svg"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "base64",
  "comemo",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "typst-syntax"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "ecow",
  "serde",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "typst-timing"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "parking_lot",
  "serde",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "typst-utils"
 version = "0.13.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.2#c5347fc5772c436dfb5dc3e43fa3fa088ac54f8e"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?branch=tinymist-v0.13.0#6e64292a272279bfa87238225703ce0a01d81b52"
 dependencies = [
  "once_cell",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,14 +256,24 @@ extend-exclude = ["/.git", "fixtures"]
 # These patches use a different version of `typst`, which only exports some private functions and information for code analysis.
 #
 # A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
-typst = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
-typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+# typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.2" }
+
+
+typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
+typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "tinymist-v0.13.0" }
 
 # These patches use local `typst` for development.
 # typst = { path = "../typst/crates/typst" }

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -580,7 +580,7 @@ impl ServerState {
             return Err(internal_error("server trace is not started or stopped"));
         };
 
-        if task.stop_tx.send(()).is_err() {
+        if task.stop_tx.send(true).is_err() {
             return Err(internal_error("cannot send stop signal to server trace"));
         }
 

--- a/editors/vscode/src/features/tool.ts
+++ b/editors/vscode/src/features/tool.ts
@@ -108,6 +108,102 @@ export async function editorTool(context: ExtensionContext, tool: EditorToolName
   await editorToolAt(context, tool, panel, opts);
 }
 
+
+// Add this function outside the switch statement but within scope
+function openPerfettoViewer(traceData) {
+  // Create a webview panel for Perfetto
+  const perfettoPanel = vscode.window.createWebviewPanel(
+    'perfettoViewer',
+    'Perfetto Trace Viewer',
+    vscode.ViewColumn.Beside, // Open beside current editor
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  );
+  
+  perfettoPanel.webview.html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Perfetto Trace Viewer</title>
+      <style>
+        body, html {
+          margin: 0;
+          padding: 0;
+          height: 100vh;
+          overflow: hidden;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        #message {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          padding: 20px;
+          background: rgba(255, 255, 255, 0.9);
+          z-index: 100;
+          border-radius: 8px;
+          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+          text-align: center;
+        }
+        iframe {
+          width: 100%;
+          height: 100%;
+          border: none;
+        }
+      </style>
+    </head>
+    <body>
+      <div id="message">Connecting to Perfetto UI...</div>
+      <iframe id="perfetto" src="https://ui.perfetto.dev" style="display: block;"></iframe>
+      
+      <script>
+        const vscode = acquireVsCodeApi();
+        const perfettoFrame = document.getElementById('perfetto');
+        const messageEl = document.getElementById('message');
+        const ORIGIN = "https://ui.perfetto.dev";
+        
+        // Create text encoder for binary data
+        const enc = new TextEncoder();
+        
+        // Convert trace data to ArrayBuffer
+        const traceData = ${JSON.stringify(traceData)};
+        const tracingContent = enc.encode(JSON.stringify(traceData)).buffer;
+        
+        // Ping Perfetto UI until it responds
+        const timer = setInterval(() => {
+          perfettoFrame.contentWindow.postMessage("PING", ORIGIN);
+        }, 50);
+        
+        // Listen for response from Perfetto UI
+        window.addEventListener("message", function onMessage(evt) {
+          if (evt.data !== "PONG") return;
+          
+          // We got a PONG, the UI is ready
+          clearInterval(timer);
+          window.removeEventListener("message", onMessage);
+          
+          messageEl.textContent = "Loading trace data...";
+          
+          // Send the trace data to Perfetto UI
+          perfettoFrame.contentWindow.postMessage({
+            perfetto: {
+              buffer: tracingContent,
+              title: "VSCode Extension Trace",
+            }
+          }, ORIGIN);
+          
+          // Hide the message after a short delay
+          setTimeout(() => {
+            messageEl.style.display = 'none';
+          }, 1000);
+        });
+      </script>
+    </body>
+    </html>`;
+}
+
 export async function editorToolAt(
   context: ExtensionContext,
   tool: EditorToolName,
@@ -280,9 +376,59 @@ export async function editorToolAt(
         break;
       }
       case "stopServerProfiling": {
-        const resp = await vscode.commands.executeCommand("tinymist.stopServerProfiling");
-        if (!disposed) {
-          panel.webview.postMessage({ type: "didStopServerProfiling", data: resp });
+        console.log("Stopping server profiling...");
+        const resp = await vscode.commands.executeCommand("tinymist.stopServerProfiling") as { tracingUrl?: string };
+        // url is sent to stopServerProfiling directly
+
+        // Check if tracingUrl exists in the response
+        if (resp && resp.tracingUrl) {
+          const serverUrl = resp.tracingUrl;
+          console.log(`Fetching trace data from: ${serverUrl}`);
+          
+          async function fetchTraceData(serverUrl: string) {
+            try {
+              const response = await fetch(serverUrl, {
+                method: 'GET',
+                headers: {
+                  'Origin': 'vscode-webview://' + panel.webview.cspSource.slice(13),
+                },
+              });
+        
+              if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+              }
+        
+              return await response.json(); // Parse as JSON
+            } catch (error) {
+              console.error('Error fetching trace data:', error);
+              return null;
+            }
+          }
+          
+          const traceData = await fetchTraceData(serverUrl);
+          
+          if (traceData) {
+            console.log('Trace data received successfully');
+            // Open a new window with Perfetto viewer immediately
+            // Log only a preview of the trace data (first 20 entries if it's an array)
+            if (Array.isArray(traceData)) {
+              console.log('Trace data preview (first 20 entries):', 
+                traceData.slice(0, 20));
+              console.log(`Total entries: ${traceData.length}`);
+            } else {
+              console.log('Trace data type:', typeof traceData);
+            }
+            openPerfettoViewer(traceData);
+            if (!disposed) {
+              panel.webview.postMessage({ type: "didStopServerProfiling", data: traceData });
+            }
+          } else {
+            console.log('No trace data received.');
+            vscode.window.showErrorMessage("Failed to load trace data");
+          }
+        } else {
+          console.log("No tracingUrl found in response.");
+          vscode.window.showErrorMessage("No tracing URL available");
         }
         break;
       }
@@ -341,11 +487,27 @@ export async function editorToolAt(
 
       // do that after the html is reloaded
       afterReloadHtml = async () => {
-        const resp = await profileTask;
+        const resp = await profileTask as { tracingUrl?: string };
         if (!disposed) {
           panel.webview.postMessage({ type: "didStartServerProfiling", data: resp });
+          // print the response
+          console.log("Here is the response of startServerProfiling: ", resp);
+          // resp is not used
         }
       };
+
+      // Add a button to the HTML to stop server profiling
+      html = html.replace(
+        "</body>", // good place to insert
+        `<button id="stop-profiling-button">Stop Server Profiling</button>
+         <script>
+           const vscode = acquireVsCodeApi();
+           document.getElementById('stop-profiling-button').addEventListener('click', () => {
+             vscode.postMessage({ type: 'stopServerProfiling' });
+           });
+         </script>
+         </body>`
+      );
 
       break;
     }


### PR DESCRIPTION
Add profile-server prototype. 
- Requires Myriad-Dreamin/typst#4
- The UI is temporary and only intended for testing purposes.
- Source code information in tracing data is not resolved correctly.
- Different compilation actions cannot be distinguished for now.
