### PR TITLE
feat: typlite supports latex export

### DIFF
--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@base.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@base.typ.snap
@@ -1,0 +1,23 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/base.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1heading level="1"><span style="display: inline-block;">Hello, World!</span></m1heading><p>This is a typst document.</p></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\section{Hello, World!}
+
+This is a typst document.
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@enum.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@enum.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/enum.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><ol><li>A</li><li>B</li></ol></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{enumerate}
+\item A
+\item B
+\end{enumerate}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@enum2.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@enum2.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/enum2.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><ol><li value="2">A</li><li>B</li></ol></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{enumerate}
+\item A
+\item B
+\end{enumerate}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_caption.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_caption.typ.snap
@@ -1,0 +1,25 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/figure_caption.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1figure caption="Caption"><m1image src="./fig.svg" alt="Content"></m1image></m1figure></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.8\textwidth]{fig.svg}
+\caption{Caption}
+\end{figure}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_image.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_image.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/figure_image.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1figure caption=""><m1image src="./fig.svg" alt=""></m1image></m1figure></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.8\textwidth]{fig.svg}
+\end{figure}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_image_alt.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@figure_image_alt.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/figure_image_alt.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1figure caption=""><m1image src="./fig.svg" alt="Content"></m1image></m1figure></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.8\textwidth]{fig.svg}
+\end{figure}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@image.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@image.typ.snap
@@ -1,0 +1,26 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/image.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1image src="./fig.svg" alt=""></m1image></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{figure}
+\centering
+\includegraphics[width=0.8\textwidth]{fig.svg}
+\end{figure}
+
+
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@image_alt.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@image_alt.typ.snap
@@ -1,0 +1,27 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/image_alt.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1image src="./fig.svg" alt="Content"></m1image></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{figure}
+\centering
+\includegraphics[width=0.8\textwidth]{fig.svg}
+\caption{Content}
+\end{figure}
+
+
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@link.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@link.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/link.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><span><m1link dest="https://example.com">https://example.com</m1link></span></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\href{https://example.com}{https://example.com}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@link2.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@link2.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/link2.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><span><m1link dest="https://example.com">Content</m1link></span></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\href{https://example.com}{Content}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@link3.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@link3.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/link3.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><span><m1link dest="https://example.com">Reverse <span><m1strong>the World</m1strong></span></m1link></span></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\href{https://example.com}{Reverse \textbf{the World}}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@list.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@list.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/list.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><ul><li>Some <span><m1strong>item</m1strong></span></li><li>Another <span><m1emph>item</m1emph></span></li></ul></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{itemize}
+\item Some \textbf{item}
+\item Another \textit{item}
+\end{itemize}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_block.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_block.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/math_block.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1eqblock>redacted-frame</m1eqblock></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_block2.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_block2.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/math_block2.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1eqblock>redacted-frame</m1eqblock></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_inline.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@math_inline.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/math_inline.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1eqinline>redacted-frame</m1eqinline></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@outline.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@outline.typ.snap
@@ -1,0 +1,97 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/outline.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1outline><m1heading level="1"><span style="display: inline-block;">Contents</span></m1heading><m1outentry level="2"><m1heading level="2"><span style="display: inline-block;">Heading 1</span></m1heading></m1outentry><m1outentry level="3"><m1heading level="3"><span style="display: inline-block;">Heading 2</span></m1heading></m1outentry></m1outline><m1parbreak></m1parbreak><m1heading level="2"><span style="display: inline-block;">Heading 1</span></m1heading><m1parbreak></m1parbreak><m1heading level="3"><span style="display: inline-block;">Heading 2</span></m1heading><m1parbreak></m1parbreak><p><span><m1link dest="https://example.com">This is a link to example.com</m1link></span></p><m1parbreak></m1parbreak><p>Inline <span><m1raw lang="" block="false" text="code"></m1raw></span> has <span><m1raw lang="" block="false" text="back-ticks around"></m1raw></span> it.</p><m1parbreak></m1parbreak><m1raw lang="cs" block="true" text="using System.IO.Compression;
+
+#pragma warning disable 414, 3021
+
+namespace MyApplication
+{
+    [Obsolete(&quot;...&quot;)]
+    class Program : IInterface
+    {
+        public static List<int> JustDoIt(int count)
+        {
+            Console.WriteLine($&quot;Hello {Name}!&quot;);
+            return new List<int>(new int[] { 1, 2, 3 })
+        }
+    }
+}"></m1raw><m1parbreak></m1parbreak><p>Math inline:</p><m1eqinline>redacted-frame</m1eqinline><p>and block:</p><m1eqblock>redacted-frame</m1eqblock><m1parbreak></m1parbreak><ul><li>First item</li><li><p>Second item</p><ol><li>First sub-item</li><li><p>Second sub-item</p><ul><li>First sub-sub-item</li></ul></li></ol></li></ul><m1parbreak></m1parbreak><dl><dt>First term</dt><dd>First definition</dd></dl><m1parbreak></m1parbreak><m1table><table><tr><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td></tr></table></m1table></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\section{Contents}
+
+\subsection{Heading 1}
+
+\subsubsection{Heading 2}
+
+\subsection{Heading 1}
+
+\subsubsection{Heading 2}
+
+\href{https://example.com}{This is a link to example.com}
+
+Inline \texttt{code} has \texttt{back-ticks around} it.
+
+\begin{lstlisting}[language=cs]
+using System.IO.Compression;
+
+#pragma warning disable 414, 3021
+
+namespace MyApplication
+{
+    [Obsolete("...")]
+    class Program : IInterface
+    {
+        public static List<int> JustDoIt(int count)
+        {
+            Console.WriteLine($"Hello {Name}!");
+            return new List<int>(new int[] { 1, 2, 3 })
+        }
+    }
+}
+\end{lstlisting}
+
+Math inline:and block:
+
+
+
+\begin{itemize}
+\item First item
+\item Second item\begin{enumerate}
+\item First sub-item
+\item Second sub-item\begin{itemize}
+\item First sub-sub-item
+\end{itemize}
+
+
+\end{enumerate}
+
+
+\end{itemize}
+
+First termFirst definition
+
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cccccccccccccccccccc}
+\hline
+0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 & 11 & 12 & 13 & 14 & 15 & 16 & 17 & 18 & 19 \\
+\hline
+\hline
+\end{tabular}
+\end{table}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@raw_inline.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@raw_inline.typ.snap
@@ -1,0 +1,21 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/raw_inline.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document>Some inlined raw <span><m1raw lang="" block="false" text="a"></m1raw></span>, <span><m1raw lang="c" block="false" text="b"></m1raw></span></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+Some inlined raw \texttt{a}, \texttt{b}
+
+
+\end{document}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@table.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@table.typ.snap
@@ -1,0 +1,42 @@
+---
+source: crates/typlite/src/tests.rs
+expression: "conv(world, ConvKind::LaTeX)"
+input_file: crates/typlite/src/fixtures/integration/table.typ
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><m1document><m1table><table><tr><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td></tr></table></m1table><m1parbreak></m1parbreak><m1table><table><tr><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr><tr><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td></tr><tr><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td></tr><tr><td>18</td><td>19</td><td></td><td></td><td></td><td></td></tr></table></m1table><m1parbreak></m1parbreak><m1table><table><tr><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr><tr><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td></tr><tr><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td></tr><tr><td>18</td><td>19</td><td colspan="2">0</td><td colspan="2">1</td></tr><tr><td colspan="2">2</td><td colspan="2">3</td><td colspan="2">4</td></tr><tr><td colspan="2">5</td><td colspan="2">6</td><td colspan="2">7</td></tr><tr><td colspan="2">8</td><td colspan="2">9</td><td colspan="2">10</td></tr><tr><td colspan="2">11</td><td colspan="2">12</td><td colspan="2">13</td></tr><tr><td colspan="2">14</td><td colspan="2">15</td><td colspan="2">16</td></tr><tr><td colspan="2">17</td><td colspan="2">18</td><td colspan="2">19</td></tr></table></m1table></m1document></body>
+</html>
+
+=====
+\begin{document}
+
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cccccccccccccccccccc}
+\hline
+0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 & 11 & 12 & 13 & 14 & 15 & 16 & 17 & 18 & 19 \\
+\hline
+\hline
+\end{tabular}
+\end{table}
+
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cccccc}
+\hline
+0 & 1 & 2 & 3 & 4 & 5 \\
+\hline
+6 & 7 & 8 & 9 & 10 & 11 \\
+12 & 13 & 14 & 15 & 16 & 17 \\
+18 & 19 \\
+\hline
+\end{tabular}
+\end{table}
+
+012345678910111213141516171819012345678910111213141516171819
+\end{document}

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -25,6 +25,7 @@ use typst::foundations::Bytes;
 use typst::html::HtmlDocument;
 use typst::World;
 use typst_syntax::VirtualPath;
