### PR TITLE
feat: completes both `#f` and `#f.paren` in some cases (#1940)

### DIFF
--- a/crates/tinymist-query/src/analysis/completion/func.rs
+++ b/crates/tinymist-query/src/analysis/completion/func.rs
@@ -53,10 +53,19 @@ impl CompletionPair<'_, '_, '_> {
             _ => false,
         };
         if !bad_instantiate {
-            if !parens
+            let only_parens = !parens
                 || (matches!(self.cursor.surrounding_syntax, SurroundingSyntax::Selector)
-                    && fn_feat.is_element)
-            {
+                    && fn_feat.is_element);
+            let is_set = matches!(self.cursor.surrounding_syntax, SurroundingSyntax::SetRule);
+
+            if !only_parens && fn_feat.prefer_to_be_scope(is_set) {
+                self.push_completion(Completion {
+                    label: name.clone(),
+                    ..base.clone()
+                });
+            }
+
+            if only_parens {
                 self.push_completion(Completion {
                     label: name,
                     ..base
@@ -64,7 +73,7 @@ impl CompletionPair<'_, '_, '_> {
             } else if (fn_feat.min_pos() < 1 || fn_feat.has_only_self()) && !fn_feat.has_rest {
                 self.push_completion(Completion {
                     apply: Some(eco_format!("{}()${{}}", name)),
-                    label: name,
+                    label: paren_label(&name, &fn_feat, is_set),
                     command: None,
                     ..base
                 });
@@ -77,7 +86,7 @@ impl CompletionPair<'_, '_, '_> {
                     );
                 self.push_completion(Completion {
                     apply: Some(eco_format!("{name}(${{}})")),
-                    label: name.clone(),
+                    label: paren_label(&name, &fn_feat, is_set),
                     ..base.clone()
                 });
                 if !scope_reject_content && accept_content_arg {
@@ -87,6 +96,14 @@ impl CompletionPair<'_, '_, '_> {
                         ..base
                     });
                 };
+            }
+        }
+
+        fn paren_label(name: &EcoString, fn_feat: &FnCompletionFeat, is_set: bool) -> EcoString {
+            if fn_feat.prefer_to_be_scope(is_set) {
+                eco_format!("{name}.paren")
+            } else {
+                name.clone()
             }
         }
     }

--- a/crates/tinymist-query/src/fixtures/completion/func_module.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_module.typ
@@ -1,0 +1,3 @@
+/// contains: table, table.paren, table.bracket
+
+#tbl/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_module_json.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_module_json.typ
@@ -1,0 +1,3 @@
+/// contains: json, json.paren, json.bracket
+
+#js/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_module_raw.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_module_raw.typ
@@ -1,0 +1,3 @@
+/// contains: raw, raw.paren, raw.bracket
+
+#r/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/func_module_raw_set.typ
+++ b/crates/tinymist-query/src/fixtures/completion/func_module_raw_set.typ
@@ -1,0 +1,3 @@
+/// contains: raw, raw.paren, raw.bracket
+
+#set r/* range 0..1 */

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/arg_content.typ
     "labelDetails": {
      "description": "alignment"
     },
