### PR TITLE
fix: correct setup of embedded languages

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -815,6 +815,7 @@
         "balancedBracketScopes": [
           "meta.expr",
           "meta.brace",
+          "meta.embedded.block.cpp",
           "markup.math.typst"
         ],
         "unbalancedBracketScopes": [
@@ -827,7 +828,12 @@
           "constant.character.escape",
           "comment.block.typst",
           "comment.line.double-slash.typst"
-        ]
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.cpp": "cpp",
+          "meta.embedded.block.js": "js",
+          "meta.embedded.block.python": "python"
+        }
       },
       {
         "language": "typst-code",

--- a/syntaxes/textmate/main.mts
+++ b/syntaxes/textmate/main.mts
@@ -1482,7 +1482,7 @@ export const typst: textmate.Grammar = {
   },
 };
 
-function generate() {
+function generate({ updatePackageJson = false } = {}) {
   let compiled = textmate.compile(typst);
 
   if (POLYFILL_P_XID) {
@@ -1529,10 +1529,17 @@ function generate() {
       repository,
     }),
   );
+
+  if (updatePackageJson) {
+    const packageJsonPath = path.join(import.meta.dirname, "../../../editors/vscode/package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    packageJson.contributes.grammars[0].scopeName = "source.typst";
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  }
 }
 
 // console.log(typst!.repository!.forStatement);
-generate();
+generate({ updatePackageJson: false });
 
 // todo: this is fixed in v0.11.0
 // #code(```typ


### PR DESCRIPTION
1. [ ] add `embeddedLanguages`: not working.
2. [ ] update `balancedBracketScopes`: not working.
3. [ ] could investigate the official markdown extension.