### PR TITLE
fix: eliminate clippy warnings

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -394,7 +394,7 @@ pub enum DefClass<'a> {
 
 impl DefClass<'_> {
     /// Gets the node of the def class.
-    pub fn node(&self) -> &LinkedNode {
+    pub fn node(&self) -> &LinkedNode<'_> {
         match self {
             DefClass::Let(node) => node,
             DefClass::Import(node) => node,
@@ -402,7 +402,7 @@ impl DefClass<'_> {
     }
 
     /// Gets the name node of the def class.
-    pub fn name(&self) -> Option<LinkedNode> {
+    pub fn name(&self) -> Option<LinkedNode<'_>> {
         match self {
             DefClass::Let(node) => {
                 let lb: ast::LetBinding<'_> = node.cast()?;
@@ -433,17 +433,17 @@ impl DefClass<'_> {
 
 // todo: whether we should distinguish between strict and loose def classes
 /// Classifies a definition loosely.
-pub fn classify_def_loosely(node: LinkedNode) -> Option<DefClass<'_>> {
+pub fn classify_def_loosely(node: LinkedNode<'_>) -> Option<DefClass<'_>> {
     classify_def_(node, false)
 }
 
 /// Classifies a definition strictly.
-pub fn classify_def(node: LinkedNode) -> Option<DefClass<'_>> {
+pub fn classify_def(node: LinkedNode<'_>) -> Option<DefClass<'_>> {
     classify_def_(node, true)
 }
 
 /// The internal implementation of classifying a definition.
-fn classify_def_(node: LinkedNode, strict: bool) -> Option<DefClass<'_>> {
+fn classify_def_(node: LinkedNode<'_>, strict: bool) -> Option<DefClass<'_>> {
     let mut ancestor = node;
     if ancestor.kind().is_trivia() || is_mark(ancestor.kind()) {
         ancestor = ancestor.prev_sibling()?;
@@ -715,7 +715,7 @@ impl<'a> SyntaxClass<'a> {
 
 /// Classifies node's syntax (inner syntax) that can be operated on by IDE
 /// functionality.
-pub fn classify_syntax(node: LinkedNode, cursor: usize) -> Option<SyntaxClass<'_>> {
+pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClass<'_>> {
     if matches!(node.kind(), SyntaxKind::Error) && node.text().starts_with('<') {
         return Some(SyntaxClass::error_as_label(node));
     }
@@ -1233,7 +1233,7 @@ pub fn classify_context_outer<'a>(
 
 /// Classifies node's context (outer syntax) that can be operated on by IDE
 /// functionality.
-pub fn classify_context(node: LinkedNode, cursor: Option<usize>) -> Option<SyntaxContext<'_>> {
+pub fn classify_context(node: LinkedNode<'_>, cursor: Option<usize>) -> Option<SyntaxContext<'_>> {
     let mut node = node;
     if node.kind().is_trivia() && node.parent_kind().is_some_and(possible_in_code_trivia) {
         loop {

--- a/crates/tinymist-package/src/pack.rs
+++ b/crates/tinymist-package/src/pack.rs
@@ -72,11 +72,11 @@ pub trait PackFs: fmt::Debug {
         f: &mut (dyn FnMut(&str, PackFile) -> PackageResult<()> + Send + Sync),
     ) -> PackageResult<()>;
     /// Read a file from the package.
-    fn read(&self, _path: &str) -> io::Result<PackFile> {
+    fn read(&self, _path: &str) -> io::Result<PackFile<'_>> {
         Err(unsupported())
     }
     /// Read entries from the package.
-    fn entries(&self) -> io::Result<PackEntries> {
+    fn entries(&self) -> io::Result<PackEntries<'_>> {
         Err(unsupported())
     }
 }

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -420,7 +420,7 @@ impl LocalContext {
     }
 
     /// Fork a new context for searching in the workspace.
-    pub fn fork_for_search(&mut self) -> SearchCtx {
+    pub fn fork_for_search(&mut self) -> SearchCtx<'_> {
         SearchCtx {
             ctx: self,
             searched: Default::default(),

--- a/crates/tinymist-render/src/lib.rs
+++ b/crates/tinymist-render/src/lib.rs
@@ -105,7 +105,8 @@ impl PeriscopeRenderer {
                 let mut doc = UsingExporter::svg_doc(paged_doc);
                 doc.module.prepare_glyphs();
                 let page0 = doc.pages.get(pos.page.get() - 1)?.clone();
-                let mut svg_text = UsingExporter::render(&doc.module, &[page0.clone()], None);
+                let mut svg_text =
+                    UsingExporter::render(&doc.module, std::slice::from_ref(&page0), None);
 
                 // todo: let typst.ts expose it
                 let svg_header = svg_text.get_mut(0)?;

--- a/crates/tinymist-std/src/fs/flock.rs
+++ b/crates/tinymist-std/src/fs/flock.rs
@@ -102,10 +102,10 @@ impl Write for FileLock {
 
 impl Drop for FileLock {
     fn drop(&mut self) {
-        if let Some(f) = self.f.take() {
-            if let Err(e) = unlock(&f) {
-                log::warn!("failed to release lock: {e:?}");
-            }
+        if let Some(f) = self.f.take()
+            && let Err(e) = unlock(&f)
+        {
+            log::warn!("failed to release lock: {e:?}");
         }
     }
 }

--- a/crates/tinymist-std/src/fs/paths.rs
+++ b/crates/tinymist-std/src/fs/paths.rs
@@ -360,10 +360,10 @@ impl<'a> Iterator for PathAncestors<'a> {
         if let Some(path) = self.current {
             self.current = path.parent();
 
-            if let Some(ref stop_at) = self.stop_at {
-                if path == stop_at {
-                    self.current = None;
-                }
+            if let Some(ref stop_at) = self.stop_at
+                && path == stop_at
+            {
+                self.current = None;
             }
 
             Some(path)
@@ -668,11 +668,11 @@ pub fn create_dir_all_excluded_from_backups_atomic(p: impl AsRef<Path>) -> Resul
     // existing behavior. If we get an error at rename() and suddenly the
     // directory (which didn't exist a moment earlier) exists we can infer from
     // it's another cargo process doing work.
-    if let Err(e) = fs::rename(tempdir.path(), path) {
-        if !path.exists() {
-            return Err(anyhow::Error::from(e))
-                .with_context(|| format!("failed to create directory `{}`", path.display()));
-        }
+    if let Err(e) = fs::rename(tempdir.path(), path)
+        && !path.exists()
+    {
+        return Err(anyhow::Error::from(e))
+            .with_context(|| format!("failed to create directory `{}`", path.display()));
     }
     Ok(())
 }

--- a/crates/tinymist-vfs/src/lib.rs
+++ b/crates/tinymist-vfs/src/lib.rs
@@ -324,7 +324,7 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
 
     /// Obtains an object to revise. The object will update the original vfs
     /// when it is dropped.
-    pub fn revise(&mut self) -> RevisingVfs<M> {
+    pub fn revise(&mut self) -> RevisingVfs<'_, M> {
         let managed = self.managed.lock().clone();
         let paths = self.paths.lock().clone();
         let goal_revision = self.revision.checked_add(1).expect("revision overflowed");
@@ -339,7 +339,7 @@ impl<M: PathAccessModel + Sized> Vfs<M> {
     }
 
     /// Obtains an object to display.
-    pub fn display(&self) -> DisplayVfs<M> {
+    pub fn display(&self) -> DisplayVfs<'_, M> {
         DisplayVfs { inner: self }
     }
 
@@ -604,7 +604,7 @@ impl EntryMap {
         }
     }
 
-    fn display(&self) -> DisplayEntryMap {
+    fn display(&self) -> DisplayEntryMap<'_> {
         DisplayEntryMap { map: self }
     }
 }
@@ -660,7 +660,7 @@ impl PathMap {
         self.paths.get(path)
     }
 
-    fn display(&self) -> DisplayPathMap {
+    fn display(&self) -> DisplayPathMap<'_> {
         DisplayPathMap { map: self }
     }
 }

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -141,7 +141,7 @@ impl ExportTask {
     pub(crate) fn signal(
         &self,
         snap: &LspCompiledArtifact,
-        client: &std::sync::Arc<(dyn ProjectClient + 'static)>,
+        client: &std::sync::Arc<dyn ProjectClient + 'static>,
     ) {
         let config = self.factory.task();
 
@@ -153,7 +153,7 @@ impl ExportTask {
         &self,
         artifact: &LspCompiledArtifact,
         config: &Arc<ExportUserConfig>,
-        client: &std::sync::Arc<(dyn ProjectClient + 'static)>,
+        client: &std::sync::Arc<dyn ProjectClient + 'static>,
     ) -> Option<()> {
         let doc = artifact.doc.as_ref()?;
         let s = artifact.snap.signal;

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -325,7 +325,7 @@ impl ServerState {
             self.preview
                 .start(cli_args, previewer, id, false, is_background)
         } else {
-            return Err(internal_error("entry file must be provided"));
+            Err(internal_error("entry file must be provided"))
         }
     }
 }


### PR DESCRIPTION
using clippy 0.1.91 (898aff704d 2025-08-14), but some warnings already exist in the latest stable version
mostly about elided lifetime and if-chain

only remaining warnings:
```
warning: struct `HashRepr` is never constructed
   --> crates\tinymist-query\src\tests.rs:462:12
    |
462 | pub struct HashRepr<T>(pub T);
    |            ^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: a method with this name may be added to the standard library in the future
   --> crates\tinymist\src\actor\editor.rs:103:30
    |
103 | ...                   .map_or_default(|fid| unix_slash(fid.vpath().as_rooted_path()));
    |                        ^^^^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `typst::typst_utils::OptionExt::map_or_default(...)` to keep using the current method
    = note: `#[warn(unstable_name_collisions)]` on by default
help: add `#![feature(result_option_map_or_default)]` to the crate attributes to enable `std::option::Option::<T>::map_or_default`
   --> crates\tinymist\src\lib.rs:3:1
    |
  3 + #![feature(result_option_map_or_default)]
    |
```