### PR TITLE
docs: Fix syntax error in Neovim docs

### DIFF
--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -57,9 +57,9 @@ Run and configure `tinymist` in Neovim with support for all major distros and pa
 - Or finally with the builtin lsp protocol:
 
   ```lua
-  vim.lsp.config['tinymist'] = {
-      cmd = {'tinymist'},
-      filetypes = {'typst'}
+  vim.lsp.config["tinymist"] = {
+      cmd = { "tinymist" },
+      filetypes = { "typst" },
       settings = {
           -- ...
       }

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -77,9 +77,9 @@ To enable LSP, you must install `tinymist`. You can find `tinymist` by:
 - Or finally with the builtin lsp protocol:
 
   ```lua
-  vim.lsp.config['tinymist'] = {
-      cmd = {'tinymist'},
-      filetypes = {'typst'}
+  vim.lsp.config["tinymist"] = {
+      cmd = { "tinymist" },
+      filetypes = { "typst" },
       settings = {
           -- ...
       }


### PR DESCRIPTION
Closes #1671 

I also updated the single quotes to double quotes to better fit the style of the surrounding code blocks.