### PR TITLE
fix: the block is assumed to be used in expressions

### DIFF
--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -416,6 +416,10 @@ impl LateFuncLinter<'_, '_> {
     where
         F: FnOnce(&mut Self) -> Option<()>,
     {
+        let ctx = match ctx {
+            ExprContext::Block if self.expr_context != ExprContext::Block => ExprContext::BlockExpr,
+            a => a,
+        };
         let old = std::mem::replace(&mut self.expr_context, ctx);
         f(self);
         self.expr_context = old;
@@ -565,6 +569,7 @@ impl DataFlowVisitor for LateFuncLinter<'_, '_> {
     fn value(&mut self, expr: ast::Expr) -> Option<()> {
         match self.expr_context {
             ExprContext::Block => {}
+            ExprContext::BlockExpr => return None,
             ExprContext::Expr => return None,
         }
 
@@ -1001,7 +1006,9 @@ impl BuggyBlockLoc<'_> {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum ExprContext {
+    BlockExpr,
     Block,
     Expr,
 }

--- a/crates/tinymist-query/src/fixtures/lint/return_loop3.typ
+++ b/crates/tinymist-query/src/fixtures/lint/return_loop3.typ
@@ -1,0 +1,10 @@
+#let mul-mat(..matrices) = {
+  matrices = matrices.pos()
+  let out = matrices.remove(0)
+  for matrix in matrices {
+    out = for i in range(m) {
+      (i,)
+    }
+  }
+  return out
+}

--- a/crates/tinymist-query/src/fixtures/lint/return_partial_if.typ
+++ b/crates/tinymist-query/src/fixtures/lint/return_partial_if.typ
@@ -1,0 +1,7 @@
+#let get-op(offset, op) = {
+  if op == none {
+    op = if offset < 0 { "<=" } else { ">=" }
+  }
+
+  return op
+}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@return_loop3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@return_loop3.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/return_loop3.typ
+---
+{}

--- a/crates/tinymist-query/src/fixtures/lint/snaps/test@return_partial_if.typ.snap
+++ b/crates/tinymist-query/src/fixtures/lint/snaps/test@return_partial_if.typ.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/lint/return_partial_if.typ
+---
+{}


### PR DESCRIPTION
the pattern caused false positive:

```typ
#let get-op(offset, op) = {
  op = if offset < 0 { "<=" } else { ">=" }
  return op
}
```

This could be viewed as `op = "<="`, so the string is not discarded by `op`