### PR TITLE
build: fix docs:typ using wrong root dir

### DIFF
--- a/scripts/link-docs.mjs
+++ b/scripts/link-docs.mjs
@@ -2,7 +2,7 @@ import { resolve, basename } from "path";
 import * as fs from "fs";
 import { execSync } from "child_process";
 
-const root = resolve(import.meta.dirname, "../..");
+const root = resolve(import.meta.dirname, "..");
 const dry = process.argv.includes("--dry");
 
 const bytes2utf8 = new TextDecoder();


### PR DESCRIPTION
See https://github.com/Myriad-Dreamin/tinymist/pull/1521#issuecomment-2727805390 for details.
