### PR TITLE
feat: allow more granular log control

### DIFF
--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -137,12 +137,29 @@ fn main() -> Result<()> {
     #[cfg(feature = "l10n")]
     set_translations(load_translations(tinymist_assets::L10N_DATA)?);
     // Starts logging
-    let _ = tinymist::init_log(tinymist::InitLogOpts {
+    let verbose = match &cmd {
+        // Short-running commands, usually run from the CLI.
+        Commands::Completion(..) | Commands::Probe => false,
         #[cfg(feature = "export")]
-        is_transient_cmd: matches!(cmd, Commands::Compile(..)),
-        #[cfg(not(feature = "export"))]
-        is_transient_cmd: false,
-        is_test_no_verbose: matches!(&cmd, Commands::Test(test) if !test.verbose),
+        Commands::Compile(..) => false,
+
+        // Long-running commands, usually run from the CLI.
+        Commands::Test(test) => test.verbose,
+        Commands::Preview(preview) => preview.verbose,
+
+        // Long-running commands, usually run from an editor.
+        Commands::Lsp(..) | Commands::Dap(..) => true,
+
+        // Hidden commands.
+        Commands::TraceLsp(..)
+        | Commands::Query(..)
+        | Commands::GenerateScript(..)
+        | Commands::Doc(..)
+        | Commands::Task(..)
+        | Commands::Cov(..) => true,
+    };
+    let _ = tinymist::init_log(tinymist::InitLogOpts {
+        verbose,
         output: None,
     });
 

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -130,7 +130,9 @@ fn main() -> Result<()> {
 
     // Parses command line arguments
     let args = Args::parse();
-    let cmd = args.cmd.unwrap_or_else(|| Commands::Lsp(Default::default()));
+    let cmd = args
+        .cmd
+        .unwrap_or_else(|| Commands::Lsp(Default::default()));
 
     // Probes soon to avoid other initializations causing errors
     if matches!(cmd, Commands::Probe) {

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -62,6 +62,10 @@ static RUNTIMES: LazyLock<Runtimes> = LazyLock::new(Runtimes::default);
 #[derive(Debug, Clone, clap::Parser)]
 #[clap(name = "tinymist", author, version, about, long_version(tinymist::LONG_VERSION.as_str()))]
 struct Args {
+    /// Configure log filter of tinymist
+    #[clap(long = "log-filter", env = "TINYMIST_LOG")]
+    pub log_filter: Option<String>,
+
     /// Mode of the binary
     #[clap(subcommand)]
     pub cmd: Option<Commands>,
@@ -125,8 +129,8 @@ fn main() -> Result<()> {
     let _profiler = dhat::Profiler::new_heap();
 
     // Parses command line arguments
-    let cmd = Args::parse().cmd;
-    let cmd = cmd.unwrap_or_else(|| Commands::Lsp(Default::default()));
+    let args = Args::parse();
+    let cmd = args.cmd.unwrap_or_else(|| Commands::Lsp(Default::default()));
 
     // Probes soon to avoid other initializations causing errors
     if matches!(cmd, Commands::Probe) {
@@ -160,6 +164,7 @@ fn main() -> Result<()> {
     };
     let _ = tinymist::init_log(tinymist::InitLogOpts {
         verbose,
+        filter: args.log_filter,
         output: None,
     });
 

--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -6,28 +6,17 @@ use super::*;
 
 /// Options for initializing the logger.
 pub struct InitLogOpts {
-    /// Whether the command is transient (e.g., compile).   
-    pub is_transient_cmd: bool,
-    /// Whether the command is a test without verbose output.
-    pub is_test_no_verbose: bool,
+    /// Whether the command should use verbose logging.
+    pub verbose: bool,
     /// Redirects output via LSP/DAP notification.
     pub output: Option<LspClient>,
 }
 
 /// Initializes the logger for the Tinymist library.
-pub fn init_log(
-    InitLogOpts {
-        is_transient_cmd,
-        is_test_no_verbose,
-        output,
-    }: InitLogOpts,
-) -> anyhow::Result<()> {
+pub fn init_log(InitLogOpts { verbose, output }: InitLogOpts) -> anyhow::Result<()> {
     use log::LevelFilter::*;
 
-    let base_no_info = is_transient_cmd || is_test_no_verbose;
-    let base_level = if base_no_info { Warn } else { Info };
-    let preview_level = if is_test_no_verbose { Warn } else { Info };
-    let diag_level = if is_test_no_verbose { Warn } else { Info };
+    let base_level = if verbose { Info } else { Warn };
 
     let mut builder = env_logger::builder();
     if let Some(output) = output {
@@ -59,12 +48,12 @@ pub fn init_log(
 
     Ok(builder
         .filter_module("tinymist", base_level)
-        .filter_module("tinymist_preview", preview_level)
+        .filter_module("tinymist_preview", base_level)
         .filter_module("typlite", base_level)
         .filter_module("reflexo", base_level)
         .filter_module("sync_ls", base_level)
         .filter_module("reflexo_typst2vec::pass::span2vec", Error)
-        .filter_module("reflexo_typst::diag::console", diag_level)
+        .filter_module("reflexo_typst::diag::console", base_level)
         .try_init()?)
 }
 

--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -8,12 +8,14 @@ use super::*;
 pub struct InitLogOpts {
     /// Whether the command should use verbose logging.
     pub verbose: bool,
+    /// Additional filters to pass directly to `env_logger`.
+    pub filter: Option<String>,
     /// Redirects output via LSP/DAP notification.
     pub output: Option<LspClient>,
 }
 
 /// Initializes the logger for the Tinymist library.
-pub fn init_log(InitLogOpts { verbose, output }: InitLogOpts) -> anyhow::Result<()> {
+pub fn init_log(InitLogOpts { verbose, filter, output }: InitLogOpts) -> anyhow::Result<()> {
     use log::LevelFilter::*;
 
     let base_level = if verbose { Info } else { Warn };
@@ -46,15 +48,20 @@ pub fn init_log(InitLogOpts { verbose, output }: InitLogOpts) -> anyhow::Result<
         });
     }
 
-    Ok(builder
+    builder
         .filter_module("tinymist", base_level)
         .filter_module("tinymist_preview", base_level)
         .filter_module("typlite", base_level)
         .filter_module("reflexo", base_level)
         .filter_module("sync_ls", base_level)
         .filter_module("reflexo_typst2vec::pass::span2vec", Error)
-        .filter_module("reflexo_typst::diag::console", base_level)
-        .try_init()?)
+        .filter_module("reflexo_typst::diag::console", base_level);
+
+    if let Some(f) = filter {
+        builder.parse_filters(&f);
+    }
+
+    Ok(builder.try_init()?)
 }
 
 struct LogNotification(LspClient, Vec<u8>);

--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -15,7 +15,13 @@ pub struct InitLogOpts {
 }
 
 /// Initializes the logger for the Tinymist library.
-pub fn init_log(InitLogOpts { verbose, filter, output }: InitLogOpts) -> anyhow::Result<()> {
+pub fn init_log(
+    InitLogOpts {
+        verbose,
+        filter,
+        output,
+    }: InitLogOpts,
+) -> anyhow::Result<()> {
     use log::LevelFilter::*;
 
     let base_level = if verbose { Info } else { Warn };

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -203,6 +203,10 @@ pub struct PreviewCliArgs {
     /// set as well, this flag will win.
     #[clap(long = "no-open")]
     pub no_open: bool,
+
+    /// Emit INFO level logging. The default is WARN.
+    #[clap(long = "verbose")]
+    pub verbose: bool,
 }
 
 impl PreviewCliArgs {

--- a/crates/tinymist/src/web.rs
+++ b/crates/tinymist/src/web.rs
@@ -42,6 +42,7 @@ impl TinymistLanguageServer {
         // Starts logging
         let _ = crate::init_log(crate::InitLogOpts {
             verbose: true,
+            filter: None,
             output: Some(_client.weak()),
         });
         let state = ServerState::install_lsp(LspBuilder::new(

--- a/crates/tinymist/src/web.rs
+++ b/crates/tinymist/src/web.rs
@@ -41,8 +41,7 @@ impl TinymistLanguageServer {
         let _client = LspClientRoot::new_js(RUNTIMES.tokio_runtime.handle().clone(), sender);
         // Starts logging
         let _ = crate::init_log(crate::InitLogOpts {
-            is_transient_cmd: false,
-            is_test_no_verbose: false,
+            verbose: true,
             output: Some(_client.weak()),
         });
         let state = ServerState::install_lsp(LspBuilder::new(

--- a/docs/tinymist/feature/cli.typ
+++ b/docs/tinymist/feature/cli.typ
@@ -87,3 +87,13 @@ tinymist completion bash
 ```
 
 Available values for the shell parameter are `bash`, `elvish`, `fig`, `fish`, `powershell`, `zsh`, and `nushell`.
+
+== Logging
+
+By default, logging is set to `INFO` for LSP and DAP modes, and `WARN` otherwise.
+This can be overridden with `--verbose` for `preview` and `test`.
+
+You can use more granular overrides by setting `TINYMIST_LOG` in the environment, or passing
+it as an argument with `tinymist --log-filter`.
+Note that to override tinymist itself you will need to override individual modules; for
+example `tinymist --log-filter tinymist_preview=debug preview main.typ`.

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -524,6 +524,9 @@ fn test_help_preview() {
               Don't open the preview in the browser after compilation. If `--open` is set as well, this
               flag will win
 
+          --verbose
+              Emit INFO level logging. The default is WARN
+
       -h, --help
               Print help (see a summary with '-h')
 

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -33,7 +33,7 @@ fn test_help() {
     ----- stdout -----
     An integrated language service for Typst.
 
-    Usage: tinymist [COMMAND]
+    Usage: tinymist [OPTIONS] [COMMAND]
 
     Commands:
       probe       Probe existence (Nop run)
@@ -46,8 +46,9 @@ fn test_help() {
       help        Print this message or the help of the given subcommand(s)
 
     Options:
-      -h, --help     Print help
-      -V, --version  Print version
+          --log-filter <LOG_FILTER>  Configure log filter of tinymist [env: TINYMIST_LOG=REDACTED]
+      -h, --help                     Print help
+      -V, --version                  Print version
 
     ----- stderr -----
     ");


### PR DESCRIPTION
- Change the default for `preview` to `WARN`. Previously it was `INFO`,
  which made it hard to see errors in the terminal.
- Add a new `preview --verbose` flag to allow bringing back the old
  behavior.
- Make verbosity calculation easier to understand by doing it all in one place.
- Allow overriding log levels with `TINYMIST_LOG`. This allows overriding individual modules without having to recompile from source.
- Add docs about logging.