### PR TITLE
docs: make translation of pinning clearer

### DIFF
--- a/locales/README.md
+++ b/locales/README.md
@@ -5,7 +5,7 @@ This folder provides the locale files for the applications. The format of the lo
 
 ```
 [extension.tinymist.command.tinymist.pinMainToCurrent] # K
-en = "Pin the Main file to the Opening Document" # V-en
+en = "Pin the Main File to the Currently Open Document" # V-en
 zh-CN = "将主文件固定到当前打开的文档" # zh-CN
 ```
 

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -86,7 +86,7 @@ zh = "将当前打开的文件导出为 PDF"
 zh-TW = "將當前打開的文件導出為 PDF"
 
 [extension.tinymist.command.tinymist.pinMainToCurrent]
-en = "Pin the Main file to the Opening Document"
+en = "Pin the Main File to the Currently Open Document"
 ar = "تثبيت الملف الرئيسي على المستند المفتوح"
 bg = "Фиксиране на основния файл към отворения документ"
 ca = "Fixar el fitxer principal al document obert"


### PR DESCRIPTION
Thanks for making this awesome extension. I find it very useful.

This PR suggests a small rewording for a sentence. With this, I hope it becomes a bit clearer what the command does. This is also closer to Google Translate's translation of "将主文件固定到当前打开的文档".