### PR TITLE
fix: set VS Code default configuration for invertColors to "never"

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -733,6 +733,7 @@
         "tinymist.preview.invertColors": {
           "title": "%extension.tinymist.config.tinymist.preview.invertColors.title%",
           "markdownDescription": "%extension.tinymist.config.tinymist.preview.invertColors.desc%",
+          "default": "never",
           "anyOf": [
             {
               "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.title%",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -744,7 +744,6 @@
                 "auto",
                 "always"
               ],
-              "default": "never",
               "enumDescriptions": [
                 "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.enum.never%",
                 "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.enum.auto%",
@@ -755,7 +754,6 @@
               "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.title%",
               "markdownDescription": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.desc%",
               "type": "object",
-              "default": {},
               "properties": {
                 "rest": {
                   "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.properties.rest.title%",

--- a/editors/vscode/package.other.json
+++ b/editors/vscode/package.other.json
@@ -51,7 +51,6 @@
               "markdownDescription": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.desc%",
               "type": "string",
               "enum": ["never", "auto", "always"],
-              "default": "never",
               "enumDescriptions": [
                 "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.enum.never%",
                 "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.enum.auto%",
@@ -62,7 +61,6 @@
               "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.title%",
               "markdownDescription": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.desc%",
               "type": "object",
-              "default": {},
               "properties": {
                 "rest": {
                   "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.object.properties.rest.title%",

--- a/editors/vscode/package.other.json
+++ b/editors/vscode/package.other.json
@@ -44,6 +44,7 @@
         "tinymist.preview.invertColors": {
           "title": "%extension.tinymist.config.tinymist.preview.invertColors.title%",
           "markdownDescription": "%extension.tinymist.config.tinymist.preview.invertColors.desc%",
+          "default": "never",
           "anyOf": [
             {
               "title": "%extension.tinymist.config.tinymist.preview.invertColors.anyOf.string.title%",


### PR DESCRIPTION
Since #1807 , VS Code pops up a warning when starting tinymist: 
<img width="464" height="162" alt="image" src="https://github.com/user-attachments/assets/aeefac88-5515-4dcd-be52-82e402db74c5" />

Because the default value was not set, it's trying to deserialize a `null`. I complete the corresponding configuration entry in the VS Code extension's package.json and package.other.json with default value "never".