### PR TITLE
fix: specially identify text that is starts with `@`

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -843,6 +843,16 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
         return Some(ref_syntax);
     }
 
+    if node.kind() == SyntaxKind::Text
+        && node.offset() + 1 == cursor
+        && node.text().starts_with('@')
+    {
+        return Some(SyntaxClass::Ref {
+            node,
+            suffix_colon: false,
+        });
+    }
+
     // todo: check if we can remove Text here
     if matches!(node.kind(), SyntaxKind::Text | SyntaxKind::MathText) {
         let mode = interpret_mode_at(Some(&node));
@@ -1633,6 +1643,14 @@ Text
 
     #[test]
     fn ref_syntax() {
+        assert_snapshot!(map_syntax("@"), @r"
+        @
+        r
+        ");
+        assert_snapshot!(map_syntax("@;"), @r"
+        @;
+        r
+        ");
         assert_snapshot!(map_syntax("@ab"), @r###"
         @ab
         rrr


### PR DESCRIPTION
Since typst v0.14, a single `@` are not longer parsed as reference syntax, because empty reference are not allowed since typst v0.14. However, the IDE should still handle case where user inputs a single `@`.