### PR TITLE
fix: goto def jumping to runtime callee for complex let bindings

### DIFF
--- a/crates/tinymist-query/src/fixtures/goto_definition/complex_let_binding.typ
+++ b/crates/tinymist-query/src/fixtures/goto_definition/complex_let_binding.typ
@@ -1,0 +1,16 @@
+#let currifyS(n, func) = {
+  assert(type(n) == int and n >= 1)
+  arg => if n == 1 {
+    func(arg)
+  } else {
+    currifyS(n - 1, func.with(arg))
+  }
+}
+
+#let currifyS0 = currifyS(2, currifyS)
+#let flip(f) = (x, y) => f(y, x)
+
+#let at_ = (x, y) => x.at(y)
+#let at = currifyS0(2)(flip(at_))
+
+#(/* position after */ at)

--- a/crates/tinymist-query/src/fixtures/goto_definition/snaps/test@complex_let_binding.typ.snap
+++ b/crates/tinymist-query/src/fixtures/goto_definition/snaps/test@complex_let_binding.typ.snap
@@ -1,0 +1,13 @@
+---
+source: crates/tinymist-query/src/goto_definition.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/goto_definition/complex_let_binding.typ
+---
+[
+ {
+  "originSelectionRange": "15:23:15:25",
+  "targetRange": "13:5:13:7",
+  "targetSelectionRange": "13:5:13:7",
+  "targetUri": "s0.typ"
+ }
+]

--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -31,7 +31,7 @@ impl SemanticRequest for GotoDefinitionRequest {
         let syntax = ctx.classify_for_decl(&source, self.position)?;
         let origin_selection_range = ctx.to_lsp_range(syntax.node().range(), &source);
 
-        let def = ctx.def_of_syntax_or_dyn(&source, syntax)?;
+        let def = ctx.def_of_syntax(&source, syntax)?;
 
         let fid = def.file_id()?;
         let name_range = def.name_range(ctx.shared()).unwrap_or_default();


### PR DESCRIPTION
Fixes the regression introduced in #1904: `GotoDefinition` allowed dynamic analysis to override static bindings, causing definitions to resolve to runtime value origins instead of identifier bindings, which does not match its semantics.

Closes #2315.