### PR TITLE
feat: persist scroll position after ejecting

### DIFF
--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -23,7 +23,7 @@ use tinymist_std::error::IgnoreLogging;
 use tokio::sync::{mpsc, oneshot};
 use typst_preview::{
     frontend_html, ControlPlaneMessage, ControlPlaneRx, ControlPlaneTx, DocToSrcJumpInfo,
-    PreviewArgs, PreviewBuilder, PreviewMode, Previewer, WsMessage,
+    PreviewArgs, PreviewBuilder, PreviewMode, PreviewViewport, Previewer, WsMessage,
 };
 
 use crate::actor::preview::{PreviewActor, PreviewRequest, PreviewTab};
@@ -349,6 +349,7 @@ impl PreviewState {
                             send_show_document(&client, &s, &tid);
                         }
                     }
+                    UpdateViewport(pos) => client.send_notification::<ReportViewport>(&pos),
                     Outline(s) => client.send_notification::<NotifDocumentOutline>(&s),
                 }
             }
@@ -586,6 +587,13 @@ struct ScrollSource;
 impl Notification for ScrollSource {
     type Params = DocToSrcJumpInfo;
     const METHOD: &'static str = "tinymist/preview/scrollSource";
+}
+
+struct ReportViewport;
+
+impl Notification for ReportViewport {
+    type Params = PreviewViewport;
+    const METHOD: &'static str = "tinymist/preview/updateViewport";
 }
 
 struct NotifDocumentOutline;

--- a/crates/typst-preview/src/actor/editor.rs
+++ b/crates/typst-preview/src/actor/editor.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use crate::actor::render::RenderActorRequest;
 use crate::debug_loc::{InternQuery, SpanInterner};
 use crate::outline::Outline;
