### PR TITLE
fix: remove system time deps from crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,7 +4192,6 @@ name = "tinymist-project"
 version = "0.13.12-rc1"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "comemo",
  "dirs",
@@ -4223,7 +4222,6 @@ dependencies = [
  "anyhow",
  "base64",
  "biblatex",
- "chrono",
  "comemo",
  "dashmap",
  "dirs",
@@ -4290,6 +4288,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitvec",
+ "chrono",
  "comemo",
  "core-foundation",
  "dashmap",
@@ -4324,7 +4323,6 @@ name = "tinymist-task"
 version = "0.13.12-rc1"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "comemo",
  "dirs",
@@ -4376,7 +4374,6 @@ name = "tinymist-world"
 version = "0.13.12-rc1"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "codespan-reporting",
  "comemo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,7 +4288,6 @@ dependencies = [
  "anyhow",
  "base64",
  "bitvec",
- "chrono",
  "comemo",
  "core-foundation",
  "dashmap",
@@ -4311,6 +4310,7 @@ dependencies = [
  "serde_with",
  "siphasher",
  "tempfile",
+ "time",
  "typst",
  "typst-shim",
  "wasm-bindgen",
@@ -4374,6 +4374,7 @@ name = "tinymist-world"
 version = "0.13.12-rc1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "codespan-reporting",
  "comemo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ open = { version = "5.1.3" }
 parking_lot = "0.12.1"
 walkdir = "2"
 chrono = "0.4"
+time = "0.3"
 dirs = "6"
 fontdb = "0.21"
 notify = "6"

--- a/crates/tinymist-project/Cargo.toml
+++ b/crates/tinymist-project/Cargo.toml
@@ -14,7 +14,6 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
 clap.workspace = true
 comemo.workspace = true
 dirs.workspace = true

--- a/crates/tinymist-query/Cargo.toml
+++ b/crates/tinymist-query/Cargo.toml
@@ -33,7 +33,6 @@ walkdir.workspace = true
 indexmap.workspace = true
 ecow.workspace = true
 siphasher.workspace = true
-chrono.workspace = true
 rpds.workspace = true
 rayon.workspace = true
 

--- a/crates/tinymist-std/Cargo.toml
+++ b/crates/tinymist-std/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 bitvec.workspace = true
+chrono = { workspace = true, optional = true }
 comemo.workspace = true
 dashmap.workspace = true
 ecow = { workspace = true, features = ["serde"] }
@@ -76,7 +77,7 @@ rkyv-validation = ["rkyv/validation"]
 
 __web = ["wasm-bindgen", "js-sys"]
 web = ["__web"]
-system = ["tempfile", "same-file"]
+system = ["tempfile", "same-file", "chrono"]
 bi-hash = []
 
 [lints]

--- a/crates/tinymist-std/Cargo.toml
+++ b/crates/tinymist-std/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 bitvec.workspace = true
-chrono = { workspace = true, optional = true }
 comemo.workspace = true
 dashmap.workspace = true
 ecow = { workspace = true, features = ["serde"] }
@@ -30,6 +29,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 siphasher.workspace = true
 web-time.workspace = true
+time.workspace = true
 lsp-types.workspace = true
 tempfile = { workspace = true, optional = true }
 same-file = { workspace = true, optional = true }
@@ -77,7 +77,7 @@ rkyv-validation = ["rkyv/validation"]
 
 __web = ["wasm-bindgen", "js-sys"]
 web = ["__web"]
-system = ["tempfile", "same-file", "chrono"]
+system = ["tempfile", "same-file"]
 bi-hash = []
 
 [lints]

--- a/crates/tinymist-std/Cargo.toml
+++ b/crates/tinymist-std/Cargo.toml
@@ -28,7 +28,7 @@ serde_repr.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 siphasher.workspace = true
-web-time.workspace = true
+web-time = { workspace = true, optional = true }
 time.workspace = true
 lsp-types.workspace = true
 tempfile = { workspace = true, optional = true }
@@ -75,7 +75,7 @@ typst = ["dep:typst", "dep:typst-shim"]
 rkyv = ["rkyv/alloc", "rkyv/archive_le"]
 rkyv-validation = ["rkyv/validation"]
 
-__web = ["wasm-bindgen", "js-sys"]
+__web = ["wasm-bindgen", "js-sys", "web-time"]
 web = ["__web"]
 system = ["tempfile", "same-file"]
 bi-hash = []

--- a/crates/tinymist-std/src/time.rs
+++ b/crates/tinymist-std/src/time.rs
@@ -2,6 +2,10 @@
 
 pub use std::time::SystemTime as Time;
 pub use time::UtcDateTime;
+
+#[cfg(not(feature = "web"))]
+pub use std::time::{Duration, Instant};
+#[cfg(feature = "web")]
 pub use web_time::{Duration, Instant};
 
 /// Returns the current datetime in utc (UTC+0).

--- a/crates/tinymist-std/src/time.rs
+++ b/crates/tinymist-std/src/time.rs
@@ -1,7 +1,13 @@
 //! Cross platform time utilities.
 
 pub use std::time::SystemTime as Time;
+pub use time::UtcDateTime;
 pub use web_time::{Duration, Instant};
+
+/// Returns the current datetime in utc (UTC+0).
+pub fn utc_now() -> UtcDateTime {
+    now().into()
+}
 
 /// Returns the current system time (UTC+0).
 #[cfg(any(feature = "system", feature = "web"))]
@@ -23,5 +29,29 @@ pub fn now() -> Time {
     Time::UNIX_EPOCH
 }
 
-#[cfg(feature = "system")]
-pub use chrono;
+/// The trait helping convert to a [`UtcDateTime`].
+pub trait ToUtcDateTime {
+    /// Converts to a [`UtcDateTime`].
+    fn to_utc_datetime(self) -> Option<UtcDateTime>;
+}
+
+impl ToUtcDateTime for i64 {
+    /// Converts a UNIX timestamp to a [`UtcDateTime`].
+    fn to_utc_datetime(self) -> Option<UtcDateTime> {
+        UtcDateTime::from_unix_timestamp(self).ok()
+    }
+}
+
+impl ToUtcDateTime for Time {
+    /// Converts a system time to a [`UtcDateTime`].
+    fn to_utc_datetime(self) -> Option<UtcDateTime> {
+        Some(UtcDateTime::from(self))
+    }
+}
+
+/// Converts a [`UtcDateTime`] to typst's datetime.
+#[cfg(feature = "typst")]
+pub fn to_typst_time(timestamp: UtcDateTime) -> typst::foundations::Datetime {
+    let datetime = ::time::PrimitiveDateTime::new(timestamp.date(), timestamp.time());
+    typst::foundations::Datetime::Datetime(datetime)
+}

--- a/crates/tinymist-std/src/time.rs
+++ b/crates/tinymist-std/src/time.rs
@@ -22,3 +22,6 @@ pub fn now() -> Time {
 pub fn now() -> Time {
     Time::UNIX_EPOCH
 }
+
+#[cfg(feature = "system")]
+pub use chrono;

--- a/crates/tinymist-task/Cargo.toml
+++ b/crates/tinymist-task/Cargo.toml
@@ -14,7 +14,6 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
 clap.workspace = true
 comemo.workspace = true
 dirs.workspace = true

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -23,6 +23,8 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PdfExport {
             .map(|ts| ts.to_utc_datetime().context("timestamp is out of range"))
             .transpose()?
             .unwrap_or_else(tinymist_std::time::utc_now);
+        // todo: this seems different from `Timestamp::new_local` which also embeds the
+        // timezone information.
         let timestamp = Timestamp::new_utc(tinymist_std::time::to_typst_time(creation_timestamp));
 
         let standards = PdfStandards::new(

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -1,8 +1,7 @@
+use tinymist_std::time::ToUtcDateTime;
 pub use typst_pdf::pdf;
 pub use typst_pdf::PdfStandard as TypstPdfStandard;
 
-use tinymist_world::args::convert_source_date_epoch;
-use typst::foundations::Datetime;
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
 
 use super::*;
@@ -19,13 +18,12 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PdfExport {
         doc: &Arc<TypstPagedDocument>,
         config: &ExportPdfTask,
     ) -> Result<Bytes> {
-        // todo: timestamp world.now()
         let creation_timestamp = config
             .creation_timestamp
-            .map(convert_source_date_epoch)
-            .transpose()
-            .context_ut("prepare pdf creation timestamp")?
-            .unwrap_or_else(chrono::Utc::now);
+            .map(|ts| ts.to_utc_datetime().context("timestamp is out of range"))
+            .transpose()?
+            .unwrap_or_else(tinymist_std::time::utc_now);
+        let timestamp = Timestamp::new_utc(tinymist_std::time::to_typst_time(creation_timestamp));
 
         let standards = PdfStandards::new(
             &config
@@ -45,23 +43,10 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PdfExport {
         Ok(Bytes::new(typst_pdf::pdf(
             doc,
             &PdfOptions {
-                timestamp: convert_datetime(creation_timestamp),
+                timestamp: Some(timestamp),
                 standards,
                 ..Default::default()
             },
         )?))
     }
-}
-
-/// Convert [`chrono::DateTime`] to [`Timestamp`]
-pub fn convert_datetime(date_time: chrono::DateTime<chrono::Utc>) -> Option<Timestamp> {
-    use chrono::{Datelike, Timelike};
-    Some(Timestamp::new_utc(Datetime::from_ymd_hms(
-        date_time.year(),
-        date_time.month().try_into().ok()?,
-        date_time.day().try_into().ok()?,
-        date_time.hour().try_into().ok()?,
-        date_time.minute().try_into().ok()?,
-        date_time.second().try_into().ok()?,
-    )?))
 }

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -15,6 +15,10 @@ rust-version.workspace = true
 [dependencies]
 
 anyhow.workspace = true
+chrono = { workspace = true, default-features = false, features = [
+    "std",
+    "clock",
+] }
 clap.workspace = true
 codespan-reporting.workspace = true
 comemo.workspace = true
@@ -48,7 +52,7 @@ web-sys = { workspace = true, optional = true, features = ["console"] }
 
 default = []
 browser-embedded-fonts = ["typst-assets/fonts"]
-http-registry = ["dep:reqwest"]
+http-registry = ["reqwest"]
 web = [
     "wasm-bindgen",
     "web-sys",
@@ -59,8 +63,8 @@ web = [
 ]
 browser = ["tinymist-vfs/browser", "web"]
 system = [
-    "dep:dirs",
-    "dep:fontdb",
+    "dirs",
+    "fontdb",
     "http-registry",
     "tinymist-std/system",
     "tinymist-vfs/system",

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 [dependencies]
 
 anyhow.workspace = true
-chrono.workspace = true
 clap.workspace = true
 codespan-reporting.workspace = true
 comemo.workspace = true

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 
 anyhow.workspace = true
-chrono = { workspace = true, default-features = false, features = [
+chrono = { workspace = true, default-features = false, optional = true, features = [
     "std",
     "clock",
 ] }
@@ -54,6 +54,7 @@ default = []
 browser-embedded-fonts = ["typst-assets/fonts"]
 http-registry = ["reqwest"]
 web = [
+    "chrono",
     "chrono/wasmbind",
     "wasm-bindgen",
     "web-sys",
@@ -66,6 +67,7 @@ browser = ["tinymist-vfs/browser", "web"]
 system = [
     "dirs",
     "fontdb",
+    "chrono",
     "http-registry",
     "tinymist-std/system",
     "tinymist-vfs/system",

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -54,6 +54,7 @@ default = []
 browser-embedded-fonts = ["typst-assets/fonts"]
 http-registry = ["reqwest"]
 web = [
+    "chrono/wasmbind",
     "wasm-bindgen",
     "web-sys",
     "js-sys",

--- a/crates/tinymist-world/src/args.rs
+++ b/crates/tinymist-world/src/args.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use chrono::{DateTime, Utc};
 use clap::{builder::ValueParser, ArgAction, Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use tinymist_std::{bail, error::prelude::*};
@@ -209,11 +208,6 @@ fn parse_input_pair(raw: &str) -> Result<(String, String), String> {
 pub fn parse_source_date_epoch(raw: &str) -> Result<i64, String> {
     raw.parse()
         .map_err(|err| format!("timestamp must be decimal integer ({err})"))
-}
-
-/// Parses a UNIX timestamp according to <https://reproducible-builds.org/specs/source-date-epoch/>
-pub fn convert_source_date_epoch(seconds: i64) -> Result<chrono::DateTime<Utc>, String> {
-    DateTime::from_timestamp(seconds, 0).ok_or_else(|| "timestamp out of range".to_string())
 }
 
 macro_rules! display_possible_values {

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, LazyLock, OnceLock},
 };
 
-use chrono::{DateTime, Datelike, Local};
+use chrono::{DateTime, Datelike, Duration, Local};
 use tinymist_std::error::prelude::*;
 use tinymist_vfs::{
     FsProvider, PathResolution, RevisingVfs, SourceCache, TypstFileId, Vfs, WorkspaceResolver,
@@ -708,11 +708,12 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     fn today(&self, offset: Option<i64>) -> Option<Datetime> {
+        // todo: typst respects creation_timestamp, but we don't...
         let now = self.now.get_or_init(|| tinymist_std::time::now().into());
 
         let naive = match offset {
             None => now.naive_local(),
-            Some(o) => now.naive_utc() + chrono::Duration::try_hours(o)?,
+            Some(o) => now.naive_utc() + Duration::try_hours(o)?,
         };
 
         Datetime::from_ymd(


### PR DESCRIPTION
This prevents building crates to `wasm-unknown-unknown`.