### PR TITLE
feat: unify and improve method completion

### DIFF
--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -49,6 +49,7 @@ use crate::upstream::{plain_docs_sentence, summarize_font_family};
 use super::SharedContext;
 
 mod field_access;
+mod func;
 mod import;
 mod kind;
 mod mode;

--- a/crates/tinymist-query/src/analysis/completion/field_access.rs
+++ b/crates/tinymist-query/src/analysis/completion/field_access.rs
@@ -1,5 +1,7 @@
 //! Completion for field access on nodes.
 
+use crate::analysis::completion::typst_specific::ValueCompletionInfo;
+
 use super::*;
 impl CompletionPair<'_, '_, '_> {
     /// Add completions for all fields on a node.
@@ -43,7 +45,16 @@ impl CompletionPair<'_, '_, '_> {
 
         if let Some(scope) = value.scope() {
             for (name, bind) in scope.iter() {
-                self.value_completion(Some(name.clone()), bind.read(), true, None);
+                self.value_completion_(
+                    bind.read(),
+                    ValueCompletionInfo {
+                        label: Some(name.clone()),
+                        parens: true,
+                        docs: None,
+                        label_details: None,
+                        bound_self: true,
+                    },
+                );
             }
         }
 
@@ -53,11 +64,15 @@ impl CompletionPair<'_, '_, '_> {
             // with method syntax;
             // 2. We can unwrap the field's value since it's a field belonging to
             // this value's type, so accessing it should not fail.
-            self.value_completion(
-                Some(field.into()),
+            self.value_completion_(
                 &value.field(field, ()).unwrap(),
-                false,
-                None,
+                ValueCompletionInfo {
+                    label: Some(field.into()),
+                    parens: false,
+                    docs: None,
+                    label_details: None,
+                    bound_self: true,
+                },
             );
         }
 

--- a/crates/tinymist-query/src/analysis/completion/func.rs
+++ b/crates/tinymist-query/src/analysis/completion/func.rs
@@ -1,0 +1,87 @@
+//! Completion for functions on nodes.
+
+use super::*;
+
+impl CompletionPair<'_, '_, '_> {
+    pub fn func_completion(
+        &mut self,
+        mode: InterpretMode,
+        fn_feat: FnCompletionFeat,
+        name: EcoString,
+        label_details: Option<EcoString>,
+        detail: Option<EcoString>,
+        parens: bool,
+    ) {
+        let base = Completion {
+            kind: CompletionKind::Func,
+            label_details,
+            detail,
+            command: self
+                .worker
+                .ctx
+                .analysis
+                .trigger_on_snippet_with_param_hint(true)
+                .map(From::from),
+            ..Default::default()
+        };
+
+        if matches!(
+            self.cursor.surrounding_syntax,
+            SurroundingSyntax::ShowTransform
+        ) && (fn_feat.min_pos() > 0 || fn_feat.min_named() > 0)
+        {
+            self.push_completion(Completion {
+                label: eco_format!("{name}.with"),
+                apply: Some(eco_format!("{name}.with(${{}})")),
+                ..base.clone()
+            });
+        }
+        if fn_feat.is_element
+            && matches!(self.cursor.surrounding_syntax, SurroundingSyntax::Selector)
+        {
+            self.push_completion(Completion {
+                label: eco_format!("{name}.where"),
+                apply: Some(eco_format!("{name}.where(${{}})")),
+                ..base.clone()
+            });
+        }
+
+        let bad_instantiate = matches!(
+            self.cursor.surrounding_syntax,
+            SurroundingSyntax::Selector | SurroundingSyntax::SetRule
+        ) && !fn_feat.is_element;
+        if !bad_instantiate {
+            if !parens || matches!(self.cursor.surrounding_syntax, SurroundingSyntax::Selector) {
+                self.push_completion(Completion {
+                    label: name,
+                    ..base
+                });
+            } else if (fn_feat.min_pos() < 1 || fn_feat.has_only_self()) && !fn_feat.has_rest {
+                self.push_completion(Completion {
+                    apply: Some(eco_format!("{}()${{}}", name)),
+                    label: name,
+                    ..base
+                });
+            } else {
+                let accept_content_arg = fn_feat.next_arg_is_content && !fn_feat.has_rest;
+                let scope_reject_content = matches!(mode, InterpretMode::Math)
+                    || matches!(
+                        self.cursor.surrounding_syntax,
+                        SurroundingSyntax::Selector | SurroundingSyntax::SetRule
+                    );
+                self.push_completion(Completion {
+                    apply: Some(eco_format!("{name}(${{}})")),
+                    label: name.clone(),
+                    ..base.clone()
+                });
+                if !scope_reject_content && accept_content_arg {
+                    self.push_completion(Completion {
+                        apply: Some(eco_format!("{name}[${{}}]")),
+                        label: eco_format!("{name}.bracket"),
+                        ..base
+                    });
+                };
+            }
+        }
+    }
+}

