### PR TITLE
fix: don't ignore user inputs in typlite

### DIFF
--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -31,8 +31,8 @@ use crate::parser::HtmlToAstParser;
 use crate::writer::WriterFactory;
 use typst_syntax::FileId;
 
-use crate::tinymist_std::typst::foundations::Value::Str;
 use crate::tinymist_std::typst::LazyHash;
+use crate::tinymist_std::typst::foundations::Value::Str;
 
 /// The result type for typlite.
 pub type Result<T, Err = Error> = std::result::Result<T, Err>;
@@ -211,7 +211,7 @@ impl TypliteFeat {
 
         // Start with existing inputs from the world (CLI inputs)
         let mut dict = (**world.inputs()).clone();
-        
+
         // Add typlite-specific inputs
         dict.insert("x-target".into(), Str("md".into()));
         if format == Format::Text || self.remove_html {


### PR DESCRIPTION
I noticed that existing inputs specified on the command line such as `typlite --input key-value ..` are ignored.

Test this as follows:
```zsh
$ echo '#sys.inputs' > test.typ
$ typlite test.typ --input key=value
```
Before this PR:
```zsh
$ cat typ.md
`(x-target: "md")`
```
After this PRL
```zsh
$ cat typ.md
`(key: "value", x-target: "md")`
```