### PR TITLE
feat(lint): add warning for vf font

### DIFF
--- a/crates/tinymist-query/src/fixtures/lint/good_font.typ
+++ b/crates/tinymist-query/src/fixtures/lint/good_font.typ
@@ -1,0 +1,5 @@
+
+#text(font: "DejaVu Sans Mono")[123]
+#text(font: ("DejaVu Sans Mono",))[123]
+#text(font: (name: "DejaVu Sans Mono"))[123]
+#text(font: ((name: "DejaVu Sans Mono"),))[123]

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@good_font.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@good_font.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/good_font.typ
+---
+{}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@vf.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@vf.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/vf.typ
+---
+{
+ "s0.typ": [
+  {
+   "message": "variable font is not supported by typst yet\nHint: consider using a static font instead. For more information, see https://github.com/typst/typst/issues/185",
+   "range": "0:10:0:30",
+   "severity": 2,
+   "source": "typst"
+  },
+  {
+   "message": "variable font is not supported by typst yet\nHint: consider using a static font instead. For more information, see https://github.com/typst/typst/issues/185",
+   "range": "2:6:2:37",
+   "severity": 2,
+   "source": "typst"
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@vf_object.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@vf_object.typ.snap
@@ -1,19 +1,19 @@
 ---
 source: crates/tinymist-query/src/analysis.rs
 expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
-input_file: crates/tinymist-query/src/fixtures/lint/vf.typ
+input_file: crates/tinymist-query/src/fixtures/lint/vf_object.typ
 ---
 {
  "s0.typ": [
   {
    "message": "variable font is not supported by typst yet\nHint: consider using a static font instead. For more information, see https://github.com/typst/typst/issues/185",
-   "range": "0:16:0:30",
+   "range": "0:20:0:34",
    "severity": 2,
    "source": "typst"
   },
   {
    "message": "variable font is not supported by typst yet\nHint: consider using a static font instead. For more information, see https://github.com/typst/typst/issues/185",
-   "range": "2:22:2:36",
+   "range": "1:19:1:33",
    "severity": 2,
    "source": "typst"
   }

--- a/crates/tinymist-query/src/fixtures/lint/vf.typ
+++ b/crates/tinymist-query/src/fixtures/lint/vf.typ
@@ -1,0 +1,3 @@
+#set text(font: "Noto Sans VF")
+
+#text(font: ("Arial", "Noto Sans VF"))[123]

--- a/crates/tinymist-query/src/fixtures/lint/vf_object.typ
+++ b/crates/tinymist-query/src/fixtures/lint/vf_object.typ
@@ -1,0 +1,3 @@
+
+#text(font: ((name: "Noto Sans VF"),))[123]
+#text(font: (name: "Noto Sans VF"))[123]


### PR DESCRIPTION
Please let me know if and how we can do better on this, for example:

1. resolve font info and see if it's vf or not(instead of check if it ends with "VF")
2. handle cases where fonts are not directly visible in ast