--- a/crates/tinymist-query/src/analysis/completion/kind.rs
+++ b/crates/tinymist-query/src/analysis/completion/kind.rs
@@ -68,6 +68,7 @@ pub(crate) struct FnCompletionFeat {
     min_pos: Option<usize>,
     has_only_self: bool,
     min_named: Option<usize>,
+    pub bound_self: bool,
     pub has_rest: bool,
     pub next_arg_is_content: bool,
     pub is_element: bool,
@@ -107,9 +108,10 @@ impl FnCompletionFeat {
                     let sig = func_signature(func.clone()).type_sig();
                     let has_only_self = self.has_only_self;
                     self.has_only_self = has_only_self
-                        || func
-                            .params()
-                            .is_some_and(|params| params.iter().all(|param| param.name == "self"));
+                        || (self.bound_self
+                            && func.params().is_some_and(|params| {
+                                params.iter().all(|param| param.name == "self")
+                            }));
                     self.check_sig(&sig, pos);
                 }
                 Value::None

--- a/crates/tinymist-query/src/analysis/completion/kind.rs
+++ b/crates/tinymist-query/src/analysis/completion/kind.rs
@@ -66,6 +66,7 @@ impl CompletionKindChecker {
 #[derive(Default, Debug)]
 pub(crate) struct FnCompletionFeat {
     min_pos: Option<usize>,
+    has_only_self: bool,
     min_named: Option<usize>,
     pub has_rest: bool,
     pub next_arg_is_content: bool,
@@ -85,6 +86,10 @@ impl FnCompletionFeat {
         self.min_pos.unwrap_or_default()
     }
 
+    pub fn has_only_self(&self) -> bool {
+        self.has_only_self
+    }
+
     pub fn min_named(&self) -> usize {
         self.min_named.unwrap_or_default()
     }
@@ -100,6 +105,11 @@ impl FnCompletionFeat {
                         self.is_element = true;
                     }
                     let sig = func_signature(func.clone()).type_sig();
+                    let has_only_self = self.has_only_self;
+                    self.has_only_self = has_only_self
+                        || func
+                            .params()
+                            .is_some_and(|params| params.iter().all(|param| param.name == "self"));
                     self.check_sig(&sig, pos);
                 }
                 Value::None

--- a/crates/tinymist-query/src/analysis/completion/scope.rs
+++ b/crates/tinymist-query/src/analysis/completion/scope.rs
@@ -172,6 +172,7 @@ impl CompletionPair<'_, '_, '_> {
             let detail = docs.or_else(|| label_details.clone());
 
             if !kind_checker.functions.is_empty() {
+                // todo: bound self checking
                 let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter());
                 crate::log_debug_ct!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
                 self.func_completion(mode, fn_feat, name, label_details, detail, parens);

--- a/crates/tinymist-query/src/analysis/completion/scope.rs
+++ b/crates/tinymist-query/src/analysis/completion/scope.rs
@@ -311,7 +311,10 @@ impl IfaceChecker for CompletionScopeChecker<'_> {
                     }
                 }
             }
