### PR TITLE
dev: propose vscode internal config refresh (#2378)

### DIFF
--- a/openspec/changes/fix-vscode-internal-config-refresh/.openspec.yaml
+++ b/openspec/changes/fix-vscode-internal-config-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/fix-vscode-internal-config-refresh/design.md
+++ b/openspec/changes/fix-vscode-internal-config-refresh/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Tinymist's VS Code extension currently builds the language-server configuration in two layers. `loadTinymistConfig` reads and normalizes user-facing settings from VS Code, including variable substitution and `tinymist.fontPaths` validation. After that, `configureEditorAndLanguage` mutates the startup config object to inject extension-managed fields such as the completion trigger flags, `supportHtmlInMarkdown`, `supportClientCodelens`, `supportExtendedCodeAction`, `customizedShowDocument`, and `delegateFsRequests`.
+
+That split works at startup, but later configuration refreshes are sourced from VS Code again and do not automatically include the extension-managed fields because they are not normal user settings. On the Rust side, config updates treat absent keys as reset-to-default values, so a runtime settings change can silently drop the client/server capability contract that the session started with. Issue `#2378` calls out `delegate_fs_requests` and `supportHtmlInMarkdown`, but the same problem applies to the other extension-managed flags set only during startup.
+
+This change spans the VS Code config-loading layer and the LSP synchronization path, so it benefits from a small design pass before implementation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep extension-managed internal configuration values stable across startup and later workspace-configuration refreshes.
+- Reuse a single source of truth for the extension-managed fields so new internal flags do not drift across code paths.
+- Preserve the current normalization of user-facing settings, including variable substitution and malformed `tinymist.fontPaths` handling.
+- Add focused regression tests around the shared config-shaping path.
+
+**Non-Goals:**
+- Changing the current values of the internal flags, including the existing `delegateFsRequests = false` behavior.
+- Exposing the extension-managed fields as user-editable settings in VS Code.
+- Changing Rust-side config defaults or deserialization behavior in this change.
+
+## Decisions
+
+### 1. Centralize extension-managed config augmentation in a shared helper
+
+The canonical list of extension-managed fields should live in one shared VS Code-side helper instead of being hard-coded only in `configureEditorAndLanguage`. That helper should take a normalized Tinymist config object and apply the internal capability flags in one place.
+
+Alternative considered:
+- Keep mutating the config inline where it is first used. Rejected because it already caused drift between startup and later refresh paths, and future flags would be easy to miss again.
+
+### 2. Reuse the same augmented config shape for every payload delivered to the server
+
+The startup `initializationOptions` path and every later configuration synchronization path should reuse the same helper so the server sees the same extension-managed fields throughout the session. That includes the current `workspace/configuration` response path and any direct configuration-change payload path that supplies settings to the server.
+
+Alternative considered:
+- Patch only the startup path. Rejected because it preserves the current bug on later refreshes.
+- Patch only one runtime path, such as `workspace/configuration`. Rejected because the extension should not depend on a single client-library delivery path staying unchanged.
+
+### 3. Keep user-setting normalization separate from internal augmentation
+
+User-facing settings should continue to flow through the existing normalization logic before the extension-managed fields are attached. This keeps `fontPaths` validation and VS Code variable substitution unchanged while making the internal booleans and capability flags deterministic.
+
+Alternative considered:
+- Fold the internal fields directly into the raw settings object before normalization. Rejected because it mixes two different responsibilities and makes the user-setting transformation logic harder to reason about.
+
+### 4. Test the shared config-shaping boundary directly
+
+The most durable regression coverage is to test the shared helper and at least one refresh-shaped config path that feeds the server after a settings change. This keeps the test surface small while still proving that runtime updates preserve the internal fields and existing user-setting processing.
+
+Alternative considered:
+- Rely only on manual verification or broad end-to-end extension tests. Rejected because the bug is narrowly about config payload shaping and is better caught with focused tests.
+
+## Risks / Trade-offs
+
+- [The VS Code client may deliver refreshed settings through more than one path] -> Mitigate by centralizing augmentation in a reusable helper and auditing every config payload path that reaches the language server.
+- [Future internal flags could be added without coverage] -> Mitigate by keeping the full internal field list in one helper and asserting representative fields in tests.
+- [Focused tests may not cover every editor-runtime edge case] -> Mitigate by testing both the shared helper and a refresh-oriented path instead of only unit-testing the raw normalization helpers.
+
+## Migration Plan
+
+1. Introduce a shared helper that augments a normalized Tinymist config object with the extension-managed internal fields.
+2. Use that helper for startup config creation and later configuration synchronization.
+3. Add focused VS Code tests that cover startup-shaped and refresh-shaped payloads.
+4. Rollback, if needed, is a straightforward revert of the shared-helper usage because this change does not introduce new persisted data.
+
+## Open Questions
+
+- The implementation should confirm which VS Code language-client path currently carries the effective runtime settings object in this repository, but the shared-helper design intentionally supports either `workspace/configuration` responses or direct configuration-change payloads.

--- a/openspec/changes/fix-vscode-internal-config-refresh/proposal.md
+++ b/openspec/changes/fix-vscode-internal-config-refresh/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Tinymist's VS Code extension injects several extension-managed configuration fields at startup, including completion trigger flags and internal capability toggles such as `supportHtmlInMarkdown`, `supportClientCodelens`, `supportExtendedCodeAction`, `customizedShowDocument`, and `delegateFsRequests`. Later workspace configuration refreshes only reflect user-facing VS Code settings, so those internal fields can disappear or reset after a configuration change, matching the bug described in issue `#2378`.
+
+This makes runtime behavior depend on whether the language server has been restarted recently instead of keeping a stable client/server contract for the lifetime of the session.
+
+## What Changes
+
+- Preserve extension-managed internal Tinymist configuration values across runtime configuration refreshes, not only during initial startup.
+- Route startup configuration and later configuration synchronization through the same augmentation path so the language server sees a consistent set of internal capability flags.
+- Keep existing user-setting processing, including VS Code variable substitution and invalid `tinymist.fontPaths` handling, while adding the missing internal fields to refresh payloads.
+- Add VS Code-side regression coverage for configuration refreshes so missing internal fields are caught before release.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `vscode-config-loading`: runtime workspace-configuration refreshes preserve extension-managed internal settings alongside user-configured values.
+
+## Impact
+
+- `editors/vscode/src/config.ts`
+- `editors/vscode/src/extension.shared.ts`
+- `editors/vscode/src/lsp.ts`
+- VS Code extension tests covering configuration loading and refresh behavior

--- a/openspec/changes/fix-vscode-internal-config-refresh/specs/vscode-config-loading/spec.md
+++ b/openspec/changes/fix-vscode-internal-config-refresh/specs/vscode-config-loading/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Runtime configuration refresh preserves extension-managed internal settings
+The Tinymist VS Code extension SHALL attach its extension-managed internal settings to every configuration payload delivered to the language server after startup. This SHALL preserve the same internal capability contract used during initialization, including the completion trigger flags, `supportHtmlInMarkdown`, `supportClientCodelens`, `supportExtendedCodeAction`, `customizedShowDocument`, and the current `delegateFsRequests` value.
+
+#### Scenario: Refresh payload keeps extension-managed capability flags
+- **WHEN** Tinymist synchronizes workspace configuration to the language server after a VS Code settings change during an active session
+- **THEN** the payload still includes the extension-managed internal settings that were attached during startup
+- **AND** the server does not lose those internal capability flags only because the configuration was refreshed
+
+#### Scenario: Unrelated user setting change does not clear internal settings
+- **WHEN** a user changes a normal Tinymist workspace setting such as `tinymist.preview` or `tinymist.fontPaths`
+- **THEN** Tinymist forwards the updated user setting to the language server
+- **AND** the same refresh keeps the extension-managed internal settings intact
+
+#### Scenario: Runtime refresh preserves existing user-setting normalization
+- **WHEN** a runtime configuration refresh includes a valid `tinymist.fontPaths` array with VS Code variables such as `${workspaceFolder}/fonts`
+- **THEN** Tinymist still expands the variables before forwarding the effective `fontPaths` value
+- **AND** the refresh also includes the extension-managed internal settings required by the session

--- a/openspec/changes/fix-vscode-internal-config-refresh/tasks.md
+++ b/openspec/changes/fix-vscode-internal-config-refresh/tasks.md
@@ -1,0 +1,17 @@
+## 1. Centralize extension-managed config shaping
+
+- [ ] 1.1 Move the extension-managed Tinymist config fields currently assigned only during startup into a shared helper or equivalent single source of truth.
+- [ ] 1.2 Keep that shared path responsible for the current internal fields, including the completion trigger flags, markdown/code-lens/code-action/show-document capability flags, and `delegateFsRequests`.
+- [ ] 1.3 Preserve existing VS Code variable substitution and malformed `tinymist.fontPaths` handling while applying the internal fields.
+
+## 2. Reuse the shared config shape for runtime synchronization
+
+- [ ] 2.1 Use the shared augmented config shape for the startup `initializationOptions` payload.
+- [ ] 2.2 Use the same augmented config shape for later configuration synchronization from VS Code to the language server, including the current refresh path used after settings changes.
+- [ ] 2.3 Verify that changing an unrelated user setting no longer causes the server to lose extension-managed internal settings during the same session.
+
+## 3. Add regression coverage
+
+- [ ] 3.1 Extend the VS Code config tests to assert the shared config-shaping path injects the internal settings while preserving `fontPaths` substitution and validation behavior.
+- [ ] 3.2 Add a refresh-oriented regression test that exercises the post-startup configuration payload delivered to the server and confirms the internal settings remain present.
+- [ ] 3.3 Run focused VS Code extension tests for the configuration-loading area.


### PR DESCRIPTION
## Summary
- add the OpenSpec change `fix-vscode-internal-config-refresh` for issue #2378
- capture the runtime config-refresh bug where extension-managed internal VS Code settings can disappear after later configuration updates
- include proposal, design, spec delta, and tasks only; implementation will follow in a later change set

## Testing
- openspec status --change "fix-vscode-internal-config-refresh"

## Notes
- this PR intentionally does not include implementation
- refs #2378