### PR TITLE
feat: reasonable default values for settings for formatterMode

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -446,7 +446,7 @@
           "title": "%extension.tinymist.config.tinymist.formatterMode.title%",
           "markdownDescription": "%extension.tinymist.config.tinymist.formatterMode.desc%",
           "type": "string",
-          "default": "disable",
+          "default": "typstyle",
           "enum": [
             "disable",
             "typstyle",


### PR DESCRIPTION
I've added, for me, meaningful values for the settings `tinymist.formatterMode` and `tinymist.fontPaths`.

With this change it is possible to
- format `*.typ` without having to make changes to the settings (by default).
~~- use fonts, that are present in the `fonts` folder inside the workspace.~~

If you guys also think this setting makes sense, I would love to see this MR being merged. (: