### PR TITLE
fix: remove `Clone` trait bounds from diagnostics iterators

### DIFF
--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -57,7 +57,7 @@ pub struct KnownIssues {
 impl KnownIssues {
     /// Collects known lint issues from the given compiler diagnostics.
     pub fn from_compiler_diagnostics<'a>(
-        diags: impl Iterator<Item = &'a SourceDiagnostic> + Clone,
+        diags: impl Iterator<Item = &'a SourceDiagnostic>,
     ) -> Self {
         let mut unknown_vars = Vec::default();
         for diag in diags {

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -114,7 +114,7 @@ impl<F: CompilerFeat> CompiledArtifact<F> {
     }
 
     /// Returns the diagnostics.
-    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> + Clone {
+    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> {
         self.diag.diagnostics()
     }
 

--- a/crates/tinymist-query/src/check.rs
+++ b/crates/tinymist-query/src/check.rs
@@ -15,9 +15,9 @@ impl SemanticRequest for CheckRequest {
 
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let worker = DiagWorker::new(ctx);
-        let compiler_diags = self.snap.diagnostics();
+        let compiler_diags = || self.snap.diagnostics();
 
-        let known_issues = KnownIssues::from_compiler_diagnostics(compiler_diags.clone());
-        Some(worker.check(&known_issues).convert_all(compiler_diags))
+        let known_issues = KnownIssues::from_compiler_diagnostics(compiler_diags());
+        Some(worker.check(&known_issues).convert_all(compiler_diags()))
     }
 }

--- a/crates/tinymist-world/src/compute.rs
+++ b/crates/tinymist-world/src/compute.rs
@@ -412,7 +412,7 @@ impl DiagnosticsTask {
     }
 
     /// Gets the diagnostics.
-    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> + Clone {
+    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> {
         self.paged
             .errors
             .iter()


### PR DESCRIPTION
This requires new release of world crates, while we didn't plan it.