### PR TITLE
fix(ci): detect create intead of push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,12 @@
 name: tinymist::ci
 on:
-  push:
-    branches:
-      - main
-      - nightly
-    tags:
-      - "*"
+  create:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
     branches:
       - main
       - nightly
-  workflow_dispatch:
 
 env:
   RUSTFLAGS: '-Dwarnings'


### PR DESCRIPTION
According to https://github.com/actions/runner/issues/1007, the push events was not created when bot creating tags.