### PR TITLE
feat: introspect and show complation statistics happening in the language server

### DIFF
--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -197,12 +197,21 @@ export const Summary = () => {
       ),
   );
 
+  const compileStats = div(
+    { class: `tinymist-card`, style: "flex: 1; width: 100%; padding: 10px" },
+    `The language servers runs compilation and traces for 2,100 times in last 5 minutes.
+- ran 94 times to export documents.
+- ran 2,006 times to analyze dynamic expressions for LSP requests.
+`,
+  );
+
   return div(
     {
       class: "flex-col",
       style: "justify-content: center; align-items: center; gap: 10px;",
     },
     fontStats,
+    compileStats,
     div(
       { class: `tinymist-card`, style: "flex: 1; width: 100%; padding: 10px" },
       div(van.derive(() => `This document is compiled with following arguments.`)),

--- a/tools/editor-tools/src/features/summary.ts
+++ b/tools/editor-tools/src/features/summary.ts
@@ -148,63 +148,65 @@ export const Summary = () => {
     return res;
   };
 
+  const fontStats = div(
+    { class: `tinymist-card`, style: "flex: 1; width: 100%; padding: 10px" },
+    div(
+      { style: "position: relative; width: 100%; height: 0px" },
+      button(
+        {
+          class: "tinymist-button",
+          style: "position: absolute; top: 0px; right: 0px",
+          onclick: () => {
+            startModal(
+              div(
+                {
+                  style: "height: calc(100% - 20px); box-sizing: border-box; padding-top: 4px",
+                },
+                fontsExportPanel({
+                  fonts: docMetrics.val.fontInfo,
+                  sources: docMetrics.val.spanInfo.sources,
+                }),
+              ),
+            );
+          },
+        },
+        CopyIcon(),
+      ),
+    ),
+    div(van.derive(() => `This document uses ${docMetrics.val.fontInfo.length} fonts.`)),
+    (_dom?: Element) =>
+      div(
+        ...docMetrics.val.fontInfo
+          .sort((x, y) => {
+            if (x.usesScale === undefined || y.usesScale === undefined) {
+              if (x.usesScale === undefined) {
+                return 1;
+              }
+              if (y.usesScale === undefined) {
+                return -1;
+              }
+
+              return x.name.localeCompare(y.name);
+            }
+            if (x.usesScale !== y.usesScale) {
+              return y.usesScale - x.usesScale;
+            }
+            return x.name.localeCompare(y.name);
+          })
+          .map(FontSlot),
+      ),
+  );
+
   return div(
     {
       class: "flex-col",
       style: "justify-content: center; align-items: center; gap: 10px;",
     },
+    fontStats,
     div(
       { class: `tinymist-card`, style: "flex: 1; width: 100%; padding: 10px" },
       div(van.derive(() => `This document is compiled with following arguments.`)),
       div({ style: "margin: 1.2em; margin-left: 0.5em" }, ...ArgSlots()),
-    ),
-    div(
-      { class: `tinymist-card`, style: "flex: 1; width: 100%; padding: 10px" },
-      div(
-        { style: "position: relative; width: 100%; height: 0px" },
-        button(
-          {
-            class: "tinymist-button",
-            style: "position: absolute; top: 0px; right: 0px",
-            onclick: () => {
-              startModal(
-                div(
-                  {
-                    style: "height: calc(100% - 20px); box-sizing: border-box; padding-top: 4px",
-                  },
-                  fontsExportPanel({
-                    fonts: docMetrics.val.fontInfo,
-                    sources: docMetrics.val.spanInfo.sources,
-                  }),
-                ),
-              );
-            },
-          },
-          CopyIcon(),
-        ),
-      ),
-      div(van.derive(() => `This document uses ${docMetrics.val.fontInfo.length} fonts.`)),
-      (_dom?: Element) =>
-        div(
-          ...docMetrics.val.fontInfo
-            .sort((x, y) => {
-              if (x.usesScale === undefined || y.usesScale === undefined) {
-                if (x.usesScale === undefined) {
-                  return 1;
-                }
-                if (y.usesScale === undefined) {
-                  return -1;
-                }
-
-                return x.name.localeCompare(y.name);
-              }
-              if (x.usesScale !== y.usesScale) {
-                return y.usesScale - x.usesScale;
-              }
-              return x.name.localeCompare(y.name);
-            })
-            .map(FontSlot),
-        ),
     ),
     div(
       {


### PR DESCRIPTION
Adds capability to introspect complations happening in the language server, to help improve efficiency. I expect most compilations are caused by tracing for analyzing dynamic expressions, but I haven't really profiled a document. Then introspection will help confirm or refute the expectation. 