### PR TITLE
fix: several fixes to auto release

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -57,7 +57,8 @@ jobs:
               const prBody = pr.body || '';
               console.log('PR Body:', prBody);
               
-              const tagRegex = /\+tag\s+(v\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/;
+              const tagRegex = /^\+tag\s+(v\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/m;
+
               const match = prBody.match(tagRegex);
               
               if (match) {

--- a/.github/workflows/detect-pr-tag.yml
+++ b/.github/workflows/detect-pr-tag.yml
@@ -19,7 +19,7 @@ jobs:
           const prBody = context.payload.pull_request.body || '';
           console.log('PR Body:', prBody);
           
-          const tagRegex = /\+tag\s+(v\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/;
+          const tagRegex = /^\+tag\s+(v\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/m;
           const match = prBody.match(tagRegex);
           
           if (match) {

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -38,8 +38,8 @@ jobs:
 
     - name: Setup Git
       run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -18,12 +18,14 @@ on:
 jobs:
   check-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         ref: nightly
-        token: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
 
     - name: Install Node.js


### PR DESCRIPTION
+ use `GITHUB_TOKEN` to checkout tinymist in `release-nightly.yml`. Therefore, GitHub Actions should be granted write permission.
+ tag directives must start from the line start.
+ use the same bot name and email in actions. 