+use writer::LaTeXWriter;
 
 use crate::common::Format;
 use crate::parser::HtmlToAstParser;
@@ -84,11 +85,14 @@ impl MarkdownDocument {
     }
 
     /// Convert the content to a LaTeX string.
-    pub fn to_tex_string(&self) -> Result<ecow::EcoString> {
+    pub fn to_tex_string(&self, prelude: bool) -> Result<ecow::EcoString> {
         let mut output = ecow::EcoString::new();
         let ast = self.parse()?;
 
         let mut writer = WriterFactory::create(Format::LaTeX);
+        if prelude {
+            LaTeXWriter::default_prelude(&mut output);
+        }
         writer.write_eco(&ast, &mut output)?;
 
         Ok(output)
@@ -166,7 +170,7 @@ impl Typlite {
     pub fn convert(self) -> Result<ecow::EcoString> {
         match self.format {
             Format::Md => self.convert_doc()?.to_md_string(),
-            Format::LaTeX => self.convert_doc()?.to_tex_string(),
+            Format::LaTeX => self.convert_doc()?.to_tex_string(true),
             _ => Err("format is not supported".into()),
         }
     }

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -11,7 +11,6 @@ pub mod value;
 pub mod worker;
 pub mod writer;
 
-use std::cell::RefCell;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -42,28 +41,54 @@ pub use tinymist_std;
 pub struct MarkdownDocument {
     pub base: HtmlDocument,
     feat: TypliteFeat,
-    ast_cache: RefCell<Option<Node>>,
+    ast: Option<Node>,
 }
 
 impl MarkdownDocument {
-    /// Parse HTML document with AST cache.
-    fn parse(&self) -> Result<Node> {
-        if let Some(ast) = self.ast_cache.borrow().as_ref() {
+    /// Create a new MarkdownDocument instance
+    pub fn new(base: HtmlDocument, feat: TypliteFeat) -> Self {
+        Self {
+            base,
+            feat,
+            ast: None,
+        }
+    }
+
+    /// Create a MarkdownDocument instance with pre-parsed AST
+    pub fn with_ast(base: HtmlDocument, feat: TypliteFeat, ast: Node) -> Self {
+        Self {
+            base,
+            feat,
+            ast: Some(ast),
+        }
+    }
+
+    /// Parse HTML document to AST
+    pub fn parse(&self) -> Result<Node> {
+        if let Some(ast) = &self.ast {
             return Ok(ast.clone());
         }
         let parser = HtmlToAstParser::new(self.feat.clone());
-        let ast = parser.parse(&self.base.root)?;
-        *self.ast_cache.borrow_mut() = Some(ast.clone());
-
-        Ok(ast)
+        parser.parse(&self.base.root)
     }
 
-    /// Convert the content to a markdown string.
+    /// Convert content to markdown string
     pub fn to_md_string(&self) -> Result<ecow::EcoString> {
         let mut output = ecow::EcoString::new();
         let ast = self.parse()?;
 
         let mut writer = WriterFactory::create(Format::Md);
+        writer.write_eco(&ast, &mut output)?;
+
+        Ok(output)
+    }
+
+    /// Convert the content to a LaTeX string.
+    pub fn to_tex_string(&self) -> Result<ecow::EcoString> {
+        let mut output = ecow::EcoString::new();
+        let ast = self.parse()?;
+
+        let mut writer = WriterFactory::create(Format::LaTeX);
         writer.write_eco(&ast, &mut output)?;
 
         Ok(output)
@@ -141,6 +166,7 @@ impl Typlite {
     pub fn convert(self) -> Result<ecow::EcoString> {
         match self.format {
             Format::Md => self.convert_doc()?.to_md_string(),
+            Format::LaTeX => self.convert_doc()?.to_tex_string(),
             _ => Err("format is not supported".into()),
         }
     }
@@ -199,11 +225,7 @@ impl Typlite {
         let base = typst::compile(&world)
             .output
             .map_err(|err| format!("convert source for main file: {err:?}"))?;
-        Ok(MarkdownDocument {
-            base,
-            feat: self.feat,
-            ast_cache: RefCell::new(None),
-        })
+        Ok(MarkdownDocument::new(base, self.feat))
     }
 }
 

--- a/crates/typlite/src/main.rs
+++ b/crates/typlite/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> typlite::Result<()> {
         match format {
             Format::Docx => todo!(),
             Format::LaTeX => {
-                let result = doc.to_tex_string();
+                let result = doc.to_tex_string(true);
                 match (result, output) {
                     (Ok(content), None) => {
                         std::io::stdout()

--- a/crates/typlite/src/main.rs
+++ b/crates/typlite/src/main.rs
@@ -93,7 +93,27 @@ fn main() -> typlite::Result<()> {
 
         match format {
             Format::Docx => todo!(),
-            Format::LaTeX => todo!(),
+            Format::LaTeX => {
+                let result = doc.to_tex_string();
+                match (result, output) {
+                    (Ok(content), None) => {
+                        std::io::stdout()
+                            .write_all(content.as_str().as_bytes())
+                            .unwrap();
+                    }
+                    (Ok(content), Some(output)) => {
+                        if let Err(err) = std::fs::write(&output, content.as_str()) {
+                            eprintln!("failed to write LaTeX file {}: {}", output.display(), err);
+                            continue;
+                        }
+                        println!("Generated LaTeX file: {}", output.display());
+                    }
+                    (Err(err), _) => {
+                        eprintln!("Error converting to LaTeX for {}: {}", output_path, err);
+                        continue;
+                    }
+                }
+            }
             Format::Md => {
                 let result = doc.to_md_string();
                 match (result, output) {

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -207,7 +207,7 @@ impl HtmlToAstParser {
                     let res = self.convert_frame(frame);
                     self.inline_buffer.push(res);
                 }
-                _ => {}
+                HtmlNode::Tag(..) => {}
             }
         }
         Ok(())

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -13,6 +13,7 @@ use super::{inline::InlineParser, list::ListParser, table::TableParser};
 
 /// HTML to AST parser implementation
 pub struct HtmlToAstParser {
+    pub frame_counter: usize,
     pub feat: TypliteFeat,
     pub list_state: Option<ListState>,
     pub list_level: usize,
@@ -24,6 +25,7 @@ impl HtmlToAstParser {
     pub fn new(feat: TypliteFeat) -> Self {
         Self {
             feat,
+            frame_counter: 0,
             list_level: 0,
             list_state: None,
             blocks: Vec::new(),
@@ -202,7 +204,8 @@ impl HtmlToAstParser {
                     self.convert_element(element)?;
                 }
                 HtmlNode::Frame(frame) => {
-                    self.inline_buffer.push(self.convert_frame(frame));
+                    let res = self.convert_frame(frame);
+                    self.inline_buffer.push(res);
                 }
                 _ => {}
             }

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -60,7 +60,7 @@ fn conv(world: LspWorld, kind: ConvKind) -> String {
     let repr = typst_html::html(&redact(doc.base.clone())).unwrap();
     let res = match kind {
         ConvKind::Md { .. } => doc.to_md_string().unwrap(),
-        ConvKind::LaTeX => doc.to_tex_string().unwrap(),
+        ConvKind::LaTeX => doc.to_tex_string(false).unwrap(),
     };
 
     static REG: OnceLock<Regex> = OnceLock::new();

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -15,20 +15,41 @@ pub fn snapshot_testing(name: &str, f: &impl Fn(LspWorld, PathBuf)) {
 #[test]
 fn convert() {
     snapshot_testing("integration", &|world, _path| {
-        insta::assert_snapshot!(conv(world, false));
+        insta::assert_snapshot!(conv(world, ConvKind::Md { for_docs: false }));
+    });
+}
+
+#[test]
+fn convert_tex() {
+    snapshot_testing("integration", &|world, _path| {
+        insta::assert_snapshot!(conv(world, ConvKind::LaTeX));
     });
 }
 
 #[test]
 fn convert_docs() {
     snapshot_testing("docs", &|world, _path| {
-        insta::assert_snapshot!(conv(world, true));
+        insta::assert_snapshot!(conv(world, ConvKind::Md { for_docs: true }));
     });
 }
 
-fn conv(world: LspWorld, for_docs: bool) -> String {
+enum ConvKind {
+    Md { for_docs: bool },
+    LaTeX,
+}
+
+impl ConvKind {
+    fn for_docs(&self) -> bool {
+        match self {
+            ConvKind::Md { for_docs } => *for_docs,
+            ConvKind::LaTeX => false,
+        }
+    }
+}
+
+fn conv(world: LspWorld, kind: ConvKind) -> String {
     let converter = Typlite::new(Arc::new(world)).with_feature(TypliteFeat {
-        annotate_elem: for_docs,
+        annotate_elem: kind.for_docs(),
         ..Default::default()
     });
     let doc = match converter.convert_doc() {
@@ -37,7 +58,11 @@ fn conv(world: LspWorld, for_docs: bool) -> String {
     };
 
     let repr = typst_html::html(&redact(doc.base.clone())).unwrap();
-    let res = doc.to_md_string().unwrap();
+    let res = match kind {
+        ConvKind::Md { .. } => doc.to_md_string().unwrap(),
+        ConvKind::LaTeX => doc.to_tex_string().unwrap(),
+    };
+
     static REG: OnceLock<Regex> = OnceLock::new();
     let reg = REG.get_or_init(|| Regex::new(r#"data:image/svg\+xml;base64,([^"]+)"#).unwrap());
     let res = reg.replace_all(&res, |_captures: &regex::Captures| {

--- a/crates/typlite/src/writer/latex.rs
+++ b/crates/typlite/src/writer/latex.rs
@@ -1,0 +1,414 @@
+//! LaTeX writer implementation
+
+use std::path::Path;
+
+use cmark_writer::ast::Node;
+use ecow::EcoString;
+use tinymist_std::path::unix_slash;
+
+use crate::common::{ExternalFrameNode, FigureNode, FormatWriter, HighlightNode, ListState};
+use crate::Result;
+
+/// LaTeX writer implementation
+pub struct LaTeXWriter {
+    list_state: Option<ListState>,
+}
+
+impl Default for LaTeXWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LaTeXWriter {
+    pub fn new() -> Self {
+        Self { list_state: None }
+    }
+
+    fn write_inline_nodes(&mut self, nodes: &[Node], output: &mut EcoString) -> Result<()> {
+        for node in nodes {
+            self.write_node(node, output)?;
+        }
+        Ok(())
+    }
+
+    /// Write the document to LaTeX format
+    fn write_node(&mut self, node: &Node, output: &mut EcoString) -> Result<()> {
+        match node {
+            Node::Document(blocks) => {
+                for block in blocks {
+                    self.write_node(block, output)?;
+                }
+            }
+            Node::Paragraph(inlines) => {
+                self.write_inline_nodes(inlines, output)?;
+                output.push_str("\n\n");
+            }
+            Node::Heading {
+                level,
+                content,
+                heading_type: _,
+            } => {
+                if *level > 4 {
+                    return Err(format!("heading level {} is not supported in LaTeX", level).into());
+                }
+
+                output.push('\\');
+                match level {
+                    1 => output.push_str("chapter{"),
+                    2 => output.push_str("section{"),
+                    3 => output.push_str("subsection{"),
+                    4 => output.push_str("subsubsection{"),
+                    _ => return Err(format!("Heading level {} is not supported", level).into()),
+                }
+
+                self.write_inline_nodes(content, output)?;
+                output.push_str("}\n\n");
+            }
+            Node::BlockQuote(content) => {
+                output.push_str("\\begin{quote}\n");
+                for block in content {
+                    self.write_node(block, output)?;
+                }
+                output.push_str("\\end{quote}\n");
+            }
+            Node::CodeBlock {
+                language,
+                content,
+                block_type: _,
+            } => {
+                if let Some(lang) = language {
+                    if !lang.is_empty() {
+                        output.push_str("\\begin{lstlisting}[language=");
+                        output.push_str(lang);
+                        output.push_str("]\n");
+                    } else {
+                        output.push_str("\\begin{verbatim}\n");
+                    }
+                } else {
+                    output.push_str("\\begin{verbatim}\n");
+                }
+
+                output.push_str(content);
+
+                if language.as_ref().is_none_or(|lang| lang.is_empty()) {
+                    output.push_str("\n\\end{verbatim}");
+                } else {
+                    output.push_str("\n\\end{lstlisting}");
+                }
+                output.push_str("\n\n");
+            }
+            Node::OrderedList { start: _, items } => {
+                let previous_state = self.list_state;
+                self.list_state = Some(ListState::Ordered);
+
+                output.push_str("\\begin{enumerate}\n");
+                for item in items {
+                    match item {
+                        cmark_writer::ast::ListItem::Ordered { content, .. }
+                        | cmark_writer::ast::ListItem::Unordered { content } => {
+                            output.push_str("\\item ");
+                            for block in content {
+                                match block {
+                                    // For paragraphs, we want inline content rather than creating a new paragraph
+                                    Node::Paragraph(inlines) => {
+                                        self.write_inline_nodes(inlines, output)?;
+                                    }
+                                    _ => self.write_node(block, output)?,
+                                }
+                            }
+                            output.push('\n');
+                        }
+                        _ => {}
+                    }
+                }
+                output.push_str("\\end{enumerate}\n\n");
+
+                self.list_state = previous_state;
+            }
+            Node::UnorderedList(items) => {
+                let previous_state = self.list_state;
+                self.list_state = Some(ListState::Unordered);
+
+                output.push_str("\\begin{itemize}\n");
+                for item in items {
+                    match item {
+                        cmark_writer::ast::ListItem::Ordered { content, .. }
+                        | cmark_writer::ast::ListItem::Unordered { content } => {
+                            output.push_str("\\item ");
+                            for block in content {
+                                match block {
+                                    // For paragraphs, we want inline content rather than creating a new paragraph
+                                    Node::Paragraph(inlines) => {
+                                        self.write_inline_nodes(inlines, output)?;
+                                    }
+                                    _ => self.write_node(block, output)?,
+                                }
+                            }
+                            output.push('\n');
+                        }
+                        _ => {}
+                    }
+                }
+                output.push_str("\\end{itemize}\n\n");
+
+                self.list_state = previous_state;
+            }
+            Node::Table {
+                headers,
+                rows,
+                alignments: _,
+            } => {
+                // Calculate column count
+                let col_count = headers
+                    .len()
+                    .max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
+
+                output.push_str("\\begin{table}[htbp]\n");
+                output.push_str("\\centering\n");
+                output.push_str("\\begin{tabular}{");
+
+                // Add column format (centered alignment)
+                for _ in 0..col_count {
+                    output.push('c');
+                }
+                output.push_str("}\n\\hline\n");
+
+                // Process header
+                if !headers.is_empty() {
+                    for (i, cell) in headers.iter().enumerate() {
+                        if i > 0 {
+                            output.push_str(" & ");
+                        }
+                        self.write_node(cell, output)?;
+                    }
+                    output.push_str(" \\\\\n\\hline\n");
+                }
+
+                // Process all rows
+                for row in rows {
+                    for (i, cell) in row.iter().enumerate() {
+                        if i > 0 {
+                            output.push_str(" & ");
+                        }
+                        self.write_node(cell, output)?;
+                    }
+                    output.push_str(" \\\\\n");
+                }
+
+                // Close table environment
+                output.push_str("\\hline\n");
+                output.push_str("\\end{tabular}\n");
+                output.push_str("\\end{table}\n\n");
+            }
+            Node::Custom(custom_node) => {
+                if let Some(figure_node) = custom_node.as_any().downcast_ref::<FigureNode>() {
+                    // Start figure environment
+                    output.push_str("\\begin{figure}[htbp]\n\\centering\n");
+
+                    // Handle the body content (typically an image)
+                    match &*figure_node.body {
+                        Node::Paragraph(content) => {
+                            for node in content {
+                                // Special handling for image nodes in figures
+                                if let Node::Image {
+                                    url,
+                                    title: _,
+                                    alt: _,
+                                } = node
+                                {
+                                    // Path to the image file
+                                    let path = unix_slash(Path::new(url));
+
+                                    // Write includegraphics command
+                                    output.push_str("\\includegraphics[width=0.8\\textwidth]{");
+                                    output.push_str(&path);
+                                    output.push_str("}\n");
+                                } else {
+                                    // For non-image content, just render it normally
+                                    self.write_node(node, output)?;
+                                }
+                            }
+                        }
+                        // Directly handle the node if it's not in a paragraph
+                        node => self.write_node(node, output)?,
+                    }
+
+                    // Add caption if present
+                    if !figure_node.caption.is_empty() {
+                        output.push_str("\\caption{");
+                        output.push_str(&escape_latex(&figure_node.caption));
+                        output.push_str("}\n");
+                    }
+
+                    // Close figure environment
+                    output.push_str("\\end{figure}\n\n");
+                } else if let Some(external_frame) =
+                    custom_node.as_any().downcast_ref::<ExternalFrameNode>()
+                {
+                    // Handle externally stored frames
+                    let path = unix_slash(&external_frame.file_path);
+
+                    output.push_str("\\begin{figure}[htbp]\n");
+                    output.push_str("\\centering\n");
+                    output.push_str("\\includegraphics[width=0.8\\textwidth]{");
+                    output.push_str(&path);
+                    output.push_str("}\n");
+
+                    if !external_frame.alt_text.is_empty() {
+                        output.push_str("\\caption{");
+                        output.push_str(&escape_latex(&external_frame.alt_text));
+                        output.push_str("}\n");
+                    }
+
+                    output.push_str("\\end{figure}\n\n");
+                } else if let Some(highlight_node) =
+                    custom_node.as_any().downcast_ref::<HighlightNode>()
+                {
+                    output.push_str("\\colorbox{yellow}{");
+                    for child in &highlight_node.content {
+                        self.write_node(child, output)?;
+                    }
+                    output.push_str("}");
+                } else {
+                    // Fallback for unknown custom nodes
+                    output.push_str("[Unknown custom node]");
+                }
+            }
+            Node::Text(text) => {
+                output.push_str(&escape_latex(text));
+            }
+            Node::Emphasis(content) => {
+                output.push_str("\\textit{");
+                self.write_inline_nodes(content, output)?;
+                output.push_str("}");
+            }
+            Node::Strong(content) => {
+                output.push_str("\\textbf{");
+                self.write_inline_nodes(content, output)?;
+                output.push_str("}");
+            }
+            Node::Strikethrough(content) => {
+                output.push_str("\\sout{");
+                self.write_inline_nodes(content, output)?;
+                output.push_str("}");
+            }
+            Node::Link {
+                url,
+                title: _,
+                content,
+            } => {
+                output.push_str("\\href{");
+                output.push_str(url);
+                output.push_str("}{");
+                self.write_inline_nodes(content, output)?;
+                output.push_str("}");
+            }
+            Node::Image { url, title: _, alt } => {
+                let alt_text = if !alt.is_empty() {
+                    let mut alt_str = EcoString::new();
+                    self.write_inline_nodes(alt, &mut alt_str)?;
+                    alt_str
+                } else {
+                    "".into()
+                };
+
+                let path = unix_slash(Path::new(url));
+
+                output.push_str("\\begin{figure}\n");
+                output.push_str("\\centering\n");
+                output.push_str("\\includegraphics[width=0.8\\textwidth]{");
+                output.push_str(&path);
+                output.push_str("}\n");
+
+                if !alt_text.is_empty() {
+                    output.push_str("\\caption{");
+                    output.push_str(&alt_text);
+                    output.push_str("}\n");
+                }
+
+                output.push_str("\\end{figure}\n\n");
+            }
+            Node::InlineCode(code) => {
+                output.push_str("\\texttt{");
+                output.push_str(&escape_latex(code));
+                output.push_str("}");
+            }
+            Node::HardBreak => {
+                output.push_str("\\\\\n");
+            }
+            Node::SoftBreak => {
+                output.push(' ');
+            }
+            Node::ThematicBreak => {
+                output.push_str("\\hrule\n\n");
+            }
+            Node::HtmlElement(element) => {
+                for child in &element.children {
+                    self.write_node(child, output)?;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+/// Escape LaTeX special characters in a string
+fn escape_latex(text: &str) -> String {
+    text.replace('&', "\\&")
+        .replace('%', "\\%")
+        .replace('$', "\\$")
+        .replace('#', "\\#")
+        .replace('_', "\\_")
+        .replace('{', "\\{")
+        .replace('}', "\\}")
+        .replace('~', "\\textasciitilde{}")
+        .replace('^', "\\textasciicircum{}")
+        .replace('\\', "\\textbackslash{}")
+}
+
+impl FormatWriter for LaTeXWriter {
+    fn write_eco(&mut self, document: &Node, output: &mut EcoString) -> Result<()> {
+        // Write LaTeX document preamble using the new method
+        output.push_str("\\documentclass[12pt,a4paper]{article}\n");
+        output.push_str("\\usepackage[utf8]{inputenc}\n");
+        output.push_str("\\usepackage{hyperref}\n"); // For links
+        output.push_str("\\usepackage{graphicx}\n"); // For images
+        output.push_str("\\usepackage{ulem}\n"); // For strikethrough \sout
+        output.push_str("\\usepackage{listings}\n"); // For code blocks
+        output.push_str("\\usepackage{xcolor}\n"); // For colored text and backgrounds
+        output.push_str("\\usepackage{amsmath}\n"); // Math formula support
+        output.push_str("\\usepackage{amssymb}\n"); // Additional math symbols
+        output.push_str("\\usepackage{array}\n"); // Enhanced table functionality
+
+        // Set code highlighting style
+        output.push_str("\\lstset{\n");
+        output.push_str("  basicstyle=\\ttfamily\\small,\n");
+        output.push_str("  breaklines=true,\n");
+        output.push_str("  frame=single,\n");
+        output.push_str("  numbers=left,\n");
+        output.push_str("  numberstyle=\\tiny,\n");
+        output.push_str("  keywordstyle=\\color{blue},\n");
+        output.push_str("  commentstyle=\\color{green!60!black},\n");
+        output.push_str("  stringstyle=\\color{red}\n");
+        output.push_str("}\n\n");
+
+        output.push_str("\\begin{document}\n\n");
+
+        // Write the document content
+        self.write_node(document, output)?;
+
+        // Add document ending
+        output.push_str("\n\\end{document}\n");
+
+        Ok(())
+    }
+
+    fn write_vec(&mut self, document: &Node) -> Result<Vec<u8>> {
+        let mut output = EcoString::new();
+        self.write_eco(document, &mut output)?;
+        Ok(output.as_str().as_bytes().to_vec())
+    }
+}

--- a/crates/typlite/src/writer/latex.rs
+++ b/crates/typlite/src/writer/latex.rs
@@ -25,6 +25,32 @@ impl LaTeXWriter {
         Self { list_state: None }
     }
 
+    pub fn default_prelude(output: &mut EcoString) {
+        // Write LaTeX document preamble using the new method
+        output.push_str("\\documentclass[12pt,a4paper]{article}\n");
+        output.push_str("\\usepackage[utf8]{inputenc}\n");
+        output.push_str("\\usepackage{hyperref}\n"); // For links
+        output.push_str("\\usepackage{graphicx}\n"); // For images
+        output.push_str("\\usepackage{ulem}\n"); // For strikethrough \sout
+        output.push_str("\\usepackage{listings}\n"); // For code blocks
+        output.push_str("\\usepackage{xcolor}\n"); // For colored text and backgrounds
+        output.push_str("\\usepackage{amsmath}\n"); // Math formula support
+        output.push_str("\\usepackage{amssymb}\n"); // Additional math symbols
+        output.push_str("\\usepackage{array}\n"); // Enhanced table functionality
+
+        // Set code highlighting style
+        output.push_str("\\lstset{\n");
+        output.push_str("  basicstyle=\\ttfamily\\small,\n");
+        output.push_str("  breaklines=true,\n");
+        output.push_str("  frame=single,\n");
+        output.push_str("  numbers=left,\n");
+        output.push_str("  numberstyle=\\tiny,\n");
+        output.push_str("  keywordstyle=\\color{blue},\n");
+        output.push_str("  commentstyle=\\color{green!60!black},\n");
+        output.push_str("  stringstyle=\\color{red}\n");
+        output.push_str("}\n\n");
+    }
+
     fn write_inline_nodes(&mut self, nodes: &[Node], output: &mut EcoString) -> Result<()> {
         for node in nodes {
             self.write_node(node, output)?;
@@ -110,7 +136,8 @@ impl LaTeXWriter {
                             output.push_str("\\item ");
                             for block in content {
                                 match block {
-                                    // For paragraphs, we want inline content rather than creating a new paragraph
+                                    // For paragraphs, we want inline content rather than creating a
+                                    // new paragraph
                                     Node::Paragraph(inlines) => {
                                         self.write_inline_nodes(inlines, output)?;
                                     }
@@ -138,7 +165,8 @@ impl LaTeXWriter {
                             output.push_str("\\item ");
                             for block in content {
                                 match block {
-                                    // For paragraphs, we want inline content rather than creating a new paragraph
+                                    // For paragraphs, we want inline content rather than creating a
+                                    // new paragraph
                                     Node::Paragraph(inlines) => {
                                         self.write_inline_nodes(inlines, output)?;
                                     }
@@ -371,30 +399,6 @@ fn escape_latex(text: &str) -> String {
 
 impl FormatWriter for LaTeXWriter {
     fn write_eco(&mut self, document: &Node, output: &mut EcoString) -> Result<()> {
-        // Write LaTeX document preamble using the new method
-        output.push_str("\\documentclass[12pt,a4paper]{article}\n");
-        output.push_str("\\usepackage[utf8]{inputenc}\n");
-        output.push_str("\\usepackage{hyperref}\n"); // For links
-        output.push_str("\\usepackage{graphicx}\n"); // For images
-        output.push_str("\\usepackage{ulem}\n"); // For strikethrough \sout
-        output.push_str("\\usepackage{listings}\n"); // For code blocks
-        output.push_str("\\usepackage{xcolor}\n"); // For colored text and backgrounds
-        output.push_str("\\usepackage{amsmath}\n"); // Math formula support
-        output.push_str("\\usepackage{amssymb}\n"); // Additional math symbols
-        output.push_str("\\usepackage{array}\n"); // Enhanced table functionality
-
-        // Set code highlighting style
-        output.push_str("\\lstset{\n");
-        output.push_str("  basicstyle=\\ttfamily\\small,\n");
-        output.push_str("  breaklines=true,\n");
-        output.push_str("  frame=single,\n");
-        output.push_str("  numbers=left,\n");
-        output.push_str("  numberstyle=\\tiny,\n");
-        output.push_str("  keywordstyle=\\color{blue},\n");
-        output.push_str("  commentstyle=\\color{green!60!black},\n");
-        output.push_str("  stringstyle=\\color{red}\n");
-        output.push_str("}\n\n");
-
         output.push_str("\\begin{document}\n\n");
 
         // Write the document content

--- a/crates/typlite/src/writer/mod.rs
+++ b/crates/typlite/src/writer/mod.rs
@@ -1,7 +1,9 @@
 //! Writer implementations for different output formats
 
+pub mod latex;
 pub mod markdown;
 
+pub use latex::LaTeXWriter;
 pub use markdown::MarkdownWriter;
 
 use crate::common::{Format, FormatWriter};
@@ -10,8 +12,9 @@ use crate::common::{Format, FormatWriter};
 pub fn create_writer(format: Format) -> Box<dyn FormatWriter> {
     match format {
         Format::Md => Box::new(markdown::MarkdownWriter::new()),
-        Format::LaTeX | Format::Docx => {
-            panic!("LaTeX and Docx writers are not implemented yet")
+        Format::LaTeX => Box::new(latex::LaTeXWriter::new()),
+        Format::Docx => {
+            panic!("Docx writers are not implemented yet")
         }
     }
 }


### PR DESCRIPTION
There are unresolved questions from #1684:

> elements created by the user calling `html.frame` inside that have predefined display rules applied to them may lead to unexpected results, which needs some further discussions i think?
> 
> for example:
> 
> ```typst
> #html.frame(
>   grid(columns: 2, [hello], [world])
> )
> ```
> 
> will render nothing in result.



> another issue should be concerned:
> 
> ```typst
> show figure: it => md-figure(it.body, caption: it.caption.body)
> ```
> 
> As caption can also be `content` type, what should we do to make this show rule work properly in all scene?

