### PR TITLE
fix(tyck): callee is not checked for `dict.at`

### DIFF
--- a/crates/tinymist-query/src/analysis/tyck/syntax.rs
+++ b/crates/tinymist-query/src/analysis/tyck/syntax.rs
@@ -430,6 +430,7 @@ impl TypeChecker<'_> {
 
     fn check_apply(&mut self, apply: &Interned<ApplyExpr>) -> Ty {
         let args = self.check(&apply.args);
+        let callee = self.check(&apply.callee);
 
         // Treat `dict.at("key")` as `dict.key` when the key is a constant string.
         if let Expr::Select(select) = &apply.callee
@@ -450,8 +451,6 @@ impl TypeChecker<'_> {
                 return res;
             }
         }
-
-        let callee = self.check(&apply.callee);
 
         crate::log_debug_ct!("func_call: {callee:?} with {args:?}");
 

--- a/crates/tinymist-query/src/fixtures/completion/dict_at_named_param.typ
+++ b/crates/tinymist-query/src/fixtures/completion/dict_at_named_param.typ
@@ -1,0 +1,4 @@
+/// contains: default
+
+#let d = (a: 1)
+#d.at("a" /* range 0..1 */)

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@dict_at_named_param.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@dict_at_named_param.typ.snap
@@ -1,0 +1,36 @@
+---
+source: crates/tinymist-query/src/completion.rs
+assertion_line: 192
+description: Completion on / (49..50)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/dict_at_named_param.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
+    },
+    "kind": 5,
+    "label": "default",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "default: ${1:}",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 3
+      },
+      "start": {
+       "character": 10,
+       "line": 3
+      }
+     }
+    }
+   }
+  ]
+ }
+]


### PR DESCRIPTION
Fixes a bug introduced in #2385, which caused `dict.at("key", |)` fail to have `default:` in the completion list.