### PR TITLE
dev: propose mock VFS/world tests and rename cache invalidation (#2359)

### DIFF
--- a/openspec/changes/add-mock-vfs-world-test-harness/.openspec.yaml
+++ b/openspec/changes/add-mock-vfs-world-test-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/add-mock-vfs-world-test-harness/design.md
+++ b/openspec/changes/add-mock-vfs-world-test-harness/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Tinymist already has several pieces that make mocked runtime testing possible in principle:
+
+- `tinymist-vfs` exposes `DummyAccessModel`, `FilesystemEvent`, and direct VFS invalidation primitives.
+- `CompilerUniverse::new_raw` can construct worlds from caller-provided VFS, registry, fonts, and entry state.
+- `tinymist-project` already records dependency paths and routes filesystem changes through compiler/runtime layers.
+
+What is missing is a reusable way to combine those pieces into deterministic tests. Current coverage mostly falls into two categories: narrow smoke tests inside individual crates and higher-level end-to-end tests under `tests/`. That leaves a gap for bugs like `#2359`, where we want to model a sequence of file mutations and assert cache, dependency, or recompilation behavior without relying on the real filesystem or editor integration.
+
+Because the desired tests span `tinymist-vfs`, `tinymist-world`, and `tinymist-project`, the test infrastructure itself needs to be reusable across crate boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a reusable mock-backed Rust test harness for VFS/world/project runtime behavior.
+- Let tests create deterministic workspaces from in-memory file state and mutate that state with file operations such as create, update, rename, and remove.
+- Avoid real filesystem, package-network, and system-font dependencies where the tested behavior does not require them.
+- Seed the harness with at least one runtime regression path that demonstrates the file-manipulation flows needed by `#2359`.
+
+**Non-Goals:**
+- Replacing existing e2e/editor integration tests.
+- Simulating OS file watcher quirks in full fidelity.
+- Solving the `#2359` cache bug in this change; this change prepares the harness that the fix can rely on.
+- General-purpose mocking of unrelated systems such as preview HTTP transport or editor configuration.
+
+## Decisions
+
+### 1. Put reusable test support in a shared workspace crate or equivalent shared support module
+
+The harness should live in shared Rust test support that multiple crates can depend on, rather than being hidden behind `#[cfg(test)]` inside one crate. This avoids dependency inversion problems and lets VFS, world, project, and later server-side tests all reuse the same workspace builder and mutation helpers.
+
+Alternative considered:
+- Add ad hoc helpers separately inside `tinymist-vfs`, `tinymist-world`, and `tinymist-project`. Rejected because the bug class we care about crosses those boundaries and duplicated helpers would drift quickly.
+- Place everything under the existing `tests/` e2e crate. Rejected because lower-level crate tests should be able to use the harness directly without going through e2e-only structure.
+
+### 2. Model the filesystem as an in-memory workspace with explicit mutations
+
+The harness should keep an in-memory map of workspace paths to file snapshots and expose mutation helpers such as `write`, `remove`, and `rename`. Those helpers should be able to return or apply the corresponding `FileChangeSet`/`FilesystemEvent` shape so tests can drive the same invalidation path the runtime uses.
+
+Alternative considered:
+- Use temp directories and real filesystem mutations for all tests. Rejected because those tests are slower, harder to make deterministic, and less suitable for precisely driving intermediate runtime states.
+
+### 3. Build test worlds from deterministic runtime components
+
+World/universe construction in the harness should use embedded or in-memory fonts plus dummy package behavior so tests do not rely on host-specific system state. The harness should wrap the mock workspace in a path access model that feeds `Vfs`/`CompilerUniverse::new_raw` consistently across tests.
+
+Alternative considered:
+- Reuse the full system-world builder and let tests touch the host filesystem. Rejected because it would make regression coverage for file invalidation sensitive to machine setup and package/network state.
+
+### 4. Start with runtime regression coverage close to the consuming crates
+
+The harness should be introduced together with a small set of focused tests that prove it can express file-manipulation sequences. Those tests should live near the runtime crates that consume the harness, with `#2359`-style rename/remove coverage as the first motivating case.
+
+Alternative considered:
+- Land the harness with no real consumer tests yet. Rejected because it would leave the design unproven and make later bug-fix work rediscover missing affordances.
+
+## Risks / Trade-offs
+
+- [A shared support crate adds workspace surface area] -> Mitigate by keeping the public API narrow and clearly test-focused.
+- [Mocked runtime tests may diverge from production watcher behavior] -> Mitigate by driving the same `FileChangeSet` and runtime invalidation entry points used in production, while keeping e2e tests for integration coverage.
+- [Deterministic fonts/package setup may still be more than some tests need] -> Mitigate by exposing small builders so tests can choose VFS-only, world-level, or project-level setup as needed.
+
+## Migration Plan
+
+1. Add the shared mock runtime test support and wire it into workspace dev-dependencies.
+2. Add initial VFS/world/project tests that use the harness for file-manipulation flows.
+3. Use the new harness in the follow-up `fix-source-rename-cache-invalidation` implementation work.
+4. Rollback, if needed, is a straightforward revert because the change only affects test infrastructure.
+
+## Open Questions
+
+- Whether the shared support should be a dedicated `crates/` member or a lighter-weight shared module arrangement, as long as multiple crate tests can depend on it without duplicating code.

--- a/openspec/changes/add-mock-vfs-world-test-harness/proposal.md
+++ b/openspec/changes/add-mock-vfs-world-test-harness/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Tinymist's runtime bugs around VFS invalidation, world snapshots, and file manipulation are hard to test precisely today. We have smoke tests and end-to-end coverage, but not a reusable mock-backed harness for exercising rename, remove, and follow-up file updates entirely inside Rust.
+
+That gap makes issues like `#2359` slower and riskier to fix because the first step is often inventing test scaffolding instead of expressing the bug directly. A shared harness would let us write deterministic regression tests for VFS/world behavior before landing cache and invalidation fixes.
+
+## What Changes
+
+- Introduce a reusable mock-based Rust test harness for Tinymist VFS, world, and project-runtime tests.
+- Provide helpers to build deterministic worlds or universes from an in-memory workspace, using embedded fonts and dummy package behavior instead of real filesystem or network setup.
+- Provide file-manipulation helpers for create, update, rename, remove, and corresponding filesystem-style notifications so tests can model runtime invalidation flows.
+- Seed the harness with initial regression-oriented coverage for file-manipulation behavior, including the scenario needed to unblock the `#2359` cache-invalidation fix.
+
+## Capabilities
+
+### New Capabilities
+- `mock-vfs-world-testing`: reusable mock-backed test support for exercising VFS, world, and file-manipulation behavior in Rust tests.
+
+### Modified Capabilities
+
+## Impact
+
+- A shared Rust test-support module or crate under `crates/` that can be reused across VFS, world, project, and server-side tests
+- `crates/tinymist-vfs/`
+- `crates/tinymist-world/`
+- `crates/tinymist-project/`
+- Workspace Cargo manifests and dev-dependencies for the shared harness
+- Initial regression tests covering mocked file-manipulation flows

--- a/openspec/changes/add-mock-vfs-world-test-harness/specs/mock-vfs-world-testing/spec.md
+++ b/openspec/changes/add-mock-vfs-world-test-harness/specs/mock-vfs-world-testing/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Mock workspace tests can create deterministic compiler runtimes
+Tinymist SHALL provide shared Rust test support that lets tests create VFS- and world-backed compiler runtimes from an in-memory workspace without depending on the host filesystem, package registry, or system-font discovery.
+
+#### Scenario: Build a world from in-memory files
+- **WHEN** a Rust test defines a workspace root, an entry file, and one or more Typst source files entirely in memory
+- **THEN** the shared test support can construct a Tinymist runtime that reads those files through the normal VFS/world path
+- **AND** the test does not need to write the workspace to disk or contact external package services to exercise that runtime
+
+### Requirement: Mock workspace tests can model file manipulation flows
+Tinymist SHALL provide shared Rust test support that lets tests apply file-manipulation operations to the in-memory workspace and drive the corresponding runtime-facing change flow for create, update, rename, and remove sequences.
+
+#### Scenario: Rename a file inside the mock workspace
+- **WHEN** a Rust test renames an in-memory workspace file such as `content.typ` to `new_name.typ`
+- **THEN** the shared test support can deliver the resulting path change to the runtime in the same change shape that Tinymist uses for filesystem-driven invalidation
+- **AND** the test can observe the runtime state after the rename without recreating the entire workspace by hand
+
+#### Scenario: Follow-up mutation after file removal or rename
+- **WHEN** a Rust test removes or renames a file and then applies a later update to a remaining file
+- **THEN** the shared test support can drive that sequence through the runtime without falling back to ad hoc per-test mocking
+- **AND** the test can assert compilation, dependency, or cache-related outcomes from the full mutation sequence

--- a/openspec/changes/add-mock-vfs-world-test-harness/tasks.md
+++ b/openspec/changes/add-mock-vfs-world-test-harness/tasks.md
@@ -1,0 +1,17 @@
+## 1. Establish shared mock runtime support
+
+- [ ] 1.1 Add shared test-support plumbing that can be reused from multiple workspace crates.
+- [ ] 1.2 Implement an in-memory workspace model plus mock path access for Typst source files.
+- [ ] 1.3 Add deterministic world/universe builders that use embedded or in-memory fonts and dummy package behavior.
+
+## 2. Drive file-manipulation flows through the runtime
+
+- [ ] 2.1 Add helpers for create, update, rename, and remove operations on the mock workspace.
+- [ ] 2.2 Add helpers that expose or apply the corresponding `FileChangeSet` or `FilesystemEvent` flow to VFS/world/project tests.
+- [ ] 2.3 Document the intended test layers so callers can choose VFS-only, world-level, or project-level coverage without reimplementing setup.
+
+## 3. Seed initial regression coverage
+
+- [ ] 3.1 Add focused tests that prove the harness can build a runtime from in-memory files and exercise follow-up mutations.
+- [ ] 3.2 Add an initial rename/remove regression-shaped test that can serve as the precursor for the `fix-source-rename-cache-invalidation` work.
+- [ ] 3.3 Run focused Rust tests for the touched crates and review the results.

--- a/openspec/changes/fix-source-rename-cache-invalidation/.openspec.yaml
+++ b/openspec/changes/fix-source-rename-cache-invalidation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/fix-source-rename-cache-invalidation/design.md
+++ b/openspec/changes/fix-source-rename-cache-invalidation/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Issue `#2359` reports that renaming a depended Typst source file can leave Tinymist compiling and previewing the old path's cached contents. The logs show a rename from `content.typ` to `new_name.typ`, followed by successful recompiles that still behave as if `content.typ` were present, and later filesystem events being treated as harmless.
+
+The current flow spans several layers:
+
+- `crates/tinymist-query/src/will_rename_files.rs` computes workspace edits for rename-aware clients, but that only affects import text and does not define runtime cache invalidation.
+- `crates/tinymist-project/src/compiler.rs` applies filesystem and memory updates into the VFS and records dependency paths for watched projects.
+- `crates/tinymist/src/project.rs` decides whether a VFS-only change can skip recompilation by calling `is_clean_compile` against the last compilation's dependent file IDs.
+- `crates/tinymist-vfs/src/lib.rs` invalidates cached bytes and parsed source entries when a known path or file ID changes.
+
+That arrangement makes rename/removal bugs subtle: a path can retire even when the next successful path identity is not the same file ID, and the current harmless-VFS optimization reasons primarily over previously compiled file IDs instead of the concrete dependency paths the project last used.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure a rename or removal of a depended Typst source path cannot leave stale source contents active for later compilation or preview.
+- Make the harmless-VFS optimization treat retired dependency paths as recompilation-worthy changes.
+- Reuse existing dependency-path tracking where possible instead of inventing a second rename-specific pipeline.
+- Add regression coverage that reproduces the rename sequence from `#2359`, including follow-up edits after the rename.
+
+**Non-Goals:**
+- Fixing import-path rewrite behavior for `workspace/willRenameFiles`; that is the separate bug tracked by `#2358`.
+- Redesigning the entire VFS cache architecture or file-watching subsystem.
+- Changing unrelated preview refresh policy beyond what is needed to stop serving stale renamed-path content.
+
+## Decisions
+
+### 1. Treat retired dependency paths as a first-class invalidation signal
+
+The fix should classify a filesystem rename or removal of a path used by the last successful compilation as a dependency-affecting change, even before considering whether surviving file IDs still look clean. The project compiler already records dependency filesystem paths (`proj.deps`) after each successful compile, so the runtime can use those paths directly when deciding whether a VFS-only change is harmless.
+
+Alternative considered:
+- Continue basing the skip decision only on `CompiledArtifact::depended_files()`. Rejected because file IDs describe surviving semantic identities, while `#2359` is specifically about a previously used path disappearing or moving away.
+
+### 2. Invalidate stale source state at the VFS/cache boundary for renamed or removed paths
+
+Once a depended path is retired, Tinymist should explicitly invalidate the old path's cached bytes and parsed source state before later compilation or preview refreshes can reuse it. The existing `invalidate_path` and `invalidate_file_id` flow in `tinymist-vfs` is the right boundary; the implementation should audit that removed or renamed dependency paths always reach that invalidation path before harmless-change filtering can suppress recompilation.
+
+Alternative considered:
+- Patch only higher-level preview or project-entry state. Rejected because the stale content originates from lower-level cached source state and would still be reachable through other compile paths.
+
+### 3. Keep rename handling scoped to observed workspace state, not to client rename support
+
+The correctness guarantee should come from observing filesystem state and dependency retirement, not from assuming the client successfully delivered `workspace/willRenameFiles` edits. If path rewrites succeed, recompilation should follow the renamed file. If they do not, recompilation should surface the missing old path instead of serving cached content from it.
+
+Alternative considered:
+- Depend on `willRenameFiles` to keep caches and entry state correct. Rejected because `#2359` must still behave correctly when rename edits are empty or when a rename happens outside the editor's assisted path.
+
+### 4. Add regression coverage at the project/runtime layer
+
+The regression should exercise the runtime rename sequence: compile a document that depends on `content.typ`, rename or remove that file, then trigger a follow-up edit or refresh and assert that Tinymist no longer serves `content.typ` from cache. A focused project/VFS test is preferred, with an e2e fixture added only if the lower-level test cannot express the bug clearly.
+
+Alternative considered:
+- Rely only on manual validation through preview. Rejected because the failure involves the interaction between VFS invalidation and compile-skip heuristics, which is easy to regress without automated coverage.
+
+## Risks / Trade-offs
+
+- [Path-based invalidation could trigger more recompiles than today] -> Mitigate by only treating paths from the last successful dependency set as non-harmless and leaving unrelated filesystem churn on the existing fast path.
+- [The stale result may involve more than one cache layer] -> Mitigate by auditing both the harmless-VFS decision in `crates/tinymist/src/project.rs` and the concrete invalidation path in `crates/tinymist-vfs/src/lib.rs`.
+- [A narrowly scoped test might miss preview-specific manifestations] -> Mitigate by asserting compile output or diagnostics freshness in the core regression test and, if needed, adding one preview-facing follow-up check.
+
+## Migration Plan
+
+1. Update the runtime invalidation logic so retired dependency paths force recompilation and retire stale cache state.
+2. Add regression coverage for the rename/removal sequence from `#2359`.
+3. Validate with focused tests in the touched crates.
+4. Rollback, if needed, is a straight revert because the change only affects in-memory invalidation and compile scheduling.
+
+## Open Questions
+
+- Whether the final implementation can satisfy the regression entirely through project/VFS tests or whether one editor-facing/e2e test is needed to capture the exact rename timing seen in VS Code.

--- a/openspec/changes/fix-source-rename-cache-invalidation/proposal.md
+++ b/openspec/changes/fix-source-rename-cache-invalidation/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Tinymist can keep compiling and previewing a removed Typst source after that file has been renamed. Issue `#2359` shows that once `content.typ` becomes `new_name.typ`, dependent files can continue reading cached `content.typ` content instead of reflecting the filesystem's current state.
+
+That leaves the language service out of sync with the workspace, hides real missing-file failures behind stale results, and makes rename-heavy workflows unreliable until the server is restarted.
+
+## What Changes
+
+- Invalidate cached Typst source state when a depended source file is renamed or removed so later compilation observes the filesystem's current state.
+- Ensure rename and removal events for depended sources are not classified as harmless VFS changes when they retire a path used by the last successful compilation.
+- Keep project entry and focused-file state aligned with renamed paths instead of allowing the old path's cached contents to survive as an active source.
+- Add regression coverage for source-file rename flows, including follow-up filesystem or editor updates after the rename.
+
+## Capabilities
+
+### New Capabilities
+- `source-file-rename-invalidation`: dependent Typst compilation and preview stay consistent with filesystem renames and removals of source files.
+
+### Modified Capabilities
+
+## Impact
+
+- `crates/tinymist/src/project.rs`
+- `crates/tinymist-project/src/compiler.rs`
+- `crates/tinymist-vfs/src/lib.rs`
+- `crates/tinymist-world/src/source.rs` and related world/VFS cache plumbing
+- Regression tests covering rename-triggered recompilation and preview freshness

--- a/openspec/changes/fix-source-rename-cache-invalidation/specs/source-file-rename-invalidation/spec.md
+++ b/openspec/changes/fix-source-rename-cache-invalidation/specs/source-file-rename-invalidation/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Retired dependency paths are not reused from cache
+Tinymist SHALL stop using cached source bytes and parsed source state for a Typst source path after that path has been renamed or removed from the workspace and was part of the last successful compilation's dependency set.
+
+#### Scenario: Renamed dependency is not served from stale cache
+- **WHEN** the last successful compilation of `base.typ` depended on `content.typ` and the workspace renames `content.typ` to `new_name.typ`
+- **THEN** a later compilation of `base.typ` MUST NOT read the old cached contents of `content.typ`
+- **AND** the compile result reflects the current workspace state, either by following updated references to `new_name.typ` or by reporting that `content.typ` is no longer available
+
+#### Scenario: Follow-up updates after rename stay fresh
+- **WHEN** a depended source path has been renamed or removed and a user then edits a remaining document such as `base.typ` or the renamed file
+- **THEN** Tinymist recompiles using the current filesystem and in-memory contents
+- **AND** preview and diagnostics MUST NOT continue showing results derived from the retired path's cached contents
+
+### Requirement: Retired dependency paths force recompilation
+Tinymist SHALL treat a rename or removal of a path used by the last successful compilation as a dependency-affecting VFS change rather than a harmless VFS change.
+
+#### Scenario: Removed dependency path forces recompilation
+- **WHEN** filesystem updates report that a path used by the last successful compilation has been removed or renamed away
+- **THEN** Tinymist schedules recompilation for any project that depended on that path
+- **AND** the change is not skipped solely because no open-buffer contents changed

--- a/openspec/changes/fix-source-rename-cache-invalidation/tasks.md
+++ b/openspec/changes/fix-source-rename-cache-invalidation/tasks.md
@@ -1,0 +1,15 @@
+## 1. Retire renamed dependency paths at runtime
+
+- [ ] 1.1 Update the rename/removal invalidation flow so a depended source path clears stale VFS/source-cache state before later compilations can reuse it.
+- [ ] 1.2 Change the harmless-VFS compile skip logic to treat paths from the last successful dependency set as recompilation-worthy when those paths are renamed or removed.
+- [ ] 1.3 Verify project entry/focus handling and downstream compile consumers stop serving the retired path after a rename.
+
+## 2. Add regression coverage
+
+- [ ] 2.1 Add a focused regression test that compiles a document depending on `content.typ`, renames or removes that file, and proves later compilation no longer serves the old path from cache.
+- [ ] 2.2 Add a follow-up update case showing that editing `base.typ` or the renamed file after the rename keeps diagnostics and preview results aligned with current workspace state.
+
+## 3. Validate the fix
+
+- [ ] 3.1 Run focused tests for the touched Rust crates and any new regression fixtures.
+- [ ] 3.2 Review the test outputs to confirm rename/removal of depended source files no longer falls through the harmless-VFS path.


### PR DESCRIPTION
## Summary

- add the `add-mock-vfs-world-test-harness` OpenSpec change for shared mock-backed VFS/world/project runtime testing
- add the `fix-source-rename-cache-invalidation` OpenSpec change for stale source-cache behavior after rename or removal
- keep this PR proposal-only, with no implementation changes yet

## Why

Issue #2359 needs deterministic runtime tests around file rename and removal flows. This PR stages that work in two pieces:

- a reusable mock test-harness proposal that can drive VFS/world/project mutations inside Rust tests
- a follow-up behavior proposal for fixing stale cache invalidation after Typst source renames

That lets us review the testing direction and the behavior change separately from the eventual implementation.

## Validation

- `openspec status --change "add-mock-vfs-world-test-harness"`
- `openspec status --change "fix-source-rename-cache-invalidation"`