+use crate::PreviewViewport;
 use crate::{
     ChangeCursorPositionRequest, DocToSrcJumpInfo, EditorServer, MemoryFiles, MemoryFilesShort,
     ResolveSourceLocRequest,
@@ -39,6 +40,7 @@ pub enum EditorActorRequest {
     Shutdown,
     DocToSrcJumpResolve(DocToSrcJumpResolveRequest),
     DocToSrcJump(DocToSrcJumpInfo),
+    UpdateViewport(PreviewViewport),
     Outline(Outline),
     CompileStatus(CompileStatus),
 }
@@ -140,6 +142,8 @@ pub enum ControlPlaneMessage {
 pub enum ControlPlaneResponse {
     #[serde(rename = "editorScrollTo")]
     EditorScrollTo(DocToSrcJumpInfo),
+    #[serde(rename = "updateViewport")]
+    UpdateViewport(PreviewViewport),
     #[serde(rename = "syncEditorChanges")]
     SyncEditorChanges(()),
     #[serde(rename = "compileStatus")]
@@ -184,6 +188,9 @@ impl<T: EditorServer> EditorActor<T> {
                         },
                         EditorActorRequest::DocToSrcJump(jump_info) => {
                             self.editor_conn.resp_ctl_plane("DocToSrcJump", ControlPlaneResponse::EditorScrollTo(jump_info)).await
+                        },
+                        EditorActorRequest::UpdateViewport(pos) => {
+                            self.editor_conn.resp_ctl_plane("UpdateViewport", ControlPlaneResponse::UpdateViewport(pos)).await
                         },
                         EditorActorRequest::DocToSrcJumpResolve(req) => {
                             self.source_scroll_by_span(req.span)

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -320,6 +320,13 @@ pub struct DocToSrcJumpInfo {
     pub end: Option<(usize, usize)>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewViewport {
+    pub page_no: usize,
+    pub y: f32,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChangeCursorPositionRequest {
     filepath: PathBuf,

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -88,9 +88,13 @@ interface JumpInfo {
   end: [number, number] | null;
 }
 
-interface ViewportInfo {
+export interface PreviewViewport {
   pageNo: number;
-  y: number;
+  y: number
+}
+interface PreviewViewportUpdate {
+  taskId: string;
+  viewport: PreviewViewport;
 }
 
 export class LanguageState {
@@ -100,13 +104,13 @@ export class LanguageState {
   outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel("Tinymist Typst", "log");
   context: vscode.ExtensionContext = undefined!;
   client: LanguageClient | undefined = undefined;
-  clientPromiseResolve = (_client: LanguageClient) => {};
+  clientPromiseResolve = (_client: LanguageClient) => { };
   clientPromise: Promise<LanguageClient> = new Promise((resolve) => {
     this.clientPromiseResolve = resolve;
   });
 
   async stop() {
-    this.clientPromiseResolve = (_client: LanguageClient) => {};
+    this.clientPromiseResolve = (_client: LanguageClient) => { };
     this.clientPromise = new Promise((resolve) => {
       this.clientPromiseResolve = resolve;
     });
@@ -457,8 +461,8 @@ export class LanguageState {
     });
 
     // (Required) The server requests to report the current viewport of the preview page.
-    client.onNotification("tinymist/preview/updateViewport", (viewport: ViewportInfo) => {
-      console.log("recv updateViewport request", viewport);
+    client.onNotification("tinymist/preview/updateViewport", (req: PreviewViewportUpdate) => {
+      extensionState.setPreviewViewport(req.taskId, req.viewport);
     });
   }
 

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -88,6 +88,11 @@ interface JumpInfo {
   end: [number, number] | null;
 }
 
+interface ViewportInfo {
+  pageNo: number;
+  y: number;
+}
+
 export class LanguageState {
   static Client: typeof LanguageClient = undefined!;
   static HoverTmpStorage?: typeof HoverTmpStorage = undefined;
@@ -449,6 +454,11 @@ export class LanguageState {
     // (Optional) The server requests to update the document outline
     client.onNotification("tinymist/documentOutline", async (data: any) => {
       previewProcessOutline(data);
+    });
+
+    // (Required) The server requests to report the current viewport of the preview page.
+    client.onNotification("tinymist/preview/updateViewport", (viewport: ViewportInfo) => {
+      console.log("recv updateViewport request", viewport);
     });
   }
 

--- a/editors/vscode/src/state.ts
+++ b/editors/vscode/src/state.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { PreviewPanelContext } from "./features/preview";
+import { PreviewViewport } from "./lsp";
 
 export type ExtensionContext = vscode.ExtensionContext;
 
@@ -27,10 +28,13 @@ interface ExtensionState {
     focusingFile: string | undefined;
     focusingDoc: vscode.TextDocument | undefined;
     focusingPreviewPanelContext: PreviewPanelContext | undefined;
+    previewViewports: Record<string, PreviewViewport>;
   };
   getFocusingFile(): string | undefined;
   getFocusingDoc(): vscode.TextDocument | undefined;
   getFocusingPreviewPanelContext(): PreviewPanelContext | undefined;
+  getPreviewViewport(taskId: string): PreviewViewport | undefined;
+  setPreviewViewport(taskId: string, viewport: PreviewViewport): void;
 }
 
 export const extensionState: ExtensionState = {
@@ -57,6 +61,7 @@ export const extensionState: ExtensionState = {
     focusingFile: undefined,
     focusingDoc: undefined,
     focusingPreviewPanelContext: undefined,
+    previewViewports: {},
   },
   getFocusingFile() {
     return extensionState.mut.focusingFile;
@@ -66,5 +71,11 @@ export const extensionState: ExtensionState = {
   },
   getFocusingPreviewPanelContext() {
     return extensionState.mut.focusingPreviewPanelContext;
+  },
+  getPreviewViewport(taskId: string) {
+    return extensionState.mut.previewViewports[taskId];
+  },
+  setPreviewViewport(taskId: string, viewport: PreviewViewport) {
+    extensionState.mut.previewViewports[taskId] = viewport;
   },
 };


### PR DESCRIPTION
This PR restores the scrolling position (also refered as "viewport") after ejecting the preview panel. The approach is to

* introduce a chain of communication, called `UpdateViewport`, from webview to the vscode lsp extension, allowing the webview inform the extension of its scroll position.
* for the preview webview, we subscribe the scroll event of the page, which is then debounced by `1000ms` and trigger an invocation of `UpdateViewport`.
* for the lsp extension, a new state keyed by `taskId` is introduced to tracking the viewport of each preview task.

---

The approach has the following drawbacks:

* The tracked viewport state is not properly disposed. It hurts grace, but does not really "leak" too much memory there. The number of preview task is bound by user interactions, and the memory footprint of viewport information is relatively small.
* After ejecting a preview panel, the browser may take some time to intiailize the preview page. Which means we must wait util its full initialization to send a request to restore the viewport. Due to the complexity of error handling in the whole communication chain, it's not easy to retry util the request succeed. We chose a simple approach: send the request after 1000ms.
