### PR TITLE
dev: propose compiler settings docs

### DIFF
--- a/openspec/changes/add-compiler-settings-docs/.openspec.yaml
+++ b/openspec/changes/add-compiler-settings-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/add-compiler-settings-docs/design.md
+++ b/openspec/changes/add-compiler-settings-docs/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Tinymist already exposes the compiler-setting surface users need, but the explanation is scattered:
+
+- The friendly VS Code walkthrough in `docs/tinymist/frontend/vscode.typ` explains where to click, but not the full compiler-setting model.
+- Preview and export docs talk about those features in isolation even though they rely on the same underlying Typst compiler environment.
+- The generated config reference is sourced from `locales/tinymist-vscode.toml`, which is the right source of truth for setting descriptions, but it currently does not tell a complete story about reproducibility, packages, or supported extra-argument examples.
+
+There is also no maintained source for the embedded-font list. Tinymist resolves embedded fonts from `typst_assets::fonts()`, but the current docs rely on manual inspection instead of generated data. Because upstream `typst-assets` can change over time, this is a good fit for a small tooling step rather than another hand-maintained list in Typst prose.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a first-class compiler-settings page that explains how Tinymist configures the Typst compiler for editing, preview, and export.
+- Preserve the user-friendly VS Code walkthrough text while linking it to a canonical shared explanation.
+- Explain how `tinymist.systemFonts`, `tinymist.fontPaths`, package paths, and supported `tinymist.typstExtraArgs` work together.
+- Make reproducible-build guidance explicit, especially that `tinymist.systemFonts = false` helps avoid host-specific font drift.
+- Generate the documented embedded-font list from `typst-assets` source through a Rust tool crate instead of maintaining it by hand.
+
+**Non-Goals:**
+- Changing Tinymist's compiler behavior or adding new configuration flags.
+- Removing the existing friendly VS Code prose in favor of a reference-only page.
+- Exhaustively documenting every flag available in external `typst` binaries beyond the subset Tinymist actually parses and supports in its settings.
+- Changing the upstream `typst-assets` bundle or the Typst app's font packaging.
+
+## Decisions
+
+### 1. Add a shared `feature/compiler-settings.typ` page as the canonical explanation
+
+The new page should live in `docs/tinymist/feature/` and be registered in the book summary. It becomes the main place to explain compiler inputs such as font paths, system fonts, package paths, package cache paths, certificate paths, and supported `typstExtraArgs` examples.
+
+Alternative considered:
+- Keep expanding `frontend/vscode.typ` only. Rejected because compiler settings affect non-VS Code users as well, and preview/export pages also need a shared destination.
+- Put everything in the generated config reference. Rejected because generated setting descriptions are useful as reference text, but they are not a friendly narrative page.
+
+### 2. Preserve and enrich the duplicated VS Code walkthrough prose
+
+The current VS Code page should stay explicit and welcoming for users who want step-by-step directions. The change should add links from that prose to the shared compiler-settings page, but should not replace the duplicated instructions with a minimal cross-reference.
+
+Alternative considered:
+- Deduplicate the VS Code page aggressively. Rejected because the walkthrough text is intentionally friendly and useful for onboarding.
+
+### 3. Document compiler settings in two tiers: guided settings first, CLI-shaped extras second
+
+The docs should present:
+
+- a straightforward JSON settings example built around `tinymist.systemFonts = false` and `tinymist.fontPaths` for reproducible builds, and
+- curated `tinymist.typstExtraArgs` examples for supported arguments such as `--input`, `--root`, `--font-path`, `--ignore-system-fonts`, `--package-path`, `--package-cache-path`, `--creation-timestamp`, and `--cert`.
+
+This keeps the docs aligned with what Tinymist parses today while still teaching users how to map familiar Typst CLI concepts into editor settings.
+
+Alternative considered:
+- Describe `typstExtraArgs` as an unrestricted passthrough. Rejected because Tinymist parses its own supported subset and the docs should not over-promise.
+
+### 4. Generate the embedded-font list with a small Rust tool crate that reads `typst-assets` source
+
+The change should introduce a dedicated tool crate whose job is to inspect the `typst-assets` source and extract the font asset names from the embedded font list. That tool should emit a docs-consumable artifact such as Typst or JSON data that the shared compiler-settings page can include.
+
+This approach satisfies two needs at once:
+
+- it keeps the docs synchronized with the actual `typst-assets` source, and
+- it avoids inventing a parallel hand-maintained list in the docs tree.
+
+Alternative considered:
+- Manually maintain the embedded-font list in Typst docs. Rejected because it will drift.
+- Depend on `typst_assets::fonts()` directly at runtime to infer names from bytes. Rejected because the API exposes font data, not a stable font-name inventory, and the requested approach is to read the source code.
+
+### 5. Keep generated config docs sourced from `locales/tinymist-vscode.toml`
+
+The setting descriptions should be updated in the locale source file so that the rendered config reference stays aligned with the shared compiler-settings guide. Generated markdown or package localization bundles should not be edited directly.
+
+Alternative considered:
+- Patch generated markdown/config output directly. Rejected because this repo treats generated docs as artifacts.
+
+## Risks / Trade-offs
+
+- [Parsing `typst-assets` source could break when upstream source layout changes] -> Mitigate by keeping the extractor narrow, testing it against the current `typst-assets` layout, and failing loudly when the expected pattern changes.
+- [Keeping friendly VS Code prose and a shared page introduces duplication] -> Mitigate by making the shared page the semantic source of truth and using the VS Code page for guided onboarding plus links.
+- [Docs may imply support for unsupported extra arguments] -> Mitigate by limiting examples to the argument subset Tinymist parses today and calling that out explicitly.
+- [The Typst app emoji-font note can drift over time] -> Mitigate by phrasing it as a documented difference in bundled experience and keeping the wording close to the generated embedded-font inventory rather than a broad promise about all future app packaging.
+
+## Migration Plan
+
+1. Add the shared compiler-settings docs page and register it in the docs summary.
+2. Add the Rust tool crate that extracts embedded font names from `typst-assets` source and wire its output into the docs source.
+3. Update VS Code, preview, export, and settings-reference text to link to the shared page and adopt the reproducible-build/package guidance.
+4. Run the docs and localization checks used by the repository to confirm the generated artifacts stay consistent.
+5. Rollback, if needed, is a straightforward revert because the change only affects documentation, supporting tooling, and generated docs inputs.
+
+## Open Questions
+
+- What generated artifact format is most convenient for the docs page to consume: a Typst include file, a JSON blob, or both?
+- Where should the tool crate live in the workspace so it fits existing repository conventions for Rust-based docs tooling?
+- Whether the docs should name the Typst app's extra emoji font exactly or keep the wording one step more general if upstream packaging changes frequently.

