### PR TITLE
fix: correct table parsing when headers and footers appear between data rows

### DIFF
--- a/crates/typlite/src/fixtures/integration/snaps/convert@issue-1845.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert@issue-1845.typ.snap
@@ -32,32 +32,9 @@ Row
 
 <td>
 
-<m1raw lang="" block="true" text="Code line 1
-Code line 2">
+<pre><code>Code line 1
+Code line 2</code></pre>
 
-<pre>
-
-<code>
-
-<p>
-
-Code line 1
-
-</p><m1linebreak>
-
-
-
-</m1linebreak><p>
-
-Code line 2
-
-</p>
-
-</code>
-
-</pre>
-
-</m1raw>
 
 </td><td>
 

--- a/crates/typlite/src/fixtures/integration/snaps/convert@outline.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert@outline.typ.snap
@@ -28,13 +28,19 @@ namespace MyApplication
 </html>
 
 =====
-## Contents
-
-1. ### Heading 1
-   1. #### Heading 2
-
 <nav role="doc-toc">
 
+<h2>Contents</h2>
+<ol>
+<li><p><h3>Heading 1</h3>
+<ol>
+<li><p><h4>Heading 2</h4>
+</p>
+</li>
+</ol>
+</p>
+</li>
+</ol>
 
 
 </nav>

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1844.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1844.typ.snap
@@ -53,8 +53,12 @@ Who loves to lie with me,
 
 Source in grid
 
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cc}
+\hline
 Placeholder for\\
-separately rendered SVG````
+separately rendered SVG & ````
 
 == Under the Greenwood Tree
 by Shakespeare.
@@ -64,4 +68,7 @@ Under the greenwood tree #emoji.tree
 Who loves to lie with me,
 ...
 ```)
-````
+```` \\
+\hline
+\end{tabular}
+\end{table}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1845.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1845.typ.snap
@@ -14,3 +14,17 @@ Code line 2"><pre><code><p>Code line 1</p><m1linebreak></m1linebreak><p>Code lin
 </html>
 
 =====
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cc}
+\hline
+Header & Row \\
+\begin{verbatim}
+Code line 1
+Code line 2
+\end{verbatim}
+
+ & Regular text \\
+\hline
+\end{tabular}
+\end{table}

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@table.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@table.typ.snap
@@ -36,4 +36,20 @@ input_file: crates/typlite/src/fixtures/integration/table.typ
 \end{tabular}
 \end{table}
 
-012345678910111213141516171819012345678910111213141516171819
+\begin{table}[htbp]
+\centering
+\begin{tabular}{cccccc}
+\hline
+0 & 1 & 2 & 3 & 4 & 5 \\
+6 & 7 & 8 & 9 & 10 & 11 \\
+12 & 13 & 14 & 15 & 16 & 17 \\
+18 & 19 & 0 & 1 \\
+2 & 3 & 4 \\
+5 & 6 & 7 \\
+8 & 9 & 10 \\
+11 & 12 & 13 \\
+14 & 15 & 16 \\
+17 & 18 & 19 \\
+\hline
+\end{tabular}
+\end{table}

--- a/crates/typlite/src/fixtures/integration/snaps/docx_generation_hash@outline.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/docx_generation_hash@outline.typ.snap
@@ -3,4 +3,4 @@ source: crates/typlite/src/tests.rs
 expression: hash
 input_file: crates/typlite/src/fixtures/integration/outline.typ
 ---
-siphash128_13:7df7eb1193ac7a252e3ceb3c403c8906
+siphash128_13:d7673517c0941981af66970485f8c6e8

--- a/crates/typlite/src/fixtures/playground/all_elements.typ
+++ b/crates/typlite/src/fixtures/playground/all_elements.typ
@@ -71,17 +71,22 @@ Referencing previous content: #ref(<ref-example>)
 
 #table(
   columns: 3,
-  [Header 1], [Header 2], [Header 3],
+  table.header([Header 1], [Header 2], [Header 3]),
+  table.cell(colspan: 2)[Row 2 Cell 1], [Row 2 Cell 3],
+  table.header([Header 1], [Header 2], [Header 3]),
   [Row 1 Cell 1], [Row 1 Cell 2], [Row 1 Cell 3],
-  [Row 2 Cell 1], [Row 2 Cell 2], [Row 2 Cell 3],
+  table.footer([Footer 1], [Footer 2], [Footer 3]),
 )
 
 === Grid
 
 #grid(
   columns: 2,
+  grid.header([Header 1], [Header 2]),
   [Grid Cell 1], [Grid Cell 2],
+  grid.header([Header 1], [Header 2]),
   [Grid Cell 3], [Grid Cell 4],
+  grid.header([Footer 1], [Footer 2]),
 )
 
 == Mathematical Formulas

--- a/crates/typlite/src/markdown.typ
+++ b/crates/typlite/src/markdown.typ
@@ -75,9 +75,10 @@
   "m1table",
   it,
 )
-#let md-grid(columns: auto, children) = html.elem(
+#let md-grid(it) = html.elem(
   "m1grid",
-  table(columns: columns, ..children
+  table(columns: it.columns, ..it
+      .children
       .map(child => {
         {
           let func = child.func()
@@ -111,7 +112,7 @@
   "",
 )
 #let md-figure(body, caption: none) = html.elem(
-  "m1figure",
+    "m1figure",
   attrs: (
     caption: if caption == none {
       ""
@@ -124,7 +125,7 @@
     },
   ),
   body,
-)
+  )
 
 #let if-not-paged(it, act) = {
   if target() == "html" {
@@ -201,7 +202,7 @@
   show outline.entry: it => if-not-paged(it, md-outline-entry(level: it.level, it.element))
   show quote: it => if-not-paged(it, md-quote(it.body))
   show table: it => if-not-paged(it, md-table(it))
-  show grid: it => if-not-paged(it, md-grid(columns: it.columns, it.children))
+  show grid: it => if-not-paged(it, md-grid(it))
 
   show math.equation.where(block: false): it => if-not-paged(
     it,

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -235,8 +235,13 @@ impl HtmlToAstParser {
             })
             .collect();
 
+        let (inline_nodes, block_nodes) = self.capture_children(element)?;
+
         let mut children = Vec::new();
-        self.convert_children_into(&mut children, element)?;
+        if !inline_nodes.is_empty() {
+            children.extend(inline_nodes);
+        }
+        children.extend(block_nodes);
 
         Ok(Node::HtmlElement(CmarkHtmlElement {
             tag: element.tag.resolve().to_string().into(),


### PR DESCRIPTION
Enhance table parsing to correctly handle headers and footers that appear between data rows, and refactor validation to return spans for complex cells.