### PR TITLE
feat: lint on bug-like show/set rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinymist-lint"
+version = "0.13.10"
+dependencies = [
+ "base64",
+ "comemo",
+ "insta",
+ "parking_lot",
+ "rayon",
+ "serde",
+ "serde_json",
+ "tinymist-analysis",
+ "tinymist-std",
+ "tinymist-world",
+ "typst",
+ "typst-library",
+]
+
+[[package]]
 name = "tinymist-project"
 version = "0.13.12-rc1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,6 +4284,7 @@ dependencies = [
  "tinymist-analysis",
  "tinymist-derive",
  "tinymist-l10n",
+ "tinymist-lint",
  "tinymist-project",
  "tinymist-std",
  "tinymist-world",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ tinymist-core = { path = "./crates/tinymist-core/", version = "0.13.10", default
 tinymist-debug = { path = "./crates/tinymist-debug/", version = "0.13.10" }
 tinymist = { path = "./crates/tinymist/", version = "0.13.10" }
 tinymist-l10n = { path = "./crates/tinymist-l10n/", version = "0.13.10" }
+tinymist-lint = { path = "./crates/tinymist-lint/", version = "0.13.10" }
 tinymist-analysis = { path = "./crates/tinymist-analysis/", version = "0.13.10" }
 tinymist-query = { path = "./crates/tinymist-query/", version = "0.13.10" }
 tinymist-render = { path = "./crates/tinymist-render/", version = "0.13.10" }

--- a/crates/tinymist-lint/Cargo.toml
+++ b/crates/tinymist-lint/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "tinymist-lint"
+description = "A linter for Typst."
+categories = ["compilers"]
+keywords = ["api", "language", "typst"]
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+typst-library.workspace = true
+typst.workspace = true
+tinymist-std.workspace = true
+tinymist-analysis.workspace = true
+tinymist-world = { workspace = true, features = ["system"] }
+parking_lot.workspace = true
+comemo.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+base64.workspace = true
+rayon.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -1,0 +1,38 @@
+//! A linter for Typst.
+
+use typst::{
+    diag::SourceDiagnostic,
+    ecow::EcoVec,
+    syntax::{Source, SyntaxNode},
+};
+
+/// A type alias for a vector of diagnostics.
+type DiagnosticVec = EcoVec<SourceDiagnostic>;
+
+/// Lints a Typst source and returns a vector of diagnostics.
+pub fn lint_source(source: &Source) -> DiagnosticVec {
+    SourceLinter::new().lint(source.root())
+}
+
+struct SourceLinter {
+    diag: DiagnosticVec,
+}
+
+impl SourceLinter {
+    fn new() -> Self {
+        Self {
+            diag: EcoVec::new(),
+        }
+    }
+
+    fn lint(self, node: &SyntaxNode) -> DiagnosticVec {
+        self.node(node);
+
+        self.diag
+    }
+
+    fn node(&self, node: &SyntaxNode) -> Option<()> {
+        let _ = node;
+        todo!()
+    }
+}

--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -266,15 +266,15 @@ impl SourceLinter {
             for set in sets {
                 match set {
                     ast::Expr::Set(..) => {
-                        self.diag.push(SourceDiagnostic::error(
+                        self.diag.push(SourceDiagnostic::warning(
                             set.span(),
-                            "This set statement takes no effect.",
+                            "This set statement doesn't take effect.",
                         ));
                     }
                     ast::Expr::Show(..) => {
-                        self.diag.push(SourceDiagnostic::error(
+                        self.diag.push(SourceDiagnostic::warning(
                             set.span(),
-                            "This show statement takes no effect.",
+                            "This show statement doesn't take effect.",
                         ));
                     }
                     _ => {}

--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -3,7 +3,10 @@
 use typst::{
     diag::SourceDiagnostic,
     ecow::EcoVec,
-    syntax::{Source, SyntaxNode},
+    syntax::{
+        ast::{self, AstNode},
+        Source, SyntaxNode,
+    },
 };
 
 /// A type alias for a vector of diagnostics.
@@ -26,13 +29,196 @@ impl SourceLinter {
     }
 
     fn lint(self, node: &SyntaxNode) -> DiagnosticVec {
-        self.node(node);
+        if let Some(expr) = node.cast() {
+            self.expr(expr);
+        }
 
         self.diag
     }
 
-    fn node(&self, node: &SyntaxNode) -> Option<()> {
-        let _ = node;
-        todo!()
+    fn exprs<'a>(&self, exprs: impl Iterator<Item = ast::Expr<'a>>) -> Option<()> {
+        for expr in exprs {
+            self.expr(expr);
+        }
+        Some(())
+    }
+
+    fn exprs_untyped(&self, to_untyped: &SyntaxNode) -> Option<()> {
+        for expr in to_untyped.children() {
+            if let Some(expr) = expr.cast() {
+                self.expr(expr);
+            }
+        }
+        Some(())
+    }
+
+    fn expr(&self, node: ast::Expr) -> Option<()> {
+        match node {
+            ast::Expr::Parenthesized(expr) => self.expr(expr.expr()),
+            ast::Expr::Code(expr) => self.exprs(expr.body().exprs()),
+            ast::Expr::Content(expr) => self.exprs(expr.body().exprs()),
+            ast::Expr::Equation(expr) => self.exprs(expr.body().exprs()),
+            ast::Expr::Math(expr) => self.exprs(expr.exprs()),
+
+            ast::Expr::Text(..) => None,
+            ast::Expr::Space(..) => None,
+            ast::Expr::Linebreak(..) => None,
+            ast::Expr::Parbreak(..) => None,
+            ast::Expr::Escape(..) => None,
+            ast::Expr::Shorthand(..) => None,
+            ast::Expr::SmartQuote(..) => None,
+            ast::Expr::Raw(..) => None,
+            ast::Expr::Link(..) => None,
+
+            ast::Expr::Label(..) => None,
+            ast::Expr::Ref(..) => None,
+            ast::Expr::None(..) => None,
+            ast::Expr::Auto(..) => None,
+            ast::Expr::Bool(..) => None,
+            ast::Expr::Int(..) => None,
+            ast::Expr::Float(..) => None,
+            ast::Expr::Numeric(..) => None,
+            ast::Expr::Str(..) => None,
+            ast::Expr::MathText(..) => None,
+            ast::Expr::MathShorthand(..) => None,
+            ast::Expr::MathAlignPoint(..) => None,
+            ast::Expr::MathPrimes(..) => None,
+            ast::Expr::MathRoot(..) => None,
+
+            ast::Expr::Strong(content) => self.exprs(content.body().exprs()),
+            ast::Expr::Emph(content) => self.exprs(content.body().exprs()),
+            ast::Expr::Heading(content) => self.exprs(content.body().exprs()),
+            ast::Expr::List(content) => self.exprs(content.body().exprs()),
+            ast::Expr::Enum(content) => self.exprs(content.body().exprs()),
+            ast::Expr::Term(content) => {
+                self.exprs(content.term().exprs());
+                self.exprs(content.description().exprs())
+            }
+            ast::Expr::MathDelimited(content) => self.exprs(content.body().exprs()),
+            ast::Expr::MathAttach(..) | ast::Expr::MathFrac(..) => {
+                self.exprs_untyped(node.to_untyped())
+            }
+
+            ast::Expr::Ident(expr) => self.ident(expr),
+            ast::Expr::MathIdent(expr) => self.math_ident(expr),
+            ast::Expr::Array(expr) => self.array(expr),
+            ast::Expr::Dict(expr) => self.dict(expr),
+            ast::Expr::Unary(expr) => self.unary(expr),
+            ast::Expr::Binary(expr) => self.binary(expr),
+            ast::Expr::FieldAccess(expr) => self.field_access(expr),
+            ast::Expr::FuncCall(expr) => self.func_call(expr),
+            ast::Expr::Closure(expr) => self.closure(expr),
+            ast::Expr::Let(expr) => self.let_binding(expr),
+            ast::Expr::DestructAssign(expr) => self.destruct_assign(expr),
+            ast::Expr::Set(expr) => self.set(expr),
+            ast::Expr::Show(expr) => self.show(expr),
+            ast::Expr::Contextual(expr) => self.contextual(expr),
+            ast::Expr::Conditional(expr) => self.conditional(expr),
+            ast::Expr::While(expr) => self.while_loop(expr),
+            ast::Expr::For(expr) => self.for_loop(expr),
+            ast::Expr::Import(expr) => self.import(expr),
+            ast::Expr::Include(expr) => self.include(expr),
+            ast::Expr::Break(expr) => self.loop_break(expr),
+            ast::Expr::Continue(expr) => self.loop_continue(expr),
+            ast::Expr::Return(expr) => self.func_return(expr),
+        }
+    }
+
+    fn ident(&self, _expr: ast::Ident<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn math_ident(&self, _expr: ast::MathIdent<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn import(&self, _expr: ast::ModuleImport<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn include(&self, _expr: ast::ModuleInclude<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn array(&self, expr: ast::Array<'_>) -> Option<()> {
+        self.exprs_untyped(expr.to_untyped())
+    }
+
+    fn dict(&self, expr: ast::Dict<'_>) -> Option<()> {
+        self.exprs_untyped(expr.to_untyped())
+    }
+
+    fn unary(&self, expr: ast::Unary<'_>) -> Option<()> {
+        self.expr(expr.expr())
+    }
+
+    fn binary(&self, expr: ast::Binary<'_>) -> Option<()> {
+        self.expr(expr.lhs());
+        self.expr(expr.rhs())
+    }
+
+    fn field_access(&self, expr: ast::FieldAccess<'_>) -> Option<()> {
+        self.expr(expr.target())
+    }
+
+    fn func_call(&self, expr: ast::FuncCall<'_>) -> Option<()> {
+        self.exprs_untyped(expr.args().to_untyped());
+        self.expr(expr.callee())
+    }
+
+    fn closure(&self, expr: ast::Closure<'_>) -> Option<()> {
+        self.exprs_untyped(expr.params().to_untyped());
+        self.expr(expr.body())
+    }
+
+    fn let_binding(&self, expr: ast::LetBinding<'_>) -> Option<()> {
+        self.expr(expr.init()?)
+    }
+
+    fn destruct_assign(&self, expr: ast::DestructAssignment<'_>) -> Option<()> {
+        self.expr(expr.value())
+    }
+
+    fn set(&self, expr: ast::SetRule<'_>) -> Option<()> {
+        if let Some(target) = expr.condition() {
+            self.expr(target);
+        }
+        self.exprs_untyped(expr.args().to_untyped());
+        self.expr(expr.target())
+    }
+
+    fn show(&self, expr: ast::ShowRule<'_>) -> Option<()> {
+        if let Some(target) = expr.selector() {
+            self.expr(target);
+        }
+        self.expr(expr.transform())
+    }
+
+    fn contextual(&self, expr: ast::Contextual<'_>) -> Option<()> {
+        self.expr(expr.body())
+    }
+
+    fn conditional(&self, expr: ast::Conditional<'_>) -> Option<()> {
+        self.exprs_untyped(expr.to_untyped())
+    }
+
+    fn while_loop(&self, expr: ast::WhileLoop<'_>) -> Option<()> {
+        self.exprs_untyped(expr.to_untyped())
+    }
+
+    fn for_loop(&self, expr: ast::ForLoop<'_>) -> Option<()> {
+        self.exprs_untyped(expr.to_untyped())
+    }
+
+    fn loop_break(&self, _expr: ast::LoopBreak<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn loop_continue(&self, _expr: ast::LoopContinue<'_>) -> Option<()> {
+        Some(())
+    }
+
+    fn func_return(&self, _expr: ast::FuncReturn<'_>) -> Option<()> {
+        Some(())
     }
 }

--- a/crates/tinymist-query/Cargo.toml
+++ b/crates/tinymist-query/Cargo.toml
@@ -48,6 +48,7 @@ tinymist-analysis.workspace = true
 tinymist-derive.workspace = true
 tinymist-std.workspace = true
 tinymist-l10n.workspace = true
+tinymist-lint.workspace = true
 typst.workspace = true
 typst-shim.workspace = true
 unscanny.workspace = true

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -598,3 +598,26 @@ mod call_info_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod lint_tests {
+    use std::collections::BTreeMap;
+
+    use crate::tests::*;
+
+    #[test]
+    fn test() {
+        snapshot_testing("lint", &|ctx, path| {
+            let source = ctx.source_by_path(&path).unwrap();
+
+            let result = tinymist_lint::lint_source(&source);
+            let result = crate::diagnostics::convert_diagnostics(
+                &ctx.world,
+                result.iter(),
+                ctx.position_encoding(),
+            );
+            let result = result.into_iter().collect::<BTreeMap<_, _>>();
+            assert_snapshot!(JsonRepr::new_redacted(result, &REDACT_LOC));
+        });
+    }
+}

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -616,7 +616,10 @@ mod lint_tests {
                 result.iter(),
                 ctx.position_encoding(),
             );
-            let result = result.into_iter().collect::<BTreeMap<_, _>>();
+            let result = result
+                .into_iter()
+                .map(|(k, v)| (file_path_(&k), v))
+                .collect::<BTreeMap<_, _>>();
             assert_snapshot!(JsonRepr::new_redacted(result, &REDACT_LOC));
         });
     }

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -611,11 +611,9 @@ mod lint_tests {
             let source = ctx.source_by_path(&path).unwrap();
 
             let result = tinymist_lint::lint_source(&source);
-            let result = crate::diagnostics::convert_diagnostics(
-                &ctx.world,
-                result.iter(),
-                ctx.position_encoding(),
-            );
+            let result =
+                crate::diagnostics::CheckDocWorker::new(&ctx.world, ctx.position_encoding())
+                    .convert(result.iter());
             let result = result
                 .into_iter()
                 .map(|(k, v)| (file_path_(&k), v))

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -613,7 +613,7 @@ mod lint_tests {
             let result = tinymist_lint::lint_source(&source);
             let result =
                 crate::diagnostics::CheckDocWorker::new(&ctx.world, ctx.position_encoding())
-                    .convert(result.iter());
+                    .convert_all(result.iter());
             let result = result
                 .into_iter()
                 .map(|(k, v)| (file_path_(&k), v))

--- a/crates/tinymist-query/src/fixtures/lint/if_set.typ
+++ b/crates/tinymist-query/src/fixtures/lint/if_set.typ
@@ -1,0 +1,6 @@
+
+#if false {
+  set text(red)
+}
+
+123

--- a/crates/tinymist-query/src/fixtures/lint/if_show.typ
+++ b/crates/tinymist-query/src/fixtures/lint/if_show.typ
@@ -1,0 +1,6 @@
+
+#if false {
+  show: text(red)
+}
+
+123

--- a/crates/tinymist-query/src/fixtures/lint/show_set.typ
+++ b/crates/tinymist-query/src/fixtures/lint/show_set.typ
@@ -1,0 +1,6 @@
+
+#show: {
+  set text(red)
+}
+
+123

--- a/crates/tinymist-query/src/fixtures/lint/show_set2.typ
+++ b/crates/tinymist-query/src/fixtures/lint/show_set2.typ
@@ -1,0 +1,6 @@
+
+#show raw: {
+  set text(red)
+}
+
+123

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@if_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@if_set.typ.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/tinymist-query/src/analysis.rs
 expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
-input_file: crates/tinymist-query/src/fixtures/lint/show_set.typ
+input_file: crates/tinymist-query/src/fixtures/lint/if_set.typ
 ---
 {
  "s0.typ": [

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@if_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@if_set.typ.snap
@@ -6,10 +6,10 @@ input_file: crates/tinymist-query/src/fixtures/lint/if_set.typ
 {
  "s0.typ": [
   {
-   "message": "This set statement takes no effect.",
+   "message": "This set statement doesn't take effect.\nHint: consider changing parent to `set text(red) if (false)`",
    "range": "1:2:1:15",
    "relatedInformation": [],
-   "severity": 1,
+   "severity": 2,
    "source": "typst"
   }
  ]

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@if_show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@if_show.typ.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/tinymist-query/src/analysis.rs
 expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
-input_file: crates/tinymist-query/src/fixtures/lint/show_set.typ
+input_file: crates/tinymist-query/src/fixtures/lint/if_show.typ
 ---
 {
  "s0.typ": [
   {
-   "message": "This set statement takes no effect.",
-   "range": "1:2:1:15",
+   "message": "This show statement takes no effect.",
+   "range": "1:2:1:17",
    "relatedInformation": [],
    "severity": 1,
    "source": "typst"

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@if_show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@if_show.typ.snap
@@ -6,10 +6,10 @@ input_file: crates/tinymist-query/src/fixtures/lint/if_show.typ
 {
  "s0.typ": [
   {
-   "message": "This show statement takes no effect.",
+   "message": "This show statement doesn't take effect.\nHint: consider changing parent to `show : if (false) { .. }`",
    "range": "1:2:1:17",
    "relatedInformation": [],
-   "severity": 1,
+   "severity": 2,
    "source": "typst"
   }
  ]

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set.typ.snap
@@ -6,10 +6,10 @@ input_file: crates/tinymist-query/src/fixtures/lint/show_set.typ
 {
  "s0.typ": [
   {
-   "message": "This set statement takes no effect.",
+   "message": "This set statement doesn't take effect.\nHint: consider changing parent to `show : set text(red)`",
    "range": "1:2:1:15",
    "relatedInformation": [],
-   "severity": 1,
+   "severity": 2,
    "source": "typst"
   }
  ]

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/show_set.typ
+---
+{}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/show_set2.typ
+---
+{}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
@@ -3,4 +3,14 @@ source: crates/tinymist-query/src/analysis.rs
 expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
 input_file: crates/tinymist-query/src/fixtures/lint/show_set2.typ
 ---
-{}
+{
+ "s0.typ": [
+  {
+   "message": "This set statement takes no effect.",
+   "range": "1:2:1:15",
+   "relatedInformation": [],
+   "severity": 1,
+   "source": "typst"
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@show_set2.typ.snap
@@ -6,10 +6,10 @@ input_file: crates/tinymist-query/src/fixtures/lint/show_set2.typ
 {
  "s0.typ": [
   {
-   "message": "This set statement takes no effect.",
+   "message": "This set statement doesn't take effect.\nHint: consider changing parent to `show raw: set text(red)`",
    "range": "1:2:1:15",
    "relatedInformation": [],
-   "severity": 1,
+   "severity": 2,
    "source": "typst"
   }
  ]

--- a/crates/tinymist-query/src/tests.rs
+++ b/crates/tinymist-query/src/tests.rs
@@ -477,12 +477,16 @@ impl Redact for RedactFields {
 }
 
 pub(crate) fn file_path(uri: &str) -> String {
+    file_path_(&lsp_types::Url::parse(uri).unwrap())
+}
+
+pub(crate) fn file_path_(uri: &lsp_types::Url) -> String {
     let root = if cfg!(windows) {
         PathBuf::from("C:\\root")
     } else {
         PathBuf::from("/root")
     };
-    let uri = lsp_types::Url::parse(uri).unwrap().to_file_path().unwrap();
+    let uri = uri.to_file_path().unwrap();
     let abs_path = Path::new(&uri).strip_prefix(root).map(|p| p.to_owned());
     let rel_path =
         abs_path.unwrap_or_else(|_| Path::new("-").join(Path::new(&uri).iter().last().unwrap()));

--- a/crates/tinymist/src/task/user_action.rs
+++ b/crates/tinymist/src/task/user_action.rs
@@ -177,8 +177,7 @@ async fn trace_main(
     let timings = writer.into_inner().unwrap();
 
     let handle = &state.project;
-    let diagnostics =
-        tinymist_query::convert_diagnostics(w, diags.iter(), handle.analysis.position_encoding);
+    let diagnostics = tinymist_query::check_doc(w, diags.iter(), handle.analysis.position_encoding);
 
     let rpc_kind = rpc_kind.as_str();
 


### PR DESCRIPTION
Runs `buggy_set` lint on:
```rs
enum BuggyShowLoc<'a> {
    Show(ast::ShowRule<'a>),
    IfTrue(ast::Conditional<'a>),
    IfFalse(ast::Conditional<'a>),
    While(ast::WhileLoop<'a>),
    For(ast::ForLoop<'a>),
}
```

If the `body` only contains show or set rules, it is suggested to refactor:

![image](https://github.com/user-attachments/assets/43403bdf-0db1-46a1-b059-16f8db8416a9)

