### PR TITLE
revert: fix: remove Clone trait bounds from diagnostics iterators (#2…

### DIFF
--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -114,7 +114,7 @@ impl<F: CompilerFeat> CompiledArtifact<F> {
     }
 
     /// Returns the diagnostics.
-    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> {
+    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> + Clone {
         self.diag.diagnostics()
     }
 

--- a/crates/tinymist-query/src/check.rs
+++ b/crates/tinymist-query/src/check.rs
@@ -15,9 +15,9 @@ impl SemanticRequest for CheckRequest {
 
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let worker = DiagWorker::new(ctx);
-        let compiler_diags = || self.snap.diagnostics();
+        let compiler_diags = self.snap.diagnostics();
 
-        let known_issues = KnownIssues::from_compiler_diagnostics(compiler_diags());
-        Some(worker.check(&known_issues).convert_all(compiler_diags()))
+        let known_issues = KnownIssues::from_compiler_diagnostics(compiler_diags.clone());
+        Some(worker.check(&known_issues).convert_all(compiler_diags))
     }
 }

--- a/crates/tinymist-world/src/compute.rs
+++ b/crates/tinymist-world/src/compute.rs
@@ -412,7 +412,7 @@ impl DiagnosticsTask {
     }
 
     /// Gets the diagnostics.
-    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> {
+    pub fn diagnostics(&self) -> impl Iterator<Item = &typst::diag::SourceDiagnostic> + Clone {
         self.paged
             .errors
             .iter()


### PR DESCRIPTION
…136)