### PR TITLE
feat: only implement Ord for interned values

### DIFF
--- a/crates/tinymist-analysis/src/ty/def.rs
+++ b/crates/tinymist-analysis/src/ty/def.rs
@@ -527,12 +527,16 @@ pub struct InsTy {
 /// For example, a float instance which is NaN.
 impl Eq for InsTy {}
 
+/// Since we compare values by pointer ([`ptr_cmp`]), only interned instances
+/// are comparable.
 impl PartialOrd for Interned<InsTy> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
+/// Since we compare values by pointer ([`ptr_cmp`]), only interned instances
+/// are comparable.
 impl Ord for Interned<InsTy> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         cmp_value(&self.val, &other.val)


### PR DESCRIPTION
Since we compare values by pointer (`ptr_cmp`), only interned instances are comparable.