### PR TITLE
Remove min-height CSS property to avoid scrolling in slide preview mode

### DIFF
--- a/tools/typst-preview-frontend/src/typst.css
+++ b/tools/typst-preview-frontend/src/typst.css
@@ -58,7 +58,6 @@ body {
 
 #typst-app {
   width: fit-content;
-  min-height: 100%;
   margin: 0;
   transform-origin: 0 0;
   background-color: #fff;


### PR DESCRIPTION
Currently the slide preview mode has a scrollbar to move the previewed slide between center and top of the page (not to the bottom). By removing the min-height property of #typst-app the slide stays at the center and the page is not scrollable anymore.

Perhaps the scrolling could be used to move between slides in the future.