-            Iface::Type { val, .. } if self.is_field_access() => {
+            Iface::Type { val, at } if self.is_field_access() => {
+                self.type_methods(Some(at.clone()), *val);
+            }
+            Iface::TypeType { val, .. } if self.is_field_access() => {
                 self.type_methods(None, *val);
             }
             Iface::Func { .. } if self.is_field_access() => {
@@ -326,7 +329,8 @@ impl IfaceChecker for CompletionScopeChecker<'_> {
             Iface::Element { val, .. } => {
                 self.defines.insert_scope(val.scope());
             }
-            Iface::Type { val, .. } => {
+            // todo: distingusish TypeType and Type
+            Iface::TypeType { val, .. } | Iface::Type { val, .. } => {
                 self.defines.insert_scope(val.scope());
             }
             Iface::Func { val, .. } => {

--- a/crates/tinymist-query/src/analysis/completion/scope.rs
+++ b/crates/tinymist-query/src/analysis/completion/scope.rs
@@ -166,89 +166,15 @@ impl CompletionPair<'_, '_, '_> {
 
             let docs = default_docs.get(&name).cloned();
 
-            let label_detail = ty.describe().or_else(|| Some("any".into()));
+            let label_details = ty.describe().or_else(|| Some("any".into()));
 
-            crate::log_debug_ct!("scope completions!: {name} {ty:?} {label_detail:?}");
-            let detail = docs.or_else(|| label_detail.clone());
+            crate::log_debug_ct!("scope completions!: {name} {ty:?} {label_details:?}");
+            let detail = docs.or_else(|| label_details.clone());
 
             if !kind_checker.functions.is_empty() {
-                let base = Completion {
-                    kind: CompletionKind::Func,
-                    label_details: label_detail,
-                    detail,
-                    command: self
-                        .worker
-                        .ctx
-                        .analysis
-                        .trigger_on_snippet_with_param_hint(true)
-                        .map(From::from),
-                    ..Default::default()
-                };
-
                 let fn_feat = FnCompletionFeat::default().check(kind_checker.functions.iter());
-
                 crate::log_debug_ct!("fn_feat: {name} {ty:?} -> {fn_feat:?}");
-
-                if matches!(
-                    self.cursor.surrounding_syntax,
-                    SurroundingSyntax::ShowTransform
-                ) && (fn_feat.min_pos() > 0 || fn_feat.min_named() > 0)
-                {
-                    self.push_completion(Completion {
-                        label: eco_format!("{name}.with"),
-                        apply: Some(eco_format!("{name}.with(${{}})")),
-                        ..base.clone()
-                    });
-                }
-                if fn_feat.is_element
-                    && matches!(self.cursor.surrounding_syntax, SurroundingSyntax::Selector)
-                {
-                    self.push_completion(Completion {
-                        label: eco_format!("{name}.where"),
-                        apply: Some(eco_format!("{name}.where(${{}})")),
-                        ..base.clone()
-                    });
-                }
-
-                let bad_instantiate = matches!(
-                    self.cursor.surrounding_syntax,
-                    SurroundingSyntax::Selector | SurroundingSyntax::SetRule
-                ) && !fn_feat.is_element;
-                if !bad_instantiate {
-                    if !parens
-                        || matches!(self.cursor.surrounding_syntax, SurroundingSyntax::Selector)
-                    {
-                        self.push_completion(Completion {
-                            label: name,
-                            ..base
-                        });
-                    } else if fn_feat.min_pos() < 1 && !fn_feat.has_rest {
-                        self.push_completion(Completion {
-                            apply: Some(eco_format!("{}()${{}}", name)),
-                            label: name,
-                            ..base
-                        });
-                    } else {
-                        let accept_content_arg = fn_feat.next_arg_is_content && !fn_feat.has_rest;
-                        let scope_reject_content = matches!(mode, InterpretMode::Math)
-                            || matches!(
-                                self.cursor.surrounding_syntax,
-                                SurroundingSyntax::Selector | SurroundingSyntax::SetRule
-                            );
-                        self.push_completion(Completion {
-                            apply: Some(eco_format!("{name}(${{}})")),
-                            label: name.clone(),
-                            ..base.clone()
-                        });
-                        if !scope_reject_content && accept_content_arg {
-                            self.push_completion(Completion {
-                                apply: Some(eco_format!("{name}[${{}}]")),
-                                label: eco_format!("{name}.bracket"),
-                                ..base
-                            });
-                        };
-                    }
-                }
+                self.func_completion(mode, fn_feat, name, label_details, detail, parens);
                 continue;
             }
 
@@ -256,7 +182,7 @@ impl CompletionPair<'_, '_, '_> {
             self.push_completion(Completion {
                 kind,
                 label: name,
-                label_details: label_detail.clone(),
+                label_details,
                 detail,
                 ..Completion::default()
             });

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -159,16 +159,7 @@ impl CompletionPair<'_, '_, '_> {
         parens: bool,
         docs: Option<&str>,
     ) {
-        self.value_completion_(
-            label,
-            value,
-            parens,
-            match value {
-                Value::Symbol(s) => Some(symbol_label_detail(s.get())),
-                _ => None,
-            },
-            docs,
-        );
+        self.value_completion_(label, value, parens, None, docs);
     }
 
     /// Add a completion for a specific value.
@@ -196,6 +187,10 @@ impl CompletionPair<'_, '_, '_> {
                 let repr = v.repr();
                 (repr.as_str() != label).then_some(repr)
             }
+        });
+        let label_details = label_details.or_else(|| match value {
+            Value::Symbol(s) => Some(symbol_label_detail(s.get())),
+            _ => None,
         });
 
         let mut apply = None;

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -211,6 +211,7 @@ impl CompletionPair<'_, '_, '_> {
                 functions: HashSet::from_iter([Ty::Value(InsTy::new(value.clone()))]),
             };
             let mut fn_feat = FnCompletionFeat::default();
