### PR TITLE
fix: allow non-commit in nightly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -184,7 +184,7 @@ jobs:
         
         cargo update
         git add -A
-        git commit -m "build: bump world crates to $new_version"
+        git commit -m "build: bump world crates to $new_version" || true
         git push origin nightly
         
         world_commit=$(git rev-parse HEAD)
@@ -219,7 +219,7 @@ jobs:
         
         cargo update
         git add -A
-        git commit -m "build: update tinymist and typst"
+        git commit -m "build: update tinymist and typst" || true
         git push origin nightly
         
         reflexo_commit=$(git rev-parse HEAD)
@@ -250,7 +250,7 @@ jobs:
         
         cargo update
         git add -A
-        git commit -m "build: update tinymist to ${new_version}"
+        git commit -m "build: update tinymist to ${new_version}" || true
         git push origin nightly
         
         typstyle_commit=$(git rev-parse HEAD)


### PR DESCRIPTION
Since #1986 eliminates the need to bump world crates for nightly releases, commits after cargo update may be empty