### PR TITLE
fix: remove extra linebreak in diagnostic message

### DIFF
--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -85,10 +85,7 @@ fn convert_diagnostic(
     let lsp_range = diagnostic_range(&source, span, ctx.position_encoding);
 
     let lsp_severity = diagnostic_severity(typst_diagnostic.severity);
-
-    let typst_message = &typst_diagnostic.message;
-    let typst_hints = &typst_diagnostic.hints;
-    let lsp_message = format!("{typst_message}{}", diagnostic_hints(typst_hints));
+    let lsp_message = diagnostic_message(&typst_diagnostic);
 
     let tracepoints =
         diagnostic_related_information(ctx, &typst_diagnostic, ctx.position_encoding)?;
@@ -185,11 +182,13 @@ fn diagnostic_severity(typst_severity: TypstSeverity) -> DiagnosticSeverity {
     }
 }
 
-fn diagnostic_hints(typst_hints: &[EcoString]) -> Format<impl Iterator<Item = EcoString> + '_> {
-    iter::repeat(EcoString::from("\n\nHint: "))
-        .take(typst_hints.len())
-        .interleave(typst_hints.iter().cloned())
-        .format("")
+fn diagnostic_message(typst_diagnostic: &TypstDiagnostic) -> String {
+    let mut message = typst_diagnostic.message.to_string();
+    for hint in &typst_diagnostic.hints {
+        message.push_str("\nHint: ");
+        message.push_str(hint);
+    }
+    message
 }
 
 trait DiagnosticRefiner {

--- a/crates/tinymist-query/src/prelude.rs
+++ b/crates/tinymist-query/src/prelude.rs
@@ -5,7 +5,7 @@ pub use std::path::{Path, PathBuf};
 pub use std::sync::{Arc, LazyLock, OnceLock};
 
 pub use ecow::{eco_vec, EcoVec};
-pub use itertools::{Format, Itertools};
+pub use itertools::Itertools;
 pub use lsp_types::{
     request::GotoDeclarationResponse, CodeAction, CodeActionKind, CodeActionOrCommand, CodeLens,
     ColorInformation, ColorPresentation, Diagnostic, DiagnosticRelatedInformation,


### PR DESCRIPTION
I don't know how it works in other editors.
But in VSCode, the change can eliminate blank lines in the "Problems".