### PR TITLE
fix(test): running test as root

### DIFF
--- a/crates/tinymist-project/src/entry.rs
+++ b/crates/tinymist-project/src/entry.rs
@@ -200,24 +200,27 @@ mod entry_tests {
     use super::*;
     use std::path::Path;
 
+    const ROOT: &str = if cfg!(windows) {
+        "C:\\dummy-root"
+    } else {
+        "/dummy-root"
+    };
+    const ROOT2: &str = if cfg!(windows) {
+        "C:\\dummy-root2"
+    } else {
+        "/dummy-root2"
+    };
+
     #[test]
     fn test_entry_resolution() {
-        let root_path = Path::new(if cfg!(windows) {
-            "C:\\dummy-root"
-        } else {
-            "/dummy-root"
-        });
+        let root_path = Path::new(ROOT);
 
         let entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
             ..Default::default()
         };
 
-        let entry = entry.resolve(if cfg!(windows) {
-            Some(Path::new("C:\\dummy-root\\main.typ").into())
-        } else {
-            Some(Path::new("/dummy-root/main.typ").into())
-        });
+        let entry = entry.resolve(Some(root_path.join("main.typ").into()));
 
         assert_eq!(entry.root(), Some(ImmutPath::from(root_path)));
         assert_eq!(
@@ -231,16 +234,8 @@ mod entry_tests {
 
     #[test]
     fn test_entry_resolution_multi_root() {
-        let root_path = Path::new(if cfg!(windows) {
-            "C:\\dummy-root"
-        } else {
-            "/dummy-root"
-        });
-        let root2_path = Path::new(if cfg!(windows) {
-            "C:\\dummy-root2"
-        } else {
-            "/dummy-root2"
-        });
+        let root_path = Path::new(ROOT);
+        let root2_path = Path::new(ROOT2);
 
         let entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
@@ -249,11 +244,7 @@ mod entry_tests {
         };
 
         {
-            let entry = entry.resolve(if cfg!(windows) {
-                Some(Path::new("C:\\dummy-root\\main.typ").into())
-            } else {
-                Some(Path::new("/dummy-root/main.typ").into())
-            });
+            let entry = entry.resolve(Some(root_path.join("main.typ").into()));
 
             assert_eq!(entry.root(), Some(ImmutPath::from(root_path)));
             assert_eq!(
@@ -266,11 +257,7 @@ mod entry_tests {
         }
 
         {
-            let entry = entry.resolve(if cfg!(windows) {
-                Some(Path::new("C:\\dummy-root2\\main.typ").into())
-            } else {
-                Some(Path::new("/dummy-root2/main.typ").into())
-            });
+            let entry = entry.resolve(Some(root2_path.join("main.typ").into()));
 
             assert_eq!(entry.root(), Some(ImmutPath::from(root2_path)));
             assert_eq!(
@@ -285,16 +272,8 @@ mod entry_tests {
 
     #[test]
     fn test_entry_resolution_default_multi_root() {
-        let root_path = Path::new(if cfg!(windows) {
-            "C:\\dummy-root"
-        } else {
-            "/dummy-root"
-        });
-        let root2_path = Path::new(if cfg!(windows) {
-            "C:\\dummy-root2"
-        } else {
-            "/dummy-root2"
-        });
+        let root_path = Path::new(ROOT);
+        let root2_path = Path::new(ROOT2);
 
         let mut entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
@@ -303,11 +282,7 @@ mod entry_tests {
         };
 
         {
-            entry.entry = if cfg!(windows) {
-                Some(Path::new("C:\\dummy-root\\main.typ").into())
-            } else {
-                Some(Path::new("/dummy-root/main.typ").into())
-            };
+            entry.entry = Some(root_path.join("main.typ").into());
 
             let default_entry = entry.resolve_default();
 
@@ -319,14 +294,7 @@ mod entry_tests {
 
             let default_entry = entry.resolve_default();
 
-            assert_eq!(
-                default_entry,
-                if cfg!(windows) {
-                    Some(Path::new("C:\\dummy-root\\main.typ").into())
-                } else {
-                    Some(Path::new("/dummy-root/main.typ").into())
-                }
-            );
+            assert_eq!(default_entry, Some(root_path.join("main.typ").into()));
         }
     }
 }

--- a/crates/tinymist-project/src/entry.rs
+++ b/crates/tinymist-project/src/entry.rs
@@ -202,7 +202,11 @@ mod entry_tests {
 
     #[test]
     fn test_entry_resolution() {
-        let root_path = Path::new(if cfg!(windows) { "C:\\root" } else { "/root" });
+        let root_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root"
+        } else {
+            "/dummy-root"
+        });
 
         let entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
@@ -210,9 +214,9 @@ mod entry_tests {
         };
 
         let entry = entry.resolve(if cfg!(windows) {
-            Some(Path::new("C:\\root\\main.typ").into())
+            Some(Path::new("C:\\dummy-root\\main.typ").into())
         } else {
-            Some(Path::new("/root/main.typ").into())
+            Some(Path::new("/dummy-root/main.typ").into())
         });
 
         assert_eq!(entry.root(), Some(ImmutPath::from(root_path)));
@@ -227,8 +231,16 @@ mod entry_tests {
 
     #[test]
     fn test_entry_resolution_multi_root() {
-        let root_path = Path::new(if cfg!(windows) { "C:\\root" } else { "/root" });
-        let root2_path = Path::new(if cfg!(windows) { "C:\\root2" } else { "/root2" });
+        let root_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root"
+        } else {
+            "/dummy-root"
+        });
+        let root2_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root2"
+        } else {
+            "/dummy-root2"
+        });
 
         let entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
@@ -238,9 +250,9 @@ mod entry_tests {
 
         {
             let entry = entry.resolve(if cfg!(windows) {
-                Some(Path::new("C:\\root\\main.typ").into())
+                Some(Path::new("C:\\dummy-root\\main.typ").into())
             } else {
-                Some(Path::new("/root/main.typ").into())
+                Some(Path::new("/dummy-root/main.typ").into())
             });
 
             assert_eq!(entry.root(), Some(ImmutPath::from(root_path)));
@@ -255,9 +267,9 @@ mod entry_tests {
 
         {
             let entry = entry.resolve(if cfg!(windows) {
-                Some(Path::new("C:\\root2\\main.typ").into())
+                Some(Path::new("C:\\dummy-root2\\main.typ").into())
             } else {
-                Some(Path::new("/root2/main.typ").into())
+                Some(Path::new("/dummy-root2/main.typ").into())
             });
 
             assert_eq!(entry.root(), Some(ImmutPath::from(root2_path)));
@@ -273,8 +285,16 @@ mod entry_tests {
 
     #[test]
     fn test_entry_resolution_default_multi_root() {
-        let root_path = Path::new(if cfg!(windows) { "C:\\root" } else { "/root" });
-        let root2_path = Path::new(if cfg!(windows) { "C:\\root2" } else { "/root2" });
+        let root_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root"
+        } else {
+            "/dummy-root"
+        });
+        let root2_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root2"
+        } else {
+            "/dummy-root2"
+        });
 
         let mut entry = EntryResolver {
             root_path: Some(ImmutPath::from(root_path)),
@@ -284,9 +304,9 @@ mod entry_tests {
 
         {
             entry.entry = if cfg!(windows) {
-                Some(Path::new("C:\\root\\main.typ").into())
+                Some(Path::new("C:\\dummy-root\\main.typ").into())
             } else {
-                Some(Path::new("/root/main.typ").into())
+                Some(Path::new("/dummy-root/main.typ").into())
             };
 
             let default_entry = entry.resolve_default();
@@ -302,9 +322,9 @@ mod entry_tests {
             assert_eq!(
                 default_entry,
                 if cfg!(windows) {
-                    Some(Path::new("C:\\root\\main.typ").into())
+                    Some(Path::new("C:\\dummy-root\\main.typ").into())
                 } else {
-                    Some(Path::new("/root/main.typ").into())
+                    Some(Path::new("/dummy-root/main.typ").into())
                 }
             );
         }

--- a/crates/tinymist-project/src/model.rs
+++ b/crates/tinymist-project/src/model.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_substitute_path() {
-        let root = Path::new("/root");
+        let root = Path::new("/dummy-root");
         let entry =
             EntryState::new_rooted(root.into(), Some(VirtualPath::new("/dir1/dir2/file.txt")));
 

--- a/crates/tinymist-query/src/tests.rs
+++ b/crates/tinymist-query/src/tests.rs
@@ -446,9 +446,9 @@ pub(crate) fn file_path(uri: &str) -> String {
 
 pub(crate) fn file_path_(uri: &lsp_types::Url) -> String {
     let root = if cfg!(windows) {
-        PathBuf::from("C:\\root")
+        PathBuf::from("C:\\dummy-root")
     } else {
-        PathBuf::from("/root")
+        PathBuf::from("/dummy-root")
     };
     let uri = uri.to_file_path().unwrap();
     let abs_path = Path::new(&uri).strip_prefix(root).map(|p| p.to_owned());

--- a/crates/tinymist-task/src/primitives.rs
+++ b/crates/tinymist-task/src/primitives.rs
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_substitute_path() {
-        let root = Path::new("/root");
+        let root = Path::new("/dummy-root");
         let entry =
             EntryState::new_rooted(root.into(), Some(VirtualPath::new("/dir1/dir2/file.txt")));
 

--- a/crates/tinymist-tests/src/lib.rs
+++ b/crates/tinymist-tests/src/lib.rs
@@ -52,9 +52,9 @@ pub fn run_with_sources<T>(source: &str, f: impl FnOnce(&mut LspUniverse, PathBu
     });
 
     let root = if cfg!(windows) {
-        PathBuf::from("C:\\root")
+        PathBuf::from("C:\\dummy-root")
     } else {
-        PathBuf::from("/root")
+        PathBuf::from("/dummy-root")
     };
     let mut verse = LspUniverseBuilder::build(
         EntryState::new_rooted(root.as_path().into(), None),

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -905,7 +905,11 @@ mod tests {
     fn test_config_update() {
         let mut config = Config::default();
 
-        let root_path = Path::new(if cfg!(windows) { "C:\\root" } else { "/root" });
+        let root_path = Path::new(if cfg!(windows) {
+            "C:\\dummy-root"
+        } else {
+            "/dummy-root"
+        });
 
         let update = json!({
             "outputPath": "out",


### PR DESCRIPTION
The dummy root path /root conflicts with root user's home directory on Linux and redacts incorrectly:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: crates/tinymist-query/src/fixtures/goto_definition/snaps/test@import_package_self.typ.snap
Snapshot: test@import_package_self.typ
Source: crates/tinymist-query/src/goto_definition.rs:74
Input file: crates/tinymist-query/src/fixtures/goto_definition/import_package_self.typ
──────────────────────────────────────────────────────────────────────────────────────
Expression: JsonRepr::new_redacted(result, &REDACT_LOC)
──────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬─────────────────────────────────────────────────────────────────────────
    1     1 │  {
    2     2 │   "originSelectionRange": "1:20:1:27",
    3     3 │   "targetRange": "0:0:0:0",
    4     4 │   "targetSelectionRange": "0:0:0:0",
    5       │-  "targetUri": "-/lib.typ"
          5 │+  "targetUri": ".cache/typst/packages/preview/example/0.1.0/lib.typ"
    6     6 │  }
    7     7 │ ]
────────────┴─────────────────────────────────────────────────────────────────────────
snapshot assertion from glob for 'test@import_package_self.typ' failed in line 74
```

Our downstream CI environment builds tinymist in docker as root and encounters the problem. Change the path to `/dummy-root` fixes it. To ensure consistency, other similar occurences are also prefixed with `dummy-`.