### PR TITLE
dev: propose math module field completion (#2401)

### DIFF
--- a/openspec/changes/fix-math-module-field-completion/proposal.md
+++ b/openspec/changes/fix-math-module-field-completion/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Math-mode dot completion currently treats module-valued targets more narrowly than code and markup mode. For expressions such as `$ calc. $`, tinymist filters out the module's pure function exports in math mode, so users only see a partial completion list even though `#calc.` outside math mode surfaces the expected helpers. Issue `#2401` reports this inconsistency and shows it interfering with common math authoring flows that rely on `calc` functions inside equations.
+
+## What Changes
+
+- Preserve exported pure function members when completing module-valued field access inside math mode, including builtins such as `calc`.
+- Keep the current math-mode behavior for non-module field access targets and postfix completions, such as symbol variants and postfix helpers on `arrow.`.
+- Add regression coverage for math-mode module completion, including both full-member and prefix-filtered `calc.` cases, while keeping existing non-module math dot-access fixtures green.
+
+## Capabilities
+
+### New Capabilities
+- `math-module-field-completion`: Surface module exports, including pure functions, when completing `module.member` expressions in math mode.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- `crates/tinymist-query/src/analysis/completion/field_access.rs`
+- Completion fixtures and snapshots under `crates/tinymist-query/src/fixtures/completion/`

--- a/openspec/changes/fix-math-module-field-completion/specs/math-module-field-completion/spec.md
+++ b/openspec/changes/fix-math-module-field-completion/specs/math-module-field-completion/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Math-mode module field access includes exported functions
+Tinymist SHALL include exported pure functions when completing a module-valued field access expression inside math mode.
+
+#### Scenario: Builtin module functions appear for `calc.`
+- **WHEN** a user requests completion on a math-mode expression like `$ calc. $`
+- **THEN** the completion list includes exported function members from the `calc` module such as `odd`
+
+#### Scenario: Prefix filtering retains matching function exports
+- **WHEN** a user requests completion on a math-mode expression like `$ calc.o $`
+- **THEN** the completion list includes matching exported function members such as `odd` instead of dropping them because the cursor is in math mode
+
+### Requirement: Math-mode module completion preserves existing non-module behavior
+Tinymist SHALL preserve current math-mode dot-access behavior for non-module values while adding module function exports.
+
+#### Scenario: Symbol field access remains available
+- **WHEN** a user requests completion on a symbol-valued math expression like `$ arrow. $`
+- **THEN** tinymist continues to offer the existing symbol field members such as `b`
+
+#### Scenario: Math postfix completions remain available
+- **WHEN** a user requests completion on a math expression where postfix completions are currently supported, such as `$ arrow. $`
+- **THEN** tinymist continues to offer the existing postfix completions such as `abs`

--- a/openspec/changes/fix-math-module-field-completion/tasks.md
+++ b/openspec/changes/fix-math-module-field-completion/tasks.md
@@ -1,0 +1,14 @@
+## 1. Relax math-mode module export filtering
+
+- [ ] 1.1 Update math-mode field access completion so module-valued targets do not drop exported pure functions from the dot-access completion path.
+- [ ] 1.2 Keep the current math-mode filtering and postfix behavior for non-module targets such as symbols, content values, and other postfix-capable expressions.
+
+## 2. Add regression coverage
+
+- [ ] 2.1 Add a completion fixture for `$ calc./* range 0..1 */ $` that snapshots exported function members such as `odd`.
+- [ ] 2.2 Add a prefix-filtered math completion fixture for `$ calc.o/* range 0..1 */ $` that verifies matching module functions remain available in math mode.
+- [ ] 2.3 Re-run existing non-module math field and postfix fixtures, such as `field_math_dot.typ` and `field_math_postfix.typ`, to confirm they keep their current behavior.
+
+## 3. Validate the change
+
+- [ ] 3.1 Run focused `tinymist-query` completion snapshot tests covering the new math-module fixtures and review the resulting snapshots.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for issue #2401 under `fix-math-module-field-completion`
- capture requirements for `calc.` completion in math mode while preserving existing non-module math dot/postfix behavior
- add implementation and regression-test tasks for the completion fix

## Validation
- `openspec validate fix-math-module-field-completion --type change --strict --no-interactive`

## Related
- Refs #2401