### PR TITLE
dev: propose named argument parameter references (#2444)

### DIFF
--- a/openspec/changes/track-named-argument-references/.openspec.yaml
+++ b/openspec/changes/track-named-argument-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/track-named-argument-references/design.md
+++ b/openspec/changes/track-named-argument-references/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`RenameRequest` already delegates to `find_references`, so tinymist's rename behavior is only as complete as the reference search it builds on. Today `find_references` ultimately relies on `ExprInfo.get_refs`, which returns lexical and already-resolved semantic references from `resolves`.
+
+Named argument labels are recognized elsewhere in the stack, but not yet surfaced through that reference path. `syntax/expr.rs` records named call arguments as identifier references, and `analysis/call.rs` can map `ast::Arg::Named` nodes to the concrete parameter name for both direct calls and `.with(...)` flows. That mapping is currently used for call-aware editor features such as inlay hints, while references and rename still miss those label sites.
+
+The result is the exact failure reported in `#2444`: renaming a user-defined parameter updates the declaration and in-function uses, but leaves call-site labels unchanged even when tinymist can already understand which parameter they bind to.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Include semantically bound named argument labels in parameter references and rename results for user-defined functions and closures.
+- Cover both direct calls and `.with(...)`-style partial application without relying on text-only identifier matching.
+- Preserve precise edit ranges so rename changes only the label token and not the colon or argument value.
+- Add regression coverage that proves unrelated same-name parameters are not renamed.
+
+**Non-Goals:**
+- Implementing dictionary-field references or rename support.
+- Changing rename support for native/builtin parameters that remain non-renamable today.
+- Broadening field-access rename, import rename, or other unrelated roadmap items.
+
+## Decisions
+
+### 1. Extend shared reference discovery instead of special-casing rename
+
+The missing behavior belongs in shared reference lookup, not only in `rename.rs`. `textDocument/rename` should continue to inherit its edit set from `find_references`, while `textDocument/references` gains the same named-argument coverage automatically.
+
+Alternative considered:
+- Add rename-only logic in `RenameRequest`. Rejected because it would leave `textDocument/references` inconsistent with rename and duplicate the same semantic matching rules.
+
+### 2. Use semantic call analysis to identify parameter-bound named arguments
+
+Named-argument matches should be discovered from call analysis that already resolves a call's effective signature and named-parameter bindings. The matching key should combine the callable that is being invoked with the bound parameter name so the search only includes labels that actually bind to the renamed parameter, including `.with(...)` signatures derived from the same user-defined function.
+
+Alternative considered:
+- Scan for matching identifier text such as every `side:` label in the workspace. Rejected because it would rename unrelated same-name parameters and could not distinguish different callables.
+
+Alternative considered:
+- Store the relationship directly in the low-level `ExprInfo.resolves` map during expression building. Rejected because call-signature binding lives later in analysis and forcing it into the earlier syntax stage would increase coupling.
+
+### 3. Compute rename ranges from the label token only
+
+When a named argument is included in a rename result, the returned range should cover only the identifier token of the label. This keeps `side: left` editable as `sd: left` without replacing the colon, whitespace, or value expression.
+
+Alternative considered:
+- Reuse the whole `ast::Arg::Named` node range. Rejected because rename would overwrite the entire argument text instead of the semantic label.
+
+### 4. Lock behavior with fixture-based regression tests
+
+The change should add focused reference and rename fixtures for:
+- a direct named call on a user-defined function
+- a `.with(...)` named argument bound to the same parameter
+- an unrelated callable with the same parameter name that must stay unchanged
+
+This keeps the change narrow and makes the expected LSP edits easy to review in snapshots.
+
+## Risks / Trade-offs
+
+- [Call-site matching could include unrelated same-name parameters] -> Mitigate by matching on semantic callable/parameter binding rather than raw identifier text.
+- [Reference lookup may do more work for parameter queries] -> Mitigate by restricting the extra search to parameter targets and reusing existing call/signature analysis instead of inventing a second resolver.
+- [`.with(...)` chains may differ from direct calls in subtle ways] -> Mitigate by leaning on the same call-analysis path already used for call-aware editor features and covering it with dedicated fixtures.
+
+## Migration Plan
+
+1. Extend shared parameter reference collection to surface named-argument label spans from semantically resolved call sites.
+2. Keep `textDocument/references` and `textDocument/rename` on that shared path so the new behavior is consistent.
+3. Add focused fixtures and snapshot tests for direct named calls, `.with(...)`, and non-matching same-name parameters.
+
+## Open Questions
+
+- The same general shape may help future dictionary-field reference work, but that broader reuse is intentionally left out of this change.

--- a/openspec/changes/track-named-argument-references/proposal.md
+++ b/openspec/changes/track-named-argument-references/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Function-parameter rename in tinymist currently updates the declaration and in-body references but skips named argument labels at call sites such as `bubble(side: left)` and `bubble.with(side: left)`. That produces partial renames that can leave semantically stale call sites behind, and it blocks the roadmap item tinymist already advertises around named function argument references.
+
+## What Changes
+
+- Track named argument labels in direct calls as semantic references to the user-defined parameter they bind to.
+- Track named argument labels supplied through `func.with(...)` as semantic references to the same parameter.
+- Make `textDocument/references` and `textDocument/rename` include those call-site labels through the same reference lookup path.
+- Add regression coverage for direct calls, `.with(...)` partial application, and unrelated same-name parameters that must remain untouched.
+
+## Capabilities
+
+### New Capabilities
+- `named-argument-references`: Treat named function argument labels as semantic references to user-defined parameters for reference-based LSP features.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- `crates/tinymist-query/src/references.rs`
+- `crates/tinymist-query/src/rename.rs`
+- `crates/tinymist-query/src/analysis/call.rs` and related semantic lookup used to resolve call parameters
+- Rename/reference fixtures under `crates/tinymist-query/src/fixtures/`

--- a/openspec/changes/track-named-argument-references/specs/named-argument-references/spec.md
+++ b/openspec/changes/track-named-argument-references/specs/named-argument-references/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Named argument labels participate in parameter references
+Tinymist SHALL treat a named argument label that semantically binds to a user-defined parameter as a reference to that parameter for `textDocument/references` and `textDocument/rename`.
+
+#### Scenario: Direct named call is included
+- **WHEN** a user requests references or rename on a user-defined parameter such as `side` and a call site invokes the same callable with a named argument like `bubble(side: left)`
+- **THEN** the result includes the `side` label at that direct call site
+
+#### Scenario: `.with(...)` named argument is included
+- **WHEN** a user requests references or rename on a user-defined parameter such as `side` and the parameter is supplied through `bubble.with(side: left)`
+- **THEN** the result includes the `side` label inside the `.with(...)` call
+
+#### Scenario: Rename edits only the label token
+- **WHEN** rename updates a named argument label that binds to the selected parameter
+- **THEN** only the label text is replaced and the colon, whitespace, and value expression remain unchanged
+
+#### Scenario: Unrelated same-name labels are excluded
+- **WHEN** another callable has a distinct parameter with the same name as the selected parameter
+- **THEN** references and rename for the selected parameter MUST NOT include the unrelated named argument label

--- a/openspec/changes/track-named-argument-references/tasks.md
+++ b/openspec/changes/track-named-argument-references/tasks.md
@@ -1,0 +1,16 @@
+## 1. Extend semantic reference matching
+
+- [ ] 1.1 Extend shared parameter reference lookup so it collects named argument label spans from direct calls that bind to the selected user-defined parameter.
+- [ ] 1.2 Extend the same lookup to `.with(...)` named arguments while excluding unrelated same-name parameters on other callables.
+- [ ] 1.3 Ensure the returned rename ranges cover only the label token for matched named arguments.
+
+## 2. Wire LSP behavior through the shared path
+
+- [ ] 2.1 Keep `textDocument/references` and `textDocument/rename` on the shared reference path so both features surface the new named-argument matches.
+- [ ] 2.2 Verify unsupported rename targets, such as field accesses and builtin/native parameters, keep their current behavior.
+
+## 3. Add regression coverage
+
+- [ ] 3.1 Add reference and rename fixtures for direct named arguments on user-defined functions.
+- [ ] 3.2 Add reference and rename fixtures for `.with(...)` named arguments plus a non-match case for another callable with the same parameter name.
+- [ ] 3.3 Run focused `tinymist-query` reference and rename tests and review the snapshot output.


### PR DESCRIPTION
## Summary
- add an OpenSpec proposal for treating named argument labels as parameter references for rename and references
- document the semantic call-analysis approach for direct calls and .with(...) bindings
- outline implementation tasks and regression coverage for tinymist-query

## Testing
- not run (spec-only change)

Related issue #2444