--- a/openspec/changes/add-compiler-settings-docs/proposal.md
+++ b/openspec/changes/add-compiler-settings-docs/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Tinymist's compiler-setting guidance is currently split across the VS Code frontend guide, preview docs, export docs, and settings reference text. That makes it harder for users to understand how fonts, packages, and extra Typst arguments affect the same compiler environment across editing, previewing, and exporting.
+
+The current docs also drift in a few important places: they do not clearly present `tinymist.systemFonts = false` as a reproducibility tool, package-path guidance is thin, and the embedded-font story is hand-discovered instead of sourced from `typst-assets`. A focused docs change now can make these settings easier to trust and easier to maintain.
+
+## What Changes
+
+- Add a shared compiler-settings documentation page in `docs/tinymist/feature/` that explains fonts, packages, and supported `tinymist.typstExtraArgs` examples for the Typst compiler environment used by Tinymist.
+- Keep the existing friendly VS Code walkthrough prose in `docs/tinymist/frontend/vscode.typ`, while adding links from that page to the shared compiler-settings guide instead of replacing it with a terse reference.
+- Update previewing and exporting docs so they explicitly explain that preview and export use the same compiler font/package environment and point readers at the shared compiler-settings guide.
+- Update VS Code settings-reference text for font-related and extra-argument settings so it matches actual behavior, including the reproducible-build guidance that `tinymist.systemFonts = false` helps avoid host-font drift.
+- Introduce a small Rust tool crate that reads `typst-assets` source code and extracts the embedded font list for documentation, so the docs do not rely on a hand-maintained inventory.
+- Document the embedded-font bundle, the extra emoji-font gap versus the official Typst app experience, and how users can add their own emoji font if they want similar rendering.
+
+## Capabilities
+
+### New Capabilities
+- `compiler-settings-docs`: shared user-facing documentation and generated embedded-font inventory for Tinymist compiler settings across frontend, config, preview, and export docs.
+
+### Modified Capabilities
+
+## Impact
+
+- `docs/tinymist/book.typ`
+- `docs/tinymist/feature/`
+- `docs/tinymist/frontend/vscode.typ`
+- `docs/tinymist/feature/preview.typ`
+- `docs/tinymist/feature/export.typ`
+- `locales/tinymist-vscode.toml`
+- A new Rust tool crate in the workspace for extracting embedded font names from `typst-assets` source
+- The documentation build/check flow that consumes generated docs inputs

