### PR TITLE
feat: delay doc switch

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -507,14 +507,12 @@ async function initTemplate(context: vscode.ExtensionContext, inPlace: boolean, 
   }
 }
 
-async function commandActivateDoc(doc: vscode.TextDocument | undefined): Promise<void> {
-  await commandActivateDocPath(doc, doc?.uri.fsPath);
+function commandActivateDoc(doc: vscode.TextDocument | undefined) {
+  commandActivateDocPath(doc, doc?.uri.fsPath);
 }
 
-async function commandActivateDocPath(
-  doc: vscode.TextDocument | undefined,
-  fsPath: string | undefined,
-): Promise<void> {
+let focusMainTimeout: NodeJS.Timeout | undefined = undefined;
+function commandActivateDocPath(doc: vscode.TextDocument | undefined, fsPath: string | undefined) {
   // console.log("focus main", fsPath, new Error().stack);
   extensionState.mut.focusingFile = fsPath;
   if (fsPath) {
@@ -528,7 +526,13 @@ async function commandActivateDocPath(
   triggerStatusBar(
     !!formatString && !!(fsPath || extensionState.mut.focusingDoc?.isClosed === false),
   );
-  await tinymist.executeCommand("tinymist.focusMain", [fsPath]);
+
+  if (focusMainTimeout) {
+    clearTimeout(focusMainTimeout);
+  }
+  focusMainTimeout = setTimeout(() => {
+    tinymist.executeCommand("tinymist.focusMain", [fsPath]);
+  }, 100);
 }
 
 async function commandRunCodeLens(...args: string[]): Promise<void> {


### PR DESCRIPTION
pattern, when vscode swtich files (by goto definition), it first close the previous doc and open the next doc.
```cjs
focus(@preview/cetz:0.3.4/lib.typ)
focus(undefined)
focus(@preview/cetz:0.3.4/canvas.typ)
```

This will cause unnecessary root change when viewing package source files. server internally does:
```cjs
change(root: /cache/preview/cetz/0.3.4, main: src/lib.typ)
change(root: /doc/root, main: None) // resetting root, all analysis cache lose
change(root: /cache/preview/cetz/0.3.4, main: src/canvas.typ) // resetting root, all analysis cache lose
```

We'll definitely be able to make root resolving stateful, but I may look if we could do that gracefully then.

