### PR TITLE
fix: correct the lexical hierarchy of comment group

### DIFF
--- a/crates/tinymist-query/src/fixtures/document_symbols/snaps/test@symbol-after-comments.typ.snap
+++ b/crates/tinymist-query/src/fixtures/document_symbols/snaps/test@symbol-after-comments.typ.snap
@@ -1,0 +1,25 @@
+---
+source: crates/tinymist-query/src/document_symbol.rs
+expression: "JsonRepr::new_redacted(result.unwrap(), &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/document_symbols/symbol-after-comments.typ
+---
+[
+ {
+  "kind": 13,
+  "name": "symbol_after_comment",
+  "range": "1:5:1:25",
+  "selectionRange": "1:5:1:25"
+ },
+ {
+  "kind": 13,
+  "name": "symbol_after_line_comments",
+  "range": "5:5:5:31",
+  "selectionRange": "5:5:5:31"
+ },
+ {
+  "kind": 13,
+  "name": "symbol_after_block_comment",
+  "range": "9:5:9:31",
+  "selectionRange": "9:5:9:31"
+ }
+]

--- a/crates/tinymist-query/src/fixtures/document_symbols/symbol-after-comments.typ
+++ b/crates/tinymist-query/src/fixtures/document_symbols/symbol-after-comments.typ
@@ -1,0 +1,10 @@
+// This is a comment
+#let symbol_after_comment = 0
+
+// This is a group
+// of line comments
+#let symbol_after_line_comments = 1
+
+/* This is a
+ * block comment */
+#let symbol_after_block_comment = 2

--- a/crates/tinymist-query/src/fixtures/folding_range/snaps/test@comment.typ.snap
+++ b/crates/tinymist-query/src/fixtures/folding_range/snaps/test@comment.typ.snap
@@ -2,18 +2,9 @@
 source: crates/tinymist-query/src/folding_range.rs
 expression: "JsonRepr::new_pure(json!({ \"false\": result_false, \"true\": result_true, }))"
 input_file: crates/tinymist-query/src/fixtures/folding_range/comment.typ
-snapshot_kind: text
 ---
 {
  "false": [
-  {
-   "collapsedText": "",
-   "endCharacter": 14,
-   "endLine": 8,
-   "kind": "comment",
-   "startCharacter": 2,
-   "startLine": 3
-  },
   {
    "collapsedText": "",
    "endCharacter": 27,
@@ -21,20 +12,28 @@ snapshot_kind: text
    "kind": "comment",
    "startCharacter": 0,
    "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endCharacter": 14,
+   "endLine": 8,
+   "kind": "comment",
+   "startCharacter": 2,
+   "startLine": 3
   }
  ],
  "true": [
   {
    "collapsedText": "",
-   "endLine": 8,
-   "kind": "comment",
-   "startLine": 3
-  },
-  {
-   "collapsedText": "",
    "endLine": 1,
    "kind": "comment",
    "startLine": 0
+  },
+  {
+   "collapsedText": "",
+   "endLine": 8,
+   "kind": "comment",
+   "startLine": 3
   }
  ]
 }

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -297,6 +297,8 @@ impl LexicalHierarchyWorker {
                             },
                             eco_vec![],
                         ));
+                        // Push the lexical node to the children of the current top of the stack.
+                        self.finish_hierarchy();
                     }
 
                     if !Self::is_plain_token(child.kind()) {


### PR DESCRIPTION
Hierarchy of comment group is always wrong previously, causing #2021.

This PR fixed it and added a test case.

BTW, the changes in the lexical hierarchy module influenced a folding range test case, but it's just changed the order of items, which doesn't affect the correctness (the order is even more correct).