### PR TITLE
feat(linter): enhance unknown font suggestions with localized mappings and validation

### DIFF
--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod rules;
 
-use std::{cell::OnceCell, collections::BTreeSet, sync::Arc};
+use std::{cell::OnceCell, sync::Arc};
 
 use tinymist_analysis::{
     adt::interner::Interned,
@@ -102,8 +102,8 @@ struct Linter<'w> {
     loop_info: Option<LoopInfo>,
     func_info: Option<FuncInfo>,
 
-    // Use BTreeSet to have a stable order for suggestions
-    available_fonts: OnceCell<BTreeSet<&'w str>>,
+    /// Cached available fonts (sorted)
+    available_fonts: OnceCell<Vec<&'w str>>,
 }
 
 impl<'w> Linter<'w> {

--- a/crates/tinymist-lint/src/rules/bad_font.rs
+++ b/crates/tinymist-lint/src/rules/bad_font.rs
@@ -65,7 +65,9 @@ impl<'w> Linter<'w> {
         // Get available fonts from the font book
         let available_fonts = self.available_fonts.get_or_init(|| {
             let book = self.world.font_resolver.font_book();
-            book.families().map(|(name, _)| name).collect()
+            let mut fonts = book.families().map(|(name, _)| name).collect::<Vec<_>>();
+            fonts.sort_unstable();
+            fonts
         });
 
         let mut diag = SourceDiagnostic::warning(
@@ -89,7 +91,7 @@ impl<'w> Linter<'w> {
             .find(|(localized, _)| *localized == unknown_font)
             .map(|(_, en)| {
                 en.iter()
-                    .filter(|&name| available_fonts.contains(name))
+                    .filter(|&name| available_fonts.binary_search(name).is_ok())
                     .copied()
                     .collect::<Vec<_>>()
             })


### PR DESCRIPTION
- Add mapping for common Chinese, Japanese, and Korean font names to English equivalents. Prioritize exact localized matches when available fonts include them
- Add hints for common errors: comma-separated strings and non-ASCII characters
