### PR TITLE
dev: fix lint warnings introduced by #2062

### DIFF
--- a/crates/tinymist-query/src/check.rs
+++ b/crates/tinymist-query/src/check.rs
@@ -14,6 +14,6 @@ impl SemanticRequest for CheckRequest {
 
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let worker = DiagWorker::new(ctx);
-        Some(worker.full_check().convert_all(self.snap.diagnostics()))
+        Some(worker.check().convert_all(self.snap.diagnostics()))
     }
 }

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -47,7 +47,7 @@ impl<'w> DiagWorker<'w> {
     }
 
     /// Runs code check on the main document and all its dependencies.
-    pub fn full_check(mut self) -> Self {
+    pub fn check(mut self) -> Self {
         for dep in self.ctx.world.depended_files() {
             if WorkspaceResolver::is_package_file(dep) {
                 continue;

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -46,14 +46,6 @@ impl<'w> DiagWorker<'w> {
         }
     }
 
-    /// Runs code check on the given document.
-    pub fn check(mut self, source: &Source) -> Self {
-        for diag in self.ctx.lint(&source) {
-            self.handle(&diag);
-        }
-        self
-    }
-
     /// Runs code check on the main document and all its dependencies.
     pub fn full_check(mut self) -> Self {
         for dep in self.ctx.world.depended_files() {


### PR DESCRIPTION
> Hm. Sorry about the lint failures here, they slipped my attention locally since they show up as warnings, not errors, in my editor. I'm happy to put a PR fixing them later unless you get to it first.
>
> Not too sure how to deal with the unused DiagWorker::check method, since it is used, just in a test-only module. We can certainly mark it as #[cfg(test)] but that feels a little nasty.

https://github.com/Myriad-Dreamin/tinymist/pull/2062#issuecomment-3237812684

I ended up inlining the logic of `DiagWorker::check` into the test.