### PR TITLE
fix: extend origin check for vscode servers

### DIFF
--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -361,20 +361,17 @@ export async function openPreviewInWebView({
   );
   html = html.replace("preview-arg:previewMode:Doc", `preview-arg:previewMode:${previewMode}`);
   html = html.replace("preview-arg:state:", `preview-arg:state:${previewStateEncoded}`);
-  html = html.replace(
-    "ws://127.0.0.1:23625",
-    translateExternalURL(`ws://127.0.0.1:${dataPlanePort}`),
+  // Forwards the localhost port to the external URL. Since WebSocket runs over HTTP, it should be fine.
+  // https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost
+  let wsURI = await vscode.env.asExternalUri(
+    vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`),
   );
+  let wsURIString = wsURI.toString().replace(/^http/, "ws")
+  html = html.replace("ws://127.0.0.1:23625", wsURIString);
 
   // Sets the HTML content to the webview panel.
   // This will reload the webview panel if it's already opened.
   panel.webview.html = html;
-
-  // Forwards the localhost port to the external URL. Since WebSocket runs over HTTP, it should be fine.
-  // https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost
-  await vscode.env.asExternalUri(
-    vscode.Uri.parse(translateExternalURL(`http://127.0.0.1:${dataPlanePort}`)),
-  );
   return panel;
 }
 


### PR DESCRIPTION
Previously, Tinymist preview does not work on VS Code web (code-server) because it tries to connect to the `localhost`, which is impossible since we are doing remote development.

Even if we fix this error, the HTTP origin check will also fail because the domain of our VS Code web is not trusted by Tinymist. One possible fix is to grab the `VSCODE_PROXY_URI` environment variable and check if the incoming request matches the URI. This will fix the issue for most standard code-server installations.

However, GitHub Codespace is an exception. I did some logging, and found that GitHub Codespace used different origins:
- `<random>.assets.github.dev`
- `https://localhost:<port>` (note HTTP**S**)
- `None`

This is very weird and difficult to debug. Moreover, the ports forwarded by GitHub Codespaces require authentication before visiting, which the VS Code webview does not support. One have to open the URL in another browser tab to authenticate. This is frustrating and is difficult to workaround. Therefore, currently, GitHub Codespaces are not supported.

(I asked LLM to generate some of the Rust code. It works, but may need improvements.)

Fixes #625