-    "sortText": "022",
+    "sortText": "023",
     "textEdit": {
      "newText": "center",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content2.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/arg_content2.typ
     "labelDetails": {
      "description": "alignment"
     },
-    "sortText": "022",
+    "sortText": "023",
     "textEdit": {
      "newText": "center",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content3.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/arg_content3.typ
     "labelDetails": {
      "description": "alignment"
     },
-    "sortText": "022",
+    "sortText": "023",
     "textEdit": {
      "newText": "center",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content4.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@arg_content4.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/arg_content4.typ
     "labelDetails": {
      "description": "alignment"
     },
-    "sortText": "022",
+    "sortText": "023",
     "textEdit": {
      "newText": "center",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@bracket_strong.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@bracket_strong.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/bracket_strong.typ
     "labelDetails": {
      "description": "(content, delta: int) => strong"
     },
-    "sortText": "183",
+    "sortText": "200",
     "textEdit": {
      "newText": "strong(${1:})",
      "range": {
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/bracket_strong.typ
     "labelDetails": {
      "description": "(content, delta: int) => strong"
     },
-    "sortText": "184",
+    "sortText": "201",
     "textEdit": {
      "newText": "strong[${1:}]",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/builtin_shadow.typ
     "labelDetails": {
      "description": "(fill-rest: false) => none"
     },
-    "sortText": "127",
+    "sortText": "139",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow_existing.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@builtin_shadow_existing.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/builtin_shadow_existin
     "labelDetails": {
      "description": "(fill-rest: false) => none"
     },
-    "sortText": "129",
+    "sortText": "141",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@context_code_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@context_code_init.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/context_code_init.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "128",
+    "sortText": "140",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@context_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@context_init.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/context_init.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "128",
+    "sortText": "140",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_args.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_args.typ.snap
@@ -89,7 +89,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_args.typ
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "034",
+    "sortText": "035",
     "textEdit": {
      "newText": "content",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module.typ.snap
@@ -1,0 +1,63 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (53..54)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_module.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
+    },
+    "kind": 3,
+    "label": "table",
+    "labelDetails": {
+     "description": "(align: alignment | array | auto | function, column-gutter: array | auto | length | type, columns: array | auto | length | type, fill: color, gutter: array | auto | length | type, inset: inset, row-gutter: array | auto | length | type, rows: array | auto | length | type, stroke: stroke, ..: content) => table"
+    },
+    "sortText": "208",
+    "textEdit": {
+     "newText": "table",
+     "range": {
+      "end": {
+       "character": 4,
+       "line": 2
+      },
+      "start": {
+       "character": 1,
+       "line": 2
+      }
+     }
+    }
+   },
+   {
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
+    },
+    "kind": 3,
+    "label": "table.paren",
+    "labelDetails": {
+     "description": "(align: alignment | array | auto | function, column-gutter: array | auto | length | type, columns: array | auto | length | type, fill: color, gutter: array | auto | length | type, inset: inset, row-gutter: array | auto | length | type, rows: array | auto | length | type, stroke: stroke, ..: content) => table"
+    },
+    "sortText": "209",
+    "textEdit": {
+     "newText": "table(${1:})",
+     "range": {
+      "end": {
+       "character": 4,
+       "line": 2
+      },
+      "start": {
+       "character": 1,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_json.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_json.typ.snap
@@ -1,29 +1,33 @@
 ---
 source: crates/tinymist-query/src/completion.rs
-description: Completion on / (28..29)
+description: Completion on / (49..50)
 expression: "JsonRepr::new_pure(results)"
-input_file: crates/tinymist-query/src/fixtures/completion/hash_math.typ
+input_file: crates/tinymist-query/src/fixtures/completion/func_module_json.typ
 ---
 [
  {
   "isIncomplete": false,
   "items": [
    {
-    "kind": 3,
-    "label": "pagebreak",
-    "labelDetails": {
-     "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
     },
-    "sortText": "139",
+    "kind": 3,
+    "label": "json",
+    "labelDetails": {
+     "description": "([json]) => any"
+    },
+    "sortText": "097",
     "textEdit": {
-     "newText": "pagebreak()${1:}",
+     "newText": "json(${1:})",
      "range": {
       "end": {
        "character": 3,
        "line": 2
       },
       "start": {
-       "character": 3,
+       "character": 1,
        "line": 2
       }
      }

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_raw.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_raw.typ.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/tinymist-query/src/completion.rs
-description: Completion on / (30..31)
+description: Completion on / (45..46)
 expression: "JsonRepr::new_pure(results)"
-input_file: crates/tinymist-query/src/fixtures/completion/func_builtin_args.typ
+input_file: crates/tinymist-query/src/fixtures/completion/func_module_raw.typ
 ---
 [
  {
@@ -13,21 +13,21 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_builtin_args.typ
      "command": "tinymist.triggerSuggestAndParameterHints",
      "title": ""
     },
-    "kind": 5,
-    "label": "columns",
+    "kind": 3,
+    "label": "raw",
     "labelDetails": {
-     "description": "array | auto | length | type"
+     "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "002",
+    "sortText": "160",
     "textEdit": {
-     "newText": "columns: ${1:}",
+     "newText": "raw",
      "range": {
       "end": {
-       "character": 7,
+       "character": 2,
        "line": 2
       },
       "start": {
-       "character": 7,
+       "character": 1,
        "line": 2
       }
      }
@@ -39,20 +39,20 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_builtin_args.typ
      "title": ""
     },
     "kind": 3,
-    "label": "columns",
+    "label": "raw.paren",
     "labelDetails": {
-     "description": "(int, content, gutter: relative) => columns"
+     "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "040",
+    "sortText": "161",
     "textEdit": {
-     "newText": "columns(${1:})",
+     "newText": "raw(${1:})",
      "range": {
       "end": {
-       "character": 7,
+       "character": 2,
        "line": 2
       },
       "start": {
-       "character": 7,
+       "character": 1,
        "line": 2
       }
      }

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_raw_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_module_raw_set.typ.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on / (49..50)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/func_module_raw_set.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
+    },
+    "kind": 3,
+    "label": "raw",
+    "labelDetails": {
+     "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
+    },
+    "sortText": "053",
+    "textEdit": {
+     "newText": "raw(${1:})",
+     "range": {
+      "end": {
+       "character": 6,
+       "line": 2
+      },
+      "start": {
+       "character": 5,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_with_args.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_with_args.typ.snap
@@ -89,7 +89,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_with_args.typ
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "034",
+    "sortText": "035",
     "textEdit": {
      "newText": "content",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@hash.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@hash.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/hash.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "127",
+    "sortText": "139",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@hash_ident.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@hash_ident.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/hash_ident.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "127",
+    "sortText": "139",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@hash_math_ident.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@hash_math_ident.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/hash_math_ident.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "127",
+    "sortText": "139",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self.typ.snap
@@ -3,7 +3,6 @@ source: crates/tinymist-query/src/completion.rs
 description: Completion on c( (74..76)
 expression: "JsonRepr::new_pure(results)"
 input_file: crates/tinymist-query/src/fixtures/completion/import_self.typ
-snapshot_kind: text
 ---
 [
  {
@@ -15,7 +14,7 @@ snapshot_kind: text
     "labelDetails": {
      "description": "module(base)"
     },
-    "sortText": "008",
+    "sortText": "009",
     "textEdit": {
      "newText": "base",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self3.typ.snap
@@ -3,7 +3,6 @@ source: crates/tinymist-query/src/completion.rs
 description: Completion on c( (85..87)
 expression: "JsonRepr::new_pure(results)"
 input_file: crates/tinymist-query/src/fixtures/completion/import_self3.typ
-snapshot_kind: text
 ---
 [
  {
@@ -15,7 +14,7 @@ snapshot_kind: text
     "labelDetails": {
      "description": "module(base)"
     },
-    "sortText": "008",
+    "sortText": "009",
     "textEdit": {
      "newText": "baz",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self4.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_self4.typ.snap
@@ -3,7 +3,6 @@ source: crates/tinymist-query/src/completion.rs
 description: Completion on c( (88..90)
 expression: "JsonRepr::new_pure(results)"
 input_file: crates/tinymist-query/src/fixtures/completion/import_self4.typ
-snapshot_kind: text
 ---
 [
  {
@@ -15,7 +14,7 @@ snapshot_kind: text
     "labelDetails": {
      "description": "module(base)"
     },
-    "sortText": "012",
+    "sortText": "013",
     "textEdit": {
      "newText": "baz",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@item_shadow2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@item_shadow2.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/item_shadow2.typ
     "labelDetails": {
      "description": "() => any"
     },
-    "sortText": "008",
+    "sortText": "009",
     "textEdit": {
      "newText": "base()${1:}",
      "range": {
@@ -40,7 +40,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/item_shadow2.typ
     "labelDetails": {
      "description": "() => any"
     },
-    "sortText": "008",
+    "sortText": "009",
     "textEdit": {
      "newText": "base()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@let_closure_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@let_closure_init.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/let_closure_init.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "129",
+    "sortText": "141",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@let_fn_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@let_fn_init.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/let_fn_init.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "129",
+    "sortText": "141",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@let_init.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@let_init.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/let_init.typ
     "labelDetails": {
      "description": "(to: \"even\" | \"odd\" | none, weak: bool) => pagebreak"
     },
-    "sortText": "129",
+    "sortText": "141",
     "textEdit": {
      "newText": "pagebreak()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@math_bold.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@math_bold.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/math_bold.typ
     "labelDetails": {
      "description": "(content | none, baseline: relative, clip: bool, fill: color, height: auto | relative, inset: inset, outset: outset, radius: radius, stroke: stroke, width: auto | fraction | relative) => box"
     },
-    "sortText": "015",
+    "sortText": "016",
     "textEdit": {
      "newText": "box(${1:})",
      "range": {
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/math_bold.typ
     "labelDetails": {
      "description": "(content | none, baseline: relative, clip: bool, fill: color, height: auto | relative, inset: inset, outset: outset, radius: radius, stroke: stroke, width: auto | fraction | relative) => box"
     },
-    "sortText": "016",
+    "sortText": "017",
     "textEdit": {
      "newText": "box[${1:}]",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@module_calc.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@module_calc.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/module_calc.typ
     "labelDetails": {
      "description": "module(\"calc\")"
     },
-    "sortText": "020",
+    "sortText": "021",
     "textEdit": {
      "newText": "calc",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@module_show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@module_show.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/module_show.typ
     "labelDetails": {
      "description": "module(\"global\")"
     },
-    "sortText": "263",
+    "sortText": "279",
     "textEdit": {
      "newText": "std",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@module_show_calc.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@module_show_calc.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/module_show_calc.typ
     "labelDetails": {
      "description": "module(\"calc\")"
     },
-    "sortText": "027",
+    "sortText": "028",
     "textEdit": {
      "newText": "calc",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@module_std.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@module_std.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/module_std.typ
     "labelDetails": {
      "description": "module(\"global\")"
     },
-    "sortText": "177",
+    "sortText": "193",
     "textEdit": {
      "newText": "std",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "165",
+    "sortText": "169",
     "textEdit": {
      "newText": "raw: ${1:}",
      "range": {
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "166",
+    "sortText": "170",
     "textEdit": {
      "newText": "raw.where(${1:}): ${2:}",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "167",
+    "sortText": "171",
     "textEdit": {
      "newText": "read(${1:}): ${2:}",
      "range": {
@@ -89,7 +89,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show.typ
     "labelDetails": {
      "description": "rgb(\"#ff4136\")"
     },
-    "sortText": "170",
+    "sortText": "174",
     "textEdit": {
      "newText": "red: ${1:}",
      "range": {
@@ -111,7 +111,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show.typ
     },
     "kind": 15,
     "label": "regex selector",
-    "sortText": "174",
+    "sortText": "178",
     "textEdit": {
      "newText": "regex(\"${1:regex}\"): ${2:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show2.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show2.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "165",
+    "sortText": "169",
     "textEdit": {
      "newText": "raw: ${1:}",
      "range": {
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show2.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "166",
+    "sortText": "170",
     "textEdit": {
      "newText": "raw.where(${1:}): ${2:}",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show2.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "167",
+    "sortText": "171",
     "textEdit": {
      "newText": "read(${1:}): ${2:}",
      "range": {
@@ -89,7 +89,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show2.typ
     "labelDetails": {
      "description": "rgb(\"#ff4136\")"
     },
-    "sortText": "170",
+    "sortText": "174",
     "textEdit": {
      "newText": "red: ${1:}",
      "range": {
@@ -111,7 +111,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show2.typ
     },
     "kind": 15,
     "label": "regex selector",
-    "sortText": "174",
+    "sortText": "178",
     "textEdit": {
      "newText": "regex(\"${1:regex}\"): ${2:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show3.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show3.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "165",
+    "sortText": "169",
     "textEdit": {
      "newText": "raw: ${1:}",
      "range": {
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show3.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "166",
+    "sortText": "170",
     "textEdit": {
      "newText": "raw.where(${1:}): ${2:}",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show3.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "167",
+    "sortText": "171",
     "textEdit": {
      "newText": "read(${1:}): ${2:}",
      "range": {
@@ -90,7 +90,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show3.typ
     },
     "kind": 15,
     "label": "regex selector",
-    "sortText": "174",
+    "sortText": "178",
     "textEdit": {
      "newText": "regex(\"${1:regex}\"): ${2:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform.typ.snap
@@ -18,9 +18,9 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "212",
+    "sortText": "227",
     "textEdit": {
-     "newText": "raw(${1:})",
+     "newText": "raw",
      "range": {
       "end": {
        "character": 12,
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "213",
+    "sortText": "229",
     "textEdit": {
      "newText": "raw.with(${1:})",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "214",
+    "sortText": "230",
     "textEdit": {
      "newText": "read(${1:})",
      "range": {
@@ -93,7 +93,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "215",
+    "sortText": "231",
     "textEdit": {
      "newText": "read.with(${1:})",
      "range": {
@@ -115,7 +115,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform.typ
     },
     "kind": 15,
     "label": "replacement",
-    "sortText": "228",
+    "sortText": "244",
     "textEdit": {
      "newText": "[${1:content}]",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform2.typ.snap
@@ -18,9 +18,9 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform2.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "212",
+    "sortText": "227",
     "textEdit": {
-     "newText": "raw(${1:})",
+     "newText": "raw",
      "range": {
       "end": {
        "character": 11,
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform2.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "213",
+    "sortText": "229",
     "textEdit": {
      "newText": "raw.with(${1:})",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform2.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "214",
+    "sortText": "230",
     "textEdit": {
      "newText": "read(${1:})",
      "range": {
@@ -93,7 +93,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform2.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "215",
+    "sortText": "231",
     "textEdit": {
      "newText": "read.with(${1:})",
      "range": {
@@ -115,7 +115,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform2.typ
     },
     "kind": 15,
     "label": "replacement",
-    "sortText": "228",
+    "sortText": "244",
     "textEdit": {
      "newText": "[${1:content}]",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@show_transform3.typ.snap
@@ -18,9 +18,9 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform3.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "212",
+    "sortText": "227",
     "textEdit": {
-     "newText": " raw(${1:})",
+     "newText": " raw",
      "range": {
       "end": {
        "character": 10,
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform3.typ
     "labelDetails": {
      "description": "(str, align: alignment, block: bool, lang: none | str, syntaxes: [syntax], tab-size: int, theme: [theme]) => raw"
     },
-    "sortText": "213",
+    "sortText": "229",
     "textEdit": {
      "newText": " raw.with(${1:})",
      "range": {
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform3.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "214",
+    "sortText": "230",
     "textEdit": {
      "newText": " read(${1:})",
      "range": {
@@ -93,7 +93,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform3.typ
     "labelDetails": {
      "description": "([any], encoding: \"utf8\" | none) => bytes | str"
     },
-    "sortText": "215",
+    "sortText": "231",
     "textEdit": {
      "newText": " read.with(${1:})",
      "range": {
@@ -115,7 +115,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/show_transform3.typ
     },
     "kind": 15,
     "label": "replacement",
-    "sortText": "228",
+    "sortText": "244",
     "textEdit": {
      "newText": " [${1:content}]",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@type_dir.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@type_dir.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/type_dir.typ
     "labelDetails": {
      "description": "alignment"
     },
-    "sortText": "183",
+    "sortText": "199",
     "textEdit": {
      "newText": "start",
      "range": {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@type_naive_completion.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@type_naive_completion.typ.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/type_naive_completion.
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "032",
+    "sortText": "033",
     "textEdit": {
      "newText": "content",
      "range": {

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-core-slides.typ-2.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-core-slides.typ-2.snap
@@ -14,7 +14,7 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-core-slides.typ
     "labelDetails": {
      "description": "() => any"
     },
-    "sortText": "032",
+    "sortText": "033",
     "textEdit": {
      "newText": "config-xxx()${1:}",
      "range": {

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-core-slides.typ.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-core-slides.typ.snap
@@ -68,7 +68,7 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-core-slides.typ
     "labelDetails": {
      "description": "(content, gap: length, justify: bool) => repeat"
     },
-    "sortText": "161",
+    "sortText": "177",
     "textEdit": {
      "newText": "repeat(${1:})",
      "range": {

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-cover-with-rect.typ.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-cover-with-rect.typ.snap
@@ -43,7 +43,7 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-cover-with-rec
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "186",
+    "sortText": "203",
     "textEdit": {
      "newText": "stroke(${1:})",
      "range": {

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-current-heading.typ-2.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-current-heading.typ-2.snap
@@ -40,9 +40,9 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-current-headin
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "090",
+    "sortText": "099",
     "textEdit": {
-     "newText": "int(${1:})",
+     "newText": "int",
      "range": {
       "end": {
        "character": 24,

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-markup-text.typ.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-markup-text.typ.snap
@@ -76,9 +76,9 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-markup-text.ty
     "labelDetails": {
      "description": "type"
     },
-    "sortText": "183",
+    "sortText": "199",
     "textEdit": {
-     "newText": "str(${1:})",
+     "newText": "str",
      "range": {
       "end": {
        "character": 19,

--- a/tests/e2e/e2e/lsp.rs
+++ b/tests/e2e/e2e/lsp.rs
@@ -22,7 +22,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:7e4a9cdceda2bf7409ec907108d0f927");
+        insta::assert_snapshot!(hash, @"siphash128_13:9409ded3fa346d873f6ab39516a53958");
     }
 
     {
@@ -33,7 +33,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:b18199e96fd07287ead7caa2b33f777");
+        insta::assert_snapshot!(hash, @"siphash128_13:8d1a21c367978b11c464a58953f0a756");
     }
 }
 


### PR DESCRIPTION
Reverts Myriad-Dreamin/tinymist#2003