### PR TITLE
feat: rework viewport position fix

### DIFF
--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -527,48 +527,26 @@ export class TypstDocumentContext<O = any> {
     return this.partialRenderPage + 1;
   }
 
-  _scrollAdjustTimeout: ReturnType<typeof setTimeout> | undefined;
-  _lastScrollPosition: DOMRect | undefined;
-  /// Adjusts scroll position with a debounce time.
+  /// Adjusts scroll position.
   private keepScrollPosition(scrollPosition: DOMRect) {
-    /// The debounce time for `scrollAdjust` task.
-    /// todo: better interval.
-    const KEEP_SCROLL_DEBOUNCE_TIME_MS = 300;
+    const domState = this.retrieveDOMState();
+    const newBBox = domState.scrollPosition;
+    if (!(newBBox && scrollPosition && newBBox.width !== scrollPosition.width)) {
+      return;
+    }
+    const scrollAdjustLeftRatio = scrollPosition.left / scrollPosition.width;
+    const scrollAdjustTopRatio = scrollPosition.top / scrollPosition.height;
+    const expectedLeft = newBBox.width * scrollAdjustLeftRatio;
+    const expectedTop = newBBox.height * scrollAdjustTopRatio;
 
-    /// If a `scrollAdjust` task is already scheduled, we register again to debounce
-    /// the scroll adjustment.
-    /// Otherwise, we record the initial position to adjust later.
-    if (!this._scrollAdjustTimeout) {
-      this._lastScrollPosition = scrollPosition;
-    } else {
-      clearTimeout(this._scrollAdjustTimeout);
+    const adjustedDiffLeft = newBBox.left - expectedLeft;
+    const adjustedDiffTop = newBBox.top - expectedTop;
+    if (Math.abs(adjustedDiffLeft) < 1e-1 && Math.abs(adjustedDiffTop) < 1e-1) {
+      return;
     }
 
-    this._scrollAdjustTimeout = setTimeout(() => {
-      this._scrollAdjustTimeout = undefined;
-      const domState = this.retrieveDOMState();
-      const newBBox = domState.scrollPosition;
-      if (!(newBBox && this._lastScrollPosition && newBBox.width !== this._lastScrollPosition.width)) {
-        return;
-      }
-      const scrollAdjustLeftRatio = this._lastScrollPosition.left / this._lastScrollPosition.width;
-      const scrollAdjustTopRatio = this._lastScrollPosition.top / this._lastScrollPosition.height;
-      const expectedLeft = newBBox.width * scrollAdjustLeftRatio;
-      const expectedTop = newBBox.height * scrollAdjustTopRatio;
-
-      const adjustedDiffLeft = newBBox.left - expectedLeft;
-      const adjustedDiffTop = newBBox.top - expectedTop;
-      if (Math.abs(adjustedDiffLeft) < 1e-1 && Math.abs(adjustedDiffTop) < 1e-1) {
-        return;
-      }
-
-      this.hookedElem.parentElement!.scrollBy({
-        left: adjustedDiffLeft,
-        top: adjustedDiffTop,
-        /// "instant" behavior is disgusting, use "smooth" instead
-        behavior: "smooth",
-      });
-    }, KEEP_SCROLL_DEBOUNCE_TIME_MS);
+    this.hookedElem.parentElement!.scrollTop = expectedTop;
+    this.hookedElem.parentElement!.scrollLeft = expectedLeft;
   }
 }
 

--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -534,19 +534,8 @@ export class TypstDocumentContext<O = any> {
     if (!(newBBox && scrollPosition && newBBox.width !== scrollPosition.width)) {
       return;
     }
-    const scrollAdjustLeftRatio = scrollPosition.left / scrollPosition.width;
-    const scrollAdjustTopRatio = scrollPosition.top / scrollPosition.height;
-    const expectedLeft = newBBox.width * scrollAdjustLeftRatio;
-    const expectedTop = newBBox.height * scrollAdjustTopRatio;
-
-    const adjustedDiffLeft = newBBox.left - expectedLeft;
-    const adjustedDiffTop = newBBox.top - expectedTop;
-    if (Math.abs(adjustedDiffLeft) < 1e-1 && Math.abs(adjustedDiffTop) < 1e-1) {
-      return;
-    }
-
-    this.hookedElem.parentElement!.scrollTop = expectedTop;
-    this.hookedElem.parentElement!.scrollLeft = expectedLeft;
+    this.hookedElem.parentElement!.scrollTop = -newBBox.height * scrollPosition.top / scrollPosition.height;
+    this.hookedElem.parentElement!.scrollLeft = -newBBox.width * scrollPosition.left / scrollPosition.width;
   }
 }
 

