### PR TITLE
feat: typst-preview: add hotkey to toggle light/dark theme

### DIFF
--- a/tools/typst-preview-frontend/index.html
+++ b/tools/typst-preview-frontend/index.html
@@ -229,6 +229,9 @@
               <div class="key-binding-desc">/</div>
               <div class="key-binding-box">l</div>
             </div>
+            <div class="key-binding-row">
+              <div class="key-binding-box">t</div>
+            </div>
             <div class="key-binding-row slide-specific">
               <div class="key-binding-box">g</div>
             </div>
@@ -258,6 +261,7 @@
             </div>
             <div class="key-binding-desc">Scroll down</div>
             <div class="key-binding-desc">Scroll up</div>
+            <div class="key-binding-desc">Toggle between dark/light theme.</div>
             <div class="key-binding-desc slide-specific">Goto the page by number.</div>
             <div class="key-binding-desc slide-specific">
               Switch to next animation or slide.

--- a/tools/typst-preview-frontend/src/ws.ts
+++ b/tools/typst-preview-frontend/src/ws.ts
@@ -177,6 +177,14 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
       }
     };
 
+    const toggleTheme = () => {
+      const typstApp = document.getElementById("typst-app");
+      console.log("toggleTheme", typstApp);
+      if (typstApp) {
+        typstApp.classList.toggle("invert-colors");
+      }
+    };
+
     const helpButton = document.getElementById("typst-top-help-button");
     helpButton?.addEventListener("click", toggleHelp);
 
@@ -227,6 +235,9 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
           removeHelp();
           blurInput();
           handled = false;
+          break;
+        case "t":
+          toggleTheme();
           break;
         default:
           handled = false;


### PR DESCRIPTION
This commit adds a hotkey "t" (abbreviated from theme) to the typst-preview frontend which allows for quickly changing the rendered theme. This is useful as it allows people working in dark mode to quickly check how the final rendered PDF (which is in light mode) would look without having to change their browser/system theme back and forth.