### PR TITLE
Add `clone_and_rebuild` so we can append fonts without a mutable access.

### DIFF
--- a/crates/tinymist-world/src/font/resolver.rs
+++ b/crates/tinymist-world/src/font/resolver.rs
@@ -125,7 +125,7 @@ impl FontResolverImpl {
         }
     }
 
-    pub fn append_font(&mut self, info: FontInfo, slot: FontSlot) {
+    pub fn append_font(&self, info: FontInfo, slot: FontSlot) {
         let mut font_book = self.partial_book.lock().unwrap();
         font_book.push((None, info, slot));
     }

--- a/crates/tinymist-world/src/font/slot.rs
+++ b/crates/tinymist-world/src/font/slot.rs
@@ -10,22 +10,23 @@ use crate::font::FontLoader;
 type FontSlotInner = QueryRef<Option<Font>, (), Box<dyn FontLoader + Send>>;
 
 /// Lazy Font Reference, load as needed.
+#[derive(Clone)]
 pub struct FontSlot {
-    inner: FontSlotInner,
+    inner: Arc<FontSlotInner>,
     pub description: Option<Arc<DataSource>>,
 }
 
 impl FontSlot {
     pub fn with_value(f: Option<Font>) -> Self {
         Self {
-            inner: FontSlotInner::with_value(f),
+            inner: Arc::new(FontSlotInner::with_value(f)),
             description: None,
         }
     }
 
     pub fn new(f: Box<dyn FontLoader + Send>) -> Self {
         Self {
-            inner: FontSlotInner::with_context(f),
+            inner: Arc::new(FontSlotInner::with_context(f)),
             description: None,
         }
     }


### PR DESCRIPTION
Since `CompilerUniverse` only holds a `Arc<FontResolver>`, we can't call `append_fonts` or `rebuild` on it.

I changed the signature on `append_fonts` and added a new method `clone_and_build`, so it's possible to build a new `FontResolverImpl` with more fonts. The new `FontResolverImpl` can then be swapped to the universe by calling `increment_revision` method.