### PR TITLE
fix: built-in CSL styles are recognized as path link

### DIFF
--- a/crates/tinymist-query/src/analysis/link_expr.rs
+++ b/crates/tinymist-query/src/analysis/link_expr.rs
@@ -120,7 +120,7 @@ impl LinkStrWorker {
                     }
                     "bibliography" => {
                         self.analyze_reader(node, call, "cite", false);
-                        self.analyze_reader(node, call, "style", false);
+                        self.analyze_bibliography_style(node, call);
                         self.analyze_reader(node, call, "path", true);
                     }
                     "cbor" | "csv" | "image" | "read" | "json" | "yaml" | "xml" => {
@@ -132,6 +132,24 @@ impl LinkStrWorker {
             }
             return None;
         }
+    }
+
+    fn analyze_bibliography_style(&mut self, node: &LinkedNode, call: ast::FuncCall) -> Option<()> {
+        for item in call.args().items() {
+            match item {
+                ast::Arg::Named(named) if named.name().get().as_str() == "style" => {
+                    if let ast::Expr::Str(style) = named.expr() {
+                        if hayagriva::archive::ArchivedStyle::by_name(&style.get()).is_some() {
+                            return Some(());
+                        }
+                    }
+                    self.analyze_path_expr(node, named.expr());
+                    return Some(());
+                }
+                _ => {}
+            }
+        }
+        Some(())
     }
 
     fn analyze_reader(

--- a/crates/tinymist-query/src/fixtures/document_link/bibliography_csl.typ
+++ b/crates/tinymist-query/src/fixtures/document_link/bibliography_csl.typ
@@ -1,0 +1,11 @@
+/// path: references.bib
+@article{Russell:1908,
+Author = {Bertand Russell},
+Journal = {American Journal of Mathematics},
+Pages = {222--262},
+Title = {Mathematical logic based on the theory of types},
+Volume = 30,
+Year = 1908}
+-----
+#bibliography("references.bib", style: "alphanumeric");
+#bibliography("references.bib", style: "style.csl");

--- a/crates/tinymist-query/src/fixtures/document_link/snaps/test@bibliography_csl.typ.snap
+++ b/crates/tinymist-query/src/fixtures/document_link/snaps/test@bibliography_csl.typ.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tinymist-query/src/document_link.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/document_link/bibliography_csl.typ
+---
+[
+ {
+  "range": "0:15:0:29",
+  "target": "references.bib"
+ },
+ {
+  "range": "1:40:1:49",
+  "target": "style.csl"
+ },
+ {
+  "range": "1:15:1:29",
+  "target": "references.bib"
+ }
+]


### PR DESCRIPTION
Wrong case: 
<img width="694" alt="image" src="https://github.com/user-attachments/assets/6b5a0d34-c809-44c2-92c8-0102c96de9e4" />
