### PR TITLE
fix(typst-preview): simplified websocket url logic to use relative url

### DIFF
--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -37,21 +37,7 @@ function retrieveWsArgs() {
   mode = mode.replace("preview-arg:previewMode:", "");
   let previewMode = PreviewMode[mode];
 
-  /// The string `ws://127.0.0.1:23625` is a placeholder
-  /// Also, it is the default url to connect to.
-  /// Note that we must resolve the url to an absolute url as
-  /// the websocket connection requires an absolute url.
-  ///
-  /// See [WebSocket and relative URLs](https://github.com/whatwg/websockets/issues/20)
-  let urlObject = new URL("ws://127.0.0.1:23625", window.location.href);
-  /// Rewrite the protocol to websocket.
-  urlObject.protocol = urlObject.protocol.replace("https:", "wss:").replace("http:", "ws:");
-  if (location.href.startsWith("https://")) {
-    urlObject.protocol = urlObject.protocol.replace("ws:", "wss:");
-  }
-
-  /// Return a `WsArgs` object.
-  return { url: urlObject.href, previewMode, isContentPreview: false };
+  return { url: window.location.href, previewMode, isContentPreview: false };
 }
 
 /// `buildWs` returns a object, which keeps track of websocket


### PR DESCRIPTION
Since the referenced WebSocket issue is resolved, and all major browsers (I tested chrome, firefox, and safari with this change) supports connecting to websocket with `http` and `https`, it would be a good idea to remove the workaround written here.

This will also bring the advantage of making typst-preview function under other paths (like `http://127.0.0.1:23625/test`), which can be useful given the user is using reverse proxies.