### PR TITLE
revert: "feat: auto-hide presentation toolbar when not hovered"

### DIFF
--- a/tools/typst-preview-frontend/src/styles/layout.css
+++ b/tools/typst-preview-frontend/src/styles/layout.css
@@ -77,15 +77,4 @@
 #typst-container.mode-slide #typst-container-top {
   flex: 0 0 35px;
   display: flex;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
-}
-
-#typst-container.mode-slide #typst-container-top:hover {
-  opacity: 1;
-  pointer-events: auto;
 }


### PR DESCRIPTION
Reverts Myriad-Dreamin/tinymist#1887

In test of v0.13.16-rc2, The CSS doesn't work as expected when previewing in both tab and browser.