### PR TITLE
Server-side SVG rendering for native editor integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6619,6 +6619,7 @@ dependencies = [
  "typst",
  "typst-assets",
  "typst-macros",
+ "typst-svg",
  "typst-timing 0.14.2",
 ]
 

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -575,6 +575,8 @@ impl Config {
             refresh_style: self.preview.refresh.clone().unwrap_or(TaskWhen::OnType),
             invert_colors: serde_json::to_string(&self.preview.invert_colors)
                 .unwrap_or_else(|_| "never".to_string()),
+            server_svg: false,
+            strip_svg_glyph_defs: false,
         }
     }
 

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -113,6 +113,23 @@ pub struct PreviewArgs {
     /// This is hidden from the CLI.
     #[clap(long, hide(true))]
     pub refresh_style: Option<RefreshStyle>,
+
+    /// Render complete SVG server-side instead of streaming vector IR.
+    ///
+    /// When enabled, the WebSocket data plane sends SVG text messages
+    /// instead of binary reflexo vector IR. Intended for native editor
+    /// integrations that can rasterize SVG directly.
+    #[clap(long = "server-svg")]
+    pub server_svg: bool,
+
+    /// Strip unchanged glyph defs from SVGs after the first frame.
+    ///
+    /// Requires --server-svg.  Reduces per-frame WebSocket transfer from
+    /// ~2MB to ~200KB by stripping the `<defs id="glyph">` section when
+    /// it hasn't changed since the previous frame.  The receiving client
+    /// must cache and re-inject the stripped defs.
+    #[clap(long = "strip-svg-glyph-defs")]
+    pub strip_svg_glyph_defs: bool,
 }
 
 impl PreviewArgs {
@@ -130,6 +147,8 @@ impl PreviewArgs {
                 Some(s) => s.clone(),
                 None => config.invert_colors.clone(),
             },
+            server_svg: self.server_svg || config.server_svg,
+            strip_svg_glyph_defs: self.strip_svg_glyph_defs || config.strip_svg_glyph_defs,
         }
     }
 }

--- a/crates/typst-preview/Cargo.toml
+++ b/crates/typst-preview/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["time", "rt-multi-thread"] }
 typst.workspace = true
 typst-macros.workspace = true
 typst-timing.workspace = true
+typst-svg.workspace = true
 typst-assets.workspace = true
 
 

