### PR TITLE
feat: use `tinymist_std::time` for wasm32 targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,6 +3877,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tinymist-std",
  "tokio",
  "tokio-util",
 ]

--- a/crates/sync-lsp/Cargo.toml
+++ b/crates/sync-lsp/Cargo.toml
@@ -22,6 +22,7 @@ lsp-types = { workspace = true, optional = true }
 parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tinymist-std.workspace = true
 
 clap = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }

--- a/crates/sync-lsp/src/server.rs
+++ b/crates/sync-lsp/src/server.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
-use std::time::Instant;
 
 use futures::future::MaybeDone;
 use parking_lot::Mutex;
 use serde::Serialize;
 use serde_json::{from_value, Value as JsonValue};
+use tinymist_std::time::Instant;
 
 #[cfg(feature = "lsp")]
 use crate::lsp::{Notification, Request};

--- a/crates/sync-lsp/src/server/dap_srv.rs
+++ b/crates/sync-lsp/src/server/dap_srv.rs
@@ -110,7 +110,7 @@ where
         if is_replay {
             let client = self.client.clone();
             let _ = std::thread::spawn(move || {
-                let since = std::time::Instant::now();
+                let since = tinymist_std::time::Instant::now();
                 let timeout = std::env::var("REPLAY_TIMEOUT")
                     .ok()
                     .and_then(|s| s.parse().ok())
@@ -122,7 +122,7 @@ where
                             client.begin_panic();
                         }
 
-                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        tokio::time::sleep(tinymist_std::time::Duration::from_millis(10)).await;
                     }
                 })
             })

