### PR TITLE
feat: replace `window` global with `windowElem` in preview web frontend

### DIFF
--- a/tools/typst-dom/src/global.d.ts
+++ b/tools/typst-dom/src/global.d.ts
@@ -1,6 +1,1 @@
-interface Window {
-  initTypstSvg(docRoot: SVGElement): void;
-  handleTypstLocation(elem: Element, page: number, x: number, y: number);
-  typstWebsocket: WebSocket;
-}
 const acquireVsCodeApi: any;

--- a/tools/typst-dom/src/typst-doc.canvas.mts
+++ b/tools/typst-dom/src/typst-doc.canvas.mts
@@ -90,7 +90,7 @@ export function provideCanvasDoc<
             pageInfo.container.style.overflow = "hidden";
             pageInfo.container.addEventListener("click", () => {
               // console.log('click', pageInfo.index);
-              window.typstWebsocket.send(`outline-sync,${pageInfo.index + 1}`);
+              this.windowElem.typstWebsocket.send(`outline-sync,${pageInfo.index + 1}`);
             });
           }
         }

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -36,7 +36,7 @@ export function provideSvgDoc<
     postRender$svg() {
       const docRoot = this.hookedElem.firstElementChild as SVGElement;
       if (docRoot) {
-        window.initTypstSvg(docRoot);
+        this.windowElem.initTypstSvg(docRoot);
         this.r.rescale();
       }
     }
@@ -636,10 +636,11 @@ export function provideSvgDoc<
       const computedRevScale = containerWidth ? this.docWidth / containerWidth : 1;
       // respect current scale ratio
       const revScale = computedRevScale / this.currentScaleRatio;
-      const left = (window.screenLeft - containerBRect.left) * revScale;
-      const top = (window.screenTop - containerBRect.top) * revScale;
-      const width = window.innerWidth * revScale;
-      const height = window.innerHeight * revScale;
+      const left =
+        (this.windowElem.offsetLeft - containerBRect.left) * revScale;
+      const top = (this.windowElem.offsetTop - containerBRect.top) * revScale;
+      const width = this.windowElem.clientWidth * revScale;
+      const height = this.windowElem.clientHeight * revScale;
 
       return { revScale, left, top, width, height };
     }

--- a/tools/typst-preview-frontend/src/global.d.ts
+++ b/tools/typst-preview-frontend/src/global.d.ts
@@ -1,14 +1,1 @@
-interface TypstPosition {
-  page: number;
-  x: number;
-  y: number;
-}
-
-interface Window {
-  initTypstSvg(docRoot: SVGElement): void;
-  currentPosition(elem: Element): TypstPosition | undefined;
-  handleTypstLocation(elem: Element, page: number, x: number, y: number);
-  documents: any[];
-  typstWebsocket: WebSocket;
-}
 const acquireVsCodeApi: any;

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -9,7 +9,8 @@ import "./styles/outline.css";
 import { wsMain, PreviewMode } from "./ws";
 import { setupDrag } from "./drag";
 
-window.documents = [];
+const windowElem = document.getElementById("typst-container");
+windowElem.documents = [];
 
 /// Main entry point of the frontend program.
 main();
