### PR TITLE
docs: Change pinning to use non-deprecated function `client:exec`

### DIFF
--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -133,35 +133,9 @@ Tinymist cannot know the main file of a multiple-files project if you don't tell
 
 The solution is a bit internal, which should get further improvement, but you can pin a main file by command.
 
-Using `vim.lsp.config`:
 ```lua
-vim.lsp.config["tinymist"] = {
-    cmd = { "tinymist" },
-    filetypes = { "typst" },
-    settings = {}
-    on_attach = function(client, bufnr)
-        vim.keymap.set("n", "<leader>tp", function()
-            client:exec_cmd({
-                title = "pin",
-                command = "tinymist.pinMain",
-                arguments = { vim.api.nvim_buf_get_name(0) },
-            }, { bufnr = bufnr })
-        end, { desc = "[T]inymist [P]in", noremap = true })
-
-        vim.keymap.set("n", "<leader>tu", function()
-            client:exec_cmd({
-                title = "unpin",
-                command = "tinymist.pinMain",
-                arguments = { vim.v.null },
-            }, { bufnr = bufnr })
-        end, { desc = "[T]inymist [U]npin", noremap = true })
-    end,
-}
-```
-
-Using `lspconfig`:
-```lua
-require("lspconfig")["tinymist"].setup {
+require("lspconfig")["tinymist"].setup { -- Alternatively, can be used `vim.lsp.config["tinymist"]`
+    -- ...
     settings = {}
     on_attach = function(client, bufnr)
         vim.keymap.set("n", "<leader>tp", function()

--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -133,12 +133,65 @@ Tinymist cannot know the main file of a multiple-files project if you don't tell
 
 The solution is a bit internal, which should get further improvement, but you can pin a main file by command.
 
+Using `vim.lsp.config`:
+```lua
+vim.lsp.config["tinymist"] = {
+    cmd = { "tinymist" },
+    filetypes = { "typst" },
+    settings = {}
+    on_attach = function(client, bufnr)
+        vim.keymap.set("n", "<leader>tp", function()
+            client:exec_cmd({
+                title = "pin",
+                command = "tinymist.pinMain",
+                arguments = { vim.api.nvim_buf_get_name(0) },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [P]in", noremap = true })
+
+        vim.keymap.set("n", "<leader>tu", function()
+            client:exec_cmd({
+                title = "unpin",
+                command = "tinymist.pinMain",
+                arguments = { vim.v.null },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [U]npin", noremap = true })
+    end,
+}
+```
+
+Using `lspconfig`:
+```lua
+require("lspconfig")["tinymist"].setup {
+    settings = {}
+    on_attach = function(client, bufnr)
+        vim.keymap.set("n", "<leader>tp", function()
+            client:exec_cmd({
+                title = "pin",
+                command = "tinymist.pinMain",
+                arguments = { vim.api.nvim_buf_get_name(0) },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [P]in", noremap = true })
+
+        vim.keymap.set("n", "<leader>tu", function()
+            client:exec_cmd({
+                title = "unpin",
+                command = "tinymist.pinMain",
+                arguments = { vim.v.null },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [U]npin", noremap = true })
+    end,
+}
+```
+Note that `vim.v.null` should be used instead of `nil` in the `arguments` table when unpinning. See #link("https://github.com/Myriad-Dreamin/tinymist/issues/1595", "issue #1595").
+
+For Neovim versions prior to 0.11.0, `vim.lsp.buf.execute_command` should be used instead:
 ```lua
 -- pin the main file
 vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.api.nvim_buf_get_name(0) } })
 -- unpin the main file
-vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { nil } })
+vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.v.null } })
 ```
+
 
 It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting Neovim.
 

--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -136,7 +136,6 @@ The solution is a bit internal, which should get further improvement, but you ca
 ```lua
 require("lspconfig")["tinymist"].setup { -- Alternatively, can be used `vim.lsp.config["tinymist"]`
     -- ...
-    settings = {}
     on_attach = function(client, bufnr)
         vim.keymap.set("n", "<leader>tp", function()
             client:exec_cmd({

--- a/docs/tinymist/frontend/neovim.typ
+++ b/docs/tinymist/frontend/neovim.typ
@@ -182,6 +182,7 @@ require("lspconfig")["tinymist"].setup {
     end,
 }
 ```
+
 Note that `vim.v.null` should be used instead of `nil` in the `arguments` table when unpinning. See #link("https://github.com/Myriad-Dreamin/tinymist/issues/1595", "issue #1595").
 
 For Neovim versions prior to 0.11.0, `vim.lsp.buf.execute_command` should be used instead:

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -155,11 +155,38 @@ Tinymist cannot know the main file of a multiple-files project if you don't tell
 The solution is a bit internal, which should get further improvement, but you can pin a main file by command.
 
 ```lua
+require("lspconfig")["tinymist"].setup { -- Alternatively, can be used `vim.lsp.config["tinymist"]`
+    -- ...
+    on_attach = function(client, bufnr)
+        vim.keymap.set("n", "<leader>tp", function()
+            client:exec_cmd({
+                title = "pin",
+                command = "tinymist.pinMain",
+                arguments = { vim.api.nvim_buf_get_name(0) },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [P]in", noremap = true })
+
+        vim.keymap.set("n", "<leader>tu", function()
+            client:exec_cmd({
+                title = "unpin",
+                command = "tinymist.pinMain",
+                arguments = { vim.v.null },
+            }, { bufnr = bufnr })
+        end, { desc = "[T]inymist [U]npin", noremap = true })
+    end,
+}
+```
+
+Note that `vim.v.null` should be used instead of `nil` in the `arguments` table when unpinning. See [issue #1595](https://github.com/Myriad-Dreamin/tinymist/issues/1595).
+
+For Neovim versions prior to 0.11.0, `vim.lsp.buf.execute_command` should be used instead:
+```lua
 -- pin the main file
 vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.api.nvim_buf_get_name(0) } })
 -- unpin the main file
-vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { nil } })
+vim.lsp.buf.execute_command({ command = 'tinymist.pinMain', arguments = { vim.v.null } })
 ```
+
 
 It also doesn't remember the pinned main file across sessions, so you may need to run the command again after restarting Neovim.
 

--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -28,8 +28,8 @@ return {
             --- You could set the formatter mode to use lsp-enhanced formatters.
             -- formatterMode = "typstyle",
             
-            --- If you love to edit the documents and preview exported pdfs in the same time,
-            --- you could set this to `onType`.
+            --- If you would love to preview exported PDF files at the same time,
+            --- you could set this to `onType` and open the file with your favorite PDF viewer.
             -- exportPdf = "onType",
           },
           on_attach = function(client, bufnr)

--- a/editors/neovim/plugins/tinymist.lua
+++ b/editors/neovim/plugins/tinymist.lua
@@ -24,7 +24,31 @@ return {
             return vim.fn.getcwd()
           end,
           --- See [Tinymist Server Configuration](https://github.com/Myriad-Dreamin/tinymist/blob/main/Configuration.md) for references.
-          settings = {}
+          settings = {
+            --- You could set the formatter mode to use lsp-enhanced formatters.
+            -- formatterMode = "typstyle",
+            
+            --- If you love to edit the documents and preview exported pdfs in the same time,
+            --- you could set this to `onType`.
+            -- exportPdf = "onType",
+          },
+          on_attach = function(client, bufnr)
+              vim.keymap.set("n", "<leader>tp", function()
+                  client:exec_cmd({
+                      title = "pin",
+                      command = "tinymist.pinMain",
+                      arguments = { vim.api.nvim_buf_get_name(0) },
+                  }, { bufnr = bufnr })
+              end, { desc = "[T]inymist [P]in", noremap = true })
+      
+              vim.keymap.set("n", "<leader>tu", function()
+                  client:exec_cmd({
+                      title = "unpin",
+                      command = "tinymist.pinMain",
+                      arguments = { vim.v.null },
+                  }, { bufnr = bufnr })
+              end, { desc = "[T]inymist [U]npin", noremap = true })
+          end,
         },
       },
     },


### PR DESCRIPTION
Related to #1670 and #1595.

Should not be merged until #1670 is resolved.