### PR TITLE
fix(tinymist-project): invalidate cached snapshot after compile

### DIFF
--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -885,6 +885,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
             revision: compiled_revision,
             doc,
         });
+        self.cached_snapshot = None; // invalidate; will be recomputed on demand
 
         // Notify the new file dependencies.
         let mut deps = eco_vec![];

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -408,7 +408,6 @@ impl<F: CompilerFeat + Send + Sync + 'static, Ext: Default + 'static> ProjectCom
             snapshot: None,
             handler,
             export_target,
-            compilation: OnceLock::default(),
             latest_success_doc: None,
             deps: Default::default(),
             committed_revision: 0,
@@ -746,8 +745,6 @@ pub struct ProjectInsState<F: CompilerFeat, Ext> {
     pub reason: CompileSignal,
     /// The latest compute graph (snapshot).
     snapshot: Option<Arc<WorldComputeGraph<F>>>,
-    /// The latest compilation.
-    pub compilation: OnceLock<CompiledArtifact<F>>,
     /// The compilation handle.
     pub handler: Arc<dyn CompileHandler<F, Ext>>,
     /// The file dependencies.


### PR DESCRIPTION
This PR fixes a latent cache invalidation issue with project compilation. I recommend reviewing commit-by-commit, even though this is a small change. Only the last commit changes behavior; the rest are cleaning up code to make it easier to see what is happening.

---

Here's what I think is the problem.

Project instance states (`ProjectInsState`) provide access to a snapshot of the latest compilation result. This snapshot is cached for performance:
```rust
match self.snapshot.as_ref() {
    Some(snap) if snap.world().revision() == self.verse.revision => snap.clone(),
    // otherwise recompute
}
```
Unfortunately, it turns out that the cached snapshot may be outdated even if the revision matches. (In practice, it will usually just lag one compilation behind, and I think this is why it hasn't caused any observable issues--one compilation behind is not that much, especially if the user is continuously typing.)

To see the issue, consider the following sequence of steps. Assume initially all revisions are `0`.
1. User triggers a recompilation, say by typing into the file.
     - This triggers an `Interrupt::Memory` or similar.
2. The changes are applied to the vfs and recompilation begins.
     - `verse.revision` is incremented to `verse.revision = 1`.
3. A new snapshot is requested.
    - The project compiler checks the cached snapshot first, which still has `snap.world().revision() == 0`.
    - Since `verse.revision = 1` was already incremented before the compilation finished, a new snapshot is created and cached.
    - The cached snapshot now has `snap.world().revision() == 1`, even though nothing changed.
4. Compilation finishes, and some data from the resulting compilation artifact is recorded.
5. Another snapshot is requested.
    - Since the snapshot was recomputed already in (3), the revisions appears to match and the outdated, cached snapshot is returned.

The fix here is to just clear the cached snapshot in (4) after recompilation finishes.