### PR TITLE
fix: emit onSaved signal to exporter when vfs is clean

### DIFF
--- a/crates/tinymist-project/src/lib.rs
+++ b/crates/tinymist-project/src/lib.rs
@@ -28,7 +28,7 @@ pub use watch::*;
 #[cfg(feature = "system")]
 pub use world::*;
 
-pub use tinymist_world::{CompileSnapshot, CompileSignal, ProjectInsId};
+pub use tinymist_world::{CompileSignal, CompileSnapshot, ProjectInsId};
 
 /// The default project route priority assigned to user actions.
 pub const PROJECT_ROUTE_USER_ACTION_PRIORITY: u32 = 256;

--- a/crates/tinymist-project/src/lib.rs
+++ b/crates/tinymist-project/src/lib.rs
@@ -28,7 +28,7 @@ pub use watch::*;
 #[cfg(feature = "system")]
 pub use world::*;
 
-pub use tinymist_world::{CompileSnapshot, ExportSignal, ProjectInsId};
+pub use tinymist_world::{CompileSnapshot, CompileSignal, ProjectInsId};
 
 /// The default project route priority assigned to user actions.
 pub const PROJECT_ROUTE_USER_ACTION_PRIORITY: u32 = 256;

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -483,7 +483,7 @@ mod tests {
 
     use super::*;
     use crate::export::ProjectCompilation;
-    use crate::project::{CompileOnceArgs, ExportSignal};
+    use crate::project::{CompileOnceArgs, CompileSignal};
     use crate::world::base::{CompileSnapshot, WorldComputeGraph};
 
     #[test]
@@ -542,7 +542,7 @@ mod tests {
 
         let mut snap = CompileSnapshot::from_world(verse.snapshot());
 
-        snap.signal = ExportSignal {
+        snap.signal = CompileSignal {
             by_entry_update: true,
             by_fs_events: false,
             by_mem_events: false,


### PR DESCRIPTION
This bugs involves two main component: the compiler and the exporter, the compiler compiles first and then exporter exports then. it is useful to emit `CompileSignal::by_fs_events` to exporter even if vfs is clean at the time we save a document.

An example triggering this bug. When user sets `exportPdf` to `onSave`, It *bugged*:
1. OnTyped first: User types some character at T1. compiler learns that the file content is of revision R1. the compiler compiles with revision R1, which is needed by diagnostics event.
2. OnSaved then: Editor saves the document at T2. the compilation is skipped early because file content is still under revision R1. In previous version, The compilation is skipped and therefore the export is also skipped. This is *bugged* if user sets `exportPdf` to `onSave`, because the exporter is not run in both steps.

This PR emits the onSaved signals to both the compiler and the exporter in the step 2.

