### PR TITLE
fix: change checkOnSave to check in .zed/settings.json

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -6,7 +6,7 @@
   "lsp": {
     "rust-analyzer": {
       "initialization_options": {
-        "checkOnSave": {
+        "check": {
           "command": "clippy"
         }
       }


### PR DESCRIPTION
To resolve warning `invalid config value: /checkOnSave: invalid type: map, expected a boolean;`. See rust-lang/rust-analyzer#13799.