### PR TITLE
fix: update VerbatimNode to use trusted HTML writing method

### DIFF
--- a/crates/typlite/src/common.rs
+++ b/crates/typlite/src/common.rs
@@ -218,12 +218,11 @@ pub struct VerbatimNode {
 
 impl VerbatimNode {
     fn write_custom(&self, writer: &mut InlineWriterProxy) -> WriteResult<()> {
-        writer.write_str(&self.content)?;
-        Ok(())
+        writer.write_str(&self.content)
     }
 
     fn write_html_custom(&self, writer: &mut HtmlWriter) -> HtmlWriteResult<()> {
-        writer.raw_html(&self.content)
+        writer.write_trusted_html(&self.content)
     }
 }
 


### PR DESCRIPTION
So that https://github.com/Myriad-Dreamin/tinymist/commit/515747c0b7e8076f1771ddd30307d309f665ecec pass the test.