### PR TITLE
feat: view values of the expression under cursor

### DIFF
--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_module.typ.snap
@@ -17,3 +17,9 @@ let sys;
 ```typc
 <module sys>
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
@@ -14,4 +14,4 @@ rgb("#ff4136")
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
@@ -14,4 +14,4 @@ rgb("#ff4136")
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var.typ.snap
@@ -9,3 +9,9 @@ Range: 0:20:0:23
 ```typc
 rgb("#ff4136")
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var2.typ.snap
@@ -17,3 +17,9 @@ let sys;
 ```typc
 <module sys>
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
@@ -22,4 +22,4 @@ let sys;
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin_var3.typ.snap
@@ -17,3 +17,9 @@ let sys;
 ```typc
 <module sys>
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
@@ -14,4 +14,4 @@ Range: 2:23:2:27
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
@@ -9,3 +9,9 @@ Range: 2:23:2:27
 ```typc
 "A"
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@content_field.typ.snap
@@ -14,4 +14,4 @@ Range: 2:23:2:27
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
@@ -15,3 +15,10 @@ Range: 2:24:2:31
 
 
 ## The Module (Alias)
+
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
@@ -21,4 +21,4 @@ Range: 2:24:2:31
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_alias.typ.snap
@@ -21,4 +21,4 @@ Range: 2:24:2:31
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
@@ -15,3 +15,9 @@ This star imports line
 ```typc
 none
 ```
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
@@ -20,4 +20,4 @@ none
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_star.typ.snap
@@ -20,4 +20,4 @@ none
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
@@ -21,4 +21,4 @@ Range: 2:24:2:30
 ======
 
 
-[Show Full Value](command:tinymist.showFullValue)
+[Show Full Value](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
@@ -15,3 +15,10 @@ Range: 2:24:2:30
 
 
 ## The Module
+
+
+
+======
+
+
+[Show Full Value](command:tinymist.showFullValue)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@module_var.typ.snap
@@ -21,4 +21,4 @@ Range: 2:24:2:30
 ======
 
 
-[Show Full Value](command:tinymist.inspectValue)
+[Inspect Values](command:tinymist.inspectValue)

--- a/crates/tinymist-query/src/full_value.rs
+++ b/crates/tinymist-query/src/full_value.rs
@@ -63,7 +63,7 @@ fn format_values(world: &dyn World, expr: &LinkedNode) -> Option<String> {
         }
     }
 
-    const SIZE_LIMIT: usize = 512 * 1024 * 1024; // 512MB
+    const SIZE_LIMIT: usize = 8 * 1024 * 1024; // 8MB
 
     let mut buf = String::new();
     let mut limited = false;

--- a/crates/tinymist-query/src/full_value.rs
+++ b/crates/tinymist-query/src/full_value.rs
@@ -24,14 +24,14 @@ impl SemanticRequest for ShowFullValueRequest {
         let cursor = offset + 1;
 
         let leaf = LinkedNode::new(source.root()).leaf_at_compat(cursor)?;
+        let expr = get_inspected_expr(&leaf)?;
+        let content = format_values(&ctx.world(), expr)?;
 
-        let tooltip = expr_tooltip(&ctx.world(), &leaf)?;
-
-        Some(tooltip)
+        Some(content)
     }
 }
 
-fn expr_tooltip(world: &dyn World, leaf: &LinkedNode) -> Option<String> {
+fn get_inspected_expr<'a>(leaf: &'a LinkedNode<'a>) -> Option<&'a LinkedNode<'a>> {
     let mut ancestor = leaf;
     while !ancestor.is::<ast::Expr>() {
         ancestor = ancestor.parent()?;
@@ -42,35 +42,33 @@ fn expr_tooltip(world: &dyn World, leaf: &LinkedNode) -> Option<String> {
         return None;
     }
 
-    let values = analyze_expr(world, ancestor);
+    Some(ancestor)
+}
 
+fn format_values(world: &dyn World, expr: &LinkedNode) -> Option<String> {
     struct Piece<'a> {
         value: &'a Value,
-        #[allow(unused)]
-        first_occur: usize,
         count: usize,
     }
 
+    let values = analyze_expr(world, expr);
+
     let mut pieces: Vec<Piece<'_>> = vec![];
     let mut last = None;
-    for (i, (value, _)) in values.iter().enumerate() {
+    for (value, _) in values.iter() {
         if last.replace(value).is_some_and(|last| *last == *value) {
             pieces.last_mut().unwrap().count += 1;
         } else {
-            pieces.push(Piece {
-                value,
-                first_occur: i,
-                count: 1,
-            });
+            pieces.push(Piece { value, count: 1 });
         }
     }
 
-    const SIZE_LIMIT: usize = 512 * 1024 * 1024 * 1024; // 512MB
+    const SIZE_LIMIT: usize = 512 * 1024 * 1024; // 512MB
 
     let mut buf = String::new();
     let mut limited = false;
     for piece in pieces {
-        let item_repr = truncated_repr_::<{ SIZE_LIMIT }>(piece.value);
+        let item_repr = truncated_repr_::<SIZE_LIMIT>(piece.value);
         if buf.len() + item_repr.len() + 50 > SIZE_LIMIT {
             buf.push_str("... (reached size limit)\n");
             limited = true;

--- a/crates/tinymist-query/src/full_value.rs
+++ b/crates/tinymist-query/src/full_value.rs
@@ -1,0 +1,91 @@
+use std::fmt::Write;
+use tinymist_analysis::{analyze_expr, upstream::truncated_repr_};
+use typst::{engine::Sink, syntax::LinkedNode};
+use typst_shim::syntax::LinkedNodeExt;
+
+use crate::prelude::*;
+
+/// A request to show the full tracked value at a specific position.
+#[derive(Debug, Clone)]
+pub struct ShowFullValueRequest {
+    /// The source file.
+    pub path: PathBuf,
+    /// The cursor position.
+    pub position: LspPosition,
+}
+
+impl SemanticRequest for ShowFullValueRequest {
+    type Response = String;
+
+    fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
+        let source = ctx.source_by_path(&self.path).ok()?;
+        let offset = ctx.to_typst_pos(self.position, &source)?;
+        // the typst's cursor is 1-based, so we need to add 1 to the offset
+        let cursor = offset + 1;
+
+        let leaf = LinkedNode::new(source.root()).leaf_at_compat(cursor)?;
+
+        let tooltip = expr_tooltip(&ctx.world(), &leaf)?;
+
+        Some(tooltip)
+    }
+}
+
+fn expr_tooltip(world: &dyn World, leaf: &LinkedNode) -> Option<String> {
+    let mut ancestor = leaf;
+    while !ancestor.is::<ast::Expr>() {
+        ancestor = ancestor.parent()?;
+    }
+
+    let expr = ancestor.cast::<ast::Expr>()?;
+    if !expr.hash() && !matches!(expr, ast::Expr::MathIdent(_)) {
+        return None;
+    }
+
+    let values = analyze_expr(world, ancestor);
+
+    struct Piece<'a> {
+        value: &'a Value,
+        #[allow(unused)]
+        first_occur: usize,
+        count: usize,
+    }
+
+    let mut pieces: Vec<Piece<'_>> = vec![];
+    let mut last = None;
+    for (i, (value, _)) in values.iter().enumerate() {
+        if last.replace(value).is_some_and(|last| *last == *value) {
+            pieces.last_mut().unwrap().count += 1;
+        } else {
+            pieces.push(Piece {
+                value,
+                first_occur: i,
+                count: 1,
+            });
+        }
+    }
+
+    const SIZE_LIMIT: usize = 512 * 1024 * 1024 * 1024; // 512MB
+
+    let mut buf = String::new();
+    let mut limited = false;
+    for piece in pieces {
+        let item_repr = truncated_repr_::<{ SIZE_LIMIT }>(piece.value);
+        if buf.len() + item_repr.len() + 50 > SIZE_LIMIT {
+            buf.push_str("... (reached size limit)\n");
+            limited = true;
+            break;
+        }
+        buf.push('#');
+        buf.push_str(&item_repr);
+        if piece.count > 1 {
+            write!(buf, " // (x{})", piece.count).unwrap();
+        }
+        buf.push('\n');
+    }
+    if !limited && values.len() == Sink::MAX_VALUES {
+        buf.push_str("... (reached max values limit)\n");
+    }
+
+    Some(buf)
+}

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -194,7 +194,8 @@ impl HoverWorker<'_> {
         self.value.push(match typst_tooltip {
             Tooltip::Text(text) => text.to_string(),
             Tooltip::Code(code) => {
-                // Add a button to show full value when we have tracked code values
+                // Add a button to show full values
+                // todo - we may need only add this button if the code is too long
                 self.actions.push(CommandLink {
                     title: Some("Show Full Value".to_string()),
                     command_or_links: vec![CommandOrLink::Command {

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -194,15 +194,12 @@ impl HoverWorker<'_> {
         self.value.push(match typst_tooltip {
             Tooltip::Text(text) => text.to_string(),
             Tooltip::Code(code) => {
-                // Add a button to show full values
+                // Add a button to inspect values
                 // todo - we may need only add this button if the code is too long
                 self.actions.push(CommandLink {
                     title: Some(
-                        tinymist_l10n::t!(
-                            "tinymist-query.hover.inspect-value",
-                            "Show Full Value"
-                        )
-                        .to_string(),
+                        tinymist_l10n::t!("tinymist-query.hover.inspect-value", "Inspect Values")
+                            .to_string(),
                     ),
                     command_or_links: vec![CommandOrLink::Command {
                         id: "tinymist.inspectValue".to_string(),

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -197,7 +197,13 @@ impl HoverWorker<'_> {
                 // Add a button to show full values
                 // todo - we may need only add this button if the code is too long
                 self.actions.push(CommandLink {
-                    title: Some("Show Full Value".to_string()),
+                    title: Some(
+                        tinymist_l10n::t!(
+                            "tinymist-query.hover.show-full-value",
+                            "Show Full Value"
+                        )
+                        .to_string(),
+                    ),
                     command_or_links: vec![CommandOrLink::Command {
                         id: "tinymist.showFullValue".to_string(),
                         args: vec![],

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -199,13 +199,13 @@ impl HoverWorker<'_> {
                 self.actions.push(CommandLink {
                     title: Some(
                         tinymist_l10n::t!(
-                            "tinymist-query.hover.show-full-value",
+                            "tinymist-query.hover.inspect-value",
                             "Show Full Value"
                         )
                         .to_string(),
                     ),
                     command_or_links: vec![CommandOrLink::Command {
-                        id: "tinymist.showFullValue".to_string(),
+                        id: "tinymist.inspectValue".to_string(),
                         args: vec![],
                     }],
                 });

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -1,9 +1,11 @@
 use core::fmt::{self, Write};
 use std::cmp::Reverse;
 
+use serde_json::Value as JsonValue;
 use tinymist_std::typst::TypstDocument;
 use tinymist_world::package::{PackageSpec, PackageSpecExt};
 use typst::foundations::repr::separated_list;
+use typst::syntax::{LinkedNode, ast};
 use typst_shim::syntax::LinkedNodeExt;
 
 use crate::analysis::get_link_exprs_in;
@@ -188,10 +190,23 @@ impl HoverWorker<'_> {
     /// Dynamic analysis results
     fn dynamic_analysis(&mut self) -> Option<()> {
         let typst_tooltip = self.ctx.tooltip(&self.source, self.cursor)?;
+
         self.value.push(match typst_tooltip {
             Tooltip::Text(text) => text.to_string(),
-            Tooltip::Code(code) => format!("### Sampled Values\n```typc\n{code}\n```"),
+            Tooltip::Code(code) => {
+                // Add a button to show full value when we have tracked code values
+                self.actions.push(CommandLink {
+                    title: Some("Show Full Value".to_string()),
+                    command_or_links: vec![CommandOrLink::Command {
+                        id: "tinymist.showFullValue".to_string(),
+                        args: vec![],
+                    }],
+                });
+
+                format!("### Sampled Values\n```typc\n{code}\n```")
+            }
         });
+
         Some(())
     }
 

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -24,6 +24,7 @@ pub use document_link::*;
 pub use document_metrics::*;
 pub use document_symbol::*;
 pub use folding_range::*;
+pub use full_value::*;
 pub use goto_declaration::*;
 pub use goto_definition::*;
 pub use hover::*;
@@ -71,6 +72,7 @@ mod document_link;
 mod document_metrics;
 mod document_symbol;
 mod folding_range;
+mod full_value;
 mod goto_declaration;
 mod goto_definition;
 mod hover;
@@ -284,6 +286,7 @@ mod polymorphic {
         SelectionRange(SelectionRangeRequest),
         /// A request to interact with the code context.
         InteractCodeContext(InteractCodeContextRequest),
+        ShowFullValue(ShowFullValueRequest),
 
         /// A request to get extra text edits on enter.
         OnEnter(OnEnterRequest),
@@ -330,6 +333,7 @@ mod polymorphic {
                 Self::FoldingRange(..) => ContextFreeUnique,
                 Self::SelectionRange(..) => ContextFreeUnique,
                 Self::InteractCodeContext(..) => PinnedFirst,
+                Self::ShowFullValue(..) => PinnedFirst,
 
                 Self::OnEnter(..) => ContextFreeUnique,
 
@@ -370,6 +374,7 @@ mod polymorphic {
                 Self::FoldingRange(req) => &req.path,
                 Self::SelectionRange(req) => &req.path,
                 Self::InteractCodeContext(req) => &req.path,
+                Self::ShowFullValue(..) => return None, // No specific path needed
 
                 Self::OnEnter(req) => &req.path,
 
@@ -435,6 +440,7 @@ mod polymorphic {
         SelectionRange(Option<Vec<SelectionRange>>),
         /// The response to the interact code context request.
         InteractCodeContext(Option<Vec<Option<InteractCodeContextResponse>>>),
+        ShowFullValue(Option<String>),
 
         /// The response to the on enter request.
         OnEnter(Option<Vec<TextEdit>>),

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -24,7 +24,6 @@ pub use document_link::*;
 pub use document_metrics::*;
 pub use document_symbol::*;
 pub use folding_range::*;
-pub use full_value::*;
 pub use goto_declaration::*;
 pub use goto_definition::*;
 pub use hover::*;
@@ -40,6 +39,7 @@ pub use semantic_tokens_delta::*;
 pub use semantic_tokens_full::*;
 pub use signature_help::*;
 pub use symbol::*;
+pub use value_inspector::*;
 pub use will_rename_files::*;
 pub use workspace_label::*;
 
@@ -72,7 +72,6 @@ mod document_link;
 mod document_metrics;
 mod document_symbol;
 mod folding_range;
-mod full_value;
 mod goto_declaration;
 mod goto_definition;
 mod hover;
@@ -87,6 +86,7 @@ mod semantic_tokens_delta;
 mod semantic_tokens_full;
 mod signature_help;
 mod symbol;
+mod value_inspector;
 mod will_rename_files;
 mod workspace_label;
 
@@ -286,7 +286,8 @@ mod polymorphic {
         SelectionRange(SelectionRangeRequest),
         /// A request to interact with the code context.
         InteractCodeContext(InteractCodeContextRequest),
-        ShowFullValue(ShowFullValueRequest),
+        /// A request to inspect the expression value.
+        InspectExpressionValue(InspectExpressionValueRequest),
 
         /// A request to get extra text edits on enter.
         OnEnter(OnEnterRequest),
@@ -333,7 +334,7 @@ mod polymorphic {
                 Self::FoldingRange(..) => ContextFreeUnique,
                 Self::SelectionRange(..) => ContextFreeUnique,
                 Self::InteractCodeContext(..) => PinnedFirst,
-                Self::ShowFullValue(..) => PinnedFirst,
+                Self::InspectExpressionValue(..) => PinnedFirst,
 
                 Self::OnEnter(..) => ContextFreeUnique,
 
@@ -374,7 +375,7 @@ mod polymorphic {
                 Self::FoldingRange(req) => &req.path,
                 Self::SelectionRange(req) => &req.path,
                 Self::InteractCodeContext(req) => &req.path,
-                Self::ShowFullValue(req) => &req.path,
+                Self::InspectExpressionValue(req) => &req.path,
 
                 Self::OnEnter(req) => &req.path,
 
@@ -440,7 +441,8 @@ mod polymorphic {
         SelectionRange(Option<Vec<SelectionRange>>),
         /// The response to the interact code context request.
         InteractCodeContext(Option<Vec<Option<InteractCodeContextResponse>>>),
-        ShowFullValue(Option<String>),
+        /// The response to the show full value request.
+        InspectExpressionValue(Option<String>),
 
         /// The response to the on enter request.
         OnEnter(Option<Vec<TextEdit>>),

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -374,7 +374,7 @@ mod polymorphic {
                 Self::FoldingRange(req) => &req.path,
                 Self::SelectionRange(req) => &req.path,
                 Self::InteractCodeContext(req) => &req.path,
-                Self::ShowFullValue(..) => return None, // No specific path needed
+                Self::ShowFullValue(req) => &req.path,
 
                 Self::OnEnter(req) => &req.path,
 

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -441,7 +441,7 @@ mod polymorphic {
         SelectionRange(Option<Vec<SelectionRange>>),
         /// The response to the interact code context request.
         InteractCodeContext(Option<Vec<Option<InteractCodeContextResponse>>>),
-        /// The response to the show full value request.
+        /// The response to the inspect values request.
         InspectExpressionValue(Option<String>),
 
         /// The response to the on enter request.

--- a/crates/tinymist-query/src/value_inspector.rs
+++ b/crates/tinymist-query/src/value_inspector.rs
@@ -108,12 +108,6 @@ fn format_values(world: &dyn World, expr: &LinkedNode) -> Option<String> {
     let mut value_limit_hit = false;
     let mut size_limit_hit = false;
 
-    // Add header explaining limitations
-    buf.push_str(&tinymist_l10n::t!(
-        "tinymist-query.value-inspector.header",
-        "# Tracked Values\n\n"
-    ));
-
     for piece in pieces {
         let item_repr = truncated_repr_::<SIZE_LIMIT>(piece.value);
         if buf.len() + item_repr.len() + 50 > SIZE_LIMIT {
@@ -144,7 +138,7 @@ fn format_values(world: &dyn World, expr: &LinkedNode) -> Option<String> {
         buf.push_str("\n\n");
         buf.push_str(&tinymist_l10n::t!(
             "tinymist-query.value-inspector.note-truncated",
-            "**Note:** Values above may be truncated due to internal limits.\n"
+            "*Note:* Values above may be truncated due to internal limits.\n"
         ));
     }
 

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -86,7 +86,7 @@ impl ServerState {
             .position
             .ok_or_else(|| internal_error("no position provided"))?;
 
-        run_query!(self.ShowFullValue(path, position))
+        run_query!(self.InspectExpressionValue(path, position))
     }
 
     fn select_range<T>(

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -12,7 +12,7 @@ use serde_json::Value as JsonValue;
 use task::TraceParams;
 use tinymist_assets::TYPST_PREVIEW_HTML;
 use tinymist_query::package::PackageInfo;
-use tinymist_query::{LocalContextGuard, LspRange};
+use tinymist_query::{LocalContextGuard, LspPosition, LspRange};
 use tinymist_std::error::prelude::*;
 use typst::syntax::{LinkedNode, Source};
 
@@ -32,6 +32,12 @@ use crate::tool::package::InitTask;
 #[serde(rename_all = "camelCase")]
 struct ExportSyntaxRangeOpts {
     range: Option<LspRange>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExportValueOpts {
+    position: Option<LspPosition>,
 }
 
 /// Here are implemented the handlers for each command.
@@ -70,6 +76,17 @@ impl ServerState {
         })?;
 
         just_ok(JsonValue::String(output))
+    }
+
+    /// Export the full tracked value at a specific position.
+    pub fn export_value(&mut self, mut args: Vec<JsonValue>) -> AnySchedulableResponse {
+        let path = get_arg!(args[0] as PathBuf);
+        let opts = get_arg_or_default!(args[1] as ExportValueOpts);
+        let position = opts
+            .position
+            .ok_or_else(|| internal_error("no position provided"))?;
+
+        run_query!(self.ShowFullValue(path, position))
     }
 
     fn select_range<T>(

--- a/crates/tinymist/src/lsp/query.rs
+++ b/crates/tinymist/src/lsp/query.rs
@@ -308,7 +308,7 @@ impl ServerState {
                 Symbol(req) => snap.run_semantic(req, R::Symbol),
                 WorkspaceLabel(req) => snap.run_semantic(req, R::WorkspaceLabel),
                 DocumentMetrics(req) => snap.run_semantic(req, R::DocumentMetrics),
-                ShowFullValue(req) => snap.run_semantic(req, R::ShowFullValue),
+                InspectExpressionValue(req) => snap.run_semantic(req, R::InspectExpressionValue),
                 _ => unreachable!(),
             };
 

--- a/crates/tinymist/src/lsp/query.rs
+++ b/crates/tinymist/src/lsp/query.rs
@@ -308,6 +308,7 @@ impl ServerState {
                 Symbol(req) => snap.run_semantic(req, R::Symbol),
                 WorkspaceLabel(req) => snap.run_semantic(req, R::WorkspaceLabel),
                 DocumentMetrics(req) => snap.run_semantic(req, R::DocumentMetrics),
+                ShowFullValue(req) => snap.run_semantic(req, R::ShowFullValue),
                 _ => unreachable!(),
             };
 

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -336,6 +336,7 @@ impl ServerState {
             .with_command_("tinymist.exportQuery", State::export_query)
             .with_command("tinymist.exportAnsiHighlight", State::export_ansi_hl)
             .with_command("tinymist.exportAst", State::export_ast)
+            .with_command("tinymist.exportValue", State::export_value)
             .with_command("tinymist.doClearCache", State::clear_cache)
             .with_command("tinymist.pinMain", State::pin_document)
             .with_command("tinymist.focusMain", State::focus_document)

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -336,7 +336,7 @@ impl ServerState {
             .with_command_("tinymist.exportQuery", State::export_query)
             .with_command("tinymist.exportAnsiHighlight", State::export_ansi_hl)
             .with_command("tinymist.exportAst", State::export_ast)
-            .with_command("tinymist.exportValue", State::export_value)
+            .with_command("tinymist.exportTrackedValues", State::export_value)
             .with_command("tinymist.doClearCache", State::clear_cache)
             .with_command("tinymist.pinMain", State::pin_document)
             .with_command("tinymist.focusMain", State::focus_document)

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1331,8 +1331,8 @@
         "category": "Typst"
       },
       {
-        "command": "tinymist.showFullValue",
-        "title": "%extension.tinymist.command.tinymist.showFullValue%",
+        "command": "tinymist.inspectValue",
+        "title": "%extension.tinymist.command.tinymist.inspectValue%",
         "category": "Typst"
       },
       {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1331,6 +1331,11 @@
         "category": "Typst"
       },
       {
+        "command": "tinymist.showFullValue",
+        "title": "%extension.tinymist.command.tinymist.showFullValue%",
+        "category": "Typst"
+      },
+      {
         "command": "tinymist.showLog",
         "title": "%extension.tinymist.command.tinymist.showLog%",
         "description": "Show log of the language server",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -380,6 +380,7 @@ function commandShowFullValue(ctx: IContext) {
   const FullValueDoc = new (class implements vscode.TextDocumentContentProvider {
     readonly uri = vscode.Uri.parse(uri);
     readonly eventEmitter = new vscode.EventEmitter<vscode.Uri>();
+    debounce: NodeJS.Timeout | undefined = undefined;
 
     constructor() {
       vscode.workspace.onDidChangeTextDocument(
@@ -406,9 +407,12 @@ function commandShowFullValue(ctx: IContext) {
     private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
       if (isTypstDocument(event.document)) {
         // commandActivateDoc(event.document);
-        // We need to order this after language server updates, but there's no API for that.
-        // Hence, good old sleep().
-        setTimeout(() => this.emitChange(), 10);
+        if (this.debounce) {
+          clearTimeout(this.debounce);
+        }
+        this.debounce = setTimeout(() => {
+          this.emitChange();
+        }, 300); // 300ms debounce delay
       }
     }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -437,7 +437,8 @@ function commandInspectValue(ctx: IContext) {
       ct: vscode.CancellationToken,
     ): Promise<string> {
       const editor = ctx.currentActiveEditor();
-      if (!editor) return l10nMsg("No active editor, change selection to view full value.");
+      if (!editor)
+        return l10nMsg("No active editor, change selection to inspect expression values.");
 
       // Cancel any previous request
       if (this.currentRequest) {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -215,6 +215,7 @@ async function languageActivate(context: IContext) {
     commands.registerCommand("tinymist.runCodeLens", commandRunCodeLens),
     commands.registerCommand("tinymist.copyAnsiHighlight", commandCopyAnsiHighlight),
     commands.registerCommand("tinymist.viewAst", commandViewAst(context)),
+    commands.registerCommand("tinymist.showFullValue", commandShowFullValue(context)),
 
     commands.registerCommand("tinymist.pinMainToCurrent", () => commandPinMain(true)),
     commands.registerCommand("tinymist.unpinMain", () => commandPinMain(false)),
@@ -365,6 +366,98 @@ function commandViewAst(ctx: IContext) {
   return async () => {
     const document = await vscode.workspace.openTextDocument(AstDoc.uri);
     setTimeout(() => AstDoc.emitChange(), 10);
+    void (await vscode.window.showTextDocument(document, {
+      viewColumn: vscode.ViewColumn.Two,
+      preserveFocus: true,
+    }));
+  };
+}
+
+function commandShowFullValue(ctx: IContext) {
+  const scheme = "tinymist-full-value";
+  const uri = `${scheme}://showFullValue/values.typ`;
+
+  const FullValueDoc = new (class implements vscode.TextDocumentContentProvider {
+    readonly uri = vscode.Uri.parse(uri);
+    readonly eventEmitter = new vscode.EventEmitter<vscode.Uri>();
+
+    constructor() {
+      vscode.workspace.onDidChangeTextDocument(
+        this.onDidChangeTextDocument,
+        this,
+        ctx.subscriptions,
+      );
+      vscode.window.onDidChangeActiveTextEditor(
+        this.onDidChangeActiveTextEditor,
+        this,
+        ctx.subscriptions,
+      );
+      vscode.window.onDidChangeTextEditorSelection(
+        this.onDidChangeTextSelection,
+        this,
+        ctx.subscriptions,
+      );
+    }
+
+    emitChange() {
+      this.eventEmitter.fire(this.uri);
+    }
+
+    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
+      if (isTypstDocument(event.document)) {
+        // commandActivateDoc(event.document);
+        // We need to order this after language server updates, but there's no API for that.
+        // Hence, good old sleep().
+        setTimeout(() => this.emitChange(), 10);
+      }
+    }
+
+    private onDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined) {
+      if (editor && isTypstDocument(editor.document)) {
+        // commandActivateDoc(editor.document);
+        this.emitChange();
+      }
+    }
+
+    private onDidChangeTextSelection(event: vscode.TextEditorSelectionChangeEvent) {
+      if (isTypstDocument(event.textEditor.document)) {
+        // commandActivateDoc(event.textEditor.document);
+        this.emitChange();
+      }
+    }
+
+    async provideTextDocumentContent(
+      _uri: vscode.Uri,
+      _ct: vscode.CancellationToken,
+    ): Promise<string> {
+      const editor = ctx.currentActiveEditor();
+      if (!editor) return "No active editor, change selection to view full value.";
+
+      try {
+        const res = await tinymist.exportValue(editor.document.uri.fsPath, {
+          position: (await tinymist.clientPromise).code2ProtocolConverter.asPosition(
+            editor.selection.active,
+          ),
+        });
+
+        return res || "No value found at this position.";
+      } catch (error) {
+        return `Error: ${error}`;
+      }
+    }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+      return this.eventEmitter.event;
+    }
+  })();
+
+  ctx.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(scheme, FullValueDoc),
+  );
+
+  return async () => {
+    const document = await vscode.workspace.openTextDocument(FullValueDoc.uri);
+    setTimeout(() => FullValueDoc.emitChange(), 10);
     void (await vscode.window.showTextDocument(document, {
       viewColumn: vscode.ViewColumn.Two,
       preserveFocus: true,

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -216,7 +216,7 @@ export class LanguageState {
         "tinymist.openInternal",
         "tinymist.openExternal",
         "tinymist.replaceText",
-        "tinymist.showFullValue",
+        "tinymist.inspectValue",
       ],
     };
     const hoverStorage =
@@ -372,7 +372,7 @@ export class LanguageState {
   exportQuery = exportCommand("tinymist.exportQuery");
   exportAnsiHighlight = exportStringCommand("tinymist.exportAnsiHighlight");
   exportAst = exportStringCommand("tinymist.exportAst");
-  exportValue = exportStringCommand("tinymist.exportValue");
+  exportTrackedValues = exportStringCommand("tinymist.exportTrackedValues");
 
   getResource<T extends keyof ResourceRoutes>(path: T, ...args: any[]) {
     return tinymist.executeCommand<ResourceRoutes[T]>("tinymist.getResources", [path, ...args]);

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -212,7 +212,12 @@ export class LanguageState {
     const context = this.context;
 
     const trustedCommands = {
-      enabledCommands: ["tinymist.openInternal", "tinymist.openExternal", "tinymist.replaceText"],
+      enabledCommands: [
+        "tinymist.openInternal",
+        "tinymist.openExternal",
+        "tinymist.replaceText",
+        "tinymist.showFullValue",
+      ],
     };
     const hoverStorage =
       extensionState.features.renderDocs && LanguageState.HoverTmpStorage
@@ -367,6 +372,7 @@ export class LanguageState {
   exportQuery = exportCommand("tinymist.exportQuery");
   exportAnsiHighlight = exportStringCommand("tinymist.exportAnsiHighlight");
   exportAst = exportStringCommand("tinymist.exportAst");
+  exportValue = exportStringCommand("tinymist.exportValue");
 
   getResource<T extends keyof ResourceRoutes>(path: T, ...args: any[]) {
     return tinymist.executeCommand<ResourceRoutes[T]>("tinymist.getResources", [path, ...args]);

--- a/locales/tinymist-rt.toml
+++ b/locales/tinymist-rt.toml
@@ -56,6 +56,26 @@ zh = "性能分析"
 en = "Wrap {func_name} in figure with a caption"
 zh = "将 {func_name} 包裹在 figure 中，并添加一个标题"
 
+[tinymist-query.full-value.max-values-limit]
+en = "... (reached max values limit)\n"
+zh = "... (已达到最大值数量限制)\n"
+
+[tinymist-query.full-value.size-limit]
+en = "... (reached size limit)\n"
+zh = "... (已达到大小限制)\n"
+
+[tinymist-query.full-value.header]
+en = "# Tracked Values\n\n"
+zh = "# 跟踪的值\n\n"
+
+[tinymist-query.full-value.note-truncated]
+en = "**Note:** Values above may be truncated due to internal limits.\n"
+zh = "**注意：** 上述值可能因内部限制而被截断。\n"
+
+[tinymist-query.hover.show-full-value]
+en = "Show Full Value"
+zh = "查看完整值"
+
 [tinymist.config.badCompileStatus]
 en = "compileStatus must be either `\"enable\"` or `\"disable\"`, got {value}"
 zh = "compileStatus 必须是`\"enable\"`（打开）或 `\"disable\"`（关闭），得到 {value}"

--- a/locales/tinymist-rt.toml
+++ b/locales/tinymist-rt.toml
@@ -57,19 +57,15 @@ en = "Wrap {func_name} in figure with a caption"
 zh = "将 {func_name} 包裹在 figure 中，并添加一个标题"
 
 [tinymist-query.hover.inspect-value]
-en = "Show Full Value"
+en = "Inspect Values"
 zh = "检查表达式值"
-
-[tinymist-query.value-inspector.header]
-en = "# Tracked Values\n\n"
-zh = "# 跟踪的值\n\n"
 
 [tinymist-query.value-inspector.max-values-limit]
 en = "... (reached max values limit)\n"
 zh = "... (已达到最大值数量限制)\n"
 
 [tinymist-query.value-inspector.note-truncated]
-en = "**Note:** Values above may be truncated due to internal limits.\n"
+en = "*Note:* Values above may be truncated due to internal limits.\n"
 zh = "**注意：** 上述值可能因内部限制而被截断。\n"
 
 [tinymist-query.value-inspector.size-limit]

--- a/locales/tinymist-rt.toml
+++ b/locales/tinymist-rt.toml
@@ -56,25 +56,25 @@ zh = "性能分析"
 en = "Wrap {func_name} in figure with a caption"
 zh = "将 {func_name} 包裹在 figure 中，并添加一个标题"
 
-[tinymist-query.full-value.max-values-limit]
-en = "... (reached max values limit)\n"
-zh = "... (已达到最大值数量限制)\n"
+[tinymist-query.hover.inspect-value]
+en = "Show Full Value"
+zh = "检查表达式值"
 
-[tinymist-query.full-value.size-limit]
-en = "... (reached size limit)\n"
-zh = "... (已达到大小限制)\n"
-
-[tinymist-query.full-value.header]
+[tinymist-query.value-inspector.header]
 en = "# Tracked Values\n\n"
 zh = "# 跟踪的值\n\n"
 
-[tinymist-query.full-value.note-truncated]
+[tinymist-query.value-inspector.max-values-limit]
+en = "... (reached max values limit)\n"
+zh = "... (已达到最大值数量限制)\n"
+
+[tinymist-query.value-inspector.note-truncated]
 en = "**Note:** Values above may be truncated due to internal limits.\n"
 zh = "**注意：** 上述值可能因内部限制而被截断。\n"
 
-[tinymist-query.hover.show-full-value]
-en = "Show Full Value"
-zh = "查看完整值"
+[tinymist-query.value-inspector.size-limit]
+en = "... (reached size limit)\n"
+zh = "... (已达到大小限制)\n"
 
 [tinymist.config.badCompileStatus]
 en = "compileStatus must be either `\"enable\"` or `\"disable\"`, got {value}"

--- a/locales/tinymist-vscode-rt.toml
+++ b/locales/tinymist-vscode-rt.toml
@@ -92,10 +92,6 @@ zh = "没有活动的编辑器，更改选择以查看完整值。"
 en = "No value found at this position."
 zh = "在此位置未找到值。"
 
-["Request cancelled."]
-en = "Request cancelled."
-zh = "请求已取消。"
-
 ["PDF (Specific Pages)"]
 en = "PDF (Specific Pages)"
 zh = "PDF (指定页码)"
@@ -135,6 +131,10 @@ zh = "查询当前文档并导出结果为 YAML 文件"
 ["Query current document and export the result as a file. We will ask a few questions and update the tasks.json file for you."]
 en = "Query current document and export the result as a file. We will ask a few questions and update the tasks.json file for you."
 zh = "查询当前文档并导出结果为文件。我们将会询问一些问题并为您更新 tasks.json 文件。"
+
+["Request cancelled."]
+en = "Request cancelled."
+zh = "请求已取消。"
 
 ["Restart Server"]
 en = "Restart Server"

--- a/locales/tinymist-vscode-rt.toml
+++ b/locales/tinymist-vscode-rt.toml
@@ -16,6 +16,10 @@ zh = "提供一个帮助导出为 TeX 的 typst 文件，例如 `/ieee-tex.typ` 
 en = "Export as Bundle"
 zh = "导出为 Bundle"
 
+["Error: {error}"]
+en = "Error: {error}"
+zh = "错误：{error}"
+
 ["Export as HTML"]
 en = "Export as HTML"
 zh = "导出为 HTML"
@@ -79,6 +83,18 @@ zh = "无效的页码范围格式：{range}"
 ["Invalid page range: {range}"]
 en = "Invalid page range: {range}"
 zh = "无效的页码范围：{range}"
+
+["No active editor, change selection to view full value."]
+en = "No active editor, change selection to view full value."
+zh = "没有活动的编辑器，更改选择以查看完整值。"
+
+["No value found at this position."]
+en = "No value found at this position."
+zh = "在此位置未找到值。"
+
+["Request cancelled."]
+en = "Request cancelled."
+zh = "请求已取消。"
 
 ["PDF (Specific Pages)"]
 en = "PDF (Specific Pages)"

--- a/locales/tinymist-vscode-rt.toml
+++ b/locales/tinymist-vscode-rt.toml
@@ -84,9 +84,9 @@ zh = "无效的页码范围格式：{range}"
 en = "Invalid page range: {range}"
 zh = "无效的页码范围：{range}"
 
-["No active editor, change selection to view full value."]
-en = "No active editor, change selection to view full value."
-zh = "没有活动的编辑器，更改选择以查看完整值。"
+["No active editor, change selection to inspect expression values."]
+en = "No active editor, change selection to inspect expression values."
+zh = "没有活动的编辑器，更改选择以查看表达式值。"
 
 ["No value found at this position."]
 en = "No value found at this position."

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -241,9 +241,9 @@ zh-TW = "複製為 ANSI 代碼"
 en = "View the AST of the current file"
 zh = "查看当前文件的 AST"
 
-[extension.tinymist.command.tinymist.showFullValue]
-en = "View the full value of the expression under cursor"
-zh = "查看光标下表达式的完整值"
+[extension.tinymist.command.tinymist.inspectValue]
+en = "View the tracked value of the expression under cursor"
+zh = "查看光标下表达式的值"
 
 [extension.tinymist.command.tinymist.showLog]
 en = "Tinymist: Show Log"

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -241,6 +241,10 @@ zh-TW = "複製為 ANSI 代碼"
 en = "View the AST of the current file"
 zh = "查看当前文件的 AST"
 
+[extension.tinymist.command.tinymist.showFullValue]
+en = "View the full value of the expression under cursor"
+zh = "查看光标下表达式的完整值"
+
 [extension.tinymist.command.tinymist.showLog]
 en = "Tinymist: Show Log"
 ar = "Tinymist: عرض السجل"

--- a/tests/e2e/e2e/lsp.rs
+++ b/tests/e2e/e2e/lsp.rs
@@ -22,7 +22,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:55108ba6479fea30ddf2edd4a5347457");
+        insta::assert_snapshot!(hash, @"siphash128_13:9010332a6f6925eb32d4f8abf19dd90d");
     }
 
     {
@@ -33,7 +33,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:20190eede2c69def771599513a0f3f08");
+        insta::assert_snapshot!(hash, @"siphash128_13:6356f9517f0414444dd1430bd9924343");
     }
 
     {
@@ -44,7 +44,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("vscode-syntax-only"));
-        insta::assert_snapshot!(hash, @"siphash128_13:fc145d62fa6a84c7f05d8f02688a158a");
+        insta::assert_snapshot!(hash, @"siphash128_13:29c9e142409d79d84dfa606e49e72a07");
     }
 }
 


### PR DESCRIPTION
New features:
- Added a command to open a temporary file (like the AST view) to inspect the value under the cursor.
- Added a command link to the hover tooltip to quickly open the value view. (problem: this link can be trimmed if the values are too long)

<img width="362" height="157" alt="image" src="https://github.com/user-attachments/assets/495df155-5d4e-4149-bfc3-30b4b8b6cd15" />

<img width="319" height="288" alt="image" src="https://github.com/user-attachments/assets/1c44c9a9-bd9e-415f-984b-7842b39d1f64" />

<img width="946" height="506" alt="image" src="https://github.com/user-attachments/assets/e405e7aa-4ec9-418b-8c3d-cc3077b99761" />

Some problems:
- [ ] The entry file does not follow the active one. Without being pinned, the values are not traced, and thus no value is displayed.
- The number of displayed values is hard-limited by typst tracking, but we do not know if values are truncated.