--- a/crates/sync-lsp/src/server/lsp_srv.rs
+++ b/crates/sync-lsp/src/server/lsp_srv.rs
@@ -180,7 +180,7 @@ where
         if is_replay {
             let client = self.client.clone();
             let _ = std::thread::spawn(move || {
-                let since = std::time::Instant::now();
+                let since = tinymist_std::time::Instant::now();
                 let timeout = std::env::var("REPLAY_TIMEOUT")
                     .ok()
                     .and_then(|s| s.parse().ok())

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -462,7 +462,12 @@ impl LsHook for TypstLsHook {
         }
     }
 
-    fn stop_request(&self, req_id: &RequestId, method: &str, received_at: std::time::Instant) {
+    fn stop_request(
+        &self,
+        req_id: &RequestId,
+        method: &str,
+        received_at: tinymist_std::time::Instant,
+    ) {
         ().stop_request(req_id, method, received_at);
 
         if let Some(scope) = self.0.lock().remove(req_id) {
@@ -477,7 +482,7 @@ impl LsHook for TypstLsHook {
     fn stop_notification(
         &self,
         method: &str,
-        received_at: std::time::Instant,
+        received_at: tinymist_std::time::Instant,
         result: LspResult<()>,
     ) {
         ().stop_notification(method, received_at, result);

--- a/crates/tinymist-cli/src/testing.rs
+++ b/crates/tinymist-cli/src/testing.rs
@@ -180,7 +180,7 @@ pub async fn test_main(args: TestArgs) -> Result<()> {
     } = start_project(verse, None, move |c, mut i, next| {
         if let Interrupt::Compiled(artifact) = &mut i {
             let mut config = ctx.lock();
-            let instant = std::time::Instant::now();
+            let instant = tinymist_std::time::Instant::now();
             // todo: well term support
             // Clear the screen and then move the cursor to the top left corner.
             eprintln!("\x1B[2J\x1B[1;1H");

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -825,7 +825,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
         graph: Arc<WorldComputeGraph<F>>,
         export_target: ExportTarget,
     ) -> impl FnOnce() -> CompiledArtifact<F> {
-        let start = tinymist_std::time::now();
+        let start = tinymist_std::time::Instant::now();
 
         // todo unwrap main id
         let id = graph.world().main_id().unwrap();
@@ -846,7 +846,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
 
             let res = CompileStatusResult {
                 diag: (compiled.warning_cnt() + compiled.error_cnt()) as u32,
-                elapsed: start.elapsed().unwrap_or_default(),
+                elapsed: start.elapsed(),
             };
             let rep = CompileReport {
                 id: compiled.id().clone(),
@@ -898,7 +898,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
 
         // Trigger an evict task.
         rayon::spawn(move || {
-            let evict_start = std::time::Instant::now();
+            let evict_start = tinymist_std::time::Instant::now();
             if is_primary {
                 comemo::evict(10);
 

--- a/crates/tinymist-project/src/watch.rs
+++ b/crates/tinymist-project/src/watch.rs
@@ -460,11 +460,11 @@ impl<F: FnMut(FilesystemEvent) + Send + Sync> NotifyActor<F> {
 
         // The async scheduler is not accurate, so we need to ensure a window here
         let reserved = now - event.at_realtime;
-        if reserved < std::time::Duration::from_millis(50) {
+        if reserved < tinymist_std::time::Duration::from_millis(50) {
             let send = self.undetermined_send.clone();
             tokio::spawn(async move {
                 // todo: sleep in browser
-                tokio::time::sleep(std::time::Duration::from_millis(50) - reserved).await;
+                tokio::time::sleep(tinymist_std::time::Duration::from_millis(50) - reserved).await;
                 log_send_error("reschedule", send.send(event));
             });
             return None;

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1089,7 +1089,7 @@ impl SharedContext {
         let entry = entry.entry(query).or_default();
         QueryStatGuard {
             bucket: entry.clone(),
-            since: std::time::SystemTime::now(),
+            since: tinymist_std::time::Instant::now(),
         }
     }
 

--- a/crates/tinymist-query/src/analysis/stats.rs
+++ b/crates/tinymist-query/src/analysis/stats.rs
@@ -1,9 +1,10 @@
 //! Statistics about the analyzers
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use tinymist_std::hash::FxDashMap;
+use tinymist_std::time::Duration;
 use typst::syntax::FileId;
 
 #[derive(Clone)]
@@ -35,12 +36,12 @@ pub(crate) struct QueryStatBucket {
 
 pub(crate) struct QueryStatGuard {
     pub bucket: QueryStatBucket,
-    pub since: std::time::SystemTime,
+    pub since: tinymist_std::time::Instant,
 }
 
 impl Drop for QueryStatGuard {
     fn drop(&mut self) {
-        let elapsed = self.since.elapsed().unwrap_or_default();
+        let elapsed = self.since.elapsed();
         let mut data = self.bucket.data.lock();
         data.query += 1;
         data.total += elapsed;

--- a/crates/tinymist-query/src/analysis/tyck.rs
+++ b/crates/tinymist-query/src/analysis/tyck.rs
@@ -54,7 +54,7 @@ pub(crate) fn type_check(
         module_exports: Default::default(),
     };
 
-    let type_check_start = std::time::Instant::now();
+    let type_check_start = tinymist_std::time::Instant::now();
 
     checker.check(&root);
 

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -16,7 +16,7 @@ pub(crate) fn get_lexical_hierarchy(
     source: &Source,
     scope_kind: LexicalScopeKind,
 ) -> Option<EcoVec<LexicalHierarchy>> {
-    let start = std::time::Instant::now();
+    let start = tinymist_std::time::Instant::now();
     let root = LinkedNode::new(source.root());
 
     let mut worker = LexicalHierarchyWorker {

--- a/crates/tinymist-world/src/font/profile.rs
+++ b/crates/tinymist-world/src/font/profile.rs
@@ -81,7 +81,7 @@ impl FontProfileItem {
     pub fn mtime(&self) -> Option<SystemTime> {
         self.meta.get("mtime").and_then(|v| {
             let v = v.parse::<u64>().ok();
-            v.map(|v| SystemTime::UNIX_EPOCH + std::time::Duration::from_micros(v))
+            v.map(|v| SystemTime::UNIX_EPOCH + tinymist_std::time::Duration::from_micros(v))
         })
     }
 

--- a/crates/tinymist/src/project.rs
+++ b/crates/tinymist/src/project.rs
@@ -565,7 +565,7 @@ impl CompileHandler<LspCompilerFeat, ProjectInsStateExt> for CompileHandlerImpl 
                     == 0;
 
                 if check_stalled {
-                    let since = (tinymist_std::time::Time::now().duration_since(*compiling_since))
+                    let since = (tinymist_std::time::now().duration_since(*compiling_since))
                         .unwrap_or_default();
 
                     if since.as_secs() > 60 {
@@ -630,7 +630,7 @@ impl CompileHandler<LspCompilerFeat, ProjectInsStateExt> for CompileHandlerImpl 
             let Some(compile_fn) = s.may_compile(&c.handler) else {
                 continue;
             };
-            s.ext.compiling_since = Some(tinymist_std::time::Time::now());
+            s.ext.compiling_since = Some(tinymist_std::time::now());
             rayon::spawn(move || {
                 compile_fn();
             });

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -345,7 +345,7 @@ impl ServerState {
         mut state: ServiceState<T, T::S>,
         params: LspInterrupt,
     ) -> anyhow::Result<()> {
-        let _start = std::time::Instant::now();
+        let _start = tinymist_std::time::Instant::now();
         // log::info!("incoming interrupt: {params:?}");
         let Some(ready) = state.ready() else {
             log::info!("interrupted on not ready server");
@@ -362,7 +362,7 @@ impl ServerState {
         mut state: ServiceState<T, T::S>,
         params: ServerEvent,
     ) -> anyhow::Result<()> {
-        let _start = std::time::Instant::now();
+        let _start = tinymist_std::time::Instant::now();
         // log::info!("incoming interrupt: {params:?}");
         let Some(ready) = state.ready() else {
             log::info!("server event sent to not ready server");


### PR DESCRIPTION
`std::time` are not implemented for wasm32 targets, so we should use the time crate made by ourselves.