### PR TITLE
feat: rename labels (#1858)

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -702,6 +702,17 @@ impl<'a> SyntaxClass<'a> {
             _ => None,
         }
     }
+
+    /// Checks if the syntax class contains an error node.
+    pub fn contains_error(&self) -> bool {
+        use SyntaxClass::*;
+        match self {
+            Label { is_error, .. } => *is_error,
+            Normal(kind, _) => *kind == SyntaxKind::Error,
+            Callee(..) | VarAccess(..) => self.node().kind() == SyntaxKind::Error,
+            Ref { .. } | ImportPath(..) | IncludePath(..) => false,
+        }
+    }
 }
 
 /// Classifies node's syntax (inner syntax) that can be operated on by IDE

--- a/crates/tinymist-query/src/fixtures/rename/label.typ
+++ b/crates/tinymist-query/src/fixtures/rename/label.typ
@@ -1,0 +1,7 @@
+/// compile: true
+
+#set heading(numbering: "1.")
+
+= Labeled <title_label>
+
+/* position after */ @title_label

--- a/crates/tinymist-query/src/fixtures/rename/label_indir.typ
+++ b/crates/tinymist-query/src/fixtures/rename/label_indir.typ
@@ -1,0 +1,5 @@
+/// compile: true
+
+#let test1(body) = figure(body)
+#test1([Test1]) <fig:test1>
+/* position after */ @fig:test1

--- a/crates/tinymist-query/src/fixtures/rename/label_indir2.typ
+++ b/crates/tinymist-query/src/fixtures/rename/label_indir2.typ
@@ -1,0 +1,9 @@
+/// compile: true
+
+#let test1(body) = figure(body)
+#test1([Test1]) <fig:test1>
+@fig:test1
+
+#let test2(body) = test1(body)
+#test2([Test2]) <fig:test2>
+/* position after */ @fig:test2

--- a/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label.typ.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tinymist-query/src/prepare_rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label.typ
+---
+{
+ "placeholder": "title_label",
+ "range": "6:21:6:33"
+}

--- a/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label_indir.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label_indir.typ.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tinymist-query/src/prepare_rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label_indir.typ
+---
+{
+ "placeholder": "fig:test1",
+ "range": "4:21:4:31"
+}

--- a/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label_indir2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/prepare@label_indir2.typ.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tinymist-query/src/prepare_rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label_indir2.typ
+---
+{
+ "placeholder": "fig:test2",
+ "range": "8:21:8:31"
+}

