### PR TITLE
feat: re-identify ref colon syntax and perform IDE operations

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -1548,6 +1548,38 @@ Text
         ");
     }
 
+    #[test]
+    fn ref_syntax() {
+        assert_snapshot!(map_syntax("@ab"), @r###"
+        @ab
+        rrr
+        "###);
+        assert_snapshot!(map_syntax("@ab:"), @r###"
+        @ab:
+        rrr
+        "###);
+        assert_snapshot!(map_syntax("@ab:ab"), @r###"
+        @ab:ab
+        rrrrrr
+        "###);
+        assert_snapshot!(map_syntax("@ab:ab:"), @r###"
+        @ab:ab:
+        rrrrrr
+        "###);
+        assert_snapshot!(map_syntax("@ab:ab:ab"), @r###"
+        @ab:ab:ab
+        rrrrrrrrr
+        "###);
+        assert_snapshot!(map_syntax("@ab :ab: ab"), @r###"
+        @ab :ab: ab
+        rrr
+        "###);
+        assert_snapshot!(map_syntax("@ab :ab:ab"), @r###"
+        @ab :ab:ab
+        rrr
+        "###);
+    }
+
     fn access_node(s: &str, cursor: i32) -> String {
         access_node_(s, cursor).unwrap_or_default()
     }

--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -625,7 +625,7 @@ impl<'a> VarClass<'a> {
                 span: node.span(),
                 offset: node.range().len() + 1,
             })),
-            Self::Ident(_) => None,
+            Self::Ident(..) => None,
         }
     }
 }
@@ -645,7 +645,13 @@ pub enum SyntaxClass<'a> {
         is_error: bool,
     },
     /// A (content) reference expression.
-    Ref(LinkedNode<'a>),
+    Ref {
+        /// The node of the reference.
+        node: LinkedNode<'a>,
+        /// A colon after a reference expression, for example, `@a:|` or
+        /// `@a:b:|`.
+        suffix_colon: bool,
+    },
     /// A callee expression.
     Callee(LinkedNode<'a>),
     /// An import path expression.
@@ -678,7 +684,7 @@ impl<'a> SyntaxClass<'a> {
         match self {
             SyntaxClass::VarAccess(cls) => cls.node(),
             SyntaxClass::Label { node, .. }
-            | SyntaxClass::Ref(node)
+            | SyntaxClass::Ref { node, .. }
             | SyntaxClass::Callee(node)
             | SyntaxClass::ImportPath(node)
             | SyntaxClass::IncludePath(node)
@@ -804,6 +810,38 @@ pub fn classify_syntax(node: LinkedNode, cursor: usize) -> Option<SyntaxClass<'_
         }
     }
 
+    /// Matches ref parsing broken by a colon.
+    ///
+    /// When in markup mode, the ref is valid if the colon is after a ref
+    /// expression.
+    fn classify_ref<'a>(node: &LinkedNode<'a>) -> Option<SyntaxClass<'a>> {
+        let prev_leaf = node.prev_leaf()?;
+
+        if matches!(prev_leaf.kind(), SyntaxKind::RefMarker)
+            && prev_leaf.range().end == node.offset()
+        {
+            return Some(SyntaxClass::Ref {
+                node: prev_leaf,
+                suffix_colon: true,
+            });
+        }
+
+        None
+    }
+
+    if node.offset() + 1 == cursor && {
+        // Check if the cursor is exactly after single dot.
+        matches!(node.kind(), SyntaxKind::Colon)
+            || (matches!(
+                node.kind(),
+                SyntaxKind::Text | SyntaxKind::MathText | SyntaxKind::Error
+            ) && node.text().starts_with(":"))
+    } {
+        if let Some(ref_syntax) = classify_ref(&node) {
+            return Some(ref_syntax);
+        }
+    }
+
     // todo: check if we can remove Text here
     if matches!(node.kind(), SyntaxKind::Text | SyntaxKind::MathText) {
         let mode = interpret_mode_at(Some(&node));
@@ -824,7 +862,10 @@ pub fn classify_syntax(node: LinkedNode, cursor: usize) -> Option<SyntaxClass<'_
     let expr = adjusted.cast::<ast::Expr>()?;
     Some(match expr {
         ast::Expr::Label(..) => SyntaxClass::label(adjusted),
-        ast::Expr::Ref(..) => SyntaxClass::Ref(adjusted),
+        ast::Expr::Ref(..) => SyntaxClass::Ref {
+            node: adjusted,
+            suffix_colon: false,
+        },
         ast::Expr::FuncCall(call) => SyntaxClass::Callee(adjusted.find(call.callee().span())?),
         ast::Expr::Set(set) => SyntaxClass::Callee(adjusted.find(set.target().span())?),
         ast::Expr::Ident(..) | ast::Expr::MathIdent(..) => {
@@ -1088,6 +1129,14 @@ pub enum SyntaxContext<'a> {
         /// Whether the label is converted from an error node.
         is_error: bool,
     },
+    /// A (content) reference expression.
+    Ref {
+        /// The node of the reference.
+        node: LinkedNode<'a>,
+        /// A colon after a reference expression, for example, `@a:|` or
+        /// `@a:b:|`.
+        suffix_colon: bool,
+    },
     /// A cursor on a normal [`SyntaxClass`].
     Normal(LinkedNode<'a>),
 }
@@ -1105,6 +1154,7 @@ impl<'a> SyntaxContext<'a> {
             SyntaxContext::VarAccess(cls) => cls.node().clone(),
             SyntaxContext::Paren { container, .. } => container.clone(),
             SyntaxContext::Label { node, .. }
+            | SyntaxContext::Ref { node, .. }
             | SyntaxContext::ImportPath(node)
             | SyntaxContext::IncludePath(node)
             | SyntaxContext::Normal(node) => node.clone(),
@@ -1147,7 +1197,7 @@ pub fn classify_context_outer<'a>(
 
     match context_syntax {
         Callee(callee)
-            if matches!(node_syntax, Normal(..) | Label { .. } | Ref(..))
+            if matches!(node_syntax, Normal(..) | Label { .. } | Ref { .. })
                 && !matches!(node_syntax, Callee(..)) =>
         {
             let parent = callee.parent()?;
@@ -1194,6 +1244,9 @@ pub fn classify_context(node: LinkedNode, cursor: Option<usize>) -> Option<Synta
         }
         SyntaxClass::Label { node, is_error } => {
             return Some(SyntaxContext::Label { node, is_error });
+        }
+        SyntaxClass::Ref { node, suffix_colon } => {
+            return Some(SyntaxContext::Ref { node, suffix_colon });
         }
         SyntaxClass::ImportPath(node) => {
             return Some(SyntaxContext::ImportPath(node));
@@ -1445,7 +1498,7 @@ mod tests {
                 Some(SyntaxClass::VarAccess(..)) => 'v',
                 Some(SyntaxClass::Normal(..)) => 'n',
                 Some(SyntaxClass::Label { .. }) => 'l',
-                Some(SyntaxClass::Ref(..)) => 'r',
+                Some(SyntaxClass::Ref { .. }) => 'r',
                 Some(SyntaxClass::Callee(..)) => 'c',
                 Some(SyntaxClass::ImportPath(..)) => 'i',
                 Some(SyntaxClass::IncludePath(..)) => 'I',
@@ -1466,6 +1519,7 @@ mod tests {
                 Some(SyntaxContext::ImportPath(..)) => 'i',
                 Some(SyntaxContext::IncludePath(..)) => 'I',
                 Some(SyntaxContext::Label { .. }) => 'l',
+                Some(SyntaxContext::Ref { .. }) => 'r',
                 Some(SyntaxContext::Normal(..)) => 'n',
                 None => ' ',
             }
@@ -1549,6 +1603,14 @@ Text
     }
 
     #[test]
+    fn ref_syntxax() {
+        assert_snapshot!(map_syntax("@ab:"), @r###"
+        @ab:
+        rrrr
+        "###);
+    }
+
+    #[test]
     fn ref_syntax() {
         assert_snapshot!(map_syntax("@ab"), @r###"
         @ab
@@ -1556,7 +1618,7 @@ Text
         "###);
         assert_snapshot!(map_syntax("@ab:"), @r###"
         @ab:
-        rrr
+        rrrr
         "###);
         assert_snapshot!(map_syntax("@ab:ab"), @r###"
         @ab:ab
@@ -1564,11 +1626,19 @@ Text
         "###);
         assert_snapshot!(map_syntax("@ab:ab:"), @r###"
         @ab:ab:
-        rrrrrr
+        rrrrrrr
         "###);
         assert_snapshot!(map_syntax("@ab:ab:ab"), @r###"
         @ab:ab:ab
         rrrrrrrrr
+        "###);
+        assert_snapshot!(map_syntax("@ab[]:"), @r###"
+        @ab[]:
+        rrrnn
+        "###);
+        assert_snapshot!(map_syntax("@ab[ab]:"), @r###"
+        @ab[ab]:
+        rrrn  n
         "###);
         assert_snapshot!(map_syntax("@ab :ab: ab"), @r###"
         @ab :ab: ab

--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -255,7 +255,7 @@ impl<'a> CompletionCursor<'a> {
 
             // @identifier
             //  ^ from
-            let is_from_ref = matches!(self.syntax, Some(SyntaxClass::Ref(..)))
+            let is_from_ref = matches!(self.syntax, Some(SyntaxClass::Ref { .. }))
                 && self.leaf.offset() + 1 == self.from;
             if is_from_ref {
                 return Some(SelectedNode::Ref(self.leaf.clone()));
@@ -287,6 +287,7 @@ impl<'a> CompletionCursor<'a> {
                     | SyntaxContext::VarAccess(..)
                     | SyntaxContext::Paren { .. }
                     | SyntaxContext::Label { .. }
+                    | SyntaxContext::Ref { .. }
                     | SyntaxContext::Normal(..),
                 )
                 | None => {}
@@ -641,8 +642,11 @@ impl CompletionPair<'_, '_, '_> {
                 return Some(());
             }
             // todo: complete reference by type
-            Some(SyntaxContext::Normal(node)) if (matches!(node.kind(), SyntaxKind::Ref)) => {
-                self.cursor.from = self.cursor.leaf.offset() + 1;
+            Some(SyntaxContext::Ref {
+                node,
+                suffix_colon: _,
+            }) => {
+                self.cursor.from = node.offset() + 1;
                 self.ref_completions();
                 return Some(());
             }

--- a/crates/tinymist-query/src/analysis/definition.rs
+++ b/crates/tinymist-query/src/analysis/definition.rs
@@ -95,11 +95,14 @@ pub fn definition(
             DefResolver::new(ctx, source)?.of_span(path.span())
         }
         SyntaxClass::Label {
-            node: r,
+            node,
             is_error: false,
         }
-        | SyntaxClass::Ref(r) => {
-            let ref_expr: ast::Expr = r.cast()?;
+        | SyntaxClass::Ref {
+            node,
+            suffix_colon: false,
+        } => {
+            let ref_expr: ast::Expr = node.cast()?;
             let name = match ref_expr {
                 ast::Expr::Ref(r) => r.target(),
                 ast::Expr::Label(r) => r.get(),
@@ -113,6 +116,10 @@ pub fn definition(
         SyntaxClass::Label {
             node: _,
             is_error: true,
+        }
+        | SyntaxClass::Ref {
+            node: _,
+            suffix_colon: true,
         }
         | SyntaxClass::Normal(..) => None,
     }

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -319,12 +319,20 @@ impl<'a> PostTypeChecker<'a> {
             | SyntaxContext::VarAccess(VarClass::FieldAccess(node))
             | SyntaxContext::VarAccess(VarClass::DotAccess(node))
             | SyntaxContext::Label { node, .. }
+            | SyntaxContext::Ref { node, .. }
             | SyntaxContext::Normal(node) => {
-                let label_ty = matches!(cursor, SyntaxContext::Label { is_error: true, .. })
-                    .then_some(Ty::Builtin(BuiltinTy::Label));
+                let label_or_ref_ty = match cursor {
+                    SyntaxContext::Label { is_error: true, .. } => {
+                        Some(Ty::Builtin(BuiltinTy::Label))
+                    }
+                    SyntaxContext::Ref {
+                        suffix_colon: true, ..
+                    } => Some(Ty::Builtin(BuiltinTy::RefLabel)),
+                    _ => None,
+                };
                 let ty = self.check_or(node, context_ty);
-                crate::log_debug_ct!("post check target normal: {ty:?} {label_ty:?}");
-                ty.or(label_ty)
+                crate::log_debug_ct!("post check target normal: {ty:?} {label_or_ref_ty:?}");
+                ty.or(label_or_ref_ty)
             }
         }
     }

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@ref_half_colon2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@ref_half_colon2.typ.snap
@@ -32,6 +32,27 @@ input_file: crates/tinymist-query/src/fixtures/completion/ref_half_colon2.typ
  },
  {
   "isIncomplete": false,
-  "items": []
+  "items": [
+   {
+    "kind": 18,
+    "label": "sec:it",
+    "labelDetails": {
+     "description": "H"
+    },
+    "textEdit": {
+     "newText": "sec:it",
+     "range": {
+      "end": {
+       "character": 5,
+       "line": 13
+      },
+      "start": {
+       "character": 1,
+       "line": 13
+      }
+     }
+    }
+   }
+  ]
  }
 ]

--- a/crates/tinymist-query/src/references.rs
+++ b/crates/tinymist-query/src/references.rs
@@ -47,8 +47,17 @@ pub(crate) fn find_references(
 ) -> Option<Vec<LspLocation>> {
     let finding_label = match syntax {
         SyntaxClass::VarAccess(..) | SyntaxClass::Callee(..) => false,
-        SyntaxClass::Label { .. } | SyntaxClass::Ref(..) => true,
-        SyntaxClass::ImportPath(..) | SyntaxClass::IncludePath(..) | SyntaxClass::Normal(..) => {
+        SyntaxClass::Label { .. }
+        | SyntaxClass::Ref {
+            suffix_colon: false,
+            ..
+        } => true,
+        SyntaxClass::ImportPath(..)
+        | SyntaxClass::IncludePath(..)
+        | SyntaxClass::Ref {
+            suffix_colon: true, ..
+        }
+        | SyntaxClass::Normal(..) => {
             return None;
         }
     };


### PR DESCRIPTION
The typst parser doesn't parse the colon in the following case into a reference node:

```typ
@ab:
```

This PR re-identifies such syntax for IDE operations.