### PR TITLE
fix: update cargo metadata and crate release script

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -46,7 +46,6 @@ jobs:
           cargo publish --no-verify -p typlite || true
           cargo publish --no-verify -p crityp || true
           
-          cargo publish --no-verify -p tinymist-analysis || true
           cargo publish --no-verify -p tinymist-debug || true
           cargo publish --no-verify -p tinymist-lint || true
           cargo publish --no-verify -p tinymist-query || true

--- a/crates/crityp/Cargo.toml
+++ b/crates/crityp/Cargo.toml
@@ -39,8 +39,11 @@ insta.workspace = true
 
 [features]
 default = ["cli", "embed-fonts", "no-content-hint"]
-cli = ["clap", "clap/wrap_help"]
+cli = ["clap", "clap/wrap_help", "system"]
 no-content-hint = ["tinymist-project/no-content-hint"]
+
+system = ["tinymist-project/system"]
+web = ["tinymist-project/web"]
 
 # Embeds Typst's default fonts for
 # - text (Linux Libertine),


### PR DESCRIPTION

This PR fixes the release script to remove the `tinymist-analysis` crate from the release process.

This PR also fixes the `crityp` crate to include the `system` feature in the `cli` feature.
