### PR TITLE
fix: preview update bug when tab and sidebar previews are both open

### DIFF
--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -43,6 +43,7 @@ impl RenderActorRequest {
 
 pub struct RenderActor {
     mailbox: broadcast::Receiver<RenderActorRequest>,
+    direct_mailbox: mpsc::UnboundedReceiver<RenderActorRequest>,
     view: Arc<parking_lot::RwLock<Option<Arc<dyn CompileView>>>>,
     renderer: IncrSvgDocServer,
     editor_conn_sender: mpsc::UnboundedSender<EditorActorRequest>,
@@ -53,6 +54,7 @@ pub struct RenderActor {
 impl RenderActor {
     pub fn new(
         mailbox: broadcast::Receiver<RenderActorRequest>,
+        direct_mailbox: mpsc::UnboundedReceiver<RenderActorRequest>,
         view: Arc<parking_lot::RwLock<Option<Arc<dyn CompileView>>>>,
         editor_conn_sender: mpsc::UnboundedSender<EditorActorRequest>,
         svg_sender: mpsc::UnboundedSender<Vec<u8>>,
@@ -60,6 +62,7 @@ impl RenderActor {
     ) -> Self {
         let mut res = Self {
             mailbox,
+            direct_mailbox,
             view,
             renderer: IncrSvgDocServer::default(),
             editor_conn_sender,
@@ -70,10 +73,11 @@ impl RenderActor {
         res
     }
 
-    async fn process_message(&mut self, msg: RenderActorRequest) -> bool {
+    async fn process_message(&mut self, msg: RenderActorRequest) -> (bool, bool) {
         log::trace!("RenderActor: received message: {msg:?}");
 
-        let res = msg.is_full_render();
+        let is_full_render = msg.is_full_render();
+        let is_incremental_render = matches!(msg, RenderActorRequest::RenderIncremental);
         match msg {
             RenderActorRequest::EditorResolveSpanRange(span_range) => {
                 log::debug!("RenderActor: resolving EditorResolveSpanRange: {span_range:?}");
@@ -86,7 +90,7 @@ impl RenderActor {
                     Ok(spans) => spans,
                     Err(err) => {
                         log::info!("RenderActor: failed to resolve span: {err}");
-                        return false;
+                        return (false, false);
                     }
                 };
 
@@ -119,28 +123,50 @@ impl RenderActor {
             RenderActorRequest::RenderFullLatest | RenderActorRequest::RenderIncremental => {}
         }
 
-        res
+        (is_full_render, is_incremental_render)
     }
 
     pub async fn run(mut self) {
         loop {
             let mut has_full_render = false;
+            let mut has_incremental_render = false;
             log::debug!("RenderActor: waiting for message");
-            match self.mailbox.recv().await {
-                Ok(msg) => {
-                    has_full_render |= self.process_message(msg).await;
+            tokio::select! {
+                msg = self.mailbox.recv() => {
+                    match msg {
+                        Ok(msg) => {
+                            let (full, incremental) = self.process_message(msg).await;
+                            has_full_render |= full;
+                            has_incremental_render |= incremental;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            log::info!("RenderActor: no more messages");
+                            break;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            log::info!("RenderActor: lagged message. Some events are dropped");
+                        }
+                    }
                 }
-                Err(broadcast::error::RecvError::Closed) => {
-                    log::info!("RenderActor: no more messages");
+                Some(msg) = self.direct_mailbox.recv() => {
+                    let (full, incremental) = self.process_message(msg).await;
+                    has_full_render |= full;
+                    has_incremental_render |= incremental;
+                }
+                else => {
                     break;
-                }
-                Err(broadcast::error::RecvError::Lagged(_)) => {
-                    log::info!("RenderActor: lagged message. Some events are dropped");
                 }
             }
             // read the queue to empty
             while let Ok(msg) = self.mailbox.try_recv() {
-                has_full_render |= self.process_message(msg).await;
+                let (full, incremental) = self.process_message(msg).await;
+                has_full_render |= full;
+                has_incremental_render |= incremental;
+            }
+            while let Ok(msg) = self.direct_mailbox.try_recv() {
+                let (full, incremental) = self.process_message(msg).await;
+                has_full_render |= full;
+                has_incremental_render |= incremental;
             }
             // if a full render is requested, we render the latest document
             // otherwise, we render the incremental changes for only once
@@ -151,7 +177,7 @@ impl RenderActor {
                 continue;
             };
 
-            let data = self.render(has_full_render, &document);
+            let data = self.render(has_full_render, has_incremental_render, &document);
             let Ok(_) = self.svg_sender.send(data) else {
                 log::info!("RenderActor: svg_sender is dropped");
                 break;
@@ -160,13 +186,22 @@ impl RenderActor {
         log::info!("RenderActor: exiting")
     }
 
-    fn render(&mut self, has_full_render: bool, document: &TypstDocument) -> Vec<u8> {
-        if has_full_render {
-            if let Some(data) = self.render_full() {
-                data
+    fn render(
+        &mut self,
+        has_full_render: bool,
+        has_incremental_render: bool,
+        document: &TypstDocument,
+    ) -> Vec<u8> {
+        if has_incremental_render {
+            let delta = self.render_delta(document);
+            if has_full_render {
+                self.render_full().unwrap_or(delta)
             } else {
-                self.render_delta(document)
+                delta
             }
+        } else if has_full_render {
+            self.render_full()
+                .unwrap_or_else(|| self.render_delta(document))
         } else {
             self.render_delta(document)
         }

--- a/crates/typst-preview/src/actor/webview.rs
+++ b/crates/typst-preview/src/actor/webview.rs
@@ -43,7 +43,7 @@ pub struct WebviewActor<'a, C> {
 
     broadcast_sender: broadcast::Sender<WebviewActorRequest>,
     editor_sender: mpsc::UnboundedSender<EditorActorRequest>,
-    render_sender: broadcast::Sender<RenderActorRequest>,
+    render_sender: mpsc::UnboundedSender<RenderActorRequest>,
 }
 
 pub struct Channels {
@@ -69,7 +69,7 @@ where
         broadcast_sender: broadcast::Sender<WebviewActorRequest>,
         mailbox: broadcast::Receiver<WebviewActorRequest>,
         editor_sender: mpsc::UnboundedSender<EditorActorRequest>,
-        render_sender: broadcast::Sender<RenderActorRequest>,
+        render_sender: mpsc::UnboundedSender<RenderActorRequest>,
     ) -> Self {
         Self {
             webview_websocket_conn: websocket_conn,

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -176,16 +176,18 @@ impl Previewer {
                 }
                 let actor::webview::Channels { svg } =
                     actor::webview::WebviewActor::<'_, C>::set_up_channels();
+                let (direct_render_tx, direct_render_rx) = mpsc::unbounded_channel();
                 let webview_actor = actor::webview::WebviewActor::new(
                     conn,
                     svg.1,
                     h.webview_tx.clone(),
                     h.webview_tx.subscribe(),
                     h.editor_tx.clone(),
-                    h.renderer_tx.clone(),
+                    direct_render_tx,
                 );
                 let render_actor = actor::render::RenderActor::new(
                     h.renderer_tx.subscribe(),
+                    direct_render_rx,
                     h.doc_sender.clone(),
                     h.editor_tx.clone(),
                     svg.0,

--- a/tools/typst-preview-frontend/src/main.js
+++ b/tools/typst-preview-frontend/src/main.js
@@ -43,7 +43,12 @@ function retrieveWsArgs() {
   /// the websocket connection requires an absolute url.
   ///
   /// See [WebSocket and relative URLs](https://github.com/whatwg/websockets/issues/20)
-  let urlObject = new URL("ws://127.0.0.1:23625", window.location.href);
+  let url = "ws://127.0.0.1:23625";
+  if (!url) {
+    return { url: "", previewMode, isContentPreview: false };
+  }
+
+  let urlObject = new URL(url, window.location.href);
   /// Rewrite the protocol to websocket.
   urlObject.protocol = urlObject.protocol.replace("https:", "wss:").replace("http:", "ws:");
   if (location.href.startsWith("https://")) {


### PR DESCRIPTION
## Summary

Fixes a preview update bug where opening the Tinymist sidebar Content preview could stop an already-open tab preview from updating, and vice versa.

The preview backend creates one renderer per connected webview, but webview-originated render requests were previously sent through the shared broadcast channel. As a result, when one preview frontend connected and sent `"current"`, every render actor handled that request, including renderers belonging to other preview views.

This PR routes webview-local render requests through a per-webview direct channel while keeping compile-driven render updates broadcast to all preview clients.

## What Changed

- Added a direct render mailbox to `RenderActor`.
- Changed `WebviewActor` to send local render requests through `mpsc` instead of the shared broadcast channel.
- Created a direct render channel per websocket connection in the preview data plane setup.
- Kept compile updates on the existing broadcast path so all connected previews continue receiving document updates.
- Fixed render batching so an incremental document update is applied before sending a full snapshot when both requests are received together.
- Made the preview frontend tolerate an empty websocket URL, which is used by the sidebar Content preview before an active preview connection is available.

## Why

Each webview has independent incremental renderer state. A `"current"` request from one webview should only affect that webview’s renderer. Broadcasting that request lets one preview view disturb another view’s renderer state, causing one of the previews to stop updating.

## Manually Verified:
  - Open preview tab first, then sidebar Content preview; both update while editing.
  - Open sidebar Content preview first, then preview tab; both update while editing.