### PR TITLE
docs: fix Neovim name casing everywhere

### DIFF
--- a/CHANGELOG/CHANGELOG-2024.md
+++ b/CHANGELOG/CHANGELOG-2024.md
@@ -242,7 +242,7 @@ We are going to add maintainers to GitHub since 2024-11-22 (in 7 days):
 
 * Added coc.nvim config example by @tanloong in https://github.com/Myriad-Dreamin/tinymist/pull/727
 * Maintained docs for tinymist 0.12.2 in https://github.com/Myriad-Dreamin/tinymist/pull/733 and https://github.com/Myriad-Dreamin/tinymist/pull/825
-* Updated neovim's setup section in https://github.com/Myriad-Dreamin/tinymist/pull/749
+* Updated Neovim's setup section in https://github.com/Myriad-Dreamin/tinymist/pull/749
 * Added documentation about docstring in https://github.com/Myriad-Dreamin/tinymist/pull/771
 
 ### Editor
@@ -517,7 +517,7 @@ This is a new release channel for Tinymist, which uses *main branch of typst*. C
 * Generating shell completion by @Eric-Song-Nop in https://github.com/Myriad-Dreamin/tinymist/pull/525
 * Added installation and configuration instruction for Emacs by @Ziqi-Yang in https://github.com/Myriad-Dreamin/tinymist/pull/538
 * Added document preview feature documentations for non-vscode clients in https://github.com/Myriad-Dreamin/tinymist/pull/560
-* Added root path hints in documentation for neovim users in https://github.com/Myriad-Dreamin/tinymist/pull/561
+* Added root path hints in documentation for Neovim users in https://github.com/Myriad-Dreamin/tinymist/pull/561
 * Added notes to stateful pin commands in documentation in https://github.com/Myriad-Dreamin/tinymist/pull/562
 
 **Full Changelog**: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.19...v0.11.20
@@ -1087,7 +1087,7 @@ This version is published with mostly internal optimizations.
 
 ### Hover (Tooltip)
 
-* Joining array of hover contents by divider for neovim clients in https://github.com/Myriad-Dreamin/tinymist/pull/157
+* Joining array of hover contents by divider for Neovim clients in https://github.com/Myriad-Dreamin/tinymist/pull/157
 
 ### Internal Optimization
 
@@ -1142,7 +1142,7 @@ This version is published with mostly internal optimizations.
 
 ### Editor
 
