### PR TITLE
fix: update tinymist-project features to include 'system'

### DIFF
--- a/crates/tinymist-tests/Cargo.toml
+++ b/crates/tinymist-tests/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 [dependencies]
 typst.workspace = true
 tinymist-analysis.workspace = true
-tinymist-project = { workspace = true, features = ["lsp"] }
+tinymist-project = { workspace = true, features = ["lsp", "system"] }
 tinymist-std.workspace = true
 comemo.workspace = true
 rayon.workspace = true


### PR DESCRIPTION
The missing feature causes build failure with test profile. Since we currently only conduct tests locally(without web), this change should not be bad.