### PR TITLE
dev: propose fix for output path pattern regressions (#2400)

### DIFF
--- a/openspec/changes/fix-output-path-pattern-regressions/.openspec.yaml
+++ b/openspec/changes/fix-output-path-pattern-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-28

--- a/openspec/changes/fix-output-path-pattern-regressions/README.md
+++ b/openspec/changes/fix-output-path-pattern-regressions/README.md
@@ -1,0 +1,3 @@
+# fix-output-path-pattern-regressions
+
+Fix issue `#2400`: preserve multi-dot filenames in output paths and keep explicit `$dir/$name` rooted like the default behavior.

--- a/openspec/changes/fix-output-path-pattern-regressions/proposal.md
+++ b/openspec/changes/fix-output-path-pattern-regressions/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Issue `#2400` reports that `tinymist.outputPath` behaves inconsistently in two common cases:
+
+- When `$name` expands to a filename stem that already contains dots, the final export path is built with `PathBuf::with_extension`, which truncates everything after the last dot of the substituted stem. That turns filenames like `Chapter 1.1.typ` into `Chapter 1.pdf` instead of `Chapter 1.1.pdf`.
+- When a file lives at the workspace root, substituting `$dir/$name` can leave a leading slash from the empty `$dir`, turning an intended workspace-relative path into an absolute filesystem-root path such as `/Chapter 1.pdf`.
+
+Those regressions make `tinymist.outputPath` unreliable for chapter-style filenames and break the documented expectation that leaving `outputPath` empty behaves like using `$dir/$name`.
+
+## What Changes
+
+- Preserve the full Typst source stem when applying the artifact extension to paths derived from `$name`.
+- Treat an empty `$dir` substitution as the workspace-relative current directory instead of a literal root slash.
+- Align explicit `"$dir/$name"` resolution with the existing empty `outputPath` default so both configurations export to the same artifact location.
+- Add regression coverage for multi-dot filenames, repeated-dot stems, and workspace-root files.
+- Review the `tinymist.outputPath` documentation source so its examples and default-behavior wording match the fixed implementation.
+
+## Capabilities
+
+### New Capabilities
+
+- `output-path-patterns`: Resolve `tinymist.outputPath` patterns without truncating multi-dot stems or escaping the workspace root when `$dir` is empty.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `crates/tinymist-task/src/primitives.rs`
+- `crates/tinymist/src/task/export.rs`
+- Output-path related tests in `crates/tinymist-task` and `crates/tinymist`
+- `docs/tinymist/feature/preview.typ` or other non-generated documentation sources if wording changes are needed

--- a/openspec/changes/fix-output-path-pattern-regressions/specs/output-path-patterns/spec.md
+++ b/openspec/changes/fix-output-path-pattern-regressions/specs/output-path-patterns/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: `$name` preserves the full source stem in export paths
+Tinymist SHALL preserve every non-extension character from the source filename when resolving `$name` inside `tinymist.outputPath`, even when the Typst filename stem contains one or more dots.
+
+#### Scenario: Multi-dot source names survive PDF extension application
+- **GIVEN** a source file named `Chapter 1.1.1.typ`
+- **WHEN** `tinymist.outputPath` is `$root/$dir/$name` and Tinymist exports a PDF
+- **THEN** the resolved artifact path ends with `Chapter 1.1.1.pdf`
+- **AND** Tinymist MUST NOT truncate the name to `Chapter 1.1.pdf`
+
+#### Scenario: Repeated dots in the source stem are preserved
+- **GIVEN** a source file named `test....typ`
+- **WHEN** `tinymist.outputPath` is `$root/$dir/$name` and Tinymist exports a PDF
+- **THEN** the resolved artifact path ends with `test....pdf`
+
+### Requirement: Empty `$dir` stays workspace-relative
+Tinymist SHALL treat an empty `$dir` substitution as the current workspace-relative directory, not as a filesystem-root prefix.
+
+#### Scenario: Workspace-root file with explicit `$dir/$name` exports beside the source
+- **GIVEN** a Typst file named `Chapter 1.1.typ` at the workspace root
+- **WHEN** `tinymist.outputPath` is `$dir/$name`
+- **THEN** Tinymist resolves the export path to `Chapter 1.1.pdf` beside the source file inside the workspace root
+- **AND** Tinymist MUST NOT attempt to write `/Chapter 1.pdf`
+
+#### Scenario: Nested file keeps its containing directory
+- **GIVEN** a Typst file at `chapters/Chapter 1.1.typ`
+- **WHEN** `tinymist.outputPath` is `$dir/$name`
+- **THEN** Tinymist resolves the export path to `chapters/Chapter 1.1.pdf` inside the workspace root
+
+### Requirement: Explicit `$dir/$name` matches the default output location
+Tinymist SHALL resolve an explicit `tinymist.outputPath = "$dir/$name"` to the same artifact location as leaving `tinymist.outputPath` empty.
+
+#### Scenario: Explicit and default output paths agree for workspace-root files
+- **WHEN** the same workspace-root Typst file is exported once with `tinymist.outputPath` unset and once with `tinymist.outputPath` set to `$dir/$name`
+- **THEN** both exports target the same artifact path
+
+#### Scenario: Explicit and default output paths agree for nested files
+- **WHEN** the same nested Typst file is exported once with `tinymist.outputPath` unset and once with `tinymist.outputPath` set to `$dir/$name`
+- **THEN** both exports target the same artifact path

--- a/openspec/changes/fix-output-path-pattern-regressions/tasks.md
+++ b/openspec/changes/fix-output-path-pattern-regressions/tasks.md
@@ -1,0 +1,16 @@
+## 1. Fix output-path resolution semantics
+
+- [ ] 1.1 Update `tinymist.outputPath` substitution so an empty `$dir` does not inject a filesystem-root separator for workspace-root files.
+- [ ] 1.2 Change export-path extension handling so paths derived from `$name` preserve every stem segment before the trailing `.typ`.
+- [ ] 1.3 Ensure leaving `tinymist.outputPath` empty and explicitly setting it to `$dir/$name` resolve to the same artifact target.
+
+## 2. Add regression coverage
+
+- [ ] 2.1 Extend `PathPattern`-level tests for workspace-root files, nested files, and multi-dot source names.
+- [ ] 2.2 Add export-path tests covering PDF output for `Chapter 1.1.typ`, `Chapter 1.1.1.typ`, and `test....typ` with `$root/$dir/$name`.
+- [ ] 2.3 Add a regression test showing that explicit `$dir/$name` at the workspace root exports beside the source file instead of attempting to write to `/`.
+
+## 3. Validate user-facing behavior
+
+- [ ] 3.1 Review and update the `tinymist.outputPath` documentation source if its wording still diverges from the fixed behavior.
+- [ ] 3.2 Run focused tests for output-path substitution and export-path preparation.


### PR DESCRIPTION
## Summary
- add an OpenSpec proposal for #2400
- capture requirements for preserving multi-dot filenames in output paths
- capture requirements for keeping explicit $dir/$name aligned with the default output location

## Validation
- openspec validate fix-output-path-pattern-regressions