### PR TITLE
feat: enhance CLI and argument documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "console",
  "globset",
  "once_cell",
+ "regex",
  "serde",
  "similar",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ vergen = { version = "8.3.1", features = [
 # Testing
 dhat = "0.3.3"
 divan = "0.1.14"
-insta = { version = "1.43", features = ["glob"] }
+insta = { version = "1.43", features = ["glob", "filters"] }
 insta-cmd = "0.6.0"
 
 

--- a/crates/tinymist-cli/src/cmd/compile.rs
+++ b/crates/tinymist-cli/src/cmd/compile.rs
@@ -8,19 +8,19 @@ use tinymist::world::WorldComputeGraph;
 use tinymist::world::system::print_diagnostics;
 use tinymist_std::{ImmutPath, error::prelude::*};
 
-/// Arguments for project compilation.
+/// Specify the project compilation.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct CompileArgs {
-    /// Inherits the compile task arguments.
+    /// Specify the compile task related arguments.
     #[clap(flatten)]
     pub compile: TaskCompileArgs,
 
-    /// Saves the compilation arguments to the lock file.
+    /// Save the compilation arguments to the lock file.
     #[clap(long)]
     pub save_lock: bool,
 
-    /// Specifies the path to the lock file. If the path is
-    /// set, the lock file will be saved.
+    /// Specify the path to the lock file. If the path is set, the lock file
+    /// will be saved, otherwise the lock file will be saved in the cwd.
     #[clap(long)]
     pub lockfile: Option<PathBuf>,
 }

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -69,39 +69,39 @@ struct Args {
 #[derive(Debug, Clone, clap::Subcommand)]
 #[clap(rename_all = "kebab-case")]
 enum Commands {
-    /// Probes existence (Nop run)
+    /// Probe existence (Nop run)
     Probe,
 
-    /// Runs language server
+    /// Run language server
     Lsp(crate::lsp::LspArgs),
-    /// Runs debug adapter
+    /// Run debug adapter
     #[cfg(feature = "dap")]
     Dap(crate::dap::DapArgs),
-    /// Runs language server for tracing some typst program.
+    /// Run language server for tracing some typst program.
     #[clap(hide(true))]
     TraceLsp(crate::trace_lsp::TraceLspArgs),
 
-    /// Runs language query
+    /// Run language query
     #[clap(hide(true))] // still in development
     #[clap(subcommand)]
     Query(crate::query::QueryCommands),
-    /// Runs preview server
+    /// Run preview server
     #[cfg(feature = "preview")]
     Preview(tinymist::tool::preview::PreviewCliArgs),
-    /// Runs compile command like `typst-cli compile`
+    /// Run compile command like `typst-cli compile`
     Compile(CompileArgs),
 
-    /// Generates completion script to stdout
+    /// Generate completion script to stdout
     Completion(crate::completion::ShellCompletionArgs),
-    /// Generates build script for compilation
+    /// Generate build script for compilation
     #[clap(hide(true))] // still in development
     GenerateScript(crate::generate_script::GenerateScriptArgs),
 
-    /// Runs documents
+    /// Run documents
     #[clap(hide(true))] // still in development
     #[clap(subcommand)]
     Doc(tinymist::project::DocCommands),
-    /// Runs tasks
+    /// Run tasks
     #[cfg(feature = "lock")]
     #[clap(hide(true))] // still in development
     #[clap(subcommand)]
@@ -110,7 +110,7 @@ enum Commands {
     /// Execute a document and collect coverage
     #[clap(hide(true))] // still in development
     Cov(crate::cov::CovArgs),
-    /// Test a document and gives summary
+    /// Test a document and give summary
     Test(crate::test::TestArgs),
 }
 

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -21,16 +21,18 @@ pub enum DocCommands {
 /// Declare a document (project's input).
 #[derive(Debug, Clone, clap::Parser)]
 pub struct DocNewArgs {
-    /// Argument to identify a project.
+    /// Specify the argument to identify a project.
     #[clap(flatten)]
     pub id: DocIdArgs,
-    /// Configures the project root (for absolute paths).
+    /// Configure the project root (for absolute paths). If the path is
+    /// relative, it will be resolved relative to the current working directory
+    /// (PWD).
     #[clap(long = "root", env = "TYPST_ROOT", value_name = "DIR")]
     pub root: Option<String>,
-    /// Common font arguments.
+    /// Specify the font related arguments.
     #[clap(flatten)]
     pub font: CompileFontArgs,
-    /// Common package arguments.
+    /// Specify the package related arguments.
     #[clap(flatten)]
     pub package: CompilePackageArgs,
 }
@@ -80,15 +82,15 @@ impl DocNewArgs {
     }
 }
 
-/// The id of a document.
+/// Specify the id of a document.
 ///
 /// If an identifier is not provided, the document's path is used as the id.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct DocIdArgs {
-    /// Give a name to the document.
+    /// Give a task name to the document.
     #[clap(long = "name")]
     pub name: Option<String>,
-    /// Path to input Typst file.
+    /// Specify the path to input Typst file.
     #[clap(value_hint = ValueHint::FilePath)]
     pub input: String,
 }
@@ -107,7 +109,7 @@ impl DocIdArgs {
 /// Configure project's priorities.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct DocConfigureArgs {
-    /// Argument to identify a project.
+    /// Specify the argument to identify a project.
     #[clap(flatten)]
     pub id: DocIdArgs,
     /// Set the unsigned priority of these task (lower numbers are higher
@@ -119,20 +121,16 @@ pub struct DocConfigureArgs {
 /// Declare an compile task.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct TaskCompileArgs {
-    /// Argument to identify a project.
+    /// Specify the argument to identify a project.
     #[clap(flatten)]
     pub declare: DocNewArgs,
 
-    /// Name a task.
-    #[clap(long = "task")]
-    pub task_name: Option<String>,
-
-    /// When to run the task
+    /// Configure when to run the task.
     #[arg(long = "when")]
     pub when: Option<TaskWhen>,
 
-    /// Path to output file (PDF, PNG, SVG, or HTML). Use `-` to write output to
-    /// stdout.
+    /// Provide the path to output file (PDF, PNG, SVG, or HTML). Use `-` to
+    /// write output to stdout.
     ///
     /// For output formats emitting one file per page (PNG & SVG), a page number
     /// template must be present if the source document renders to multiple
@@ -142,11 +140,12 @@ pub struct TaskCompileArgs {
     #[clap(value_hint = ValueHint::FilePath)]
     pub output: Option<String>,
 
-    /// The format of the output file, inferred from the extension by default.
+    /// Specify the format of the output file, inferred from the extension by
+    /// default.
     #[arg(long = "format", short = 'f')]
     pub format: Option<OutputFormat>,
 
-    /// Which pages to export. When unspecified, all pages are exported.
+    /// Specify which pages to export. When unspecified, all pages are exported.
     ///
     /// Pages to export are separated by commas, and can be either simple page
     /// numbers (e.g. '2,5' to export only pages 2 and 5) or page ranges (e.g.
@@ -159,23 +158,23 @@ pub struct TaskCompileArgs {
     #[arg(long = "pages", value_delimiter = ',')]
     pub pages: Option<Vec<Pages>>,
 
-    /// The argument to export to PDF.
+    /// Specify the PDF export related arguments.
     #[clap(flatten)]
     pub pdf: PdfExportArgs,
 
-    /// The argument to export to PNG.
+    /// Specify the PNG export related arguments.
     #[clap(flatten)]
     pub png: PngExportArgs,
 
-    /// The output format.
+    /// Specify the output format.
     #[clap(skip)]
     pub output_format: OnceLock<Result<OutputFormat>>,
 }
 
 impl TaskCompileArgs {
-    /// Convert the arguments to a project task.
+    /// Converts the arguments to a project task.
     pub fn to_task(self, doc_id: Id, cwd: &Path) -> Result<ApplyProjectTask> {
-        let new_task_id = self.task_name.map(Id::new);
+        let new_task_id = self.declare.id.name.map(Id::new);
         let task_id = new_task_id.unwrap_or(doc_id.clone());
 
         let output_format = if let Some(specified) = self.format {
@@ -247,19 +246,20 @@ impl TaskCompileArgs {
     }
 }
 
-/// Declare arguments for exporting a document to PDF.
+/// Specify the PDF export related arguments.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct PdfExportArgs {
-    /// One (or multiple comma-separated) PDF standards that Typst will enforce
-    /// conformance with.
+    /// Specify the PDF standards that Typst will enforce conformance with.
+    ///
+    /// If multiple standards are specified, they are separated by commas.
     #[arg(long = "pdf-standard", value_delimiter = ',')]
     pub pdf_standard: Vec<PdfStandard>,
 }
 
-/// Declare arguments for exporting a document to PNG.
+/// Specify the PNG export related arguments.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct PngExportArgs {
-    /// The PPI (pixels per inch) to use for PNG export.
+    /// Specify the PPI (pixels per inch) to use for PNG export.
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f32,
 }

--- a/crates/tinymist-world/src/args.rs
+++ b/crates/tinymist-world/src/args.rs
@@ -16,11 +16,14 @@ use crate::EntryOpts;
 
 const ENV_PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
 
-/// The font arguments for the world.
+/// The font arguments for the world to specify the way to search for fonts.
 #[derive(Debug, Clone, Default, Parser, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompileFontArgs {
-    /// Font paths
+    /// Add additional directories that are recursively searched for fonts.
+    ///
+    /// If multiple paths are specified, they are separated by the system's path
+    /// separator (`:` on Unix-like systems and `;` on Windows).
     #[clap(
         long = "font-path",
         value_name = "DIR",
@@ -30,20 +33,23 @@ pub struct CompileFontArgs {
     )]
     pub font_paths: Vec<PathBuf>,
 
-    /// Ensures system fonts won't be searched, unless explicitly included via
-    /// `--font-path`
+    /// Ensure system fonts won't be searched, unless explicitly included via
+    /// `--font-path`.
     #[clap(long, default_value = "false")]
     pub ignore_system_fonts: bool,
 }
 
-/// Arguments related to where packages are stored in the system.
+/// The package arguments for the world to specify where packages are stored in
+/// the system.
 #[derive(Debug, Clone, Parser, Default, PartialEq, Eq)]
 pub struct CompilePackageArgs {
-    /// Custom path to local packages, defaults to system-dependent location
+    /// Specify a custom path to local packages, defaults to system-dependent
+    /// location.
     #[clap(long = "package-path", env = "TYPST_PACKAGE_PATH", value_name = "DIR")]
     pub package_path: Option<PathBuf>,
 
-    /// Custom path to package cache, defaults to system-dependent location
+    /// Specify a custom path to package cache, defaults to system-dependent
+    /// location.
     #[clap(
         long = "package-cache-path",
         env = "TYPST_PACKAGE_CACHE_PATH",
@@ -52,31 +58,41 @@ pub struct CompilePackageArgs {
     pub package_cache_path: Option<PathBuf>,
 }
 
-/// Common arguments of compile, watch, and query.
+/// Common arguments to create a world (environment) to run typst tasks, e.g.
+/// `compile`, `watch`, and `query`.
 #[derive(Debug, Clone, Parser, Default)]
 pub struct CompileOnceArgs {
-    /// Path to input Typst file
+    /// Specify the path to input Typst file. If the path is relative, it will
+    /// be resolved relative to the current working directory (PWD).
     #[clap(value_name = "INPUT")]
     pub input: Option<String>,
 
-    /// Configures the project root (for absolute paths)
+    /// Configure the project root (for absolute paths).
     #[clap(long = "root", value_name = "DIR")]
     pub root: Option<PathBuf>,
 
-    /// Font related arguments.
+    /// Specify the font related arguments.
     #[clap(flatten)]
     pub font: CompileFontArgs,
 
-    /// Package related arguments.
+    /// Specify the package related arguments.
     #[clap(flatten)]
     pub package: CompilePackageArgs,
 
-    /// Enables in-development features that may be changed or removed at any
+    /// Enable in-development features that may be changed or removed at any
     /// time.
     #[arg(long = "features", value_delimiter = ',', env = "TYPST_FEATURES")]
     pub features: Vec<Feature>,
 
-    /// Add a string key-value pair visible through `sys.inputs`
+    /// Add a string key-value pair visible through `sys.inputs`.
+    ///
+    /// ### Examples
+    ///
+    /// Tell the script that `sys.inputs.foo` is `"bar"` (type: `str`).
+    ///
+    /// ```bash
+    /// tinymist compile --input foo=bar
+    /// ```
     #[clap(
         long = "input",
         value_name = "key=value",
@@ -85,7 +101,8 @@ pub struct CompileOnceArgs {
     )]
     pub inputs: Vec<(String, String)>,
 
-    /// The document's creation date formatted as a UNIX timestamp (in seconds).
+    /// Configure the document's creation date formatted as a UNIX timestamp
+    /// (in seconds).
     ///
     /// For more information, see <https://reproducible-builds.org/specs/source-date-epoch/>.
     #[clap(
@@ -97,13 +114,14 @@ pub struct CompileOnceArgs {
     )]
     pub creation_timestamp: Option<i64>,
 
-    /// One (or multiple comma-separated) PDF standards that Typst will enforce
-    /// conformance with.
+    /// Specify the PDF standards that Typst will enforce conformance with.
+    ///
+    /// If multiple standards are specified, they are separated by commas.
     #[arg(long = "pdf-standard", value_delimiter = ',')]
     pub pdf_standard: Vec<PdfStandard>,
 
-    /// Path to CA certificate file for network access, especially for
-    /// downloading typst packages.
+    /// Specify the path to CA certificate file for network access, especially
+    /// for downloading typst packages.
     #[clap(long = "cert", env = "TYPST_CERT", value_name = "CERT_PATH")]
     pub cert: Option<PathBuf>,
 }
@@ -227,7 +245,7 @@ macro_rules! display_possible_values {
     };
 }
 
-/// When to export an output file.
+/// Configure when to run a task.
 ///
 /// By default, a `tinymist compile` only provides input information and
 /// doesn't change the `when` field. However, you can still specify a `when`
@@ -269,7 +287,7 @@ impl TaskWhen {
 
 display_possible_values!(TaskWhen);
 
-/// Which format to use for the generated output file.
+/// Configure the format of the output file.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
 pub enum OutputFormat {
     /// Export to PDF.
@@ -284,7 +302,7 @@ pub enum OutputFormat {
 
 display_possible_values!(OutputFormat);
 
-/// Specifies the current export target.
+/// Configure the current export target.
 ///
 /// The design of this configuration is not yet finalized and for this reason it
 /// is guarded behind the html feature. Visit the HTML documentation page for

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -63,20 +63,24 @@ impl From<RefreshStyle> for TaskWhen {
     }
 }
 
-/// Specia Arguments for the preview tool.
+/// Specify arguments related to the preview service.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct PreviewArgs {
-    /// Preview mode
+    /// Configure the preview mode.
     #[clap(long = "preview-mode", default_value = "document", value_name = "MODE")]
     pub preview_mode: PreviewMode,
 
-    /// Only render visible part of the document. This can improve performance
-    /// but still being experimental.
+    /// Only render visible part of the document.
+    ///
+    /// This can improve performance but still being experimental.
     #[clap(long = "partial-rendering")]
     pub enable_partial_rendering: Option<bool>,
 
-    /// Invert colors of the preview (useful for dark themes without cost).
-    /// Please note you could see the origin colors when you hover elements in
+    /// Configure the way to invert colors of the preview.
+    ///
+    /// This is useful for dark themes without cost.
+    ///
+    /// Please note you could see the original colors when you hover elements in
     /// the preview.
     ///
     /// It is also possible to specify strategy to each element kind by an
@@ -105,6 +109,8 @@ pub struct PreviewArgs {
     pub invert_colors: Option<String>,
 
     /// Used by lsp for controlling the preview refresh style.
+    ///
+    /// This is hidden from the CLI.
     #[clap(long, hide(true))]
     pub refresh_style: Option<RefreshStyle>,
 }
@@ -128,18 +134,21 @@ impl PreviewArgs {
     }
 }
 
-/// CLI Arguments for the preview tool.
+/// Specify arguments related to the preview CLI.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct PreviewCliArgs {
-    /// Preview arguments
+    /// Configure the preview service.
     #[clap(flatten)]
     pub preview: PreviewArgs,
 
-    /// Compile arguments
+    /// Specify common arguments to create a world (environment) to run typst
+    /// tasks.
     #[clap(flatten)]
     pub compile: CompileOnceArgs,
 
     /// Used by lsp for identifying the task.
+    ///
+    /// This is hidden from the CLI.
     #[clap(
         long = "task-id",
         default_value = "default_preview",
@@ -148,8 +157,9 @@ pub struct PreviewCliArgs {
     )]
     pub task_id: String,
 
-    /// Data plane server will bind to this address. Note: if it equals to
-    /// `static_file_host`, same address will be used.
+    /// Configure the data plane server address.
+    ///
+    /// Note: if it equals to `static_file_host`, same address will be used.
     #[clap(
         long = "data-plane-host",
         default_value = "127.0.0.1:23625",
@@ -158,7 +168,7 @@ pub struct PreviewCliArgs {
     )]
     pub data_plane_host: String,
 
