### PR TITLE
fix: remove some compatiblility to preview configuration

### DIFF
--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -800,6 +800,8 @@ pub struct PreviewFeat {
     /// The background preview options.
     #[serde(default)]
     pub background: BackgroundPreviewOpts,
+    /// When to refresh the preview.
+    pub refresh: Option<TaskWhen>,
 }
 
 /// The lint features.
@@ -1091,6 +1093,48 @@ mod tests {
             "typstExtraArgs": ["--ignore-system-fonts"]
         })));
         assert!(!font_opts.ignore_system_fonts);
+    }
+
+    // "preview":{"refresh":"onType"}
+
+    #[test]
+    fn test_preview_opts() {
+        fn opts(update: Option<&JsonValue>) -> PreviewFeat {
+            let mut config = Config::default();
+            if let Some(update) = update {
+                good_config(&mut config, update);
+            }
+
+            config.preview
+        }
+
+        let preview = opts(Some(&json!({
+            "preview": {
+            }
+        })));
+        assert_eq!(preview.refresh, Some(TaskWhen::OnType));
+
+        let preview = opts(Some(&json!({
+            "preview": {
+                "refresh":"onType"
+            }
+        })));
+        assert_eq!(preview.refresh, Some(TaskWhen::OnType));
+
+        let preview = opts(Some(&json!({
+            "preview": {
+                "refresh":"onSave"
+            }
+        })));
+        assert_eq!(preview.refresh, Some(TaskWhen::OnSave));
+
+        panic!("preview opts from editors/vscode/src/features/preview-compat.ts should be implemented at server side");
+        //   const refreshStyle =
+        //     vscode.workspace.getConfiguration().get<string>("typst-preview.
+        // refresh") || "onSave";   const scrollSyncMode =
+        //     ScrollSyncModeEnum[
+        //       vscode.workspace.getConfiguration().get<ScrollSyncMode>("
+        // typst-preview.scrollSync") || "never"     ];
     }
 
     #[test]

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -104,7 +104,10 @@ export function previewActivate(context: vscode.ExtensionContext, isCompat: bool
     vscode.commands.registerCommand("typst-preview.browser", launch("browser", "doc")),
     vscode.commands.registerCommand("typst-preview.preview-slide", launch("webview", "slide")),
     vscode.commands.registerCommand("typst-preview.browser-slide", launch("browser", "slide")),
-    vscode.commands.registerCommand("typst-preview.eject", isCompat ? ejectPreviewPanelCompat : ejectPreviewPanelLsp),
+    vscode.commands.registerCommand(
+      "typst-preview.eject",
+      isCompat ? ejectPreviewPanelCompat : ejectPreviewPanelLsp,
+    ),
     vscode.commands.registerCommand("tinymist.previewDev", launchDevPreview),
     vscode.commands.registerCommand(
       "typst-preview.revealDocument",
@@ -186,18 +189,23 @@ export function previewActivate(context: vscode.ExtensionContext, isCompat: bool
     };
   }
 
-  async function launchForURI(uri: vscode.Uri, kind: "browser" | "webview", mode: "doc" | "slide", opts?: LaunchOpts) {
+  async function launchForURI(
+    uri: vscode.Uri,
+    kind: "browser" | "webview",
+    mode: "doc" | "slide",
+    opts?: LaunchOpts,
+  ) {
     const doc =
       vscode.workspace.textDocuments.find((doc) => {
         return doc.uri.toString() === uri.toString();
       }) || (await vscode.workspace.openTextDocument(uri));
     const editor = await vscode.window.showTextDocument(doc, getSensibleTextEditorColumn(), true);
-  
+
     const bindDocument = editor.document;
     const isBrowsing = opts?.isBrowsing;
     const isDev = opts?.isDev;
     const isNotPrimary = opts?.isNotPrimary;
-  
+
     await launchImpl({
       kind,
       context,
@@ -209,7 +217,7 @@ export function previewActivate(context: vscode.ExtensionContext, isCompat: bool
       isNotPrimary,
     });
   }
-  
+
   /**
    * Ejects the preview panel to the external browser.
    */
@@ -220,10 +228,10 @@ export function previewActivate(context: vscode.ExtensionContext, isCompat: bool
       return;
     }
     const { panel, state } = focusingContext;
-  
+
     // Close the preview panel, basically kill the previous preview task.
     panel.dispose();
-  
+
     await launchForURI(vscode.Uri.parse(state.uri), "browser", state.mode, {
       isBrowsing: state.isBrowsing,
       isDev: state.isDev,
@@ -318,7 +326,7 @@ export async function openPreviewInWebView({
     uri: activeEditor.document.uri.toString(),
   };
 
-  const updateActivePanel =() => {
+  const updateActivePanel = () => {
     if (panel.active) {
       extensionState.mut.focusingPreviewPanelContext = {
         panel,
@@ -400,6 +408,7 @@ async function launchPreviewLsp(task: LaunchInBrowserTask | LaunchInWebViewTask)
   const taskId = Math.random().toString(36).substring(7);
   const filePath = bindDocument.uri.fsPath;
 
+  // todo: move me to the server side.
   const refreshStyle = getPreviewConfCompat<string>("refresh") || "onSave";
   const scrollSyncMode =
     ScrollSyncModeEnum[getPreviewConfCompat<ScrollSyncMode>("scrollSync") || "never"];


### PR DESCRIPTION
`tinymist.preview.refresh` should work.
- [ ] ensure `--refresh-style` is respected
- [ ] not need to pass `--refresh-style` in extension/src/features/preview.ts
- [ ] ensure configuration is working