### PR TITLE
ci: skip nightly release workflow on fork repos

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   check-and-release:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Add logic to skip the nightly release GitHub Actions workflow when the repository is a fork.