### PR TITLE
feat: update global runner configuration to ubuntu 22.04

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -73,4 +73,5 @@ riscv64gc-unknown-linux-gnu = "2.31"
 "*" = "2.17"
 
 [dist.github-custom-runners]
+global = "ubuntu-22.04"
 aarch64-pc-windows-msvc = "windows-latest"


### PR DESCRIPTION
min-glibc-version is only used for detecting in the installer script, i.e. not useful to limit a minimal glibc version. A global runner is needed to be specified for running with older glibc.