@@ -56,7 +57,7 @@ function retrieveWsArgs() {
 /// `buildWs` returns a object, which keeps track of websocket
 ///  connections.
 function buildWs() {
-  let previousDispose = Promise.resolve(() => {});
+  let previousDispose = Promise.resolve(() => { });
   /// `nextWs` will always hold a global unique websocket connection
   /// to the preview backend.
   function nextWs(nextWsArgs) {

--- a/tools/typst-preview-frontend/src/typst.ts
+++ b/tools/typst-preview-frontend/src/typst.ts
@@ -4,6 +4,9 @@
 // @param (delay): integer in milliseconds
 // @param (id): string value of a unique event id
 // @doc (event.timeStamp): http://api.jquery.com/event.timeStamp/
+
+import { TypstDomWindowElement } from "typst-dom";
+
 // @bug (event.currentTime): https://bugzilla.mozilla.org/show_bug.cgi?id=238041
 let ignoredEvent = (function () {
   let last: Record<string, any> = {},
@@ -35,11 +38,11 @@ var overLapping = function (a: Element, b: Element) {
     ) &&
     /// determine overlapping by area
     (Math.abs(aRect.left - bRect.left) + Math.abs(aRect.right - bRect.right)) /
-      Math.max(aRect.width, bRect.width) <
-      0.5 &&
+    Math.max(aRect.width, bRect.width) <
+    0.5 &&
     (Math.abs(aRect.bottom - bRect.bottom) + Math.abs(aRect.top - bRect.top)) /
-      Math.max(aRect.height, bRect.height) <
-      0.5
+    Math.max(aRect.height, bRect.height) <
+    0.5
   );
 };
 
@@ -89,7 +92,9 @@ function findAncestor(el: Element, cls: string) {
   return el;
 }
 
-window.initTypstSvg = function (docRoot: SVGElement) {
+const windowElem = document.getElementById("typst-container")! as TypstDomWindowElement;
+
+windowElem.initTypstSvg = function (docRoot: SVGElement) {
   /// initialize pseudo links
   var elements = docRoot.getElementsByClassName("pseudo-link");
   for (var i = 0; i < elements.length; i++) {
@@ -178,7 +183,7 @@ function layoutText(svg: SVGElement) {
   console.log(`layoutText used time ${performance.now() - layoutBegin} ms`);
 }
 
-window.currentPosition = function (elem: Element) {
+windowElem.currentPosition = function (elem: Element) {
   const docRoot = findAncestor(elem, "typst-doc");
   if (!docRoot) {
     console.warn("no typst-doc found", elem);
@@ -239,7 +244,7 @@ window.currentPosition = function (elem: Element) {
 };
 
 type ScrollRect = Pick<DOMRect, "left" | "top" | "width" | "height">;
-window.handleTypstLocation = function (elem: Element, pageNo: number, x: number, y: number) {
+windowElem.handleTypstLocation = function (elem: Element, pageNo: number, x: number, y: number) {
   const docRoot = findAncestor(elem, "typst-doc");
   if (!docRoot) {
     console.warn("no typst-doc found", elem);
@@ -249,7 +254,7 @@ window.handleTypstLocation = function (elem: Element, pageNo: number, x: number,
   // scrollTo(pageRect: ScrollRect, pageNo: number, innerLeft: number, innerTop: number)
 
   const scrollTo = (pageRect: ScrollRect, pageNo: number, innerLeft: number, innerTop: number) => {
-    for (const doc of window.documents) {
+    for (const doc of windowElem.documents) {
       doc.impl.scrollTo(pageRect, pageNo, innerLeft, innerTop);
     }
   };

--- a/tools/typst-preview-frontend/src/ws.ts
+++ b/tools/typst-preview-frontend/src/ws.ts
@@ -1,5 +1,5 @@
 import { PreviewMode } from "typst-dom/typst-doc.mjs";
-import { TypstPreviewDocument as TypstDocument } from "typst-dom/index.preview.mjs";
+import { TypstPreviewDocument as TypstDocument, TypstDomHookedElement, TypstDomWindowElement } from "typst-dom/index.preview.mjs";
 import {
   rendererBuildInfo,
   createTypstRenderer,
@@ -33,21 +33,23 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
     if (hookedElem) {
       hookedElem.innerHTML = "";
     }
-    return () => {};
+    return () => { };
   }
+  const windowElem = document.getElementById("typst-container")! as TypstDomWindowElement;
 
   let disposed = false;
   let $ws: WebSocketSubject<ArrayBuffer> | undefined = undefined;
   const subsribes: Subscription[] = [];
 
   function createSvgDocument(kModule: RenderSession) {
-    const hookedElem = document.getElementById("typst-app")!;
+    const hookedElem = document.getElementById("typst-app")! as TypstDomHookedElement;
     if (hookedElem.firstElementChild?.tagName !== "svg") {
       hookedElem.innerHTML = "";
     }
     const resizeTarget = document.getElementById("typst-container-main")!;
 
     const svgDoc = new TypstDocument({
+      windowElem,
       hookedElem,
       kModule,
       previewMode,
@@ -218,7 +220,7 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
   }
 
   function setupSocket(svgDoc: TypstDocument): () => void {
-    window.documents.push(svgDoc);
+    windowElem.documents.push(svgDoc);
 
     // todo: reconnect setTimeout(() => setupSocket(svgDoc), 1000);
     $ws = webSocket<ArrayBuffer>({
@@ -230,9 +232,9 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
         next: (e) => {
           const sock = e.target;
           console.log("WebSocket connection opened", sock);
-          window.typstWebsocket = sock as any;
+          windowElem.typstWebsocket = sock as any;
           svgDoc.reset();
-          window.typstWebsocket.send("current");
+          windowElem.typstWebsocket.send("current");
         },
       },
       closeObserver: {
@@ -251,9 +253,9 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
     const dispose = () => {
       disposed = true;
       svgDoc.dispose();
-      const index = window.documents.indexOf(svgDoc);
+      const index = windowElem.documents.indexOf(svgDoc);
       if (index >= 0) {
-        window.documents.splice(index, 1);
+        windowElem.documents.splice(index, 1);
       }
       for (const sub of subsribes.splice(0, subsribes.length)) {
         sub.unsubscribe();
@@ -329,7 +331,7 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
         if (previewMode === PreviewMode.Slide) {
           currentPageNumber = svgDoc.getPartialPageNumber();
         } else if (rootElem) {
-          currentPageNumber = window.currentPosition(rootElem)?.page || 1;
+          currentPageNumber = windowElem.currentPosition(rootElem)?.page || 1;
         }
 
         let positions = dec
@@ -377,7 +379,7 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
         if (rootElem) {
           /// Note: when it is really scrolled, it will trigger `svgDoc.addViewportChange`
           /// via `window.onscroll` event
-          window.handleTypstLocation(rootElem, pageToJump, x, y);
+          windowElem.handleTypstLocation(rootElem, pageToJump, x, y);
         }
         return;
       } else if (message[0] === "cursor") {


### PR DESCRIPTION
The preview feature heavily relies on the global `window` object. This forces the preview to be used only as a standalone page.

In this PR, I replaced `window` with `windowElem` to make the preview component modular and reusable.