### PR TITLE
feat: fold list and enum item content

### DIFF
--- a/crates/tinymist-query/src/fixtures/folding_range/block-in-list-enum.typ
+++ b/crates/tinymist-query/src/fixtures/folding_range/block-in-list-enum.typ
@@ -1,0 +1,27 @@
+- Hi there
+
+  #[
+    This is a content block.
+  ]
+
+  #{
+    "This is a code block."
+  }
+
+  $
+    "This is a math block."
+  $
+
++ Hi there
+
+  #[
+    This is a content block.
+  ]
+
+  #{
+    "This is a code block."
+  }
+
+  $
+    "This is a math block."
+  $

--- a/crates/tinymist-query/src/fixtures/folding_range/list-enum.typ
+++ b/crates/tinymist-query/src/fixtures/folding_range/list-enum.typ
@@ -1,0 +1,9 @@
+- Hi there
+
+  Paragraph in a list item.
+- This will be a big single line list item. This will be a big single line list item. This will be a big single line list item. 
+
++ Hi there
+
+  Paragraph in a enum item.
++ This will be a big single line enum item. This will be a big single line enum item. This will be a big single line enum item. 

--- a/crates/tinymist-query/src/fixtures/folding_range/nested-list-enum.typ
+++ b/crates/tinymist-query/src/fixtures/folding_range/nested-list-enum.typ
@@ -1,0 +1,15 @@
+- Hi there
+
+  - A nested list
+  - A nested list
+
+    + A nested enum in list
+    + A nested enum in list
+
++ Hi there
+
+  + A nested enum
+  + A nested enum
+
+    - A nested list in enum
+    - A nested list in enum

--- a/crates/tinymist-query/src/fixtures/folding_range/snaps/test@block-in-list-enum.typ.snap
+++ b/crates/tinymist-query/src/fixtures/folding_range/snaps/test@block-in-list-enum.typ.snap
@@ -1,0 +1,107 @@
+---
+source: crates/tinymist-query/src/folding_range.rs
+expression: "JsonRepr::new_pure(json!({ \"false\": result_false, \"true\": result_true, }))"
+input_file: crates/tinymist-query/src/fixtures/folding_range/block-in-list-enum.typ
+---
+{
+ "false": [
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 4,
+   "startCharacter": 3,
+   "startLine": 2
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 8,
+   "startCharacter": 3,
+   "startLine": 6
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 12,
+   "startCharacter": 2,
+   "startLine": 10
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 12,
+   "startCharacter": 0,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 18,
+   "startCharacter": 3,
+   "startLine": 16
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 22,
+   "startCharacter": 3,
+   "startLine": 20
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 26,
+   "startCharacter": 2,
+   "startLine": 24
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 3,
+   "endLine": 26,
+   "startCharacter": 0,
+   "startLine": 14
+  }
+ ],
+ "true": [
+  {
+   "collapsedText": "",
+   "endLine": 4,
+   "startLine": 2
+  },
+  {
+   "collapsedText": "",
+   "endLine": 8,
+   "startLine": 6
+  },
+  {
+   "collapsedText": "",
+   "endLine": 12,
+   "startLine": 10
+  },
+  {
+   "collapsedText": "",
+   "endLine": 12,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endLine": 18,
+   "startLine": 16
+  },
+  {
+   "collapsedText": "",
+   "endLine": 22,
+   "startLine": 20
+  },
+  {
+   "collapsedText": "",
+   "endLine": 26,
+   "startLine": 24
+  },
+  {
+   "collapsedText": "",
+   "endLine": 26,
+   "startLine": 14
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/folding_range/snaps/test@list-enum.typ.snap
+++ b/crates/tinymist-query/src/fixtures/folding_range/snaps/test@list-enum.typ.snap
@@ -1,0 +1,49 @@
+---
+source: crates/tinymist-query/src/folding_range.rs
+expression: "JsonRepr::new_pure(json!({ \"false\": result_false, \"true\": result_true, }))"
+input_file: crates/tinymist-query/src/fixtures/folding_range/list-enum.typ
+---
+{
+ "false": [
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 2,
+   "startCharacter": 0,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 127,
+   "endLine": 3,
+   "startCharacter": 0,
+   "startLine": 3
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 7,
+   "startCharacter": 0,
+   "startLine": 5
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 127,
+   "endLine": 8,
+   "startCharacter": 0,
+   "startLine": 8
+  }
+ ],
+ "true": [
+  {
+   "collapsedText": "",
+   "endLine": 2,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endLine": 7,
+   "startLine": 5
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/folding_range/snaps/test@nested-list-enum.typ.snap
+++ b/crates/tinymist-query/src/fixtures/folding_range/snaps/test@nested-list-enum.typ.snap
@@ -1,0 +1,101 @@
+---
+source: crates/tinymist-query/src/folding_range.rs
+expression: "JsonRepr::new_pure(json!({ \"false\": result_false, \"true\": result_true, }))"
+input_file: crates/tinymist-query/src/fixtures/folding_range/nested-list-enum.typ
+---
+{
+ "false": [
+  {
+   "collapsedText": "",
+   "endCharacter": 17,
+   "endLine": 2,
+   "startCharacter": 2,
+   "startLine": 2
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 5,
+   "startCharacter": 4,
+   "startLine": 5
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 6,
+   "startCharacter": 4,
+   "startLine": 6
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 6,
+   "startCharacter": 2,
+   "startLine": 3
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 6,
+   "startCharacter": 0,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 17,
+   "endLine": 10,
+   "startCharacter": 2,
+   "startLine": 10
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 13,
+   "startCharacter": 4,
+   "startLine": 13
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 14,
+   "startCharacter": 4,
+   "startLine": 14
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 14,
+   "startCharacter": 2,
+   "startLine": 11
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 27,
+   "endLine": 14,
+   "startCharacter": 0,
+   "startLine": 8
+  }
+ ],
+ "true": [
+  {
+   "collapsedText": "",
+   "endLine": 6,
+   "startLine": 3
+  },
+  {
+   "collapsedText": "",
+   "endLine": 6,
+   "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endLine": 14,
+   "startLine": 11
+  },
+  {
+   "collapsedText": "",
+   "endLine": 14,
+   "startLine": 8
+  }
+ ]
+}

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -533,12 +533,8 @@ impl LexicalHierarchyWorker {
 
                 (name, kind)
             }
-            SyntaxKind::ListItem => {
-                (EcoString::new(), LexicalKind::Block)
-            }
-            SyntaxKind::EnumItem => {
-                (EcoString::new(), LexicalKind::Block)
-            }
+            SyntaxKind::ListItem => (EcoString::new(), LexicalKind::Block),
+            SyntaxKind::EnumItem => (EcoString::new(), LexicalKind::Block),
             _ => return Some(None),
         };
 

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -533,6 +533,12 @@ impl LexicalHierarchyWorker {
 
                 (name, kind)
             }
+            SyntaxKind::ListItem => {
+                (EcoString::new(), LexicalKind::Block)
+            }
+            SyntaxKind::EnumItem => {
+                (EcoString::new(), LexicalKind::Block)
+            }
             _ => return Some(None),
         };
 


### PR DESCRIPTION
An attempt to fix #1265. Currently it can only fold the content of an list/enum item, not a sequence of adjacent items.

Actually I'm not really sure about these changes, please check if there's any problems!