### PR TITLE
feat: add change selections command

### DIFF
--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -26,6 +26,8 @@ use crate::lsp::query::{run_query, LspClientExt};
 use crate::tool::ast::AstRepr;
 use crate::tool::package::InitTask;
 
+mod pin_focus;
+
 /// See [`ProjectTask`].
 #[derive(Debug, Clone, Default, Deserialize)]
 struct ExportOpts {
@@ -63,6 +65,8 @@ struct ExportSyntaxRangeOpts {
 }
 
 /// Here are implemented the handlers for each command.
+/// Some command group are placed in the sub crates:
+/// - [`pin_focus`] implements commands for pinning and focusing documents.
 impl ServerState {
     /// Export the current document as PDF file(s).
     pub fn export_pdf(&mut self, req_id: RequestId, mut args: Vec<JsonValue>) -> ScheduledResult {
@@ -274,35 +278,6 @@ impl ServerState {
     pub fn clear_cache(&mut self, _arguments: Vec<JsonValue>) -> AnySchedulableResponse {
         comemo::evict(0);
         self.project.analysis.clear_cache();
-        just_ok(JsonValue::Null)
-    }
-
-    /// Pin main file to some path.
-    pub fn pin_document(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
-        let entry = get_arg!(args[0] as Option<PathBuf>).map(From::from);
-
-        let update_result = self.pin_main_file(entry.clone());
-        update_result.map_err(|err| internal_error(format!("could not pin file: {err}")))?;
-
-        log::info!("file pinned: {entry:?}");
-        just_ok(JsonValue::Null)
-    }
-
-    /// Focus main file to some path.
-    pub fn focus_document(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
-        let entry = get_arg!(args[0] as Option<PathBuf>).map(From::from);
-
-        if !self.ever_manual_focusing {
-            self.ever_manual_focusing = true;
-            log::info!("first manual focusing is coming");
-        }
-
-        let ok = self.focus_main_file(entry.clone());
-        let ok = ok.map_err(|err| internal_error(format!("could not focus file: {err}")))?;
-
-        if ok {
-            log::info!("file focused: {entry:?}");
-        }
         just_ok(JsonValue::Null)
     }
 

--- a/crates/tinymist/src/cmd/pin_focus.rs
+++ b/crates/tinymist/src/cmd/pin_focus.rs
@@ -1,0 +1,55 @@
+//! Tinymist LSP commands: pinning and focusing documents.
+
+use super::*;
+
+type Selections = Vec<LspRange>;
+
+/// Extra options for the focus command.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct FocusDocOpts {
+    /// An optional list of selections to be set after focusing. The first
+    /// selection is the primary one.
+    #[serde(default)]
+    selections: Option<Selections>,
+}
+
+impl ServerState {
+    /// Pins main file to some path.
+    pub fn pin_document(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
+        let entry = get_arg!(args[0] as Option<PathBuf>).map(From::from);
+        let opts = get_arg_or_default!(args[1] as FocusDocOpts);
+
+        let update_result = self.pin_main_file(entry.clone());
+        update_result.map_err(|err| internal_error(format!("could not pin file: {err}")))?;
+
+        self.do_change_selections(opts.selections);
+
+        log::info!("file pinned: {entry:?}");
+        just_ok(JsonValue::Null)
+    }
+
+    /// Focuses main file to some path.
+    pub fn focus_document(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
+        let entry = get_arg!(args[0] as Option<PathBuf>).map(From::from);
+
+        if !self.ever_manual_focusing {
+            self.ever_manual_focusing = true;
+            log::info!("first manual focusing is coming");
+        }
+
+        let ok = self.focus_main_file(entry.clone());
+        let ok = ok.map_err(|err| internal_error(format!("could not focus file: {err}")))?;
+
+        if ok {
+            log::info!("file focused: {entry:?}");
+        }
+        just_ok(JsonValue::Null)
+    }
+
+    /// Changes the selections.
+    pub fn change_selections(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
+        let selections = get_arg!(args[0] as Selections);
+        self.do_change_selections(Some(selections));
+        just_ok(JsonValue::Null)
+    }
+}

--- a/crates/tinymist/src/input.rs
+++ b/crates/tinymist/src/input.rs
@@ -1,6 +1,6 @@
 use lsp_types::*;
 use reflexo_typst::Bytes;
-use tinymist_query::{to_typst_range, PositionEncoding};
+use tinymist_query::{to_typst_range, LspRange, PositionEncoding};
 use tinymist_std::error::prelude::*;
 use tinymist_std::ImmutPath;
 use typst::{diag::FileResult, syntax::Source};
@@ -192,6 +192,16 @@ impl ServerState {
             }
             Ok(false) => {}
         }
+    }
+
+    /// Does the selection change. It accepts an optional list of selections.
+    /// The first selection is the primary one.
+    pub fn do_change_selections(&mut self, selections: Option<Vec<LspRange>>) -> Option<()> {
+        let selections = selections?;
+        let primary_selection = selections.into_iter().next()?;
+
+        self.focusing_selection = Some(primary_selection);
+        Some(())
     }
 }
 

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -76,8 +76,18 @@ pub struct ServerState {
     pub pinning_by_browsing_preview: bool,
     /// The client focusing file.
     pub focusing: Option<ImmutPath>,
-    /// The client focusing range. There might be multiple ranges selected by
-    /// the client at the same time, but we only record the primary one.
+    /// The client focusing selection ranges.
+    ///
+    /// To reduce complexity, we only record the primary selection range, while
+    /// there can be multiple ranges selected by the client at the same time.
+    /// - Example: In VS Code, you can create multiple cursors by `Ctrl + D`.
+    ///
+    /// To reduce complexity, A further question that we haven't covered
+    /// currently is that: The client may select ranges in multiple files at
+    /// the same time, but we only preasume that all of the selections are
+    /// in the [`Self::focusing`] file.
+    /// - Example: In VS Code, you can pick multiple ranges in multiple files by
+    ///   the text search command.
     pub focusing_selection: Option<LspRange>,
     /// The client focusing position, implicitly. It is inferred from the LSP
     /// requests so may be inaccurate.

--- a/editors/vscode/src/extension.shared.ts
+++ b/editors/vscode/src/extension.shared.ts
@@ -103,6 +103,9 @@ export async function tinymistActivate(
 
   configureEditorAndLanguage(context, trait);
 
+  // todo: a better model is `focusing.transfer(newClient)`, since the old request must not be cancelled and must
+  // be sent to the new client.
+  extensionState.mut.focusing.reset();
   // Initializes language client
   if (extensionState.features.lsp) {
     const executable = tinymist.probeEnvPath("tinymist.serverPath", config.serverPath);

--- a/editors/vscode/src/focus.ts
+++ b/editors/vscode/src/focus.ts
@@ -1,0 +1,38 @@
+import { tinymist } from "./lsp";
+import * as vscode from "vscode";
+
+export class FocusState {
+  private mainTimeout: NodeJS.Timeout | undefined = undefined;
+  private mainPath: string | undefined = undefined;
+  private mainDoc: vscode.TextDocument | undefined = undefined;
+
+  reset() {
+    if (this.mainTimeout) {
+      clearTimeout(this.mainTimeout);
+    }
+  }
+
+  // Informs the server after a while. This is not done intemediately to avoid
+  // the cases that the user removes the file from the editor and then opens
+  // another one in a short time.
+  focusMain(doc?: vscode.TextDocument, fsPath?: string) {
+    if (this.mainTimeout) {
+      clearTimeout(this.mainTimeout);
+    }
+    this.mainDoc = doc;
+    if (this.mainDoc?.isClosed) {
+      this.mainDoc = undefined;
+    }
+    this.mainPath = fsPath;
+    this.mainTimeout = setTimeout(async () => {
+      tinymist.executeCommand("tinymist.focusMain", [fsPath]);
+    }, 100);
+  }
+
+  get path() {
+    return this.mainPath;
+  }
+  get doc() {
+    return this.mainDoc;
+  }
+}

--- a/editors/vscode/src/focus.ts
+++ b/editors/vscode/src/focus.ts
@@ -3,36 +3,83 @@ import * as vscode from "vscode";
 
 export class FocusState {
   private mainTimeout: NodeJS.Timeout | undefined = undefined;
-  private mainPath: string | undefined = undefined;
   private mainDoc: vscode.TextDocument | undefined = undefined;
+  private subscribedSelection: boolean = false;
+  private lastSyncPath?: string;
 
+  get doc() {
+    return this.mainDoc;
+  }
+
+  /**
+   * Resets the state of the focus. This is called before the extension is
+   * (re-)activated.
+   */
   reset() {
     if (this.mainTimeout) {
       clearTimeout(this.mainTimeout);
     }
+    this.lastSyncPath = undefined;
   }
 
-  // Informs the server after a while. This is not done intemediately to avoid
-  // the cases that the user removes the file from the editor and then opens
-  // another one in a short time.
-  focusMain(doc?: vscode.TextDocument, fsPath?: string) {
-    if (this.mainTimeout) {
-      clearTimeout(this.mainTimeout);
-    }
+  /**
+   * Informs the server after a while. This is not done intemediately to avoid
+   * the cases that the user removes the file from the editor and then opens
+   * another one in a short time.
+   */
+  focusMain(doc?: vscode.TextDocument, editor?: vscode.TextEditor) {
     this.mainDoc = doc;
     if (this.mainDoc?.isClosed) {
       this.mainDoc = undefined;
     }
-    this.mainPath = fsPath;
+
+    this.subscribeChange();
+    this.lspChangeSelect(doc, editor ? () => editor.selections : undefined);
+  }
+
+  /**
+   * Lazily subscribes to the selection change event.
+   */
+  private subscribeChange() {
+    if (this.subscribedSelection) {
+      return;
+    }
+    this.subscribedSelection = true;
+
+    vscode.window.onDidChangeTextEditorSelection((event) => {
+      if (this.mainDoc && uriEquals(event.textEditor.document.uri, this.mainDoc.uri)) {
+        this.lspChangeSelect(event.textEditor.document, () => event.selections);
+      }
+    });
+  }
+
+  private lspChangeSelect(doc?: vscode.TextDocument, select?: () => readonly vscode.Selection[]) {
+    if (this.mainTimeout) {
+      clearTimeout(this.mainTimeout);
+    }
     this.mainTimeout = setTimeout(async () => {
-      tinymist.executeCommand("tinymist.focusMain", [fsPath]);
+      const fsPath = doc
+        ? doc.isUntitled
+          ? "/untitled/" + doc.uri.fsPath
+          : doc.uri.fsPath
+        : undefined;
+      const opts = select ? { selections: await this.convertLspSelections(select()) } : undefined;
+
+      if (this.lastSyncPath === fsPath) {
+        tinymist.executeCommand("tinymist.changeSelections", [opts?.selections]);
+      } else {
+        tinymist.executeCommand("tinymist.focusMain", [fsPath, opts]);
+      }
     }, 100);
   }
 
-  get path() {
-    return this.mainPath;
+  async convertLspSelections(selections: readonly vscode.Selection[]) {
+    const client = await tinymist.getClient();
+
+    return selections.map((s) => client.code2ProtocolConverter.asRange(s));
   }
-  get doc() {
-    return this.mainDoc;
-  }
+}
+
+function uriEquals(lhs: vscode.Uri, rhs: vscode.Uri) {
+  return lhs.toString(true) === rhs.toString(true);
 }

--- a/editors/vscode/src/state.ts
+++ b/editors/vscode/src/state.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { PreviewPanelContext } from "./features/preview";
+import { FocusState } from "./focus";
 
 export type ExtensionContext = vscode.ExtensionContext;
 
@@ -24,12 +25,9 @@ interface ExtensionState {
     renderDocs: boolean;
   };
   mut: {
-    focusingFile: string | undefined;
-    focusingDoc: vscode.TextDocument | undefined;
+    focusing: FocusState;
     focusingPreviewPanelContext: PreviewPanelContext | undefined;
   };
-  getFocusingFile(): string | undefined;
-  getFocusingDoc(): vscode.TextDocument | undefined;
   getFocusingPreviewPanelContext(): PreviewPanelContext | undefined;
 }
 
@@ -54,15 +52,8 @@ export const extensionState: ExtensionState = {
     renderDocs: false,
   },
   mut: {
-    focusingFile: undefined,
-    focusingDoc: undefined,
+    focusing: new FocusState(),
     focusingPreviewPanelContext: undefined,
-  },
-  getFocusingFile() {
-    return extensionState.mut.focusingFile;
-  },
-  getFocusingDoc() {
-    return extensionState.mut.focusingDoc;
   },
   getFocusingPreviewPanelContext() {
     return extensionState.mut.focusingPreviewPanelContext;


### PR DESCRIPTION
Adding a command to track user selections in the editor, then we can use the `focusing_selection` stored in the global state:

https://github.com/Myriad-Dreamin/tinymist/blob/8db172c6b40804a4cc368f6cb40b3392fba13997/crates/tinymist/src/server.rs#L79-L91

This is unfriendly for the editors that cannot make client-side extensions.