--- a/openspec/changes/add-compiler-settings-docs/specs/compiler-settings-docs/spec.md
+++ b/openspec/changes/add-compiler-settings-docs/specs/compiler-settings-docs/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Tinymist provides a shared compiler-settings guide
+Tinymist documentation SHALL include a shared guide that explains how compiler settings affect the Typst environment used for editing, previewing, and exporting.
+
+#### Scenario: Shared guide covers fonts, packages, and supported extra arguments
+- **WHEN** a user reads the compiler-settings guide
+- **THEN** the docs explain `tinymist.fontPaths`, `tinymist.systemFonts`, package-related compiler paths, and supported `tinymist.typstExtraArgs` usage
+- **AND** the docs include concrete configuration examples for font setup and package setup
+
+#### Scenario: Shared guide explains reproducible font configuration
+- **WHEN** a user reads about font configuration
+- **THEN** the docs explain that `tinymist.systemFonts = false` helps reproducible builds by avoiding host-specific system-font discovery
+- **AND** the docs show how to pair that setting with explicit `tinymist.fontPaths`
+
+#### Scenario: Shared guide limits extra-argument examples to supported settings
+- **WHEN** the docs show `tinymist.typstExtraArgs` examples
+- **THEN** the examples use arguments Tinymist parses today, such as `--input`, `--root`, `--font-path`, `--ignore-system-fonts`, `--package-path`, `--package-cache-path`, `--creation-timestamp`, and `--cert`
+- **AND** the docs do not imply that unsupported flags are accepted automatically
+
+### Requirement: Friendly VS Code docs remain in place while linking to canonical compiler-setting details
+The VS Code frontend documentation SHALL keep step-by-step setup prose for users while pointing to the shared compiler-settings guide for deeper explanations.
+
+#### Scenario: VS Code walkthrough remains explicit
+- **WHEN** a user reads the VS Code frontend documentation
+- **THEN** the docs still include direct instructions for configuring compiler-related settings in VS Code
+- **AND** the change does not reduce that section to a bare settings-reference link
+
+#### Scenario: Preview and export docs point to the shared guide
+- **WHEN** a user reads preview or export documentation
+- **THEN** the docs explain that those features use the same compiler font and package environment
+- **AND** they point the reader to the shared compiler-settings guide for setup details
+
+#### Scenario: Settings reference aligns with reproducibility guidance
+- **WHEN** a user reads the VS Code settings reference for `tinymist.systemFonts`, `tinymist.fontPaths`, or `tinymist.typstExtraArgs`
+- **THEN** the descriptions explain the reproducible-build role of `tinymist.systemFonts = false`
+- **AND** the descriptions clarify the interaction between dedicated settings and `typstExtraArgs`
+
+### Requirement: Embedded font docs are generated from `typst-assets` source
+Tinymist documentation SHALL derive the embedded font inventory from the current `typst-assets` source through repository tooling instead of a hand-maintained font list.
+
+#### Scenario: Generated font list tracks the current embedded bundle
+- **WHEN** `typst-assets` changes the embedded font list and the docs are regenerated
+- **THEN** the compiler-settings docs rebuild the embedded-font inventory from the `typst-assets` source
+- **AND** the font names do not require manual editing in the documentation page itself
+
+#### Scenario: Docs explain the emoji-font gap with the official Typst app experience
+- **WHEN** a user checks the embedded-font section to understand emoji rendering differences
+- **THEN** the docs explain that Tinymist's binary does not embed the extra Twitter emoji font used in the official Typst app experience
+- **AND** the docs tell the user they can add an emoji font manually if they want similar rendering

--- a/openspec/changes/add-compiler-settings-docs/tasks.md
+++ b/openspec/changes/add-compiler-settings-docs/tasks.md
@@ -1,0 +1,17 @@
+## 1. Establish the shared compiler-settings docs structure
+
+- [ ] 1.1 Add a shared compiler-settings documentation page under `docs/tinymist/feature/` and register it in the docs summary.
+- [ ] 1.2 Keep the existing friendly VS Code walkthrough text, while adding links from the VS Code, preview, and export docs to the shared compiler-settings guide.
+- [ ] 1.3 Add concrete examples that show reproducible font setup with `tinymist.systemFonts = false`, explicit `tinymist.fontPaths`, and supported `tinymist.typstExtraArgs` package/font arguments.
+
+## 2. Generate the embedded font inventory from `typst-assets`
+
+- [ ] 2.1 Add a small Rust tool crate that reads `typst-assets` source code and extracts the embedded font names used by Tinymist docs.
+- [ ] 2.2 Wire the generated font inventory into the docs source so the compiler-settings page consumes generated data instead of a hand-maintained list.
+- [ ] 2.3 Document the difference between Tinymist's embedded bundle and the official Typst app emoji-font experience, including guidance for adding an emoji font manually.
+
+## 3. Align settings reference text and validate the docs flow
+
+- [ ] 3.1 Update `locales/tinymist-vscode.toml` for `tinymist.systemFonts`, `tinymist.fontPaths`, `tinymist.typstExtraArgs`, and related deprecated preview font settings so the rendered config docs match the shared guide.
+- [ ] 3.2 Run the repository's localization and docs checks needed for the touched files and generated outputs.
+- [ ] 3.3 Review the rendered docs and generated embedded-font inventory for consistency across frontend, config, preview, and export pages.


### PR DESCRIPTION
## Summary
- add the OpenSpec proposal, design, tasks, and spec delta for shared compiler-settings documentation
- define the docs, settings-reference, and generated embedded-font inventory work needed for the change
- scope follow-up updates across Tinymist docs, localization text, and a supporting Rust tool crate

## Testing
- Not run (proposal-only change)
