### PR TITLE
fix: incorrect feature configuration for separate compilation

### DIFF
--- a/crates/sync-lsp/src/lib.rs
+++ b/crates/sync-lsp/src/lib.rs
@@ -30,7 +30,7 @@ pub type LspResult<T> = Result<T, ResponseError>;
 pub type Event = Box<dyn Any + Send>;
 
 /// Note that we must have our logging only write out to stderr.
-#[cfg(feature = "web")]
+#[cfg(all(feature = "server", feature = "web"))]
 fn dummy_transport<M: TryFrom<Message, Error = anyhow::Error> + GetMessageKind>() -> Connection<M> {
     let (event_sender, event_receiver) = crossbeam_channel::bounded::<crate::Event>(0);
     let (writer_sender, writer_receiver) = crossbeam_channel::bounded::<Message>(0);

--- a/crates/tinymist-cli/Cargo.toml
+++ b/crates/tinymist-cli/Cargo.toml
@@ -134,7 +134,7 @@ no-content-hint = [
 export = ["tinymist/export"]
 lock = ["tinymist/lock"]
 open = ["tinymist/open", "dep:open"]
-preview = ["tinymist/preview", "hyper-tungstenite"]
+preview = ["tinymist/preview", "tinymist-preview", "hyper-tungstenite"]
 trace = ["tinymist/trace"]
 battery = ["tinymist/battery"]
 

--- a/crates/tinymist-cli/src/cmd/trace_lsp.rs
+++ b/crates/tinymist-cli/src/cmd/trace_lsp.rs
@@ -5,7 +5,7 @@ use reflexo::ImmutPath;
 use sync_ls::transport::{MirrorArgs, with_stdio_transport};
 use sync_ls::{LspBuilder, LspMessage, RequestId};
 use tinymist::world::TaskInputs;
-use tinymist::{CompileOnceArgs, Config, ServerState, SuperInit, UserActionTask};
+use tinymist::{CompileOnceArgs, Config, ServerState, SuperInit};
 use tinymist_project::EntryResolver;
 use tinymist_std::{bail, error::prelude::*};
 
@@ -85,13 +85,14 @@ pub fn trace_lsp_main(args: TraceLspArgs) -> Result<()> {
 
         let snap = state.snapshot().unwrap();
 
+        #[cfg(feature = "trace")]
         RUNTIMES.tokio_runtime.block_on(async {
             let g = snap.task(TaskInputs {
                 entry: Some(entry),
                 inputs,
             });
 
-            UserActionTask::trace_main(client, state, g, args.rpc_kind, req_id).await
+            tinymist::UserActionTask::trace_main(client, state, g, args.rpc_kind, req_id).await
         });
 
         Ok(())

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -31,6 +31,7 @@ use tinymist_l10n::{load_translations, set_translations};
 use tinymist_std::error::prelude::*;
 
 use crate::cmd::*;
+#[cfg(feature = "export")]
 use crate::compile::CompileArgs;
 use crate::conn::client_root;
 use crate::utils::*;
@@ -89,6 +90,7 @@ enum Commands {
     #[cfg(feature = "preview")]
     Preview(tinymist::tool::preview::PreviewCliArgs),
     /// Run compile command like `typst-cli compile`
+    #[cfg(feature = "export")]
     #[clap(alias = "c")]
     Compile(CompileArgs),
 
@@ -99,6 +101,7 @@ enum Commands {
     GenerateScript(crate::generate_script::GenerateScriptArgs),
 
     /// Run documents
+    #[cfg(feature = "lock")]
     #[clap(hide(true))] // still in development
     #[clap(subcommand)]
     Doc(tinymist::project::DocCommands),
@@ -135,7 +138,10 @@ fn main() -> Result<()> {
     set_translations(load_translations(tinymist_assets::L10N_DATA)?);
     // Starts logging
     let _ = tinymist::init_log(tinymist::InitLogOpts {
+        #[cfg(feature = "export")]
         is_transient_cmd: matches!(cmd, Commands::Compile(..)),
+        #[cfg(not(feature = "export"))]
+        is_transient_cmd: false,
         is_test_no_verbose: matches!(&cmd, Commands::Test(test) if !test.verbose),
         output: None,
     });

--- a/crates/tinymist-package/Cargo.toml
+++ b/crates/tinymist-package/Cargo.toml
@@ -44,7 +44,7 @@ insta.workspace = true
 
 default = []
 fs-pack = ["walkdir"]
-gitcl-pack = ["toml", "tinymist-std/system"]
+gitcl-pack = ["fs-pack", "toml", "tinymist-std/system"]
 http-pack = ["http-registry"]
 release-pack = ["http-pack"]
 universe-pack = ["http-pack"]

--- a/crates/tinymist-package/src/registry/dummy.rs
+++ b/crates/tinymist-package/src/registry/dummy.rs
@@ -2,11 +2,20 @@
 
 use std::{path::Path, sync::Arc};
 
+use tinymist_std::ImmutPath;
+
 use super::{PackageError, PackageRegistry, PackageSpec};
 
 /// Dummy package registry that always returns a `NotFound` error.
 #[derive(Default, Debug)]
 pub struct DummyRegistry;
+
+impl DummyRegistry {
+    /// Get data & cache dir (empty)
+    pub fn paths(&self) -> Vec<ImmutPath> {
+        vec![]
+    }
+}
 
 impl PackageRegistry for DummyRegistry {
     fn resolve(&self, spec: &PackageSpec) -> Result<Arc<Path>, PackageError> {

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -25,7 +25,7 @@ comemo.workspace = true
 dirs = { workspace = true, optional = true }
 ecow.workspace = true
 flate2.workspace = true
-fontdb = { workspace = true, optional = true }
+fontdb = { workspace = true, optional = true, features = ["fs", "memmap"] }
 hex.workspace = true
 js-sys = { workspace = true, optional = true }
 log.workspace = true

--- a/crates/tinymist-world/src/entry.rs
+++ b/crates/tinymist-world/src/entry.rs
@@ -166,7 +166,7 @@ impl EntryState {
 }
 
 /// The options to create the entry
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum EntryOpts {
     /// Creates the entry with a specified root directory and a main file.
     Workspace {
@@ -182,13 +182,8 @@ pub enum EntryOpts {
         entry: PathBuf,
     },
     /// Creates the entry with no root and no main file.
+    #[default]
     Detached,
-}
-
-impl Default for EntryOpts {
-    fn default() -> Self {
-        Self::Detached
-    }
 }
 
 impl EntryOpts {

--- a/crates/tinymist/src/input/watch.rs
+++ b/crates/tinymist/src/input/watch.rs
@@ -118,13 +118,6 @@ impl PathAccessModel for WatchAccessModel {
     }
 }
 
-/// The file content request for the client.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DelegateFileContent {
-    // default encoding is base64
-    content: String,
-}
-
 /// The file system watch request for the client.
 /// This is used to watch the file content from the client.
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -415,6 +415,7 @@ impl PreviewState {
         });
 
         let task_id = args.task_id.clone();
+        #[cfg(feature = "open")]
         let open_in_browser = args.open_in_browser(false);
         log::info!("PreviewTask({task_id}): arguments: {args:#?}");
 


### PR DESCRIPTION
This PR fixes several bugs that lead to compilation errors if we compile some crates separately, without default features.

Using command:
```sh
cargo hack check --workspace --each-feature --keep-going
```

Warnings due to conditionally unsed items are not handled.

The remaining common problem, without `no-content-hint` feature enabled:
```
no method named `content_hint` found for reference `&typst::layout::Frame` in the current scope
```
which tries to call a non-existent function.