--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::ops::Range;
+use std::hash::{DefaultHasher, Hasher};
 use std::sync::Arc;
 
 use reflexo_typst::debug_loc::{
@@ -6,6 +8,7 @@ use reflexo_typst::debug_loc::{
 };
 use reflexo_vec2svg::IncrSvgDocServer;
 use tinymist_std::typst::TypstDocument;
+use typst::layout::Abs;
 use tokio::sync::{broadcast, mpsc};
 
 use super::{editor::EditorActorRequest, webview::WebviewActorRequest};
@@ -48,6 +51,9 @@ pub struct RenderActor {
     editor_conn_sender: mpsc::UnboundedSender<EditorActorRequest>,
     svg_sender: mpsc::UnboundedSender<Vec<u8>>,
     webview_sender: broadcast::Sender<WebviewActorRequest>,
+    server_svg: bool,
+    strip_svg_glyph_defs: bool,
+    cached_glyph_defs_hashes: HashMap<usize, u64>,
 }
 
 impl RenderActor {
@@ -57,6 +63,8 @@ impl RenderActor {
         editor_conn_sender: mpsc::UnboundedSender<EditorActorRequest>,
         svg_sender: mpsc::UnboundedSender<Vec<u8>>,
         webview_sender: broadcast::Sender<WebviewActorRequest>,
+        server_svg: bool,
+        strip_svg_glyph_defs: bool,
     ) -> Self {
         let mut res = Self {
             mailbox,
@@ -65,6 +73,9 @@ impl RenderActor {
             editor_conn_sender,
             svg_sender,
             webview_sender,
+            server_svg,
+            strip_svg_glyph_defs,
+            cached_glyph_defs_hashes: HashMap::new(),
         };
         res.renderer.set_should_attach_debug_info(true);
         res
@@ -151,11 +162,26 @@ impl RenderActor {
                 continue;
             };
 
-            let data = self.render(has_full_render, &document);
-            let Ok(_) = self.svg_sender.send(data) else {
-                log::info!("RenderActor: svg_sender is dropped");
-                break;
-            };
+            if self.server_svg {
+                let pages = self.render_svg(&document);
+                let mut sender_dropped = false;
+                for page_data in pages {
+                    if self.svg_sender.send(page_data).is_err() {
+                        log::info!("RenderActor: svg_sender is dropped");
+                        sender_dropped = true;
+                        break;
+                    }
+                }
+                if sender_dropped {
+                    break;
+                }
+            } else {
+                let data = self.render(has_full_render, &document);
+                let Ok(_) = self.svg_sender.send(data) else {
+                    log::info!("RenderActor: svg_sender is dropped");
+                    break;
+                };
+            }
         }
         log::info!("RenderActor: exiting")
     }
@@ -169,6 +195,67 @@ impl RenderActor {
             }
         } else {
             self.render_delta(document)
+        }
+    }
+
+    fn render_svg(&mut self, document: &TypstDocument) -> Vec<Vec<u8>> {
+        match document {
+            TypstDocument::Paged(doc) => {
+                let total = doc.pages.len();
+                log::info!("RenderActor: render_svg: Paged document with {total} pages");
+                if total == 0 {
+                    return Vec::new();
+                }
+                doc.pages
+                    .iter()
+                    .enumerate()
+                    .map(|(index, page)| {
+                        let svg = typst_svg::svg(page);
+                        let svg_bytes = if self.strip_svg_glyph_defs {
+                            self.strip_cached_glyph_defs(index, svg)
+                        } else {
+                            svg.into_bytes()
+                        };
+                        let header = format!("page:{index}:{total}\n");
+                        let mut data = header.into_bytes();
+                        data.extend_from_slice(&svg_bytes);
+                        data
+                    })
+                    .collect()
+            }
+            TypstDocument::Html(_) => {
+                log::info!("RenderActor: render_svg: Html document (not supported)");
+                vec![b"<svg xmlns=\"http://www.w3.org/2000/svg\"><text>HTML target not supported in SVG mode</text></svg>".to_vec()]
+            }
+        }
+    }
+
+    fn strip_cached_glyph_defs(&mut self, page_index: usize, svg: String) -> Vec<u8> {
+        let defs_start_tag = "<defs id=\"glyph\">";
+        let defs_end_tag = "</defs>";
+
+        let Some(start) = svg.find(defs_start_tag) else {
+            return svg.into_bytes();
+        };
+        let Some(end_rel) = svg[start..].find(defs_end_tag) else {
+            return svg.into_bytes();
+        };
+        let end = start + end_rel + defs_end_tag.len();
+        let defs_section = &svg[start..end];
+
+        let mut hasher = DefaultHasher::new();
+        hasher.write(defs_section.as_bytes());
+        let hash = hasher.finish();
+
+        let cached = self.cached_glyph_defs_hashes.get(&page_index).copied();
+        if cached == Some(hash) {
+            let mut result = String::with_capacity(svg.len() - defs_section.len());
+            result.push_str(&svg[..start]);
+            result.push_str(&svg[end..]);
+            result.into_bytes()
+        } else {
+            self.cached_glyph_defs_hashes.insert(page_index, hash);
+            svg.into_bytes()
         }
     }
 

--- a/crates/typst-preview/src/actor/webview.rs
+++ b/crates/typst-preview/src/actor/webview.rs
@@ -44,6 +44,7 @@ pub struct WebviewActor<'a, C> {
     broadcast_sender: broadcast::Sender<WebviewActorRequest>,
     editor_sender: mpsc::UnboundedSender<EditorActorRequest>,
     render_sender: broadcast::Sender<RenderActorRequest>,
