### PR TITLE
fix: set default formatter mode to `typstyle` for non-vscode clients

### DIFF
--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -944,9 +944,9 @@ impl From<&dapts::InitializeRequestArguments> for ConstDapConfig {
 #[serde(rename_all = "camelCase")]
 pub enum FormatterMode {
     /// Disable the formatter.
-    #[default]
     Disable,
     /// Use `typstyle` formatter.
+    #[default]
     Typstyle,
     /// Use `typstfmt` formatter.
     Typstfmt,

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -1446,7 +1446,7 @@ mod tests {
     #[test]
     fn test_default_formatting_config() {
         let config = Config::default().formatter();
-        assert!(matches!(config.config, FormatterConfig::Disable));
+        assert!(matches!(config.config, FormatterConfig::Typstyle(_)));
         assert_eq!(config.position_encoding, PositionEncoding::Utf16);
     }
 


### PR DESCRIPTION
## Summary
- default the formatter to typstyle for non-VS Code clients instead of disabling formatting
- update the config test to match the new default

## Testing
- cargo test -p tinymist