### PR TITLE
feat: try setting root_dir to TYPST_ROOT in Neovim

### DIFF
--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -31,7 +31,7 @@ return {
             return vim.fn.getcwd()
           end
         end,
-        --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/Configuration.md) for references.
+        --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md) for references.
         settings = {},
       }
     end,

--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -26,10 +26,10 @@ return {
         single_file_support = true,
         root_dir = function()
           if vim.env.TYPST_ROOT ~= nil then
-            return Path:new(vim.env.TYPST_ROOT):absolute()
-          else
-            return vim.fn.getcwd()
+            local typst_root = Path:new(vim.env.TYPST_ROOT)
+            if typst_root:exists() then return typst_root:absolute() end
           end
+          return vim.fn.getcwd()
         end,
         --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md) for references.
         settings = {},

--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -1,3 +1,4 @@
+---@type LazySpec[]
 return {
   -- requires tinymist
   {
@@ -13,22 +14,26 @@ return {
     "neovim/nvim-lspconfig",
     dependencies = {
       "mason.nvim",
+      "nvim-lua/plenary.nvim",
       "williamboman/mason-lspconfig.nvim",
     },
-    ---@class PluginLspOpts
-    opts = {
-      ---@type lspconfig.options
-      servers = {
-        tinymist = {
-          --- todo: these configuration from lspconfig maybe broken
-          single_file_support = true,
-          root_dir = function()
+    config = function()
+      local lspconfig = require "lspconfig"
+      local Path = require "plenary.path"
+
+      lspconfig.tinymist.setup {
+        --- todo: these configuration from lspconfig maybe broken
+        single_file_support = true,
+        root_dir = function()
+          if vim.env.TYPST_ROOT ~= nil then
+            return Path:new(vim.env.TYPST_ROOT):absolute()
+          else
             return vim.fn.getcwd()
-          end,
-          --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/Configuration.md) for references.
-          settings = {}
-        },
-      },
-    },
+          end
+        end,
+        --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/Configuration.md) for references.
+        settings = {},
+      }
+    end,
   },
 }


### PR DESCRIPTION
Answering [my own question](https://discord.com/channels/1054443721975922748/1260973804637786224/1350083276496441444). Since my project structure is somewhat complex and I do use `TYPST_ROOT` for some of its parts, it's nice that tinymist can finally follow it automatically. Now no absolute path will show an error reading a file.
