### PR TITLE
fix: local registry feature was not enabled

### DIFF
--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -34,16 +34,15 @@ impl CompletionPair<'_, '_, '_> {
             .iter()
             .map(|(spec, desc)| (spec, desc.clone()))
             .collect();
-        #[cfg(feature = "http-registry")]
-        {
-            // local_packages to references and add them to the packages
-            let local_packages_refs = self.worker.ctx.local_packages();
-            packages.extend(
-                local_packages_refs
-                    .iter()
-                    .map(|spec| (spec, Some(eco_format!("{} v{}", spec.name, spec.version)))),
-            );
-        }
+        // local_packages to references and add them to the packages
+        #[cfg(feature = "local-registry")]
+        let local_packages_refs = self.worker.ctx.local_packages();
+        #[cfg(feature = "local-registry")]
+        packages.extend(
+            local_packages_refs
+                .iter()
+                .map(|spec| (spec, Some(eco_format!("{} v{}", spec.name, spec.version)))),
+        );
 
         packages.sort_by_key(|(spec, _)| (&spec.namespace, &spec.name, Reverse(spec.version)));
         if !all_versions {


### PR DESCRIPTION
There was a typo of the feature and it was never enabled. This was introduced when compiling tinymist for wasm targets.