-* Integrated neovim support in https://github.com/Myriad-Dreamin/tinymist/pull/91
+* Integrated Neovim support in https://github.com/Myriad-Dreamin/tinymist/pull/91
 * docs: mention how to work with multiple-file projects in https://github.com/Myriad-Dreamin/tinymist/pull/108
 * feat: add minimal helix support in https://github.com/Myriad-Dreamin/tinymist/pull/107
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The release cycle is as follows:
 
 Follow the instructions to enable tinymist in your favorite editor.
 - [VS Cod(e,ium)](https://myriad-dreamin.github.io/tinymist//frontend/vscode.html)
-- [NeoVim](https://myriad-dreamin.github.io/tinymist//frontend/neovim.html)
+- [Neovim](https://myriad-dreamin.github.io/tinymist//frontend/neovim.html)
 - [Emacs](https://myriad-dreamin.github.io/tinymist//frontend/emacs.html)
 - [Sublime Text](https://myriad-dreamin.github.io/tinymist//frontend/sublime-text.html)
 - [Helix](https://myriad-dreamin.github.io/tinymist//frontend/helix.html)

--- a/crates/tinymist/src/input.rs
+++ b/crates/tinymist/src/input.rs
@@ -152,7 +152,7 @@ impl ServerState {
     ///
     /// we do want to focus the file implicitly by `textDocument/diagnostic`
     /// (pullDiagnostics mode), as suggested by language-server-protocol#718,
-    /// however, this has poor support, e.g. since neovim 0.10.0.
+    /// however, this has poor support, e.g. since Neovim 0.10.0.
     pub fn implicit_focus_entry(
         &mut self,
         new_entry: impl FnOnce() -> Option<ImmutPath>,

--- a/docs/tinymist/book.typ
+++ b/docs/tinymist/book.typ
@@ -15,7 +15,7 @@
     #prefix-chapter("configurations.typ")[Common Configurations]
     - #chapter("frontend/main.typ")[Editor Frontends]
       - #chapter("frontend/vscode.typ")[VS Cod(e,ium)]
-      - #chapter("frontend/neovim.typ")[NeoVim]
+      - #chapter("frontend/neovim.typ")[Neovim]
       - #chapter("frontend/emacs.typ")[Emacs]
       - #chapter("frontend/sublime-text.typ")[Sublime Text]
       - #chapter("frontend/helix.typ")[Helix]

--- a/docs/tinymist/feature/preview.typ
+++ b/docs/tinymist/feature/preview.typ
@@ -10,7 +10,7 @@ Whenever you can get a web preview feature, it is recommended since it is much f
 
 == PDF Preview
 
-For non-vscode clients, neovim client as an example. One who uses `nvim-lspconfig` can place their configuration in the `servers.tinymist.settings` section. If you want to export PDF on typing and output files in `$root_dir/target` directory, please configure it like that:
+For non-vscode clients, Neovim client as an example. One who uses `nvim-lspconfig` can place their configuration in the `servers.tinymist.settings` section. If you want to export PDF on typing and output files in `$root_dir/target` directory, please configure it like that:
 
 ```lua
 return {

--- a/docs/tinymist/frontend/main.typ
+++ b/docs/tinymist/frontend/main.typ
@@ -6,7 +6,7 @@ Leveraging the interface of LSP, tinymist provides frontends to each editor, loc
 
 Check the following chapters for uses:
 - #cross-link("/frontend/vscode.typ")[VS Cod(e,ium)]
-- #cross-link("/frontend/neovim.typ")[NeoVim]
+- #cross-link("/frontend/neovim.typ")[Neovim]
 - #cross-link("/frontend/emacs.typ")[Emacs]
 - #cross-link("/frontend/sublime-text.typ")[Sublime Text]
 - #cross-link("/frontend/helix.typ")[Helix]

--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -136,7 +136,7 @@ vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.ap
 vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { nil } })
 ```
 
-It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting neovim.
+It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting Neovim.
 
 This could be improved in the future.
 
@@ -154,7 +154,7 @@ This is most commonly due to nvim not recognizing the `.typ` file extension as a
 :set filetype=typst
 ```
 
-In older versions of neovim an autocommand may be necessary.
+In older versions of Neovim an autocommand may be necessary.
 
 ```vim
 autocmd BufNewFile,BufRead *.typ setfiletype typst

--- a/docs/tinymist/introduction.typ
+++ b/docs/tinymist/introduction.typ
@@ -29,7 +29,7 @@ The release cycle is as follows:
 
 Follow the instructions to enable tinymist in your favorite editor.
 - #cross-link("/frontend/vscode.typ")[VS Cod(e,ium)]
-- #cross-link("/frontend/neovim.typ")[NeoVim]
+- #cross-link("/frontend/neovim.typ")[Neovim]
 - #cross-link("/frontend/emacs.typ")[Emacs]
 - #cross-link("/frontend/sublime-text.typ")[Sublime Text]
 - #cross-link("/frontend/helix.typ")[Helix]

--- a/editors/neovim/Configuration.md
+++ b/editors/neovim/Configuration.md
@@ -40,7 +40,7 @@ The extension can export PDFs of your Typst files. This setting controls whether
 
 ## `rootPath`
 
-Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for neovim users, if it complains root not found, you must set `require("lspconfig")["tinymist"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528).
+Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for Neovim users, if it complains root not found, you must set `require("lspconfig")["tinymist"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528).
 
 - **Type**: `string` or `null`
 

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -156,7 +156,7 @@ vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.ap
 vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { nil } })
 ```
 
-It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting neovim.
+It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting Neovim.
 
 This could be improved in the future.
 
@@ -174,7 +174,7 @@ This is most commonly due to nvim not recognizing the `.typ` file extension as a
 :set filetype=typst
 ```
 
-In older versions of neovim an autocommand may be necessary.
+In older versions of Neovim an autocommand may be necessary.
 
 ```vim
 autocmd BufNewFile,BufRead *.typ setfiletype typst

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -24,7 +24,7 @@ The changelog lines unspecified with authors are all written by the @Myriad-Drea
 ## v0.13.6 - [2025-03-13]
 
 We has provided more ways of previewing documents for editors having poor lsp support.
-- Default Preview: The editors supporting lsp commands, e.g. neovim and helix, can use [`tinymist.startDefaultPreview`](https://myriad-dreamin.github.io/tinymist/feature/preview.html#label-default-preview) to start a browsing preview server directly.
+- Default Preview: The editors supporting lsp commands, e.g. Neovim and helix, can use [`tinymist.startDefaultPreview`](https://myriad-dreamin.github.io/tinymist/feature/preview.html#label-default-preview) to start a browsing preview server directly.
 - Background Preview: The editors not supporting lsp commands can use the [background preview](https://myriad-dreamin.github.io/tinymist/feature/preview.html#label-background-preview) feature to start a preview server in background. You can bind a shortcut editor to open the preview in browser.
 
 See the [Issue: Preview feature for all editors](https://github.com/Myriad-Dreamin/tinymist/issues/1237) for unimplemented features.
@@ -302,7 +302,7 @@ For `tinymist.lock` feature, please check the [tinymist.projectResolution = "loc
 
 ### Misc
 
-* Revised neovim's install section by @SylvanFranklin and @YDX-2147483647 in https://github.com/Myriad-Dreamin/tinymist/pull/1090 and https://github.com/Myriad-Dreamin/tinymist/pull/1276
+* Revised Neovim's install section by @SylvanFranklin and @YDX-2147483647 in https://github.com/Myriad-Dreamin/tinymist/pull/1090 and https://github.com/Myriad-Dreamin/tinymist/pull/1276
 * Added release instruction by @ParaN3xus and @Myriad-Dreamin in https://github.com/Myriad-Dreamin/tinymist/pull/1163, https://github.com/Myriad-Dreamin/tinymist/pull/1169, https://github.com/Myriad-Dreamin/tinymist/pull/1173, and https://github.com/Myriad-Dreamin/tinymist/pull/1212
 * Documenting `sync-lsp` crate in https://github.com/Myriad-Dreamin/tinymist/pull/1155
 * CI used newest deploy-pages, upload-pages-artifact, and configure-pages actions in https://github.com/Myriad-Dreamin/tinymist/pull/1249 and https://github.com/Myriad-Dreamin/tinymist/pull/1251

--- a/editors/vscode/Configuration.md
+++ b/editors/vscode/Configuration.md
@@ -40,7 +40,7 @@ The extension can export PDFs of your Typst files. This setting controls whether
 
 ## `tinymist.rootPath`
 
-Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for neovim users, if it complains root not found, you must set `require("lspconfig")["tinymist"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528).
+Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for Neovim users, if it complains root not found, you must set `require("lspconfig")["tinymist"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528).
 
 - **Type**: `string` or `null`
 

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -87,7 +87,7 @@ function determineVscodeTheme(): any {
 
 // "tinymist.hoverPeriscope": {
 //     "title": "Show preview document in periscope mode on hovering",
-//     "description": "In VSCode, enable compile status meaning that the extension will show the compilation status in the status bar. Since neovim and helix don't have a such feature, it is disabled by default at the language server label.",
+//     "description": "In VSCode, enable compile status meaning that the extension will show the compilation status in the status bar. Since Neovim and helix don't have a such feature, it is disabled by default at the language server label.",
 //     "type": [
 //         "object",
 //         "string"

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -1030,8 +1030,8 @@ en = "Root path"
 zh = "根路径"
 
 [extension.tinymist.config.tinymist.rootPath.desc]
-en = "Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for neovim users, if it complains root not found, you must set `require(\"lspconfig\")[\"tinymist\"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528)."
-zh = "配置 typst 中绝对路径的根。提示：您可以将 rootPath 设置为 `-`，这样 tinymist 将始终使用文件的父目录作为根路径。注意：对于 neovim 用户，如果它抱怨找不到根目录，您还必须设置 `require(\"lspconfig\")[\"tinymist\"].setup { root_dir }`，请参见 [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528)。"
+en = "Configure the root for absolute paths in typst. Hint: you can set the rootPath to `-`, so that tinymist will always use parent directory of the file as the root path. Note: for Neovim users, if it complains root not found, you must set `require(\"lspconfig\")[\"tinymist\"].setup { root_dir }` as well, see [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528)."
+zh = "配置 typst 中绝对路径的根。提示：您可以将 rootPath 设置为 `-`，这样 tinymist 将始终使用文件的父目录作为根路径。注意：对于 Neovim 用户，如果它抱怨找不到根目录，您还必须设置 `require(\"lspconfig\")[\"tinymist\"].setup { root_dir }`，请参见 [tinymist#528](https://github.com/Myriad-Dreamin/tinymist/issues/528)。"
 
 [extension.tinymist.config.tinymist.configureDefaultWordSeparator.title]
 en = "Configure default word separators"


### PR DESCRIPTION
From the https://neovim.io/ it's clearly seen that the proper naming would be "Neovim" and not "NeoVim". This PR fixes the casing and also capitalizes the first letter wherever is necessary. I would've automated it, but there are a lot of places where it's used as a part of a path etc., so I went through all files manually.