--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -419,7 +419,6 @@ export class TypstDocumentContext<O = any> {
 
     this.isRendering = true;
     const doUpdate = async () => {
-      const lastScrollPosition = this.cachedDOMState.scrollPosition;
       this.cachedDOMState = this.retrieveDOMState();
 
       if (this.patchQueue.length === 0) {
@@ -443,18 +442,11 @@ export class TypstDocumentContext<O = any> {
           this.r.rescale();
           await this.r.rerender();
           this.r.rescale();
-          /// Adjusts scroll position to keep visual position in "doc" mode.
-          /// Using `requestAnimationFrame` ensures the scroll adjustment happens after DOM updates.
-          requestAnimationFrame(() => {
-            if (lastScrollPosition && this.previewMode === PreviewMode.Doc) {
-              this.keepScrollPosition(lastScrollPosition);
-            }
-          });
         }
 
         let t2 = performance.now();
 
-        /// Perf event
+        /// perf event
         const d = (e: string, x: number, y: number) => `${e} ${(y - x).toFixed(2)} ms`;
         this.sampledRenderTime = t2 - t0;
         console.log([d("parse", t0, t1), d("rerender", t1, t2), d("total", t0, t2)].join(", "));
@@ -525,17 +517,6 @@ export class TypstDocumentContext<O = any> {
 
   getPartialPageNumber(): number {
     return this.partialRenderPage + 1;
-  }
-
-  /// Adjusts scroll position.
-  private keepScrollPosition(scrollPosition: DOMRect) {
-    const domState = this.retrieveDOMState();
-    const newBBox = domState.scrollPosition;
-    if (!(newBBox && scrollPosition && newBBox.width !== scrollPosition.width)) {
-      return;
-    }
-    this.hookedElem.parentElement!.scrollTop = -newBBox.height * scrollPosition.top / scrollPosition.height;
-    this.hookedElem.parentElement!.scrollLeft = -newBBox.width * scrollPosition.left / scrollPosition.width;
   }
 }
 

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -288,8 +288,15 @@ export function provideSvgDoc<
       // apply scale
       const dataWidth = Number.parseFloat(svg.getAttribute("data-width")!);
       const dataHeight = Number.parseFloat(svg.getAttribute("data-height")!);
+      const appliedWidth = (dataWidth * scale).toString();
       const scaledWidth = Math.ceil(dataWidth * scale);
       const scaledHeight = Math.ceil(dataHeight * scale);
+
+      // keep scroll position if width changed
+      if (svg.getAttribute("data-applied-width") !== appliedWidth && container.scrollPosition) {
+        this.hookedElem.parentElement!.scrollTop = -scaledHeight * container.scrollPosition.top / container.scrollPosition.height;
+        this.hookedElem.parentElement!.scrollLeft = -scaledWidth * container.scrollPosition.left / container.scrollPosition.width;
+      }
 
       this.rescaleSvgOn(svg);
 

--- a/tools/typst-preview-frontend/src/typst.css
+++ b/tools/typst-preview-frontend/src/typst.css
@@ -52,7 +52,6 @@ body {
 
 #typst-container-main {
   flex: 1;
-  overflow: auto;
   position: relative;
 }
 

--- a/tools/typst-preview-frontend/src/typst.css
+++ b/tools/typst-preview-frontend/src/typst.css
@@ -52,6 +52,7 @@ body {
 
 #typst-container-main {
   flex: 1;
+  overflow: auto;
   position: relative;
 }
 


### PR DESCRIPTION
# TL;DR

Rework #2341.

Fix #2432, Close #1929.

# Description

In commit 12dd00fea68b0d42c226880197e63aee653c97f2, the `overflow: auto` property was removed. #2432 now works correctly after reverting this change.

Regarding the view tests mentioned in #1929, the required effort currently seems too high to be cost-effective.

Additionally, the `Fit to Width` mode and `Absolute Size` mode mentioned in #1929 should already be supported in #2341.