### PR TITLE
dev: propose fix for field-access import items (#2410)

### DIFF
--- a/openspec/changes/fix-field-access-import-items/.openspec.yaml
+++ b/openspec/changes/fix-field-access-import-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/fix-field-access-import-items/proposal.md
+++ b/openspec/changes/fix-field-access-import-items/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Import statements such as `#import theoretic.presets.corners: theorem, lemma` are valid Typst and eventually work once tinymist falls back to dynamic import analysis, but tinymist's static import analysis currently treats the field-access source as unsupported for non-wildcard item imports. That gap produces the warning reported in issue `#2410`, leaves editor-side import scope analysis incomplete, and can force the slower full-compilation fallback called out in the issue comments.
+
+## What Changes
+
+- Resolve module-valued field-access import sources during static analysis for item imports such as `#import foo.bar: baz`.
+- Populate imported bindings from those sources through the same import declaration path used for string and alias-based module imports.
+- Keep unsupported non-module source expressions failing closed instead of manufacturing bindings from unresolved expressions.
+- Add regression coverage for direct item imports from field-access sources, nested import item paths, and existing wildcard field-access imports.
+
+## Capabilities
+
+### New Capabilities
+- `field-access-import-items`: Treat module-valued field-access expressions as valid static sources for non-wildcard import item lists.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- `crates/tinymist-query/src/syntax/expr.rs`
+- `crates/tinymist-query/src/analysis/global.rs` and related import-resolution helpers
+- Import-related fixtures under `crates/tinymist-query/src/fixtures/`

--- a/openspec/changes/fix-field-access-import-items/specs/field-access-import-items/spec.md
+++ b/openspec/changes/fix-field-access-import-items/specs/field-access-import-items/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Static import analysis resolves module-valued field-access sources
+Tinymist SHALL treat a field-access expression that resolves to a module as a valid source for a non-wildcard `#import ...: item` statement during static analysis.
+
+#### Scenario: Simple item list from a field-access source is bound
+- **WHEN** a user writes `#import theoretic.presets.corners: theorem, lemma` and `theoretic.presets.corners` resolves to a module
+- **THEN** tinymist statically binds `theorem` and `lemma` to the corresponding exports from that module for editor-side semantic features
+
+#### Scenario: Nested import item path is resolved from the selected module
+- **WHEN** a user writes an import item path such as `#import pkg.section: nested.value` and `pkg.section` resolves to a module
+- **THEN** tinymist resolves the item path against that module's export scope and binds the imported name to the targeted export
+
+#### Scenario: Unsupported non-module source stays unresolved
+- **WHEN** a non-wildcard import item list uses a field-access source that does not resolve to a module
+- **THEN** tinymist MUST NOT create imported bindings for the requested items
+
+### Requirement: Supported field-access item imports do not degrade to empty static scope
+Tinymist SHALL provide static import scope for supported module-valued field-access item imports instead of degrading them to an empty import scope that requires dynamic import analysis to recover editor behavior.
+
+#### Scenario: Supported item import produces static scope immediately
+- **WHEN** tinymist analyzes a supported import like `#import theoretic.presets.corners: theorem`
+- **THEN** the imported item scope is available through static analysis for subsequent editor features in the file
+
+#### Scenario: Existing wildcard field-access import behavior is preserved
+- **WHEN** a user writes `#import lib.draw: *`
+- **THEN** tinymist continues to resolve the wildcard import as before while adding support for non-wildcard item imports from module-valued field-access sources

--- a/openspec/changes/fix-field-access-import-items/tasks.md
+++ b/openspec/changes/fix-field-access-import-items/tasks.md
@@ -1,0 +1,15 @@
+## 1. Resolve module-valued field-access sources for item imports
+
+- [ ] 1.1 Extend the non-wildcard import source resolution path so `check_import` recognizes field-access expressions that resolve to modules.
+- [ ] 1.2 Feed the resolved module scope into `import_decls` for item imports such as `#import foo.bar: baz` while keeping unsupported non-module expressions failing closed.
+- [ ] 1.3 Verify existing wildcard field-access imports continue to work through their current resolution path.
+
+## 2. Add regression coverage
+
+- [ ] 2.1 Add an `expr_of` or equivalent scope fixture covering `#import module.field: item1, item2` so the imported bindings appear in static analysis output.
+- [ ] 2.2 Add an editor-facing regression fixture, such as hover or goto-definition, showing a name imported from a field-access source resolves to the exported definition.
+- [ ] 2.3 Add regression coverage for a nested import item path from a field-access source plus a negative case where the source does not resolve to a module.
+
+## 3. Validate the change
+
+- [ ] 3.1 Run focused `tinymist-query` import-analysis and editor-feature tests that exercise the new field-access item import coverage and review the resulting snapshots.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for issue #2410
- describe the static-analysis gap for non-wildcard imports sourced from module-valued field access
- capture spec scenarios and implementation tasks for the eventual fix

## Validation
- openspec validate fix-field-access-import-items