### PR TITLE
feat(completion): path inference for concatenation and let init

### DIFF
--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -121,10 +121,7 @@ impl CompletionPair<'_, '_, '_> {
 
             if rhs_node.find(focus.span()).is_some() {
                 if let Some(lhs) = self.const_string_expr(&lhs_node) {
-                    let mut new_prefix = EcoString::new();
-                    new_prefix.push_str(lhs.as_str());
-                    new_prefix.push_str(prefix.as_str());
-                    prefix = new_prefix;
+                    prefix.insert_str(0, lhs.as_str());
                 }
                 focus = parent;
                 continue;

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -57,8 +57,8 @@ impl CompletionPair<'_, '_, '_> {
             return self.const_string_expr(&expr_node);
         }
 
-        if let Some(binary) = node.cast::<ast::Binary>() {
-            if binary.op() == ast::BinOp::Add {
+        if let Some(binary) = node.cast::<ast::Binary>()
+            && binary.op() == ast::BinOp::Add {
                 let lhs = binary.lhs();
                 let rhs = binary.rhs();
                 let lhs_node = node.find(lhs.span())?;
@@ -67,14 +67,12 @@ impl CompletionPair<'_, '_, '_> {
                 let rhs = self.const_string_expr(&rhs_node)?;
                 return Some(eco_format!("{lhs}{rhs}"));
             }
-        }
 
         // Resolve constant string values through type checking info (e.g. `#let dir = "dir/"`).
-        if let Some(ty) = self.worker.ctx.post_type_of_node(node.clone()) {
-            if let Some(s) = Self::unique_const_string(&ty) {
+        if let Some(ty) = self.worker.ctx.post_type_of_node(node.clone())
+            && let Some(s) = Self::unique_const_string(&ty) {
                 return Some(s);
             }
-        }
 
         None
     }

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -58,21 +58,23 @@ impl CompletionPair<'_, '_, '_> {
         }
 
         if let Some(binary) = node.cast::<ast::Binary>()
-            && binary.op() == ast::BinOp::Add {
-                let lhs = binary.lhs();
-                let rhs = binary.rhs();
-                let lhs_node = node.find(lhs.span())?;
-                let rhs_node = node.find(rhs.span())?;
-                let lhs = self.const_string_expr(&lhs_node)?;
-                let rhs = self.const_string_expr(&rhs_node)?;
-                return Some(eco_format!("{lhs}{rhs}"));
-            }
+            && binary.op() == ast::BinOp::Add
+        {
+            let lhs = binary.lhs();
+            let rhs = binary.rhs();
+            let lhs_node = node.find(lhs.span())?;
+            let rhs_node = node.find(rhs.span())?;
+            let lhs = self.const_string_expr(&lhs_node)?;
+            let rhs = self.const_string_expr(&rhs_node)?;
+            return Some(eco_format!("{lhs}{rhs}"));
+        }
 
         // Resolve constant string values through type checking info (e.g. `#let dir = "dir/"`).
         if let Some(ty) = self.worker.ctx.post_type_of_node(node.clone())