+    server_svg: bool,
 }
 
 pub struct Channels {
@@ -70,6 +71,7 @@ where
         mailbox: broadcast::Receiver<WebviewActorRequest>,
         editor_sender: mpsc::UnboundedSender<EditorActorRequest>,
         render_sender: broadcast::Sender<RenderActorRequest>,
+        server_svg: bool,
     ) -> Self {
         Self {
             webview_websocket_conn: websocket_conn,
@@ -78,6 +80,7 @@ where
             broadcast_sender,
             editor_sender,
             render_sender,
+            server_svg,
         }
     }
 
@@ -112,8 +115,14 @@ where
                 Some(svg) = self.svg_receiver.recv() => {
                     log::trace!("WebviewActor: received svg from renderer");
                     let _scope = typst_timing::TimingScope::new("webview_actor_send_svg");
-                    self.webview_websocket_conn.send(WsMessage::Binary(svg.into()))
-                    .await.log_error("WebViewActor");
+                    if self.server_svg {
+                        let text = String::from_utf8_lossy(&svg).into_owned();
+                        self.webview_websocket_conn.send(WsMessage::Text(text))
+                            .await.log_error("WebViewActor");
+                    } else {
+                        self.webview_websocket_conn.send(WsMessage::Binary(svg.into()))
+                            .await.log_error("WebViewActor");
+                    }
                 }
                 Some(msg) = self.webview_websocket_conn.next() => {
                     log::trace!("WebviewActor: received message from websocket: {msg:?}");

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -54,6 +54,14 @@ pub struct PreviewConfig {
     pub refresh_style: TaskWhen,
     /// The invert colors setting for the preview.
     pub invert_colors: String,
+    /// When true, render complete SVG server-side and send as text WebSocket
+    /// messages instead of binary vector IR.
+    pub server_svg: bool,
+    /// When true (and `server_svg` is also true), strip unchanged glyph
+    /// `<defs>` from SVGs after the first frame.  Reduces per-frame
+    /// WebSocket transfer from ~2MB to ~200KB.  The receiving client must
+    /// cache and re-inject the stripped defs.
+    pub strip_svg_glyph_defs: bool,
 }
 
 /// Gets the HTML for the frontend by a given preview mode and server to connect
@@ -148,6 +156,7 @@ impl Previewer {
                     h.webview_tx.subscribe(),
                     h.editor_tx.clone(),
                     h.renderer_tx.clone(),
+                    h.server_svg,
                 );
                 let render_actor = actor::render::RenderActor::new(
                     h.renderer_tx.subscribe(),
@@ -155,6 +164,8 @@ impl Previewer {
                     h.editor_tx.clone(),
                     svg.0,
                     h.webview_tx,
+                    h.server_svg,
+                    h.strip_svg_glyph_defs,
                 );
                 tokio::spawn(render_actor.run());
                 let outline_render_actor = actor::render::OutlineRenderActor::new(
@@ -293,6 +304,8 @@ impl PreviewBuilder {
             renderer_tx: renderer_mailbox.0.clone(),
             enable_partial_rendering: config.enable_partial_rendering,
             doc_sender,
+            server_svg: config.server_svg,
+            strip_svg_glyph_defs: config.strip_svg_glyph_defs,
         };
 
         Previewer {
@@ -485,6 +498,8 @@ struct DataPlane {
     invert_colors: String,
     renderer_tx: broadcast::Sender<RenderActorRequest>,
     doc_sender: Arc<parking_lot::RwLock<Option<Arc<dyn CompileView>>>>,
+    server_svg: bool,
+    strip_svg_glyph_defs: bool,
 }
 
 /// The invert colors for the preview.


### PR DESCRIPTION
Adds `--server-svg` and `--strip-svg-glyph-defs` flags to the preview server for native editor integrations that can rasterise SVG directly, without the reflexo vector IR / WASM frontend.

## Motivation

Native editors that already have an SVG rasteriser (e.g. via resvg) can display typst output without pulling in ~250 reflexo rendering crates or shipping a WASM frontend. The tinymist LSP is already running, already watching the file, and already doing incremental compilation with comemo. The only missing piece is a way to get rendered output as SVG instead of vector IR.

This is useful for any editor integration where:
- The editor can rasterise SVG natively or already has resvg/usvg in its dependency tree
- Pulling in the reflexo vector format and its rendering pipeline is too heavy
- A simple text-based WebSocket protocol is preferable to binary vector IR

## Changes

### `--server-svg`

When passed to `tinymist preview` or via `tinymist.doStartPreview` as a CLI-style argument, the `RenderActor` calls `typst_svg::svg(page)` for each page and sends the result as `WsMessage::Text` instead of the usual `WsMessage::Binary` vector IR.

Multi-page documents send one WebSocket message per page with a header:

```
page:0:5\n<svg class="typst-doc" ...>...</svg>
page:1:5\n<svg class="typst-doc" ...>...</svg>
...
```

The existing incremental/delta rendering path is completely unchanged when the flag is off.

### `--strip-svg-glyph-defs`

Typst SVGs embed every glyph outline as a `<symbol>` inside `<defs id="glyph">`. For a typical document this is 80–90% of the SVG (~1.5MB of ~2MB). The glyph set rarely changes between keystrokes.

When `--strip-svg-glyph-defs` is passed alongside `--server-svg`, the `RenderActor` hashes each page's `<defs id="glyph">` section and strips it from subsequent frames where the hash matches. Per-page hashing so multi-page documents don't cross-contaminate. Reduces per-frame transfer from ~2MB to ~200KB.

Off by default because it changes the SVG content in a way that requires client-side cooperation — the receiving client must cache the defs from the first frame and re-inject them into subsequent frames.

### Files changed

**`crates/typst-preview/src/actor/render.rs`** (+97/-3)
- `render_svg()`: iterates `doc.pages`, renders each with `typst_svg::svg(page)`, prepends `page:{idx}:{total}\n` header
- `strip_cached_glyph_defs()`: per-page hash-based stripping, gated on `self.strip_svg_glyph_defs`
- `cached_glyph_defs_hashes: HashMap<usize, u64>` on `RenderActor`
- Run loop dispatches to `render_svg()` when `self.server_svg` is set, sends each page as a separate channel message

**`crates/typst-preview/src/actor/webview.rs`** (+11/-2)
- Sends `WsMessage::Text` when `server_svg` enabled, `WsMessage::Binary` otherwise

**`crates/typst-preview/src/lib.rs`** (+15)
- `server_svg` and `strip_svg_glyph_defs` fields on `PreviewConfig` and `DataPlane`
- Plumbed through to `RenderActor::new()`

**`crates/tinymist/src/tool/preview.rs`** (+19)
- `--server-svg` and `--strip-svg-glyph-defs` clap arguments on `PreviewArgs`

**`crates/tinymist/src/config.rs`** (+2)
- Defaults for both fields (`false`)

## Example usage

An editor integration would start the preview via the LSP:

```json
{"command": "tinymist.doStartPreview", "arguments": [["--server-svg", "--strip-svg-glyph-defs", "--data-plane-host=127.0.0.1:0", "--task-id=my-preview", "/path/to/file.typ"]]}
```

Then connect to the returned WebSocket port, send `"current"` to trigger the initial render, and receive SVG text messages as the document changes. With `--strip-svg-glyph-defs`, the client caches `<defs id="glyph">...</defs>` from the first frame and injects it into subsequent frames that have it stripped.

The `--task-id` flag allows concurrent previews for different files. `tinymist.doKillPreview` with the same task ID cleans up.

## Performance

On a complex A4 2-column document (536 glyphs, 7704 glyph uses, 5 pages, ~2MB SVG per page): comemo incremental recompile takes ~26ms, leaving ~120ms of frame budget for the client to rasterise and display at typing speed.

## Design notes

- No changes to the default preview behaviour. Both flags are opt-in.
- The vector IR path, browser-based frontend, and all existing preview functionality are untouched.
- The `page:{idx}:{total}\n` header is a simple text prefix, not JSON, to avoid escaping a multi-megabyte SVG string.
