### PR TITLE
feat: model and make `reset_read` public

### DIFF
--- a/crates/tinymist-vfs/src/lib.rs
+++ b/crates/tinymist-vfs/src/lib.rs
@@ -260,7 +260,7 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
     /// Resets all state.
     pub fn reset_all(&mut self) {
         self.reset_access_model();
-        self.reset_mapping();
+        self.reset_read();
         self.take_source_cache();
     }
 
@@ -269,9 +269,12 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
         self.access_model.reset();
     }
 
-    /// Resets all possible caches.
-    pub fn reset_mapping(&mut self) {
-        self.revise().reset_cache();
+    /// Resets all read caches. This can happen when:
+    /// - package paths are reconfigured.
+    /// - The root of the workspace is switched.
+    pub fn reset_read(&mut self) {
+        self.managed = Arc::default();
+        self.paths = Arc::default();
     }
 
     /// Clears the cache that is not touched for a long time.
@@ -498,15 +501,6 @@ impl<M: PathAccessModel + Sized> RevisingVfs<'_, M> {
 
         self.am().clear_shadow();
         self.am().inner.inner.clear_shadow();
-    }
-
-    /// Resets all caches. This can happen when:
-    /// - package paths are reconfigured.
-    /// - The root of the workspace is switched.
-    pub fn reset_cache(&mut self) {
-        self.view_changed = true;
-        self.managed = EntryMap::default();
-        self.paths = PathMap::default();
     }
 
     /// Adds a shadowing file to the [`OverlayAccessModel`].

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -358,7 +358,7 @@ impl<F: CompilerFeat> Drop for RevisingUniverse<'_, F> {
 
             // The registry has changed affects the vfs cache.
             log::info!("resetting shadow registry_changed");
-            self.vfs().reset_cache();
+            self.vfs.reset_read();
         }
         let view_changed = view_changed || self.vfs_changed();
 
@@ -403,7 +403,7 @@ impl<F: CompilerFeat> RevisingUniverse<'_, F> {
         let root_changed = self.inner.entry.workspace_root() != state.workspace_root();
         if root_changed {
             log::info!("resetting shadow root_changed");
-            self.vfs().reset_cache();
+            self.vfs.reset_read();
         }
 
         self.inner.mutate_entry_(state)
@@ -504,20 +504,28 @@ impl<F: CompilerFeat> CompilerWorld<F> {
         };
 
         if root_changed {
-            world.vfs.revise().reset_cache();
+            world.vfs.reset_read();
         }
 
         world
     }
 
-    pub fn take_cache(&mut self) -> SourceCache {
+    /// See [`Vfs::reset_read`].
+    pub fn reset_read(&mut self) {
+        self.vfs.reset_read();
+    }
+
+    /// See [`Vfs::take_source_cache`].
+    pub fn take_source_cache(&mut self) -> SourceCache {
         self.vfs.take_source_cache()
     }
 
-    pub fn clone_cache(&mut self) -> SourceCache {
+    /// See [`Vfs::clone_source_cache`].
+    pub fn clone_source_cache(&mut self) -> SourceCache {
         self.vfs.clone_source_cache()
     }
 
+    /// See [`SourceDb::take_state`].
     pub fn take_db(&mut self) -> SourceDb {
         self.source_db.take_state()
     }


### PR DESCRIPTION
Sometimes, the tools may like read all the things from the system again.