### PR TITLE
fix: combine VS Code language specific default settings into one block

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -686,13 +686,7 @@
       }
     },
     "configurationDefaults": {
-      "[typst]": {
-        "editor.wordWrap": "on",
-        "editor.semanticHighlighting.enabled": true,
-        "editor.tabSize": 2,
-        "editor.inlayHints.enabled": "off"
-      },
-      "[typst-code]": {
+      "[typst][typst-code]": {
         "editor.wordWrap": "on",
         "editor.semanticHighlighting.enabled": true,
         "editor.tabSize": 2,


### PR DESCRIPTION
This works around VS Code's undocumented behavior which is described in https://github.com/microsoft/vscode-docs/issues/7773 that language specific settings for a single language take precedence over language specific settings set for multiple languages the same time. Before this change, if a user wanted to overwrite the defaults, they would have to set it for each language individually.

After this change, users can overwrite `configurationDefaults` whether or not they chose to specify them for one language or multiple languages at the same time. Fixes #1460.