-            && let Some(s) = Self::unique_const_string(&ty) {
-                return Some(s);
-            }
+            && let Some(s) = Self::unique_const_string(&ty)
+        {
+            return Some(s);
+        }
 
         None
     }

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -121,7 +121,7 @@ impl CompletionPair<'_, '_, '_> {
 
             if rhs_node.find(focus.span()).is_some() {
                 if let Some(lhs) = self.const_string_expr(&lhs_node) {
-                    prefix.insert_str(0, lhs.as_str());
+                    prefix = lhs + prefix;
                 }
                 focus = parent;
                 continue;

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -4,6 +4,138 @@ use tinymist_world::vfs::WorkspaceResolver;
 
 use super::*;
 impl CompletionPair<'_, '_, '_> {
+    fn unique_const_string(ty: &Ty) -> Option<EcoString> {
+        fn visit(ty: &Ty, acc: &mut Option<EcoString>) -> bool {
+            match ty {
+                Ty::Value(ins) => match &ins.val {
+                    Value::Str(s) => {
+                        let s: EcoString = s.as_str().into();
+                        if acc.as_ref().is_some_and(|prev| prev != &s) {
+                            return false;
+                        }
+                        *acc = Some(s);
+                        true
+                    }
+                    _ => true,
+                },
+                Ty::Let(bounds) => bounds.lbs.iter().all(|ty| visit(ty, acc)),
+                Ty::Union(types) => types.iter().all(|ty| visit(ty, acc)),
+                Ty::Param(p) => visit(&p.ty, acc),
+                Ty::Array(elem) => visit(elem, acc),
+                Ty::Tuple(elems) => elems.iter().all(|ty| visit(ty, acc)),
+                Ty::Dict(record) => record.interface().all(|(_, ty)| visit(ty, acc)),
+                Ty::Select(sel) => visit(&sel.ty, acc),
+                Ty::With(with) => {
+                    visit(&with.sig, acc) && with.with.inputs().all(|ty| visit(ty, acc))
+                }
+                Ty::Args(args) => args.inputs().all(|ty| visit(ty, acc)),
+                Ty::Func(sig) | Ty::Pattern(sig) => sig.inputs().all(|ty| visit(ty, acc)),
+                Ty::Unary(unary) => visit(&unary.lhs, acc),
+                Ty::Binary(binary) => {
+                    let [lhs, rhs] = binary.operands();
+                    visit(lhs, acc) && visit(rhs, acc)
+                }
+                Ty::If(if_) => {
+                    visit(&if_.cond, acc) && visit(&if_.then, acc) && visit(&if_.else_, acc)
+                }
+                Ty::Builtin(_) | Ty::Var(_) | Ty::Any | Ty::Boolean(_) => true,
+            }
+        }
+
+        let mut acc = None;
+        visit(ty, &mut acc).then_some(acc).flatten()
+    }
+
+    fn const_string_expr(&mut self, node: &LinkedNode) -> Option<EcoString> {
+        if let Some(str) = node.cast::<ast::Str>() {
+            return Some(str.get());
+        }
+
+        if let Some(paren) = node.cast::<ast::Parenthesized>() {
+            let expr = paren.expr();
+            let expr_node = node.find(expr.span())?;
+            return self.const_string_expr(&expr_node);
+        }
+
+        if let Some(binary) = node.cast::<ast::Binary>() {
+            if binary.op() == ast::BinOp::Add {
+                let lhs = binary.lhs();
+                let rhs = binary.rhs();
+                let lhs_node = node.find(lhs.span())?;
+                let rhs_node = node.find(rhs.span())?;
+                let lhs = self.const_string_expr(&lhs_node)?;
+                let rhs = self.const_string_expr(&rhs_node)?;
+                return Some(eco_format!("{lhs}{rhs}"));
+            }
+        }
+
+        // Resolve constant string values through type checking info (e.g. `#let dir = "dir/"`).
+        if let Some(ty) = self.worker.ctx.post_type_of_node(node.clone()) {
+            if let Some(s) = Self::unique_const_string(&ty) {
+                return Some(s);
+            }
+        }
+
+        None
+    }
+
+    fn concat_string_affixes(&mut self) -> (EcoString, EcoString) {
+        let mut prefix = EcoString::new();
+        let mut suffix = EcoString::new();
+        let mut focus = self.cursor.leaf.clone();
+
+        loop {
+            let Some(parent) = focus.parent() else {
+                break;
+            };
+            let parent = (*parent).clone();
+
+            if let Some(paren) = parent.cast::<ast::Parenthesized>() {
+                let _ = paren;
+                focus = parent;
+                continue;
+            }
+
+            let Some(binary) = parent.cast::<ast::Binary>() else {
+                break;
+            };
+            if binary.op() != ast::BinOp::Add {
+                break;
+            }
+
+            let lhs = binary.lhs();
+            let rhs = binary.rhs();
+            let lhs_node = parent.find(lhs.span());
+            let rhs_node = parent.find(rhs.span());
+            let (Some(lhs_node), Some(rhs_node)) = (lhs_node, rhs_node) else {
+                break;
+            };
+
+            if lhs_node.find(focus.span()).is_some() {
+                if let Some(rhs) = self.const_string_expr(&rhs_node) {
+                    suffix.push_str(rhs.as_str());
+                }
+                focus = parent;
+                continue;
+            }
+
+            if rhs_node.find(focus.span()).is_some() {
+                if let Some(lhs) = self.const_string_expr(&lhs_node) {
+                    let mut new_prefix = EcoString::new();
+                    new_prefix.push_str(lhs.as_str());
+                    new_prefix.push_str(prefix.as_str());
+                    prefix = new_prefix;
+                }
+                focus = parent;
+                continue;
+            }
+
+            break;
+        }
+
+        (prefix, suffix)
+    }
+
     pub fn complete_path(&mut self, preference: &PathKind) -> Option<Vec<CompletionItem>> {
         let id = self.cursor.source.id();
         if WorkspaceResolver::is_package_file(id) {
@@ -57,8 +189,15 @@ impl CompletionPair<'_, '_, '_> {
         }
 
         // find directory or files in the path
-        let folder_completions = vec![];
-        let mut module_completions = vec![];
+        let folder_completions: Vec<(EcoString, EcoString, CompletionKind)> = vec![];
+        let mut module_completions: Vec<(EcoString, EcoString, CompletionKind)> = vec![];
+
+        let (concat_prefix, concat_suffix) = if is_in_text {
+            self.concat_string_affixes()
+        } else {
+            (EcoString::new(), EcoString::new())
+        };
+
         // todo: test it correctly
         for path in self.worker.ctx.completion_files(preference) {
             crate::log_debug_ct!("compl_check_path: {path:?}");
@@ -83,7 +222,33 @@ impl CompletionPair<'_, '_, '_> {
             };
             crate::log_debug_ct!("compl_label: {label:?}");
 
-            module_completions.push((label, CompletionKind::File));
+            let insert = {
+                let label_str = label.as_str();
+                if !concat_prefix.is_empty() && !label_str.starts_with(concat_prefix.as_str()) {
+                    continue;
+                }
+                if !concat_suffix.is_empty() && !label_str.ends_with(concat_suffix.as_str()) {
+                    continue;
+                }
+
+                let mut insert_str = label_str;
+                if !concat_prefix.is_empty() {
+                    let Some(stripped) = insert_str.strip_prefix(concat_prefix.as_str()) else {
+                        continue;
+                    };
+                    insert_str = stripped;
+                }
+                if !concat_suffix.is_empty() {
+                    let Some(stripped) = insert_str.strip_suffix(concat_suffix.as_str()) else {
+                        continue;
+                    };
+                    insert_str = stripped;
+                }
+
+                EcoString::from(insert_str)
+            };
+
+            module_completions.push((label, insert, CompletionKind::File));
 
             // todo: looks like the folder completion is broken
             // if path.is_dir() {
@@ -121,7 +286,7 @@ impl CompletionPair<'_, '_, '_> {
         Some(
             completions
                 .map(|typst_completion| {
-                    let lsp_snippet = &typst_completion.0;
+                    let lsp_snippet = &typst_completion.1;
                     let text_edit = EcoTextEdit::new(
                         replace_range,
                         if is_in_text {
@@ -137,7 +302,7 @@ impl CompletionPair<'_, '_, '_> {
                     // todo: not all clients support label details
                     LspCompletion {
                         label: typst_completion.0,
-                        kind: typst_completion.1,
+                        kind: typst_completion.2,
                         detail: None,
                         text_edit: Some(text_edit.into()),
                         // don't sort me

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -5,45 +5,51 @@ use tinymist_world::vfs::WorkspaceResolver;
 use super::*;
 impl CompletionPair<'_, '_, '_> {
     fn unique_const_string(ty: &Ty) -> Option<EcoString> {
-        fn visit(ty: &Ty, acc: &mut Option<EcoString>) -> bool {
+        fn merge_unique<'a>(mut values: impl Iterator<Item = &'a Ty>) -> Option<EcoString> {
+            let first = unique_const_string(values.next()?)?;
+            values.try_fold(first, |acc, ty| {
+                let value = unique_const_string(ty)?;
+                (value == acc).then_some(acc)
+            })
+        }
+
+        fn unique_bound_const<'a>(values: impl Iterator<Item = &'a Ty>) -> Option<EcoString> {
+            let mut found = None;
+            for ty in values {
+                let Some(value) = unique_const_string(ty) else {
+                    continue;
+                };
+                if found.as_ref().is_some_and(|prev| prev != &value) {
+                    return None;
+                }
+                found = Some(value);
+            }
+            found
+        }
+
+        fn unique_const_string(ty: &Ty) -> Option<EcoString> {
             match ty {
                 Ty::Value(ins) => match &ins.val {
-                    Value::Str(s) => {
-                        let s: EcoString = s.as_str().into();
-                        if acc.as_ref().is_some_and(|prev| prev != &s) {
-                            return false;
-                        }
-                        *acc = Some(s);
-                        true
-                    }
-                    _ => true,
+                    Value::Str(s) => Some(s.as_str().into()),
+                    _ => None,
                 },
-                Ty::Let(bounds) => bounds.lbs.iter().all(|ty| visit(ty, acc)),
-                Ty::Union(types) => types.iter().all(|ty| visit(ty, acc)),
-                Ty::Param(p) => visit(&p.ty, acc),
-                Ty::Array(elem) => visit(elem, acc),
-                Ty::Tuple(elems) => elems.iter().all(|ty| visit(ty, acc)),
-                Ty::Dict(record) => record.interface().all(|(_, ty)| visit(ty, acc)),
-                Ty::Select(sel) => visit(&sel.ty, acc),
-                Ty::With(with) => {
-                    visit(&with.sig, acc) && with.with.inputs().all(|ty| visit(ty, acc))
-                }
-                Ty::Args(args) => args.inputs().all(|ty| visit(ty, acc)),
-                Ty::Func(sig) | Ty::Pattern(sig) => sig.inputs().all(|ty| visit(ty, acc)),
-                Ty::Unary(unary) => visit(&unary.lhs, acc),
-                Ty::Binary(binary) => {
+                Ty::Param(p) => unique_const_string(&p.ty),
+                Ty::Let(bounds) => unique_bound_const(bounds.lbs.iter()),
+                Ty::Union(types) => unique_bound_const(types.iter()),
+                Ty::Binary(binary) if binary.op == ast::BinOp::Add => {
                     let [lhs, rhs] = binary.operands();
-                    visit(lhs, acc) && visit(rhs, acc)
+                    Some(eco_format!(
+                        "{}{}",
+                        unique_const_string(lhs)?,
+                        unique_const_string(rhs)?
+                    ))
                 }
-                Ty::If(if_) => {
-                    visit(&if_.cond, acc) && visit(&if_.then, acc) && visit(&if_.else_, acc)
-                }
-                Ty::Builtin(_) | Ty::Var(_) | Ty::Any | Ty::Boolean(_) => true,
+                Ty::If(if_) => merge_unique([if_.then.as_ref(), if_.else_.as_ref()].into_iter()),
+                _ => None,
             }
         }
 
-        let mut acc = None;
-        visit(ty, &mut acc).then_some(acc).flatten()
+        unique_const_string(ty)
     }
 
     fn const_string_expr(&mut self, node: &LinkedNode) -> Option<EcoString> {

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use super::{DynTypeBounds, ParamAttrs, ParamTy, SharedContext, prelude::*};
 use crate::syntax::{ArgClass, SyntaxContext, VarClass, classify_context, classify_context_outer};
-use crate::ty::{BuiltinTy, RecordTy, TypeInterface};
+use crate::ty::{BuiltinTy, TypeInterface};
 
 /// With given type information, check the type of a literal expression again by
 /// touching the possible related nodes.

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -387,11 +387,7 @@ impl<'a> PostTypeChecker<'a> {
                         let [lhs, rhs] = binary.operands();
                         has_path(this, lhs) || has_path(this, rhs)
                     }
-                    Ty::If(if_) => {
-                        has_path(this, &if_.cond)
-                            || has_path(this, &if_.then)
-                            || has_path(this, &if_.else_)
-                    }
+                    Ty::If(if_) => has_path(this, &if_.then) || has_path(this, &if_.else_),
                     Ty::Var(v) => this.info.vars.get(&v.def).is_some_and(|bounds| {
                         let bounds = bounds.bounds.bounds().read();
                         bounds.lbs.iter().any(|ty| has_path(this, ty))

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use super::{DynTypeBounds, ParamAttrs, ParamTy, SharedContext, prelude::*};
 use crate::syntax::{ArgClass, SyntaxContext, VarClass, classify_context, classify_context_outer};
-use crate::ty::{BuiltinTy, RecordTy};
+use crate::ty::{BuiltinTy, RecordTy, TypeInterface};
 
 /// With given type information, check the type of a literal expression again by
 /// touching the possible related nodes.
@@ -356,7 +356,86 @@ impl<'a> PostTypeChecker<'a> {
 
     /// Checks the context of a node and returns the type of the context.
     fn check_context(&mut self, context: &LinkedNode, node: &LinkedNode) -> Option<Ty> {
+        if let Some(binary) = context.cast::<ast::Binary>() {
+            if binary.op() == ast::BinOp::Add {
+                let parent = context.parent()?;
+                let expected = self.check_context(&parent, context)?;
+
+                fn has_path(this: &PostTypeChecker<'_>, ty: &Ty) -> bool {
+                    match ty {
+                        Ty::Builtin(BuiltinTy::Path(..)) => true,
+                        Ty::Builtin(_) => false,
+                        Ty::Param(p) => has_path(this, &p.ty),
+                        Ty::Let(b) => {
+                            b.lbs.iter().any(|ty| has_path(this, ty))
+                                || b.ubs.iter().any(|ty| has_path(this, ty))
+                        }
+                        Ty::Union(types) => types.iter().any(|ty| has_path(this, ty)),
+                        Ty::Array(elem) => has_path(this, elem),
+                        Ty::Tuple(elems) => elems.iter().any(|ty| has_path(this, ty)),
+                        Ty::Dict(record) => record.interface().any(|(_, ty)| has_path(this, ty)),
+                        Ty::Select(sel) => has_path(this, &sel.ty),
+                        Ty::With(with) => {
+                            has_path(this, &with.sig)
+                                || with.with.inputs().any(|ty| has_path(this, ty))
+                        }
+                        Ty::Args(args) => args.inputs().any(|ty| has_path(this, ty)),
+                        Ty::Func(sig) | Ty::Pattern(sig) => {
+                            sig.inputs().any(|ty| has_path(this, ty))
+                        }
+                        Ty::Unary(unary) => has_path(this, &unary.lhs),
+                        Ty::Binary(binary) => {
+                            let [lhs, rhs] = binary.operands();
+                            has_path(this, lhs) || has_path(this, rhs)
+                        }
+                        Ty::If(if_) => {
+                            has_path(this, &if_.cond)
+                                || has_path(this, &if_.then)
+                                || has_path(this, &if_.else_)
+                        }
+                        Ty::Var(v) => this.info.vars.get(&v.def).is_some_and(|bounds| {
+                            let bounds = bounds.bounds.bounds().read();
+                            bounds.lbs.iter().any(|ty| has_path(this, ty))
+                                || bounds.ubs.iter().any(|ty| has_path(this, ty))
+                        }),
+                        Ty::Any | Ty::Boolean(_) | Ty::Value(_) => false,
+                    }
+                }
+
+                // Only propagate expected types for path concatenations so string literals in
+                // `"dir/" + ""` get path completion.
+                if !has_path(self, &expected) {
+                    return None;
+                }
+
+                // Ensure the queried node is part of the binary expression.
+                let lhs = binary.lhs();
+                let rhs = binary.rhs();
+                let lhs_node = context.find(lhs.span())?;
+                let rhs_node = context.find(rhs.span())?;
+                if lhs_node.find(node.span()).is_some() || rhs_node.find(node.span()).is_some() {
+                    return Some(expected);
+                }
+            }
+        }
+
         match context.kind() {
+            SyntaxKind::ModuleImport | SyntaxKind::ModuleInclude => {
+                let source = if context.kind() == SyntaxKind::ModuleImport {
+                    let import = context.cast::<ast::ModuleImport>()?;
+                    import.source()
+                } else {
+                    let include = context.cast::<ast::ModuleInclude>()?;
+                    include.source()
+                };
+
+                let source_node = context.find(source.span())?;
+                source_node.find(node.span())?;
+
+                Some(Ty::Builtin(BuiltinTy::Path(crate::ty::PathKind::Source {
+                    allow_package: true,
+                })))
+            }
             SyntaxKind::LetBinding => {
                 let let_binding = context.cast::<ast::LetBinding>()?;
                 let let_init = let_binding.init()?;

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -357,66 +357,64 @@ impl<'a> PostTypeChecker<'a> {
     /// Checks the context of a node and returns the type of the context.
     fn check_context(&mut self, context: &LinkedNode, node: &LinkedNode) -> Option<Ty> {
         if let Some(binary) = context.cast::<ast::Binary>()
-            && binary.op() == ast::BinOp::Add {
-                let parent = context.parent()?;
-                let expected = self.check_context(parent, context)?;
+            && binary.op() == ast::BinOp::Add
+        {
+            let parent = context.parent()?;
+            let expected = self.check_context(parent, context)?;
 
-                fn has_path(this: &PostTypeChecker<'_>, ty: &Ty) -> bool {
-                    match ty {
-                        Ty::Builtin(BuiltinTy::Path(..)) => true,
-                        Ty::Builtin(_) => false,
-                        Ty::Param(p) => has_path(this, &p.ty),
-                        Ty::Let(b) => {
-                            b.lbs.iter().any(|ty| has_path(this, ty))
-                                || b.ubs.iter().any(|ty| has_path(this, ty))
-                        }
-                        Ty::Union(types) => types.iter().any(|ty| has_path(this, ty)),
-                        Ty::Array(elem) => has_path(this, elem),
-                        Ty::Tuple(elems) => elems.iter().any(|ty| has_path(this, ty)),
-                        Ty::Dict(record) => record.interface().any(|(_, ty)| has_path(this, ty)),
-                        Ty::Select(sel) => has_path(this, &sel.ty),
-                        Ty::With(with) => {
-                            has_path(this, &with.sig)
-                                || with.with.inputs().any(|ty| has_path(this, ty))
-                        }
-                        Ty::Args(args) => args.inputs().any(|ty| has_path(this, ty)),
-                        Ty::Func(sig) | Ty::Pattern(sig) => {
-                            sig.inputs().any(|ty| has_path(this, ty))
-                        }
-                        Ty::Unary(unary) => has_path(this, &unary.lhs),
-                        Ty::Binary(binary) => {
-                            let [lhs, rhs] = binary.operands();
-                            has_path(this, lhs) || has_path(this, rhs)
-                        }
-                        Ty::If(if_) => {
-                            has_path(this, &if_.cond)
-                                || has_path(this, &if_.then)
-                                || has_path(this, &if_.else_)
-                        }
-                        Ty::Var(v) => this.info.vars.get(&v.def).is_some_and(|bounds| {
-                            let bounds = bounds.bounds.bounds().read();
-                            bounds.lbs.iter().any(|ty| has_path(this, ty))
-                                || bounds.ubs.iter().any(|ty| has_path(this, ty))
-                        }),
-                        Ty::Any | Ty::Boolean(_) | Ty::Value(_) => false,
+            fn has_path(this: &PostTypeChecker<'_>, ty: &Ty) -> bool {
+                match ty {
+                    Ty::Builtin(BuiltinTy::Path(..)) => true,
+                    Ty::Builtin(_) => false,
+                    Ty::Param(p) => has_path(this, &p.ty),
+                    Ty::Let(b) => {
+                        b.lbs.iter().any(|ty| has_path(this, ty))
+                            || b.ubs.iter().any(|ty| has_path(this, ty))
                     }
-                }
-
-                // Only propagate expected types for path concatenations so string literals in
-                // `"dir/" + ""` get path completion.
-                if !has_path(self, &expected) {
-                    return None;
-                }
-
-                // Ensure the queried node is part of the binary expression.
-                let lhs = binary.lhs();
-                let rhs = binary.rhs();
-                let lhs_node = context.find(lhs.span())?;
-                let rhs_node = context.find(rhs.span())?;
-                if lhs_node.find(node.span()).is_some() || rhs_node.find(node.span()).is_some() {
-                    return Some(expected);
+                    Ty::Union(types) => types.iter().any(|ty| has_path(this, ty)),
+                    Ty::Array(elem) => has_path(this, elem),
+                    Ty::Tuple(elems) => elems.iter().any(|ty| has_path(this, ty)),
+                    Ty::Dict(record) => record.interface().any(|(_, ty)| has_path(this, ty)),
+                    Ty::Select(sel) => has_path(this, &sel.ty),
+                    Ty::With(with) => {
+                        has_path(this, &with.sig) || with.with.inputs().any(|ty| has_path(this, ty))
+                    }
+                    Ty::Args(args) => args.inputs().any(|ty| has_path(this, ty)),
+                    Ty::Func(sig) | Ty::Pattern(sig) => sig.inputs().any(|ty| has_path(this, ty)),
+                    Ty::Unary(unary) => has_path(this, &unary.lhs),
+                    Ty::Binary(binary) => {
+                        let [lhs, rhs] = binary.operands();
+                        has_path(this, lhs) || has_path(this, rhs)
+                    }
+                    Ty::If(if_) => {
+                        has_path(this, &if_.cond)
+                            || has_path(this, &if_.then)
+                            || has_path(this, &if_.else_)
+                    }
+                    Ty::Var(v) => this.info.vars.get(&v.def).is_some_and(|bounds| {
+                        let bounds = bounds.bounds.bounds().read();
+                        bounds.lbs.iter().any(|ty| has_path(this, ty))
+                            || bounds.ubs.iter().any(|ty| has_path(this, ty))
+                    }),
+                    Ty::Any | Ty::Boolean(_) | Ty::Value(_) => false,
                 }
             }
+
+            // Only propagate expected types for path concatenations so string literals in
+            // `"dir/" + ""` get path completion.
+            if !has_path(self, &expected) {
+                return None;
+            }
+
+            // Ensure the queried node is part of the binary expression.
+            let lhs = binary.lhs();
+            let rhs = binary.rhs();
+            let lhs_node = context.find(lhs.span())?;
+            let rhs_node = context.find(rhs.span())?;
+            if lhs_node.find(node.span()).is_some() || rhs_node.find(node.span()).is_some() {
+                return Some(expected);
+            }
+        }
 
         match context.kind() {
             SyntaxKind::ModuleImport | SyntaxKind::ModuleInclude => {

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -10,6 +10,7 @@ use super::{
 use super::{DynTypeBounds, ParamAttrs, ParamTy, SharedContext, prelude::*};
 use crate::syntax::{ArgClass, SyntaxContext, VarClass, classify_context, classify_context_outer};
 use crate::ty::{BuiltinTy, TypeInterface};
+use tinymist_analysis::ty::RecordTy;
 
 /// With given type information, check the type of a literal expression again by
 /// touching the possible related nodes.

--- a/crates/tinymist-query/src/analysis/post_tyck.rs
+++ b/crates/tinymist-query/src/analysis/post_tyck.rs
@@ -356,10 +356,10 @@ impl<'a> PostTypeChecker<'a> {
 
     /// Checks the context of a node and returns the type of the context.
     fn check_context(&mut self, context: &LinkedNode, node: &LinkedNode) -> Option<Ty> {
-        if let Some(binary) = context.cast::<ast::Binary>() {
-            if binary.op() == ast::BinOp::Add {
+        if let Some(binary) = context.cast::<ast::Binary>()
+            && binary.op() == ast::BinOp::Add {
                 let parent = context.parent()?;
-                let expected = self.check_context(&parent, context)?;
+                let expected = self.check_context(parent, context)?;
 
                 fn has_path(this: &PostTypeChecker<'_>, ty: &Ty) -> bool {
                     match ty {
@@ -417,7 +417,6 @@ impl<'a> PostTypeChecker<'a> {
                     return Some(expected);
                 }
             }
-        }
 
         match context.kind() {
             SyntaxKind::ModuleImport | SyntaxKind::ModuleInclude => {

--- a/crates/tinymist-query/src/completion.rs
+++ b/crates/tinymist-query/src/completion.rs
@@ -131,6 +131,10 @@ mod tests {
             let mut excludes = HashSet::new();
 
             for kk in properties.get("contains").iter().flat_map(|v| v.split(',')) {
+                let kk = kk.trim();
+                if kk.is_empty() {
+                    continue;
+                }
                 // split first char
                 let (kind, item) = kk.split_at(1);
                 if kind == "+" {

--- a/crates/tinymist-query/src/fixtures/completion/import_let_path.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_let_path.typ
@@ -1,0 +1,8 @@
+/// path: a.typ
+#let foo = 1
+
+-----
+/// contains: +a.typ
+#let p = ""/* range -1..0 */
+#import p: foo
+

--- a/crates/tinymist-query/src/fixtures/completion/include_let_path.typ
+++ b/crates/tinymist-query/src/fixtures/completion/include_let_path.typ
@@ -1,0 +1,8 @@
+/// path: a.typ
+// dummy
+
+-----
+/// contains: +a.typ
+#let p = ""/* range -1..0 */
+#include p
+

--- a/crates/tinymist-query/src/fixtures/completion/path_concat_both.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_concat_both.typ
@@ -1,0 +1,15 @@
+/// path: dir/a.typ
+// dummy
+
+-----
+/// path: dir/b.typ
+// dummy
+
+-----
+/// path: dir/c.txt
+// dummy
+
+-----
+/// contains: +dir/a.typ, +dir/b.typ, -dir/c.txt
+#include "dir/" + ""/* range -1..0 */ + ".typ"
+

--- a/crates/tinymist-query/src/fixtures/completion/path_concat_if_condition_not_prefix.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_concat_if_condition_not_prefix.typ
@@ -1,0 +1,11 @@
+/// path: dir/a.typ
+// dummy
+
+-----
+/// path: a.typ
+// dummy
+
+-----
+/// contains: a.typ, dir/a.typ
+#let prefix = if "dir/" == "dir/" { none } else { none }
+#include prefix + ""/* range -1..0 */

--- a/crates/tinymist-query/src/fixtures/completion/path_concat_prefix.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_concat_prefix.typ
@@ -1,0 +1,12 @@
+/// path: dir/a.typ
+// dummy
+
+-----
+/// path: a.typ
+// dummy
+
+-----
+/// contains: +dir/a.typ, -a.typ
+#let dir = "dir/"
+#include dir + ""/* range -1..0 */
+

--- a/crates/tinymist-query/src/fixtures/completion/path_concat_suffix.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_concat_suffix.typ
@@ -1,0 +1,11 @@
+/// path: a.typ
+// dummy
+
+-----
+/// path: b.typ
+// dummy
+
+-----
+/// contains: +a.typ, +b.typ
+#include ""/* range -1..0 */ + ".typ"
+

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_let_path.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_let_path.typ.snap
@@ -1,0 +1,32 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 196
+description: "Completion on \" (31..32)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/import_let_path.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 1
+      },
+      "start": {
+       "character": 10,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@include_let_path.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@include_let_path.typ.snap
@@ -1,0 +1,32 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 196
+description: "Completion on \" (31..32)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/include_let_path.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 1
+      },
+      "start": {
+       "character": 10,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_both.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_both.typ.snap
@@ -1,0 +1,50 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 196
+description: "Completion on \" (68..69)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_concat_both.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "dir/a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 1
+      },
+      "start": {
+       "character": 19,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "dir/b.typ",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "b",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 1
+      },
+      "start": {
+       "character": 19,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_if_condition_not_prefix.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_if_condition_not_prefix.typ.snap
@@ -1,0 +1,50 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 198
+description: "Completion on \" (109..110)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_concat_if_condition_not_prefix.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a.typ",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 2
+      },
+      "start": {
+       "character": 19,
+       "line": 2
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "dir/a.typ",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "dir/a.typ",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 2
+      },
+      "start": {
+       "character": 19,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_prefix.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_prefix.typ.snap
@@ -1,0 +1,32 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 196
+description: "Completion on \" (67..68)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_concat_prefix.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "dir/a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a.typ",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 2
+      },
+      "start": {
+       "character": 16,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_suffix.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_concat_suffix.typ.snap
@@ -1,0 +1,50 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 196
+description: "Completion on \" (39..40)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_concat_suffix.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "a.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "a",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 1
+      },
+      "start": {
+       "character": 10,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "b.typ",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "b",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 1
+      },
+      "start": {
+       "character": 10,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]


### PR DESCRIPTION
Enables path completion for string concatenation and let-initialized strings, with a small completion filter refinement. Includes related fixtures/snapshots and minor clippy/fmt touchups.

Depends on #2386.