### PR TITLE
feat: Incremental build using nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -315,13 +330,13 @@
     "rust-manifest": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-hqDb78PazBKoHw8IJqOfiiR2kBI1VTzo+HiPSswf4zk=",
+        "narHash": "sha256-YZfjbpqCYQFG1qLl2zMyFq2nFwmB2aFo5DSOCaBtGLY=",
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.85.1.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.88.0.toml"
       },
       "original": {
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.85.1.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.88.0.toml"
       }
     },
     "systems": {
@@ -356,17 +371,18 @@
     },
     "tinymist-dev": {
       "inputs": {
+        "crane": "crane",
         "fenix": "fenix",
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs",
         "rust-manifest": "rust-manifest"
       },
       "locked": {
-        "path": "contrib/nix/dev",
+        "path": "./contrib/nix/dev",
         "type": "path"
       },
       "original": {
-        "path": "contrib/nix/dev",
+        "path": "./contrib/nix/dev",
         "type": "path"
       },
       "parent": []

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     
     tinymist-unstable.url = "path:contrib/nix/unstable";
-    tinymist-dev.url = "path:contrib/nix/dev";
+    tinymist-dev.url = "path:./contrib/nix/dev";
     tinymist-nixvim.url = "path:editors/neovim/samples/nixvim";
   };
 


### PR DESCRIPTION
Tried:
1. cargo2nix, this PR: undefined reference
2. crate2nix using IFD: network error
3. crate2nix without IFD without [crate2nix#394](https://github.com/nix-community/crate2nix/pull/394): parse error
4. crate2nix without IFD with [crate2nix#394](https://github.com/nix-community/crate2nix/pull/394): failed because of https://github.com/nix-community/crate2nix/issues/311
5. crane: generated bad vendor dependencies.

The most successful build is `cargo2nix`. It reports that:
```log
typlite.5a32196cb993e0b8-cgu.0:(.text._ZN18codespan_reporting4term4emit17ha833d551b17689cdE+0x1751): undefined reference to `alloc::sync::Arc<T,A>::drop_slow'
```

@GaetanLepage do you have idea?
  