--- a/crates/tinymist-query/src/fixtures/rename/snaps/test@label.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/test@label.typ.snap
@@ -1,0 +1,29 @@
+---
+source: crates/tinymist-query/src/rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label.typ
+---
+{
+ "changeAnnotations": {
+  "Typst Rename Labels": {
+   "description": "The language server searched the labels ambiguously",
+   "label": "Typst Rename Labels",
+   "needsConfirmation": true
+  }
+ },
+ "documentChanges": [
+  {
+   "edits": [
+    {
+     "annotationId": "Typst Rename Labels",
+     "newText": "new_name",
+     "range": "6:21:6:33"
+    }
+   ],
+   "textDocument": {
+    "uri": "s0.typ",
+    "version": null
+   }
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/rename/snaps/test@label_indir.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/test@label_indir.typ.snap
@@ -1,0 +1,29 @@
+---
+source: crates/tinymist-query/src/rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label_indir.typ
+---
+{
+ "changeAnnotations": {
+  "Typst Rename Labels": {
+   "description": "The language server searched the labels ambiguously",
+   "label": "Typst Rename Labels",
+   "needsConfirmation": true
+  }
+ },
+ "documentChanges": [
+  {
+   "edits": [
+    {
+     "annotationId": "Typst Rename Labels",
+     "newText": "new_name",
+     "range": "4:21:4:31"
+    }
+   ],
+   "textDocument": {
+    "uri": "s0.typ",
+    "version": null
+   }
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/rename/snaps/test@label_indir2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/test@label_indir2.typ.snap
@@ -1,0 +1,29 @@
+---
+source: crates/tinymist-query/src/rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/label_indir2.typ
+---
+{
+ "changeAnnotations": {
+  "Typst Rename Labels": {
+   "description": "The language server searched the labels ambiguously",
+   "label": "Typst Rename Labels",
+   "needsConfirmation": true
+  }
+ },
+ "documentChanges": [
+  {
+   "edits": [
+    {
+     "annotationId": "Typst Rename Labels",
+     "newText": "new_name",
+     "range": "8:21:8:31"
+    }
+   ],
+   "textDocument": {
+    "uri": "s0.typ",
+    "version": null
+   }
+  }
+ ]
+}

--- a/crates/tinymist-query/src/rename.rs
+++ b/crates/tinymist-query/src/rename.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
-    DocumentChangeOperation, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
-    RenameFile, TextDocumentEdit,
+    AnnotatedTextEdit, ChangeAnnotation, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, RenameFile, TextDocumentEdit,
 };
 use rustc_hash::FxHashSet;
 use tinymist_std::path::{PathClean, unix_slash};
@@ -78,7 +78,7 @@ impl StatefulRequest for RenameRequest {
                 let mut edits: HashMap<Url, Vec<TextEdit>> = HashMap::new();
                 do_rename_file(ctx, def_fid, diff, &mut edits);
 
-                let mut document_changes = edits_to_document_changes(edits);
+                let mut document_changes = edits_to_document_changes(edits, None);
 
                 document_changes.push(lsp_types::DocumentChangeOperation::Op(
                     lsp_types::ResourceOp::Rename(RenameFile {
@@ -96,6 +96,8 @@ impl StatefulRequest for RenameRequest {
                 })
             }
             _ => {
+                let is_label = matches!(def.decl.kind(), DefKind::Reference);
+
                 let references = find_references(ctx, &source, doc, syntax)?;
 
                 let mut edits = HashMap::new();
@@ -110,12 +112,30 @@ impl StatefulRequest for RenameRequest {
                     });
                 }
 
-                log::info!("rename edits: {edits:?}");
+                crate::log_debug_ct!("rename edits: {edits:?}");
 
-                Some(WorkspaceEdit {
-                    changes: Some(edits),
-                    ..Default::default()
-                })
+                if !is_label {
+                    Some(WorkspaceEdit {
+                        changes: Some(edits),
+                        ..Default::default()
+                    })
+                } else {
+                    let change_id = "Typst Rename Labels";
+
+                    let document_changes = edits_to_document_changes(edits, Some(change_id));
+
+                    let change_annotations = Some(create_change_annotation(
+                        change_id,
+                        true,
+                        Some("The language server searched the labels ambiguously".to_string()),
+                    ));
+
+                    Some(WorkspaceEdit {
+                        document_changes: Some(DocumentChanges::Operations(document_changes)),
+                        change_annotations,
+                        ..Default::default()
+                    })
+                }
             }
         }
     }
@@ -302,17 +322,45 @@ impl RenameFileWorker<'_> {
 
 pub(crate) fn edits_to_document_changes(
     edits: HashMap<Url, Vec<TextEdit>>,
+    change_id: Option<&str>,
 ) -> Vec<DocumentChangeOperation> {
     let mut document_changes = vec![];
 
     for (uri, edits) in edits {
         document_changes.push(lsp_types::DocumentChangeOperation::Edit(TextDocumentEdit {
             text_document: OptionalVersionedTextDocumentIdentifier { uri, version: None },
-            edits: edits.into_iter().map(OneOf::Left).collect(),
+            edits: edits
+                .into_iter()
+                .map(|edit| match change_id {
+                    Some(change_id) => OneOf::Right(AnnotatedTextEdit {
+                        text_edit: edit,
+                        annotation_id: change_id.to_owned(),
+                    }),
+                    None => OneOf::Left(edit),
+                })
+                .collect(),
         }));
     }
 
     document_changes
+}
+
+pub(crate) fn create_change_annotation(
+    label: &str,
+    needs_confirmation: bool,
+    description: Option<String>,
+) -> HashMap<String, ChangeAnnotation> {
+    let mut change_annotations = HashMap::new();
+    change_annotations.insert(
+        label.to_owned(),
+        ChangeAnnotation {
+            label: label.to_owned(),
+            needs_confirmation: Some(needs_confirmation),
+            description,
+        },
+    );
+
+    change_annotations
 }
 
 #[cfg(test)]
@@ -325,14 +373,17 @@ mod tests {
         snapshot_testing("rename", &|ctx, path| {
             let source = ctx.source_by_path(&path).unwrap();
 
+            let docs = find_module_level_docs(&source).unwrap_or_default();
+            let properties = get_test_properties(&docs);
+            let graph = compile_doc_for_test(ctx, &properties);
+
             let request = RenameRequest {
                 path: path.clone(),
                 position: find_test_position(&source),
                 new_name: "new_name".to_string(),
             };
-            let snap = WorldComputeGraph::from_world(ctx.world.clone());
 
-            let mut result = request.request(ctx, snap);
+            let mut result = request.request(ctx, graph);
             // sort the edits to make the snapshot stable
             if let Some(r) = result.as_mut().and_then(|r| r.changes.as_mut()) {
                 for edits in r.values_mut() {

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -30,6 +30,10 @@ The changelog lines unspecified with authors are all written by the @Myriad-Drea
 
 * Completing both `#f` and `#f.paren` in some cases (#1940) in https://github.com/Myriad-Dreamin/tinymist/pull/2014
 
+### Rename
+
+* Renaming labels in https://github.com/Myriad-Dreamin/tinymist/pull/1858
+
 ### Docstring
 
 * (Fix) Cleaning typlite markers from doc strings by @hongjr03 in https://github.com/Myriad-Dreamin/tinymist/pull/2017


### PR DESCRIPTION
Rework on the reverted commit 856a1e4485af7a4352466391be4566809ef66237 (#2084). Didn't pass the test `label_indir.typ.snap`.