### PR TITLE
feat: add rust and yarn to nix devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,27 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "tinymist-dev",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1753944209,
+        "narHash": "sha256-dcGdqxhRRGoA/S38BsWOrwIiLYEBOqXKauHdFwKR310=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "5ef8607d6e8a08cfb3946aaacaa0494792adf4ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -273,6 +295,35 @@
         "tinymist-unstable": "tinymist-unstable"
       }
     },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753838657,
+        "narHash": "sha256-4FA7NTmrAqW5yt4A3hhzgDmAFD0LbGRMGKhb1LBSItI=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "8611b714597c89b092f3d4874f14acd3f72f44fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-manifest": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-hqDb78PazBKoHw8IJqOfiiR2kBI1VTzo+HiPSswf4zk=",
+        "type": "file",
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.85.1.toml"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.85.1.toml"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -305,8 +356,10 @@
     },
     "tinymist-dev": {
       "inputs": {
+        "fenix": "fenix",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-manifest": "rust-manifest"
       },
       "locked": {
         "path": "contrib/nix/dev",

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,8 @@
         devShells = {
           # nix develop
           default = tinymist-dev.devShells.${system}.default;
+          # nix develop #neovim
+          neovim = tinymist-dev.devShells.${system}.neovim;
           # nix develop .#unstable
           unstable = tinymist-unstable.devShells.${system}.default;
           # nix develop .#nixvim

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         devShells = {
           # nix develop
           default = tinymist-dev.devShells.${system}.default;
-          # nix develop #neovim
+          # nix develop .#neovim
           neovim = tinymist-dev.devShells.${system}.neovim;
           # nix develop .#unstable
           unstable = tinymist-unstable.devShells.${system}.default;


### PR DESCRIPTION
by default, we assume people would like develop the language server and editor tools. The building of tinymist-cli is moved to the neovim shell.