### PR TITLE
feat: allow to configure when to run diagnostics task

### DIFF
--- a/crates/tinymist-task/src/model.rs
+++ b/crates/tinymist-task/src/model.rs
@@ -76,7 +76,7 @@ pub enum ProjectTask {
     ExportTeX(ExportTeXTask),
     /// An export Text task.
     ExportText(ExportTextTask),
-    /// An query task.
+    /// A query task.
     Query(QueryTask),
     // todo: compatibility
     // An export task of another type.


### PR DESCRIPTION
To reduce power comsumption, people may love to configure the language server to reduce compilations. I gather the tasks needs compilation, which should all have `TaskWhen`. 

```
struct PostCompileHooks {
    pub(crate) export: ExportHook
    pub(crate) preview: PreviewHook,
    pub(crate) diag: DiagHook,
    pub(crate) word_count: WordCountHook,
}
```

Previously, `diag` always runs on `TaskWhen::onType` thus makes it impossible to run compilations only on save (because `diag` needs compilation on type). This PR allows to configure it.