+            // todo: unify bound self checking
             fn_feat.bound_self = bound_self;
             let fn_feat = fn_feat.check(kind_checker.functions.iter());
             self.func_completion(mode, fn_feat, label, label_details, detail, parens);

--- a/crates/tinymist-query/src/fixtures/completion/func_self.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_self.typ
@@ -1,0 +1,2 @@
+/// contains: flatten
+#(1,).f/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_self2.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_self2.typ
@@ -1,0 +1,2 @@
+/// contains: flatten
+#array.flat/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_self3.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_self3.typ
@@ -1,0 +1,2 @@
+/// contains: flatten
+#let ff() = (1,).f/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_self4.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_self4.typ
@@ -1,0 +1,2 @@
+/// contains: flatten
+#let ff() = array.flat/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_self5.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_self5.typ
@@ -1,0 +1,4 @@
+/// contains: flatten
+
+/// - arr (array): The array to flatten.
+#let ff(arr) = arr.f/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/show_outline.typ
+++ b/crates/tinymist-query/src/fixtures/completion/show_outline.typ
@@ -1,0 +1,2 @@
+/// contains: entry
+#show outline.en/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow_existing.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow_existing.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/builtin_shadow_existin
     "labelDetails": {
      "description": "(fill-rest: false) => none"
     },