-    /// Control plane server will bind to this address
+    /// Configure the control plane server address.
     #[clap(
         long = "control-plane-host",
         default_value = "127.0.0.1:23626",
@@ -167,8 +177,9 @@ pub struct PreviewCliArgs {
     )]
     pub control_plane_host: String,
 
-    /// (Deprecated) (File) Host for the preview server. Note: if it equals to
-    /// `data_plane_host`, same address will be used.
+    /// (Deprecated) Configure (File) Host address for the preview server.
+    ///
+    /// Note: if it equals to `data_plane_host`, same address will be used.
     #[clap(
         long = "host",
         value_name = "HOST",
@@ -178,6 +189,8 @@ pub struct PreviewCliArgs {
     pub static_file_host: String,
 
     /// Let it not be the primary instance.
+    ///
+    /// This is hidden from the CLI.
     #[clap(long = "not-primary", hide(true))]
     pub not_as_primary: bool,
 
@@ -193,13 +206,13 @@ pub struct PreviewCliArgs {
 }
 
 impl PreviewCliArgs {
-    /// Whether to open the preview in the browser after compilation.
+    /// Determines whether to open the preview in the browser after compilation.
     pub fn open_in_browser(&self, default: bool) -> bool {
         !self.no_open && (self.open || default)
     }
 }
 
-/// Response for starting a preview.
+/// Response for starting a preview instance.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StartPreviewResponse {

--- a/tests/e2e/e2e/.cli.rs.pending-snap
+++ b/tests/e2e/e2e/.cli.rs.pending-snap
@@ -1,0 +1,2 @@
+{"run_id":"1755988819-559335217","line":7,"new":{"module_name":"tinymist_e2e_tests__e2e__cli","snapshot_name":"probe","metadata":{"source":"tests/e2e/e2e/cli.rs","assertion_line":7,"info":{"program":"tinymist","args":["probe"]}},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n\n----- stderr -----"},"old":{"module_name":"tinymist_e2e_tests__e2e__cli","metadata":{},"snapshot":"success: true\nexit_code: 0\n----- stdout -----"}}
+{"run_id":"1755988856-449795873","line":7,"new":null,"old":null}

--- a/tests/e2e/e2e/.cli.rs.pending-snap
+++ b/tests/e2e/e2e/.cli.rs.pending-snap
@@ -1,2 +1,0 @@
-{"run_id":"1755988819-559335217","line":7,"new":{"module_name":"tinymist_e2e_tests__e2e__cli","snapshot_name":"probe","metadata":{"source":"tests/e2e/e2e/cli.rs","assertion_line":7,"info":{"program":"tinymist","args":["probe"]}},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n\n----- stderr -----"},"old":{"module_name":"tinymist_e2e_tests__e2e__cli","metadata":{},"snapshot":"success: true\nexit_code: 0\n----- stdout -----"}}
-{"run_id":"1755988856-449795873","line":7,"new":null,"old":null}

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -1,6 +1,7 @@
 use tinymist_std::path::PathClean;
 
 use crate::artifact::{cli, GIT_ROOT};
+
 macro_rules! apply_common_filters {
     {} => {
         let mut settings = insta::Settings::clone_current();
@@ -10,6 +11,7 @@ macro_rules! apply_common_filters {
         let _bound = settings.bind_to_scope();
     }
 }
+
 #[test]
 fn test_probe() {
     insta_cmd::assert_cmd_snapshot!(cli().arg("probe"), @r"

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -1,7 +1,15 @@
 use tinymist_std::path::PathClean;
 
 use crate::artifact::{cli, GIT_ROOT};
-
+macro_rules! apply_common_filters {
+    {} => {
+        let mut settings = insta::Settings::clone_current();
+        // Env redaction
+        // [env: key=value]
+        settings.add_filter(r"\[env:\s*([^=]+)=[^\]]*\]", "[env: $1=REDACTED]");
+        let _bound = settings.bind_to_scope();
+    }
+}
 #[test]
 fn test_probe() {
     insta_cmd::assert_cmd_snapshot!(cli().arg("probe"), @r"
@@ -15,6 +23,7 @@ fn test_probe() {
 
 #[test]
 fn test_help() {
+    apply_common_filters!();
     insta_cmd::assert_cmd_snapshot!(cli().arg("--help"), @r"
     success: true
     exit_code: 0
@@ -43,6 +52,7 @@ fn test_help() {
 
 #[test]
 fn test_help_lsp() {
+    apply_common_filters!();
     insta_cmd::assert_cmd_snapshot!(cli().arg("lsp").arg("--help"), @r"
     success: true
     exit_code: 0
@@ -68,7 +78,7 @@ fn test_help_lsp() {
               If multiple paths are specified, they are separated by the system's path separator (`:` on
               Unix-like systems and `;` on Windows).
               
-              [env: TYPST_FONT_PATHS=]
+              [env: TYPST_FONT_PATHS=REDACTED]
 
           --ignore-system-fonts
               Ensure system fonts won't be searched, unless explicitly included via `--font-path`
@@ -82,6 +92,7 @@ fn test_help_lsp() {
 
 #[test]
 fn test_help_compile() {
+    apply_common_filters!();
     insta_cmd::assert_cmd_snapshot!(cli().arg("compile").arg("--help"), @r"
     success: true
     exit_code: 0
@@ -111,7 +122,7 @@ fn test_help_compile() {
               Configure the project root (for absolute paths). If the path is relative, it will be
               resolved relative to the current working directory (PWD)
               
-              [env: TYPST_ROOT=]
+              [env: TYPST_ROOT=REDACTED]
 
           --font-path <DIR>
               Add additional directories that are recursively searched for fonts.
@@ -119,7 +130,7 @@ fn test_help_compile() {
               If multiple paths are specified, they are separated by the system's path separator (`:` on
               Unix-like systems and `;` on Windows).
               
-              [env: TYPST_FONT_PATHS=]
+              [env: TYPST_FONT_PATHS=REDACTED]
 
           --ignore-system-fonts
               Ensure system fonts won't be searched, unless explicitly included via `--font-path`
@@ -127,12 +138,12 @@ fn test_help_compile() {
           --package-path <DIR>
               Specify a custom path to local packages, defaults to system-dependent location
               
-              [env: TYPST_PACKAGE_PATH=]
+              [env: TYPST_PACKAGE_PATH=REDACTED]
 
           --package-cache-path <DIR>
               Specify a custom path to package cache, defaults to system-dependent location
               
-              [env: TYPST_PACKAGE_CACHE_PATH=]
+              [env: TYPST_PACKAGE_CACHE_PATH=REDACTED]
 
           --when <WHEN>
               Configure when to run the task
@@ -196,6 +207,7 @@ fn test_help_compile() {
 
 #[test]
 fn test_help_preview() {
+    apply_common_filters!();
     insta_cmd::assert_cmd_snapshot!(cli().arg("preview").arg("--help"), @r#"
     success: true
     exit_code: 0
@@ -260,7 +272,7 @@ fn test_help_preview() {
               If multiple paths are specified, they are separated by the system's path separator (`:` on
               Unix-like systems and `;` on Windows).
               
-              [env: TYPST_FONT_PATHS=]
+              [env: TYPST_FONT_PATHS=REDACTED]
 
           --ignore-system-fonts
               Ensure system fonts won't be searched, unless explicitly included via `--font-path`
@@ -268,17 +280,17 @@ fn test_help_preview() {
           --package-path <DIR>
               Specify a custom path to local packages, defaults to system-dependent location
               
-              [env: TYPST_PACKAGE_PATH=]
+              [env: TYPST_PACKAGE_PATH=REDACTED]
 
           --package-cache-path <DIR>
               Specify a custom path to package cache, defaults to system-dependent location
               
-              [env: TYPST_PACKAGE_CACHE_PATH=]
+              [env: TYPST_PACKAGE_CACHE_PATH=REDACTED]
 
           --features <FEATURES>
               Enable in-development features that may be changed or removed at any time
               
-              [env: TYPST_FEATURES=]
+              [env: TYPST_FEATURES=REDACTED]
 
               Possible values:
               - html: The HTML feature
@@ -306,7 +318,7 @@ fn test_help_preview() {
               Specify the path to CA certificate file for network access, especially for downloading
               typst packages
               
-              [env: TYPST_CERT=]
+              [env: TYPST_CERT=REDACTED]
 
           --host <HOST>
               (Deprecated) Configure (File) Host address for the preview server.

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -14,6 +14,322 @@ fn test_probe() {
 }
 
 #[test]
+fn test_help() {
+    insta_cmd::assert_cmd_snapshot!(cli().arg("--help"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    An integrated language service for Typst.
+
+    Usage: tinymist [COMMAND]
+
+    Commands:
+      probe       Probe existence (Nop run)
+      lsp         Run language server
+      dap         Run debug adapter
+      preview     Run preview server
+      compile     Run compile command like `typst-cli compile`
+      completion  Generate completion script to stdout
+      test        Test a document and give summary
+      help        Print this message or the help of the given subcommand(s)
+
+    Options:
+      -h, --help     Print help
+      -V, --version  Print version
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_help_lsp() {
+    insta_cmd::assert_cmd_snapshot!(cli().arg("lsp").arg("--help"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Run language server
+
+    Usage: tinymist lsp [OPTIONS]
+
+    Options:
+          --mirror <FILE>
+              Mirror the stdin to the file
+              
+              [default: ]
+
+          --replay <FILE>
+              Replay input from the file
+              
+              [default: ]
+
+          --font-path <DIR>
+              Add additional directories that are recursively searched for fonts.
+              
+              If multiple paths are specified, they are separated by the system's path separator (`:` on
+              Unix-like systems and `;` on Windows).
+              
+              [env: TYPST_FONT_PATHS=]
+
+          --ignore-system-fonts
+              Ensure system fonts won't be searched, unless explicitly included via `--font-path`
+
+      -h, --help
+              Print help (see a summary with '-h')
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_help_compile() {
+    insta_cmd::assert_cmd_snapshot!(cli().arg("compile").arg("--help"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Run compile command like `typst-cli compile`
+
+    Usage: tinymist compile [OPTIONS] <INPUT> [OUTPUT]
+
+    Arguments:
+      <INPUT>
+              Specify the path to input Typst file
+
+      [OUTPUT]
+              Provide the path to output file (PDF, PNG, SVG, or HTML). Use `-` to write output to
+              stdout.
+              
+              For output formats emitting one file per page (PNG & SVG), a page number template must be
+              present if the source document renders to multiple pages. Use `{p}` for page numbers,
+              `{0p}` for zero padded page numbers and `{t}` for page count. For example,
+              `page-{0p}-of-{t}.png` creates `page-01-of-10.png`, `page-02-of-10.png`, and so on.
+
+    Options:
+          --name <NAME>
+              Give a task name to the document
+
+          --root <DIR>
+              Configure the project root (for absolute paths). If the path is relative, it will be
+              resolved relative to the current working directory (PWD)
+              
+              [env: TYPST_ROOT=]
+
+          --font-path <DIR>
+              Add additional directories that are recursively searched for fonts.
+              
+              If multiple paths are specified, they are separated by the system's path separator (`:` on
+              Unix-like systems and `;` on Windows).
+              
+              [env: TYPST_FONT_PATHS=]
+
+          --ignore-system-fonts
+              Ensure system fonts won't be searched, unless explicitly included via `--font-path`
+
+          --package-path <DIR>
+              Specify a custom path to local packages, defaults to system-dependent location
+              
+              [env: TYPST_PACKAGE_PATH=]
+
+          --package-cache-path <DIR>
+              Specify a custom path to package cache, defaults to system-dependent location
+              
+              [env: TYPST_PACKAGE_CACHE_PATH=]
+
+          --when <WHEN>
+              Configure when to run the task
+
+              Possible values:
+              - never:              Never watch to run task
+              - onSave:             Run task on saving the document, i.e. on `textDocument/didSave`
+                events
+              - onType:             Run task on typing, i.e. on `textDocument/didChange` events
+              - onDocumentHasTitle: *DEPRECATED* Run task when a document has a title and on saved,
+                which is useful to filter out template files
+              - script:             Checks by running a typst script
+
+      -f, --format <FORMAT>
+              Specify the format of the output file, inferred from the extension by default
+
+              Possible values:
+              - pdf:  Export to PDF
+              - png:  Export to PNG
+              - svg:  Export to SVG
+              - html: Export to HTML
+
+          --pages <PAGES>
+              Specify which pages to export. When unspecified, all pages are exported.
+              
+              Pages to export are separated by commas, and can be either simple page numbers (e.g. '2,5'
+              to export only pages 2 and 5) or page ranges (e.g. '2,3-6,8-' to export page 2, pages 3 to
+              6 (inclusive), page 8 and any pages after it).
+              
+              Page numbers are one-indexed and correspond to physical page numbers in the document
+              (therefore not being affected by the document's page counter).
+
+          --pdf-standard <PDF_STANDARD>
+              Specify the PDF standards that Typst will enforce conformance with.
+              
+              If multiple standards are specified, they are separated by commas.
+
+              Possible values:
+              - 1.7:  PDF 1.7
+              - a-2b: PDF/A-2b
+              - a-3b: PDF/A-3b
+
+          --ppi <PPI>
+              Specify the PPI (pixels per inch) to use for PNG export
+              
+              [default: 144]
+
+          --save-lock
+              Save the compilation arguments to the lock file
+
+          --lockfile <LOCKFILE>
+              Specify the path to the lock file. If the path is set, the lock file will be saved,
+              otherwise the lock file will be saved in the cwd
+
+      -h, --help
+              Print help (see a summary with '-h')
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_help_preview() {
+    insta_cmd::assert_cmd_snapshot!(cli().arg("preview").arg("--help"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Run preview server
+
+    Usage: tinymist preview [OPTIONS] [INPUT]
+
+    Arguments:
+      [INPUT]
+              Specify the path to input Typst file. If the path is relative, it will be resolved
+              relative to the current working directory (PWD)
+
+    Options:
+          --preview-mode <MODE>
+              Configure the preview mode
+              
+              [default: document]
+
+              Possible values:
+              - document: Would like to preview a regular document
+              - slide:    Would like to preview slides
+
+          --partial-rendering <ENABLE_PARTIAL_RENDERING>
+              Only render visible part of the document.
+              
+              This can improve performance but still being experimental.
+              
+              [possible values: true, false]
+
+          --invert-colors <INVERT_COLORS>
+              Configure the way to invert colors of the preview.
+              
+              This is useful for dark themes without cost.
+              
+              Please note you could see the original colors when you hover elements in the preview.
+              
+              It is also possible to specify strategy to each element kind by an object map in JSON
+              format.
+              
+              Possible element kinds: - `image`: Images in the preview. - `rest`: Rest elements in the
+              preview.
+              
+              By default, the preview will never invert colors.
+              
+              ## Example
+              
+              By string:
+              
+              ```shell --invert-colors=auto ```
+              
+              By element:
+              
+              ```shell --invert-colors='{"rest": "always", "image": "never"}' ```
+
+          --root <DIR>
+              Configure the project root (for absolute paths)
+
+          --font-path <DIR>
+              Add additional directories that are recursively searched for fonts.
+              
+              If multiple paths are specified, they are separated by the system's path separator (`:` on
+              Unix-like systems and `;` on Windows).
+              
+              [env: TYPST_FONT_PATHS=]
+
+          --ignore-system-fonts
+              Ensure system fonts won't be searched, unless explicitly included via `--font-path`
+
+          --package-path <DIR>
+              Specify a custom path to local packages, defaults to system-dependent location
+              
+              [env: TYPST_PACKAGE_PATH=]
+
+          --package-cache-path <DIR>
+              Specify a custom path to package cache, defaults to system-dependent location
+              
+              [env: TYPST_PACKAGE_CACHE_PATH=]
+
+          --features <FEATURES>
+              Enable in-development features that may be changed or removed at any time
+              
+              [env: TYPST_FEATURES=]
+
+              Possible values:
+              - html: The HTML feature
+
+          --input <key=value>
+              Add a string key-value pair visible through `sys.inputs`.
+              
+              ### Examples
+              
+              Tell the script that `sys.inputs.foo` is `"bar"` (type: `str`).
+              
+              ```bash tinymist compile --input foo=bar ```
+
+          --pdf-standard <PDF_STANDARD>
+              Specify the PDF standards that Typst will enforce conformance with.
+              
+              If multiple standards are specified, they are separated by commas.
+
+              Possible values:
+              - 1.7:  PDF 1.7
+              - a-2b: PDF/A-2b
+              - a-3b: PDF/A-3b
+
+          --cert <CERT_PATH>
+              Specify the path to CA certificate file for network access, especially for downloading
+              typst packages
+              
+              [env: TYPST_CERT=]
+
+          --host <HOST>
+              (Deprecated) Configure (File) Host address for the preview server.
+              
+              Note: if it equals to `data_plane_host`, same address will be used.
+              
+              [default: ]
+
+          --open
+              Open the preview in the browser after compilation. If `--no-open` is set, this flag will
+              be ignored
+
+          --no-open
+              Don't open the preview in the browser after compilation. If `--open` is set as well, this
+              flag will win
+
+      -h, --help
+              Print help (see a summary with '-h')
+
+    ----- stderr -----
+    "#);
+}
+#[test]
 fn test_compile() {
     const INPUT_REL: &str = "tests/workspaces/individuals/tiny.typ";
 


### PR DESCRIPTION
This PR improves the help message of the CLL. Also, we change the verbs in the help message from plural (e.g. `compiles`) to singular (e.g. `compile`). This matches the style of `clap-rs`.

Added tests about critical help messages.