### PR TITLE
fix: ignore non-typst files for implicit focus

### DIFF
--- a/crates/tinymist-query/src/lsp_typst_boundary.rs
+++ b/crates/tinymist-query/src/lsp_typst_boundary.rs
@@ -20,6 +20,11 @@ pub fn untitled_url(path: &Path) -> anyhow::Result<Url> {
     Ok(Url::parse(&format!("untitled:{}", path.display()))?)
 }
 
+/// Determines if a path is untitled.
+pub fn is_untitled_path(p: &Path) -> bool {
+    p.starts_with(UNTITLED_ROOT)
+}
+
 /// Convert a path to a URL.
 pub fn path_to_url(path: &Path) -> anyhow::Result<Url> {
     if let Ok(untitled) = path.strip_prefix(UNTITLED_ROOT) {
@@ -102,7 +107,6 @@ fn url_to_file_path(uri: &Url) -> PathBuf {
     // In WASM, manually parse the URL path
     PathBuf::from(uri.path())
 }
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -116,6 +120,7 @@ mod test {
 
         let path = url_to_path(&uri);
         assert_eq!(path, Path::new("/untitled/test").clean());
+        assert!(is_untitled_path(&path));
     }
 
     #[test]

--- a/crates/tinymist-tests/Cargo.toml
+++ b/crates/tinymist-tests/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 [dependencies]
 typst.workspace = true
 tinymist-analysis.workspace = true
-tinymist-project = { workspace = true, features = ["lsp"] }
+tinymist-project = { workspace = true, features = ["lsp", "system"] }
 tinymist-std.workspace = true
 comemo.workspace = true
 rayon.workspace = true

--- a/crates/tinymist/src/input.rs
+++ b/crates/tinymist/src/input.rs
@@ -1,7 +1,8 @@
 use lsp_types::*;
 use reflexo_typst::Bytes;
 use serde::{Deserialize, Serialize};
-use tinymist_query::{to_typst_range, PositionEncoding};
+use tinymist_query::ty::PathKind;
+use tinymist_query::{is_untitled_path, to_typst_range, PositionEncoding};
 use tinymist_std::error::prelude::*;
 use tinymist_std::ImmutPath;
 use typst::ecow::EcoString;
@@ -248,6 +249,17 @@ impl ServerState {
         }
 
         let new_entry = new_entry();
+
+        // Don't implicit focus non source file.
+        if new_entry.as_ref().is_some_and(|entry| {
+            !is_untitled_path(entry)
+                && !PathKind::Source {
+                    allow_package: true,
+                }
+                .is_match(entry)
+        }) {
+            return;
+        }
 
         let update_result = self.focus_main_file(new_entry.clone());
         match update_result {


### PR DESCRIPTION
When a file, for example a rust source file, is sent to the language server by `didOpen`, it is implicitly focused and starts a typst compilation with the file. However, this is not expected. The error is rarely triggered because vscode extension also explicitly send focus events which prevents the implicit focus happens. So in conclusion this bug was triggered stably by following steps:
- activate tinymist for some reason, and no typst source file is opened.
- open a rust source file and tinymist reports typst syntax error in the file.
