### PR TITLE
fix: clean typlite markers from doc strings

### DIFF
--- a/crates/tinymist-analysis/src/docs.rs
+++ b/crates/tinymist-analysis/src/docs.rs
@@ -2,5 +2,5 @@
 
 mod def;
 pub use def::*;
-mod tidy;
+pub mod tidy;
 pub use tidy::*;

--- a/crates/tinymist-analysis/src/docs/tidy.rs
+++ b/crates/tinymist-analysis/src/docs/tidy.rs
@@ -23,6 +23,21 @@ pub struct TidyModuleDocs {
     pub docs: EcoString,
 }
 
+fn clean_typlite_markers(text: &str) -> String {
+    let mut result = text.to_string();
+
+    while let Some(start) = result.find("<!-- typlite:") {
+        if let Some(end) = result[start..].find(" -->") {
+            let end_pos = start + end + 4; // 4 = len(" -->")
+            result.replace_range(start..end_pos, "");
+        } else {
+            break;
+        }
+    }
+
+    result
+}
+
 pub fn identify_pat_docs(converted: &str) -> StrResult<TidyPatDocs> {
     let lines = converted.lines().collect::<Vec<_>>();
 
@@ -120,7 +135,7 @@ pub fn identify_pat_docs(converted: &str) -> StrResult<TidyPatDocs> {
                 name: param_line.0,
                 types: param_line.1,
                 default: None,
-                docs: buf.into_iter().join("\n").into(),
+                docs: clean_typlite_markers(&buf.into_iter().join("\n")).into(),
             });
             break_line = Some(line_width);
 
@@ -129,8 +144,10 @@ pub fn identify_pat_docs(converted: &str) -> StrResult<TidyPatDocs> {
     }
 
     let docs = match break_line {
-        Some(line_no) => (lines[..line_no]).iter().copied().join("\n").into(),
-        None => converted.into(),
+        Some(line_no) => {
+            clean_typlite_markers(&(lines[..line_no]).iter().copied().join("\n")).into()
+        }
+        None => clean_typlite_markers(converted).into(),
     };
 
     params.reverse();
@@ -142,7 +159,9 @@ pub fn identify_pat_docs(converted: &str) -> StrResult<TidyPatDocs> {
 }
 
 pub fn identify_tidy_module_docs(docs: EcoString) -> StrResult<TidyModuleDocs> {
-    Ok(TidyModuleDocs { docs })
+    Ok(TidyModuleDocs {
+        docs: clean_typlite_markers(&docs).into(),
+    })
 }
 
 fn match_brace(trim_start: &str) -> Option<(&str, &str)> {
@@ -224,9 +243,9 @@ See show-module() for outputting the results of this function.
 -> string"###), @r"
         >> docs:
         These again are dictionaries with the keys
-        - <!-- typlite:begin:list-item 0 -->`description` (optional): The description for the argument.<!-- typlite:end:list-item 0 -->
-        - <!-- typlite:begin:list-item 0 -->`types` (optional): A list of accepted argument types.<!-- typlite:end:list-item 0 --> 
-        - <!-- typlite:begin:list-item 0 -->`default` (optional): Default value for this argument.<!-- typlite:end:list-item 0 -->
+        - `description` (optional): The description for the argument.
+        - `types` (optional): A list of accepted argument types. 
+        - `default` (optional): Default value for this argument.
 
         See show-module() for outputting the results of this function.
         << docs
@@ -273,7 +292,7 @@ See show-module() for outputting the results of this function.
 -> string"###), @r"
         >> docs:
         These again are dictionaries with the keys
-        - <!-- typlite:begin:list-item 0 -->`description` (optional): The description for the argument.<!-- typlite:end:list-item 0 -->
+        - `description` (optional): The description for the argument.
 
         See show-module() for outputting the results of this function.
         << docs
@@ -286,8 +305,8 @@ See show-module() for outputting the results of this function.
         >>arg label-prefix: auto, string
         The label-prefix for internal function
                 references. If `auto`, the label-prefix name will be the module name. 
-          - <!-- typlite:begin:list-item 1 -->nested something<!-- typlite:end:list-item 1 -->
-          - <!-- typlite:begin:list-item 1 -->nested something 2<!-- typlite:end:list-item 1 -->
+          - nested something
+          - nested something 2
         << arg
         ");
     }

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -13,6 +13,8 @@ use crate::docs::{file_id_repr, module_docs, DefDocs, PackageDefInfo};
 use crate::package::{get_manifest_id, PackageInfo};
 use crate::LocalContext;
 
+use tinymist_analysis::docs::tidy::remove_list_annotations;
+
 /// Generate full documents in markdown format
 pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<String> {
     log::info!("generate_md_docs {spec:?}");
@@ -336,14 +338,6 @@ pub struct FileMeta {
 #[derive(Serialize, Deserialize)]
 struct ConvertResult {
     errors: Vec<String>,
-}
-
-fn remove_list_annotations(s: &str) -> String {
-    let s = s.to_string();
-    static REG: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r"<!-- typlite:(?:begin|end):[\w\-]+ \d+ -->").unwrap()
-    });
-    REG.replace_all(&s, "").to_string()
 }
 
 #[cfg(test)]

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@render_equation.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@render_equation.typ.snap
@@ -2,6 +2,7 @@
 source: crates/tinymist-query/src/hover.rs
 expression: content
 input_file: crates/tinymist-query/src/fixtures/hover/render_equation.typ
+snapshot_kind: text
 ---
 Range: 12:20:12:23
 
@@ -31,7 +32,7 @@ type: type
 ```
 
 The type of the argument.
-  - <!-- typlite:begin:list-item 1 -->It can be also regarded as the condition of the proposition.<!-- typlite:end:list-item 1 -->
+  - It can be also regarded as the condition of the proposition.
 
 ## B (positional)
 
@@ -40,4 +41,4 @@ type: type
 ```
 
 The type of the body.
-  - <!-- typlite:begin:list-item 1 -->It can be also regarded as the conclusion of the proposition.<!-- typlite:end:list-item 1 -->
+  - It can be also regarded as the conclusion of the proposition.


### PR DESCRIPTION
When there's HTML comments in list, the markdown syntax won't be parsed as expected. This pr cleans typlite markers from doc string to avoid this behavior.

<img width="654" height="223" alt="bfedf840bc92a34c44212006232a7e17" src="https://github.com/user-attachments/assets/9015952b-a5de-4d59-a8ff-61a5e3d09d1b" />
<img width="641" height="257" alt="0267db904824cf09b67234bdcb0919e7" src="https://github.com/user-attachments/assets/938fabaa-d6fe-42d4-adca-6c96b59443e2" />