-    "sortText": "128",
+    "sortText": "129",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self.typ.snap
@@ -1,0 +1,30 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (29..30)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_self.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "flatten",
+    "textEdit": {
+     "newText": "flatten(${1:})",
+     "range": {
+      "end": {
+       "character": 7,
+       "line": 1
+      },
+      "start": {
+       "character": 6,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self2.typ.snap
@@ -1,0 +1,30 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (33..34)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_self2.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "flatten",
+    "textEdit": {
+     "newText": "flatten()${1:}",
+     "range": {
+      "end": {
+       "character": 11,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self3.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (40..41)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_self3.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "flatten",
+    "labelDetails": {
+     "description": "(array) => array"
+    },
+    "textEdit": {
+     "newText": "flatten()${1:}",
+     "range": {
+      "end": {
+       "character": 18,
+       "line": 1
+      },
+      "start": {
+       "character": 17,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self4.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self4.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (44..45)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_self4.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "flatten",
+    "labelDetails": {
+     "description": "(array) => array"
+    },
+    "textEdit": {
+     "newText": "flatten(${1:})",
+     "range": {
+      "end": {
+       "character": 22,
+       "line": 1
+      },
+      "start": {
+       "character": 18,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self5.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_self5.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (84..85)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_self5.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "flatten",
+    "labelDetails": {
+     "description": "(array) => array"
+    },
+    "textEdit": {
+     "newText": "flatten()${1:}",
+     "range": {
+      "end": {
+       "character": 20,
+       "line": 3
+      },
+      "start": {
+       "character": 19,
+       "line": 3
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show_outline.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show_outline.typ.snap
@@ -1,0 +1,30 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (36..37)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/show_outline.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 3,
+    "label": "entry",
+    "textEdit": {
+     "newText": "entry",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 14,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/syntax/def.rs
+++ b/crates/tinymist-query/src/syntax/def.rs
@@ -23,11 +23,11 @@ pub enum Expr {
     /// A sequence of expressions
     Block(Interned<Vec<Expr>>),
     /// An array literal
-    Array(Interned<Vec<ArgExpr>>),
+    Array(Interned<ArgsExpr>),
     /// A dict literal
-    Dict(Interned<Vec<ArgExpr>>),
+    Dict(Interned<ArgsExpr>),
     /// An args literal
-    Args(Interned<Vec<ArgExpr>>),
+    Args(Interned<ArgsExpr>),
     /// A pattern
     Pattern(Interned<Pattern>),
     /// An element literal
@@ -748,6 +748,18 @@ impl SelectExpr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ArgsExpr {
+    pub args: Vec<ArgExpr>,
+    pub span: Span,
+}
+
+impl ArgsExpr {
+    pub fn new(span: Span, args: Vec<ArgExpr>) -> Interned<Self> {
+        Interned::new(Self { args, span })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ElementExpr {
     pub elem: Element,
     pub content: EcoVec<Expr>,
@@ -936,6 +948,7 @@ impl<T> BinInst<T> {
 
 impl_internable!(
     Expr,
+    ArgsExpr,
     ElementExpr,
     ContentSeqExpr,
     RefExpr,

--- a/crates/tinymist-query/src/syntax/expr.rs
+++ b/crates/tinymist-query/src/syntax/expr.rs
@@ -887,7 +887,7 @@ impl ExprWorker<'_> {
             }
         }
 
-        Expr::Array(items.into())
+        Expr::Array(ArgsExpr::new(typed.span(), items))
     }
 
     fn check_dict(&mut self, typed: ast::Dict) -> Expr {
@@ -921,7 +921,7 @@ impl ExprWorker<'_> {
             }
         }
 
-        Expr::Dict(items.into())
+        Expr::Dict(ArgsExpr::new(typed.span(), items))
     }
 
     fn check_args(&mut self, typed: ast::Args) -> Expr {
@@ -941,7 +941,7 @@ impl ExprWorker<'_> {
                 }
             }
         }
-        Expr::Args(args.into())
+        Expr::Args(ArgsExpr::new(typed.span(), args))
     }
 
     fn check_unary(&mut self, typed: ast::Unary) -> Expr {

--- a/crates/tinymist-query/src/syntax/repr.rs
+++ b/crates/tinymist-query/src/syntax/repr.rs
@@ -20,9 +20,9 @@ impl<'a, T: fmt::Write> ExprPrinter<'a, T> {
     pub fn write_expr(&mut self, expr: &Expr) -> fmt::Result {
         match expr {
             Expr::Block(exprs) => self.write_seq(exprs),
-            Expr::Array(elems) => self.write_array(elems),
-            Expr::Dict(elems) => self.write_dict(elems),
-            Expr::Args(args) => self.write_args(args),
+            Expr::Array(elems) => self.write_array(&elems.args),
+            Expr::Dict(elems) => self.write_dict(&elems.args),
+            Expr::Args(args) => self.write_args(&args.args),
             Expr::Pattern(pat) => self.write_pattern(pat),
             Expr::Element(elem) => self.write_element(elem),
             Expr::Unary(unary) => self.write_unary(unary),
@@ -64,7 +64,7 @@ impl<'a, T: fmt::Write> ExprPrinter<'a, T> {
         write!(self.f, "]")
     }
 
-    fn write_array(&mut self, elems: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_array(&mut self, elems: &[ArgExpr]) -> fmt::Result {
         writeln!(self.f, "(")?;
         self.indent += 1;
         for arg in elems.iter() {
@@ -77,7 +77,7 @@ impl<'a, T: fmt::Write> ExprPrinter<'a, T> {
         write!(self.f, ")")
     }
 
-    fn write_dict(&mut self, elems: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_dict(&mut self, elems: &[ArgExpr]) -> fmt::Result {
         writeln!(self.f, "(:")?;
         self.indent += 1;
         for arg in elems.iter() {
@@ -90,7 +90,7 @@ impl<'a, T: fmt::Write> ExprPrinter<'a, T> {
         write!(self.f, ")")
     }
 
-    fn write_args(&mut self, args: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_args(&mut self, args: &[ArgExpr]) -> fmt::Result {
         writeln!(self.f, "(")?;
         for arg in args.iter() {
             self.write_indent()?;
@@ -352,9 +352,9 @@ impl<'a, T: fmt::Write> ExprDescriber<'a, T> {
     pub fn write_expr(&mut self, expr: &Expr) -> fmt::Result {
         match expr {
             Expr::Block(..) => self.f.write_str("Expr(..)"),
-            Expr::Array(elems) => self.write_array(elems),
-            Expr::Dict(elems) => self.write_dict(elems),
-            Expr::Args(args) => self.write_args(args),
+            Expr::Array(elems) => self.write_array(&elems.args),
+            Expr::Dict(elems) => self.write_dict(&elems.args),
+            Expr::Args(args) => self.write_args(&args.args),
             Expr::Pattern(pat) => self.write_pattern(pat),
             Expr::Element(elem) => self.write_element(elem),
             Expr::Unary(unary) => self.write_unary(unary),
@@ -381,7 +381,7 @@ impl<'a, T: fmt::Write> ExprDescriber<'a, T> {
         write!(self.f, "{:indent$}", "", indent = self.indent)
     }
 
-    fn write_array(&mut self, elems: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_array(&mut self, elems: &[ArgExpr]) -> fmt::Result {
         if elems.len() <= 1 {
             self.f.write_char('(')?;
             if let Some(arg) = elems.first() {
@@ -403,7 +403,7 @@ impl<'a, T: fmt::Write> ExprDescriber<'a, T> {
         write!(self.f, ")")
     }
 
-    fn write_dict(&mut self, elems: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_dict(&mut self, elems: &[ArgExpr]) -> fmt::Result {
         if elems.len() <= 1 {
             self.f.write_char('(')?;
             if let Some(arg) = elems.first() {
@@ -426,7 +426,7 @@ impl<'a, T: fmt::Write> ExprDescriber<'a, T> {
         write!(self.f, ")")
     }
 
-    fn write_args(&mut self, args: &Interned<Vec<ArgExpr>>) -> fmt::Result {
+    fn write_args(&mut self, args: &[ArgExpr]) -> fmt::Result {
         writeln!(self.f, "(")?;
         for arg in args.iter() {
             self.write_indent()?;

--- a/crates/tinymist-query/src/ty/iface.rs
+++ b/crates/tinymist-query/src/ty/iface.rs
@@ -13,6 +13,10 @@ pub enum Iface<'a> {
         val: &'a typst::foundations::Element,
         at: &'a Ty,
     },
+    TypeType {
+        val: &'a typst::foundations::Type,
+        at: &'a Ty,
+    },
     Type {
         val: &'a typst::foundations::Type,
         at: &'a Ty,
@@ -42,6 +46,7 @@ impl Iface<'_> {
             Iface::Tuple(tys) => Ty::Tuple(tys.clone()),
             Iface::Dict(dict) => Ty::Dict(dict.clone()),
             Iface::Element { at, .. }
+            | Iface::TypeType { at, .. }
             | Iface::Type { at, .. }
             | Iface::Func { at, .. }
             | Iface::Value { at, .. }
@@ -58,7 +63,10 @@ impl Iface<'_> {
             Iface::Array(..) | Iface::Tuple(..) => None,
             Iface::Dict(dict) => dict.field_by_name(key).cloned(),
             Iface::Element { val, .. } => select_scope(Some(val.scope()), key),
-            Iface::Type { val, .. } => select_scope(Some(val.scope()), key),
+            // todo: distinguish TypeType and Type
+            Iface::TypeType { val, .. } | Iface::Type { val, .. } => {
+                select_scope(Some(val.scope()), key)
+            }
             Iface::Func { val, .. } => select_scope(val.scope(), key),
             Iface::Value { val, at: _ } => ctx.type_of_dict(val).field_by_name(key).cloned(),
             Iface::Module { val, at: _ } => ctx.check_module_item(val, key),
@@ -177,7 +185,7 @@ impl IfaceCheckDriver<'_> {
                         }
                         Value::Type(ty) => {
                             self.checker
-                                .check(Iface::Type { val: ty, at }, &mut self.ctx, pol);
+                                .check(Iface::TypeType { val: ty, at }, &mut self.ctx, pol);
                         }
                         Value::Func(func) => {
                             self.checker


### PR DESCRIPTION
The "function field" (usually methods) completion is unified as one function and in `completion::func` crate.
- if a function to completion is a method, and it is called with a value, and there is only a self argument, the cursor moves after the paren.
  - e.g. `(1,).flat| => (1,).flatten()|`
- if it is not bound with a self argument, the cursor moves inside of the paren.
  - e.g. `array.flat| => array.flatten(|)`

Code analysis improvements:
- It now records tuple and dict literal types.
- The interface checker now binds the self argument to a function whenever necessary.
