### PR TITLE
fix: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946cd448051e8061e4e17d88ecaceea8d84c33da52b93a9391b4a657def1b8bd"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,19 +3781,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lsp-types"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
 
 [[package]]
 name = "mach"
@@ -6377,7 +6375,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
- "skrifa 0.37.0",
+ "skrifa 0.42.1",
  "yazi",
  "zeno",
 ]
@@ -6413,9 +6411,9 @@ dependencies = [
  "crossbeam-channel",
  "dapts",
  "futures",
+ "gen-lsp-types",
  "js-sys",
  "log",
- "lsp-types",
  "parking_lot",
  "serde",
  "serde-wasm-bindgen",
@@ -6540,9 +6538,9 @@ dependencies = [
 name = "tests"
 version = "0.15.0-rc1"
 dependencies = [
+ "gen-lsp-types",
  "insta",
  "insta-cmd",
- "lsp-types",
  "serde",
  "serde_json",
  "sync-ls",
@@ -6718,6 +6716,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
+ "gen-lsp-types",
  "http-body-util",
  "hyper",
  "hyper-tungstenite",
@@ -6725,7 +6724,6 @@ dependencies = [
  "itertools 0.13.0",
  "js-sys",
  "log",
- "lsp-types",
  "open",
  "parking_lot",
  "paste",
@@ -6782,11 +6780,11 @@ dependencies = [
  "dashmap",
  "ecow",
  "ena",
+ "gen-lsp-types",
  "hashbrown 0.14.5",
  "insta",
  "itertools 0.13.0",
  "log",
- "lsp-types",
  "parking_lot",
  "regex",
  "rpds",
@@ -6847,13 +6845,13 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
+ "gen-lsp-types",
  "http-body-util",
  "hyper",
  "hyper-tungstenite",
  "hyper-util",
  "itertools 0.13.0",
  "log",
- "lsp-types",
  "open",
  "parking_lot",
  "paste",
@@ -7085,12 +7083,12 @@ dependencies = [
  "dirs",
  "ecow",
  "ena",
+ "gen-lsp-types",
  "hayagriva",
  "hex",
  "indexmap 2.14.0",
  "itertools 0.13.0",
  "log",
- "lsp-types",
  "parking_lot",
  "percent-encoding",
  "rayon",
@@ -7155,11 +7153,11 @@ dependencies = [
  "dashmap",
  "ecow",
  "fxhash",
+ "gen-lsp-types",
  "hex",
  "js-sys",
  "libc",
  "log",
- "lsp-types",
  "parking_lot",
  "path-clean",
  "pathdiff",
@@ -7318,10 +7316,10 @@ dependencies = [
  "ecow",
  "flate2",
  "fontdb",
+ "gen-lsp-types",
  "hex",
  "js-sys",
  "log",
- "lsp-types",
  "parking_lot",
  "rayon",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ typstyle-core = { version = "0.14.4", default-features = false }
 # LSP
 crossbeam-channel = "0.5.15"
 dapts = "0.0.6"
-lsp-types = { version = "=0.95.0", features = ["proposed"] }
+lsp-types = { package = "gen-lsp-types", version = "0.9.0", features = ["url"] }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env", "unicode"] }

--- a/crates/sync-lsp/src/server.rs
+++ b/crates/sync-lsp/src/server.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, Weak};
 
 use futures::future::MaybeDone;
+use lsp_types::{LspNotificationMethod, LspRequestMethod};
 use parking_lot::Mutex;
 use serde::Serialize;
 use serde_json::{Value as JsonValue, from_value};
@@ -634,8 +635,8 @@ type RawHandler<S, T> = fn(srv: &mut S, args: T) -> ScheduleResult;
 type BoxPureHandler<S, T> = Box<dyn Fn(&mut S, T) -> LspResult<()>>;
 type BoxHandler<S, T> = Box<dyn Fn(&mut S, T) -> SchedulableResponse<JsonValue>>;
 type ExecuteCmdMap<S> = HashMap<&'static str, BoxHandler<S, Vec<JsonValue>>>;
-type RegularCmdMap<S> = HashMap<&'static str, BoxHandler<S, JsonValue>>;
-type NotifyCmdMap<S> = HashMap<&'static str, BoxPureHandler<S, JsonValue>>;
+type RegularCmdMap<S> = HashMap<LspRequestMethod<'static>, BoxHandler<S, JsonValue>>;
+type NotifyCmdMap<S> = HashMap<LspNotificationMethod<'static>, BoxPureHandler<S, JsonValue>>;
 type ResourceMap<S> = HashMap<ImmutPath, BoxHandler<S, Vec<JsonValue>>>;
 type MayInitBoxHandler<A, S, T> =
     Box<dyn for<'a> Fn(ServiceState<'a, A, S>, &LspClient, T) -> anyhow::Result<()>>;

--- a/crates/sync-lsp/src/server/dap_srv.rs
+++ b/crates/sync-lsp/src/server/dap_srv.rs
@@ -42,7 +42,8 @@ where
         mut self,
         handler: RawHandler<Args::S, JsonValue>,
     ) -> Self {
-        self.req_handlers.insert(R::COMMAND, Box::new(handler));
+        self.req_handlers
+            .insert(R::COMMAND.into(), Box::new(handler));
         self
     }
 
@@ -54,7 +55,7 @@ where
         handler: fn(&mut Args::S, R::Arguments) -> ScheduleResult,
     ) -> Self {
         self.req_handlers.insert(
-            R::COMMAND,
+            R::COMMAND.into(),
             Box::new(move |s, req| handler(s, from_json(req)?)),
         );
         self
@@ -66,7 +67,7 @@ where
         handler: AsyncHandler<Args::S, R::Arguments, R::Response>,
     ) -> Self {
         self.req_handlers.insert(
-            R::COMMAND,
+            R::COMMAND.into(),
             Box::new(move |s, req| erased_response(handler(s, from_json(req)?))),
         );
         self
@@ -222,7 +223,7 @@ where
 
                 let is_disconnect = method == dapts::request::Disconnect::COMMAND;
 
-                let Some(handler) = self.requests.get(method) else {
+                let Some(handler) = self.requests.get(&method.into()) else {
                     log::warn!("unhandled dap request: {method}");
                     break 'serve_req just_result(Err(method_not_found()));
                 };
@@ -251,7 +252,7 @@ where
                           event,
                           body,
                       }: dap::Event| {
-            let Some(handler) = self.notifications.get(event.as_str()) else {
+            let Some(handler) = self.notifications.get(&event.as_str().into()) else {
                 log::warn!("unhandled event: {event}");
                 return Ok(());
             };

--- a/crates/sync-lsp/src/server/lsp_srv.rs
+++ b/crates/sync-lsp/src/server/lsp_srv.rs
@@ -1,4 +1,4 @@
-use lsp_types::{notification::Notification as Notif, request::Request as Req, *};
+use lsp_types::{Notification as Notif, Request as Req, *};
 
 use super::*;
 
@@ -27,7 +27,7 @@ impl LspClient {
     ) {
         let mut req_queue = self.req_queue.lock();
         let request = req_queue.outgoing.register(
-            R::METHOD.to_owned(),
+            R::METHOD.to_string(),
             params,
             Box::new(|s, resp| handler(s, resp.try_into().unwrap())),
         );
@@ -42,7 +42,7 @@ impl LspClient {
 
     /// Sends a typed notification to the client.
     pub fn send_notification<N: Notif>(&self, params: &N::Params) {
-        self.send_notification_(lsp::Notification::new(N::METHOD.to_owned(), params));
+        self.send_notification_(lsp::Notification::new(N::METHOD.to_string(), params));
     }
 
     /// Sends an untyped notification to the client.
@@ -199,7 +199,7 @@ where
         // }
 
         while let Ok(msg) = inbox.recv() {
-            const EXIT_METHOD: &str = notification::Exit::METHOD;
+            const EXIT_METHOD: LspNotificationMethod = ExitNotification::METHOD;
             let loop_start = tinymist_std::time::now();
             match msg {
                 Evt(event) => {
@@ -228,7 +228,7 @@ where
                     self.client.handle.spawn(fut);
                 }
                 Msg(LspMessage::Notification(not)) => {
-                    let is_exit = not.method == EXIT_METHOD;
+                    let is_exit = not.method == EXIT_METHOD.as_str();
                     let track_id = self
                         .next_not_id
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -294,8 +294,8 @@ where
     /// Registers and handles a request. This should only be called once per
     /// incoming request.
     pub fn on_lsp_request(&mut self, method: &str, params: JsonValue) -> ScheduleResult {
-        match (&mut self.state, method) {
-            (State::Uninitialized(args), request::Initialize::METHOD) => {
+        match (&mut self.state, LspRequestMethod::from(method)) {
+            (State::Uninitialized(args), InitializeRequest::METHOD) => {
                 // todo: what will happen if the request cannot be deserialized?
                 let params = serde_json::from_value::<Args::I>(params);
                 match params {
@@ -311,15 +311,15 @@ where
             (State::Uninitialized(..) | State::Initializing(..), _) => {
                 just_result(Err(not_initialized()))
             }
-            (_, request::Initialize::METHOD) => {
+            (_, InitializeRequest::METHOD) => {
                 just_result(Err(invalid_request("server is already initialized")))
             }
             // todo: generalize this
-            (State::Ready(..), request::ExecuteCommand::METHOD) => self.on_execute_command(params),
+            (State::Ready(..), ExecuteCommandRequest::METHOD) => self.on_execute_command(params),
             (State::Ready(s), method) => 'serve_req: {
-                let is_shutdown = method == request::Shutdown::METHOD;
+                let is_shutdown = method == ShutdownRequest::METHOD;
 
-                let Some(handler) = self.requests.get(method) else {
+                let Some(handler) = self.requests.get(&method) else {
                     log::warn!("unhandled lsp request: {method}");
                     break 'serve_req just_result(Err(method_not_found()));
                 };
@@ -351,20 +351,20 @@ where
 
         // todo: generalize this
         if command == "tinymist.getResources" {
-            self.get_resources(arguments)
+            self.get_resources(arguments.unwrap_or_default())
         } else {
             let Some(handler) = self.commands.get(command.as_str()) else {
                 log::error!("asked to execute unknown command: {command}");
                 return Err(method_not_found());
             };
-            handler(s, arguments)
+            handler(s, arguments.unwrap_or_default())
         }
     }
 
     /// Handles an incoming notification.
     pub fn on_notification(&mut self, method: &str, params: JsonValue) -> LspResult<()> {
         let handle = |s, method: &str, params: JsonValue| {
-            let Some(handler) = self.notifications.get(method) else {
+            let Some(handler) = self.notifications.get(&method.into()) else {
                 log::warn!("unhandled notification: {method}");
                 return Ok(());
             };
@@ -372,8 +372,8 @@ where
             handler(s, params)
         };
 
-        match (&mut self.state, method) {
-            (state, notification::Initialized::METHOD) => {
+        match (&mut self.state, LspNotificationMethod::from(method)) {
+            (state, InitializedNotification::METHOD) => {
                 let mut s = State::ShuttingDown;
                 std::mem::swap(state, &mut s);
                 match s {
@@ -394,7 +394,7 @@ where
                 };
                 handle(s, method, params)
             }
-            (State::Ready(state), method) => handle(state, method, params),
+            (State::Ready(state), method) => handle(state, method.as_str(), params),
             // todo: whether it is safe to ignore notifications
             (State::Uninitialized(..) | State::Initializing(..), method) => {
                 log::warn!("server is not ready yet, while received notification {method}");

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -36,7 +36,7 @@ pub use typst_shim::syntax::VirtualPathExt;
 use std::sync::Arc;
 
 use ecow::eco_format;
-use lsp_types::Url;
+use lsp_types::Uri as Url;
 use tinymist_project::LspComputeGraph;
 use tinymist_std::error::WithContextUntyped;
 use tinymist_std::{Result, bail};

--- a/crates/tinymist-query/src/analysis/code_action.rs
+++ b/crates/tinymist-query/src/analysis/code_action.rs
@@ -3,7 +3,7 @@
 mod figure;
 
 use ecow::eco_format;
-use lsp_types::{ChangeAnnotation, CreateFile, CreateFileOptions};
+use lsp_types::{ChangeAnnotation, CreateFile, CreateFileOptions, Message};
 use regex::Regex;
 use tinymist_analysis::syntax::{
     PreviousItem, SyntaxClass, adjust_expr, node_ancestors, previous_items,
@@ -68,7 +68,7 @@ impl<'a> CodeActionWorker<'a> {
             && !only.is_empty()
             && !only
                 .iter()
-                .any(|kind| *kind == CodeActionKind::EMPTY || *kind == CodeActionKind::QUICKFIX)
+                .any(|kind| *kind == CodeActionKind::Empty || *kind == CodeActionKind::QuickFix)
         {
             return None;
         }
@@ -78,14 +78,16 @@ impl<'a> CodeActionWorker<'a> {
                 continue;
             }
 
-            match match_autofix_kind(diag.message.as_str()) {
-                Some(AutofixKind::UnknownVariable) => {
-                    self.autofix_unknown_variable(root, range);
+            if let Message::String(message) = &diag.message {
+                match match_autofix_kind(message) {
+                    Some(AutofixKind::UnknownVariable) => {
+                        self.autofix_unknown_variable(root, range);
+                    }
+                    Some(AutofixKind::FileNotFound) => {
+                        self.autofix_file_not_found(root, range);
+                    }
+                    _ => {}
                 }
-                Some(AutofixKind::FileNotFound) => {
-                    self.autofix_file_not_found(root, range);
-                }
-                _ => {}
             }
         }
 
@@ -200,7 +202,7 @@ impl<'a> CodeActionWorker<'a> {
         let edit = self.local_edit(EcoSnippetTextEdit::new(range, new_text))?;
         let action = CodeAction {
             title: "Create missing variable".to_string(),
-            kind: Some(CodeActionKind::QUICKFIX),
+            kind: Some(CodeActionKind::QuickFix),
             edit: Some(edit),
             ..CodeAction::default()
         };
@@ -229,7 +231,7 @@ impl<'a> CodeActionWorker<'a> {
         let edit = self.local_edit(EcoSnippetTextEdit::new(range, new_text))?;
         let action = CodeAction {
             title: "Add spaces between letters".to_string(),
-            kind: Some(CodeActionKind::QUICKFIX),
+            kind: Some(CodeActionKind::QuickFix),
             edit: Some(edit),
             ..CodeAction::default()
         };
@@ -266,7 +268,7 @@ impl<'a> CodeActionWorker<'a> {
         let file_to_create = target.vpath().get_with_slash();
         let action = CodeAction {
             title: format!("Create missing file at `{file_to_create}`"),
-            kind: Some(CodeActionKind::QUICKFIX),
+            kind: Some(CodeActionKind::QuickFix),
             edit: Some(edit),
             ..CodeAction::default()
         };
@@ -366,7 +368,7 @@ impl<'a> CodeActionWorker<'a> {
             let edit = self.edit_str(node, unix_slash(&new_path))?;
             let action = CodeAction {
                 title: "Convert to relative path".to_string(),
-                kind: Some(CodeActionKind::REFACTOR_REWRITE),
+                kind: Some(CodeActionKind::RefactorRewrite),
                 edit: Some(edit),
                 ..CodeAction::default()
             };
@@ -393,7 +395,7 @@ impl<'a> CodeActionWorker<'a> {
             let edit = self.edit_str(node, unix_slash(&new_path))?;
             let action = CodeAction {
                 title: "Convert to absolute path".to_string(),
-                kind: Some(CodeActionKind::REFACTOR_REWRITE),
+                kind: Some(CodeActionKind::RefactorRewrite),
                 edit: Some(edit),
                 ..CodeAction::default()
             };
@@ -440,7 +442,7 @@ impl<'a> CodeActionWorker<'a> {
 
         let action = CodeAction {
             title: "Wrap with content block".to_string(),
-            kind: Some(CodeActionKind::REFACTOR_REWRITE),
+            kind: Some(CodeActionKind::RefactorRewrite),
             edit: Some(edit),
             ..CodeAction::default()
         };
@@ -463,7 +465,7 @@ impl<'a> CodeActionWorker<'a> {
             // Decrease depth of heading
             let action = CodeAction {
                 title: "Decrease depth of heading".to_string(),
-                kind: Some(CodeActionKind::REFACTOR_REWRITE),
+                kind: Some(CodeActionKind::RefactorRewrite),
                 edit: Some(self.local_edit(EcoSnippetTextEdit::new_plain(
                     self.ctx.to_lsp_range(marker_range.clone(), &self.source),
                     EcoString::inline("=").repeat(depth - 1),
@@ -476,7 +478,7 @@ impl<'a> CodeActionWorker<'a> {
         // Increase depth of heading
         let action = CodeAction {
             title: "Increase depth of heading".to_string(),
-            kind: Some(CodeActionKind::REFACTOR_REWRITE),
+            kind: Some(CodeActionKind::RefactorRewrite),
             edit: Some(self.local_edit(EcoSnippetTextEdit::new_plain(
                 self.ctx.to_lsp_range(marker_range, &self.source),
                 EcoString::inline("=").repeat(depth + 1),
@@ -568,7 +570,7 @@ impl<'a> CodeActionWorker<'a> {
 
             Some(CodeAction {
                 title: title.to_owned(),
-                kind: Some(CodeActionKind::REFACTOR_REWRITE),
+                kind: Some(CodeActionKind::RefactorRewrite),
                 edit: Some(self.local_edits(edits)?),
                 ..CodeAction::default()
             })
@@ -593,14 +595,14 @@ impl<'a> CodeActionWorker<'a> {
     fn create_file(&self, uri: Url, needs_confirmation: bool) -> EcoWorkspaceEdit {
         let change_id = "Typst Create Missing Files".to_string();
 
-        let create_op = EcoDocumentChangeOperation::Op(lsp_types::ResourceOp::Create(CreateFile {
+        let create_op = EcoDocumentChangeOperation::CreateFile(CreateFile {
             uri,
             options: Some(CreateFileOptions {
                 overwrite: Some(false),
                 ignore_if_exists: None,
             }),
             annotation_id: Some(change_id.clone()),
-        }));
+        });
 
         let mut change_annotations = HashMap::new();
         change_annotations.insert(

--- a/crates/tinymist-query/src/analysis/code_action/figure.rs
+++ b/crates/tinymist-query/src/analysis/code_action/figure.rs
@@ -77,7 +77,7 @@ impl<'a> CodeActionWorker<'a> {
                 func_name = func_name.into()
             )
             .to_string(),
-            kind: Some(CodeActionKind::REFACTOR_REWRITE),
+            kind: Some(CodeActionKind::RefactorRewrite),
             edit: Some(edit_before),
             ..CodeAction::default()
         };

--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -378,7 +378,7 @@ impl<'a> CompletionCursor<'a> {
             label_details: item.label_details.clone().map(From::from),
             text_edit: Some(text_edit),
             additional_text_edits: item.additional_text_edits.clone(),
-            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            insert_text_format: Some(InsertTextFormat::Snippet),
             command: item.command.clone(),
             ..Default::default()
         }

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -143,7 +143,7 @@ impl CompletionPair<'_, '_, '_> {
                         // don't sort me
                         sort_text: Some(sort_text),
                         filter_text: Some("".into()),
-                        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+                        insert_text_format: Some(InsertTextFormat::PlainText),
                         ..Default::default()
                     }
                 })

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::{collections::HashSet, ops::Deref};
 
 use comemo::{Track, Tracked};
-use lsp_types::Url;
+use lsp_types::Uri as Url;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use tinymist_analysis::docs::DocString;

--- a/crates/tinymist-query/src/analysis/link_expr.rs
+++ b/crates/tinymist-query/src/analysis/link_expr.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use lsp_types::Url;
+use lsp_types::Uri as Url;
 use tinymist_world::package::PackageSpec;
 use tinymist_world::vfs::PathResolution;
 

--- a/crates/tinymist-query/src/analysis/semantic_tokens.rs
+++ b/crates/tinymist-query/src/analysis/semantic_tokens.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use lsp_types::SemanticToken;
-use lsp_types::{SemanticTokenModifier, SemanticTokenType};
+use lsp_types::{SemanticTokenModifiers, SemanticTokenTypes};
 use parking_lot::Mutex;
 use strum::EnumIter;
 use tinymist_std::ImmutPath;
@@ -115,20 +115,20 @@ impl Drop for SemanticTokenContext {
     }
 }
 
-const BOOL: SemanticTokenType = SemanticTokenType::new("bool");
-const PUNCTUATION: SemanticTokenType = SemanticTokenType::new("punct");
-const ESCAPE: SemanticTokenType = SemanticTokenType::new("escape");
-const LINK: SemanticTokenType = SemanticTokenType::new("link");
-const RAW: SemanticTokenType = SemanticTokenType::new("raw");
-const LABEL: SemanticTokenType = SemanticTokenType::new("label");
-const REF: SemanticTokenType = SemanticTokenType::new("ref");
-const HEADING: SemanticTokenType = SemanticTokenType::new("heading");
-const LIST_MARKER: SemanticTokenType = SemanticTokenType::new("marker");
-const LIST_TERM: SemanticTokenType = SemanticTokenType::new("term");
-const DELIMITER: SemanticTokenType = SemanticTokenType::new("delim");
-const INTERPOLATED: SemanticTokenType = SemanticTokenType::new("pol");
-const ERROR: SemanticTokenType = SemanticTokenType::new("error");
-const TEXT: SemanticTokenType = SemanticTokenType::new("text");
+const BOOL: SemanticTokenTypes = SemanticTokenTypes::new("bool");
+const PUNCTUATION: SemanticTokenTypes = SemanticTokenTypes::new("punct");
+const ESCAPE: SemanticTokenTypes = SemanticTokenTypes::new("escape");
+const LINK: SemanticTokenTypes = SemanticTokenTypes::new("link");
+const RAW: SemanticTokenTypes = SemanticTokenTypes::new("raw");
+const LABEL: SemanticTokenTypes = SemanticTokenTypes::new("label");
+const REF: SemanticTokenTypes = SemanticTokenTypes::new("ref");
+const HEADING: SemanticTokenTypes = SemanticTokenTypes::new("heading");
+const LIST_MARKER: SemanticTokenTypes = SemanticTokenTypes::new("marker");
+const LIST_TERM: SemanticTokenTypes = SemanticTokenTypes::new("term");
+const DELIMITER: SemanticTokenTypes = SemanticTokenTypes::new("delim");
+const INTERPOLATED: SemanticTokenTypes = SemanticTokenTypes::new("pol");
+const ERROR: SemanticTokenTypes = SemanticTokenTypes::new("error");
+const TEXT: SemanticTokenTypes = SemanticTokenTypes::new("text");
 
 /// Very similar to `typst_ide::Tag`, but with convenience traits, and
 /// extensible because we want to further customize highlighting
@@ -193,20 +193,20 @@ pub enum TokenType {
     None,
 }
 
-impl From<TokenType> for SemanticTokenType {
+impl From<TokenType> for SemanticTokenTypes {
     fn from(token_type: TokenType) -> Self {
         use TokenType::*;
 
         match token_type {
-            Comment => Self::COMMENT,
-            String => Self::STRING,
-            Keyword => Self::KEYWORD,
-            Operator => Self::OPERATOR,
-            Number => Self::NUMBER,
-            Function => Self::FUNCTION,
-            Decorator => Self::DECORATOR,
-            Type => Self::TYPE,
-            Namespace => Self::NAMESPACE,
+            Comment => Self::Comment,
+            String => Self::String,
+            Keyword => Self::Keyword,
+            Operator => Self::Operator,
+            Number => Self::Number,
+            Function => Self::Function,
+            Decorator => Self::Decorator,
+            Type => Self::Type,
+            Namespace => Self::Namespace,
             Bool => BOOL,
             Punctuation => PUNCTUATION,
             Escape => ESCAPE,
@@ -226,9 +226,9 @@ impl From<TokenType> for SemanticTokenType {
     }
 }
 
-const STRONG: SemanticTokenModifier = SemanticTokenModifier::new("strong");
-const EMPH: SemanticTokenModifier = SemanticTokenModifier::new("emph");
-const MATH: SemanticTokenModifier = SemanticTokenModifier::new("math");
+const STRONG: SemanticTokenModifiers = SemanticTokenModifiers::new("strong");
+const EMPH: SemanticTokenModifiers = SemanticTokenModifiers::new("emph");
+const MATH: SemanticTokenModifiers = SemanticTokenModifiers::new("math");
 
 /// A modifier to some semantic token.
 #[derive(Clone, Copy, EnumIter)]
@@ -260,7 +260,7 @@ impl Modifier {
     }
 }
 
-impl From<Modifier> for SemanticTokenModifier {
+impl From<Modifier> for SemanticTokenModifiers {
     fn from(modifier: Modifier) -> Self {
         use Modifier::*;
 
@@ -268,9 +268,9 @@ impl From<Modifier> for SemanticTokenModifier {
             Strong => STRONG,
             Emph => EMPH,
             Math => MATH,
-            ReadOnly => Self::READONLY,
-            Static => Self::STATIC,
-            DefaultLibrary => Self::DEFAULT_LIBRARY,
+            ReadOnly => Self::Readonly,
+            Static => Self::Static,
+            DefaultLibrary => Self::DefaultLibrary,
         }
     }
 }

--- a/crates/tinymist-query/src/code_action/proto.rs
+++ b/crates/tinymist-query/src/code_action/proto.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use ecow::EcoString;
 use lsp_types::{
     ChangeAnnotation, ChangeAnnotationIdentifier, CodeActionDisabled, CodeActionKind, Command,
-    Diagnostic, InsertTextFormat, OneOf, OptionalVersionedTextDocumentIdentifier, ResourceOp, Url,
+    CreateFile, DeleteFile, Diagnostic, InsertTextFormat, OptionalVersionedTextDocumentIdentifier,
+    RenameFile, Uri as Url,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -27,7 +28,7 @@ impl EcoSnippetTextEdit {
     pub fn new_plain(range: LspRange, new_text: EcoString) -> EcoSnippetTextEdit {
         EcoSnippetTextEdit {
             edit: EcoTextEdit::new(range, new_text),
-            insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+            insert_text_format: Some(InsertTextFormat::PlainText),
         }
     }
 
@@ -35,7 +36,7 @@ impl EcoSnippetTextEdit {
     pub fn new(range: LspRange, new_text: EcoString) -> EcoSnippetTextEdit {
         EcoSnippetTextEdit {
             edit: EcoTextEdit::new(range, new_text),
-            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            insert_text_format: Some(InsertTextFormat::Snippet),
         }
     }
 }
@@ -52,6 +53,15 @@ pub struct EcoAnnotatedTextEdit {
 
     /// The actual annotation
     pub annotation_id: ChangeAnnotationIdentifier,
+}
+
+/// A value that can be one of two types.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OneOf<T, U> {
+    #[allow(missing_docs)]
+    Left(T),
+    #[allow(missing_docs)]
+    Right(U),
 }
 
 /// Describes textual changes on a single text document. The text document is
@@ -201,8 +211,12 @@ pub enum EcoDocumentChanges {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum EcoDocumentChangeOperation {
-    /// A resource operation.
-    Op(ResourceOp),
+    /// Create file operation.
+    CreateFile(CreateFile),
+    /// Rename file operation.
+    RenameFile(RenameFile),
+    /// Delete file operation.
+    DeleteFile(DeleteFile),
     /// A text document edit.
     Edit(EcoTextDocumentEdit),
 }
@@ -211,7 +225,7 @@ mod url_map {
     use std::marker::PhantomData;
     use std::{collections::HashMap, fmt};
 
-    use lsp_types::Url;
+    use lsp_types::Uri as Url;
     use serde::de;
 
     pub fn deserialize<'de, D, V>(deserializer: D) -> Result<Option<HashMap<Url, V>>, D::Error>

--- a/crates/tinymist-query/src/code_lens.rs
+++ b/crates/tinymist-query/src/code_lens.rs
@@ -31,6 +31,7 @@ impl SemanticRequest for CodeLensRequest {
                     title: title.to_string(),
                     command: "tinymist.runCodeLens".to_string(),
                     arguments: Some(args),
+                    tooltip: None,
                 }),
                 data: None,
             })
@@ -87,6 +88,7 @@ impl SemanticRequest for CodeLensRequest {
                     }
                     .to_string(),
                     arguments: Some(vec![uri]),
+                    tooltip: None,
                 }),
                 data: None,
             })

--- a/crates/tinymist-query/src/completion/proto.rs
+++ b/crates/tinymist-query/src/completion/proto.rs
@@ -39,18 +39,18 @@ pub enum CompletionKind {
 impl From<&CompletionKind> for lsp_types::CompletionItemKind {
     fn from(value: &CompletionKind) -> Self {
         match value {
-            CompletionKind::Syntax => Self::SNIPPET,
-            CompletionKind::Func => Self::FUNCTION,
-            CompletionKind::Param => Self::VARIABLE,
-            CompletionKind::Field => Self::FIELD,
-            CompletionKind::Variable => Self::VARIABLE,
-            CompletionKind::Constant => Self::CONSTANT,
-            CompletionKind::Reference => Self::REFERENCE,
-            CompletionKind::Symbol(_) => Self::FIELD,
-            CompletionKind::Type => Self::CLASS,
-            CompletionKind::Module => Self::MODULE,
-            CompletionKind::File => Self::FILE,
-            CompletionKind::Folder => Self::FOLDER,
+            CompletionKind::Syntax => Self::Snippet,
+            CompletionKind::Func => Self::Function,
+            CompletionKind::Param => Self::Variable,
+            CompletionKind::Field => Self::Field,
+            CompletionKind::Variable => Self::Variable,
+            CompletionKind::Constant => Self::Constant,
+            CompletionKind::Reference => Self::Reference,
+            CompletionKind::Symbol(_) => Self::Field,
+            CompletionKind::Type => Self::Class,
+            CompletionKind::Module => Self::Module,
+            CompletionKind::File => Self::File,
+            CompletionKind::Folder => Self::Folder,
         }
     }
 }
@@ -71,16 +71,16 @@ impl<'de> serde::Deserialize<'de> for CompletionKind {
     {
         let kind = lsp_types::CompletionItemKind::deserialize(deserializer)?;
         Ok(match kind {
-            lsp_types::CompletionItemKind::SNIPPET => CompletionKind::Syntax,
-            lsp_types::CompletionItemKind::FUNCTION => CompletionKind::Func,
-            lsp_types::CompletionItemKind::VARIABLE => CompletionKind::Param,
-            lsp_types::CompletionItemKind::FIELD => CompletionKind::Field,
-            lsp_types::CompletionItemKind::CONSTANT => CompletionKind::Constant,
-            lsp_types::CompletionItemKind::REFERENCE => CompletionKind::Reference,
-            lsp_types::CompletionItemKind::CLASS => CompletionKind::Type,
-            lsp_types::CompletionItemKind::MODULE => CompletionKind::Module,
-            lsp_types::CompletionItemKind::FILE => CompletionKind::File,
-            lsp_types::CompletionItemKind::FOLDER => CompletionKind::Folder,
+            lsp_types::CompletionItemKind::Snippet => CompletionKind::Syntax,
+            lsp_types::CompletionItemKind::Function => CompletionKind::Func,
+            lsp_types::CompletionItemKind::Variable => CompletionKind::Param,
+            lsp_types::CompletionItemKind::Field => CompletionKind::Field,
+            lsp_types::CompletionItemKind::Constant => CompletionKind::Constant,
+            lsp_types::CompletionItemKind::Reference => CompletionKind::Reference,
+            lsp_types::CompletionItemKind::Class => CompletionKind::Type,
+            lsp_types::CompletionItemKind::Module => CompletionKind::Module,
+            lsp_types::CompletionItemKind::File => CompletionKind::File,
+            lsp_types::CompletionItemKind::Folder => CompletionKind::Folder,
             _ => CompletionKind::Variable,
         })
     }

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -150,7 +150,7 @@ impl<'w> DiagWorker<'w> {
         let diagnostic = Diagnostic {
             range: lsp_range,
             severity: Some(lsp_severity),
-            message: lsp_message,
+            message: lsp_message.into(),
             source: Some(self.source.to_owned()),
             related_information: (!typst_diagnostic.trace.is_empty()).then(|| {
                 typst_diagnostic
@@ -209,8 +209,8 @@ impl<'w> DiagWorker<'w> {
 
 fn diagnostic_severity(typst_severity: TypstSeverity) -> DiagnosticSeverity {
     match typst_severity {
-        TypstSeverity::Error => DiagnosticSeverity::ERROR,
-        TypstSeverity::Warning => DiagnosticSeverity::WARNING,
+        TypstSeverity::Error => DiagnosticSeverity::Error,
+        TypstSeverity::Warning => DiagnosticSeverity::Warning,
     }
 }
 

--- a/crates/tinymist-query/src/document_symbol.rs
+++ b/crates/tinymist-query/src/document_symbol.rs
@@ -32,7 +32,7 @@ impl SyntaxRequest for DocumentSymbolRequest {
     ) -> Option<Self::Response> {
         let hierarchy = get_lexical_hierarchy(source, LexicalScopeKind::Symbol)?;
         let symbols = symbols_in_hierarchy(&hierarchy, source, position_encoding);
-        Some(DocumentSymbolResponse::Nested(symbols))
+        Some(symbols.into())
     }
 }
 

--- a/crates/tinymist-query/src/goto_declaration.rs
+++ b/crates/tinymist-query/src/goto_declaration.rs
@@ -28,7 +28,7 @@ pub struct GotoDeclarationRequest {
 }
 
 impl SemanticRequest for GotoDeclarationRequest {
-    type Response = GotoDeclarationResponse;
+    type Response = DeclarationResponse;
 
     fn request(self, _ctx: &mut LocalContext) -> Option<Self::Response> {
         let _ = find_declarations;

--- a/crates/tinymist-query/src/goto_definition.rs
+++ b/crates/tinymist-query/src/goto_definition.rs
@@ -24,7 +24,7 @@ pub struct GotoDefinitionRequest {
 }
 
 impl SemanticRequest for GotoDefinitionRequest {
-    type Response = GotoDefinitionResponse;
+    type Response = DefinitionResponse;
 
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
@@ -37,7 +37,7 @@ impl SemanticRequest for GotoDefinitionRequest {
         let name_range = def.name_range(ctx.shared()).unwrap_or_default();
         let full_range = def.full_range().unwrap_or_else(|| name_range.clone());
 
-        let res = Some(GotoDefinitionResponse::Link(vec![LocationLink {
+        let res = Some(DefinitionResponse::DefinitionLinkList(vec![LocationLink {
             origin_selection_range: Some(origin_selection_range),
             target_uri: ctx.uri_for_id(fid).ok()?,
             target_range: ctx.to_lsp_range_(full_range, fid)?,

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -73,7 +73,10 @@ impl SemanticRequest for HoverRequest {
         Some(Hover {
             // Neovim shows ugly hover if the hover content is in array, so we join them
             // manually with divider bars.
-            contents: HoverContents::Scalar(MarkedString::String(contents.join("\n\n---\n\n"))),
+            contents: Contents::MarkupContent(MarkupContent::new(
+                MarkupKind::Markdown,
+                contents.join("\n\n---\n\n"),
+            )),
             range: Some(range),
         })
     }
@@ -624,23 +627,24 @@ mod tests {
             };
 
             // write contents
+            #[allow(deprecated)]
             match contents {
-                HoverContents::Markup(content) => {
+                Contents::MarkupContent(content) => {
                     writeln!(f, "{}", content.value)?;
                 }
-                HoverContents::Scalar(MarkedString::String(content)) => {
+                Contents::MarkedString(lsp_types::MarkedString::String(content)) => {
                     writeln!(f, "{content}")?;
                 }
-                HoverContents::Scalar(MarkedString::LanguageString(lang_str)) => {
-                    writeln!(f, "=== {} ===\n{}", lang_str.language, lang_str.value)?
-                }
-                HoverContents::Array(contents) => {
+                Contents::MarkedString(lsp_types::MarkedString::MarkedStringWithLanguage(
+                    lang_str,
+                )) => writeln!(f, "=== {} ===\n{}", lang_str.language, lang_str.value)?,
+                Contents::MarkedStringList(contents) => {
                     // interperse the contents with a divider
                     let content = contents
                         .iter()
                         .map(|content| match content {
-                            MarkedString::String(text) => text.to_string(),
-                            MarkedString::LanguageString(lang_str) => {
+                            lsp_types::MarkedString::String(text) => text.to_string(),
+                            lsp_types::MarkedString::MarkedStringWithLanguage(lang_str) => {
                                 format!("=== {} ===\n{}", lang_str.language, lang_str.value)
                             }
                         })

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -13,7 +13,7 @@ use crate::index::protocol::ResultSet;
 use crate::prelude::Definition;
 use crate::{LocalContext, path_to_url};
 use ecow::EcoString;
-use lsp_types::Url;
+use lsp_types::Uri as Url;
 use tinymist_analysis::syntax::classify_syntax;
 use tinymist_std::error::WithContextUntyped;
 use tinymist_std::hash::FxHashMap;

--- a/crates/tinymist-query/src/index/protocol.rs
+++ b/crates/tinymist-query/src/index/protocol.rs
@@ -9,7 +9,7 @@
 // todo: large_enum_variant
 
 use ecow::EcoString;
-use lsp_types::{Range, SemanticTokens, Url};
+use lsp_types::{Range, SemanticTokens, Uri as Url};
 use serde::{Deserialize, Serialize};
 
 pub type Id = i32;

--- a/crates/tinymist-query/src/inlay_hint.rs
+++ b/crates/tinymist-query/src/inlay_hint.rs
@@ -1,4 +1,4 @@
-use lsp_types::{InlayHintKind, InlayHintLabel};
+use lsp_types::{InlayHintKind, Label};
 use typst::syntax::{LinkedNode, SyntaxKind, ast};
 
 use crate::{
@@ -253,7 +253,7 @@ impl InlayHintWorker<'_> {
                     let pos = arg_node.range().start;
                     let lsp_pos = self.ctx.to_lsp_pos(pos, self.source);
 
-                    let label = InlayHintLabel::String(if info.kind == ParamKind::Rest {
+                    let label = Label::String(if info.kind == ParamKind::Rest {
                         format!("..{name}:")
                     } else {
                         format!("{name}:")
@@ -262,7 +262,7 @@ impl InlayHintWorker<'_> {
                     self.hints.push(InlayHint {
                         position: lsp_pos,
                         label,
-                        kind: Some(InlayHintKind::PARAMETER),
+                        kind: Some(InlayHintKind::Parameter),
                         text_edits: None,
                         tooltip: None,
                         padding_left: None,
@@ -333,10 +333,10 @@ impl InlayHintWorker<'_> {
 
         self.hints.push(InlayHint {
             position: lsp_pos,
-            label: InlayHintLabel::String(label.to_string()),
-            kind: Some(InlayHintKind::TYPE),
+            label: Label::String(label.to_string()),
+            kind: Some(InlayHintKind::Type),
             text_edits: None,
-            tooltip: tooltip.map(|t| lsp_types::InlayHintTooltip::String(t.to_string())),
+            tooltip: tooltip.map(|t| lsp_types::Tooltip::String(t.to_string())),
             padding_left: Some(true),
             padding_right: None,
             data: None,

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -380,9 +380,9 @@ mod polymorphic {
         /// The response to the hover request.
         Hover(Option<Hover>),
         /// The response to the goto definition request.
-        GotoDefinition(Option<GotoDefinitionResponse>),
+        GotoDefinition(Option<DefinitionResponse>),
         /// The response to the goto declaration request.
-        GotoDeclaration(Option<GotoDeclarationResponse>),
+        GotoDeclaration(Option<DeclarationResponse>),
         /// The response to the references request.
         References(Option<Vec<LspLocation>>),
         /// The response to the inlay hint request.
@@ -404,7 +404,7 @@ mod polymorphic {
         /// The response to the signature help request.
         SignatureHelp(Option<SignatureHelp>),
         /// The response to the prepare rename request.
-        PrepareRename(Option<PrepareRenameResponse>),
+        PrepareRename(Option<PrepareRenameResult>),
         /// The response to the rename request.
         Rename(Option<WorkspaceEdit>),
         /// The response to the will rename files request.
@@ -416,9 +416,9 @@ mod polymorphic {
         /// The response to the workspace label request.
         WorkspaceLabel(Option<Vec<SymbolInformation>>),
         /// The response to the semantic tokens full request.
-        SemanticTokensFull(Option<SemanticTokensResult>),
+        SemanticTokensFull(Option<SemanticTokens>),
         /// The response to the semantic tokens delta request.
-        SemanticTokensDelta(Option<SemanticTokensFullDeltaResult>),
+        SemanticTokensDelta(Option<SemanticTokensDeltaResponse>),
         /// The response to the formatting request.
         Formatting(Option<Vec<TextEdit>>),
         /// The response to the folding range request.

--- a/crates/tinymist-query/src/prelude.rs
+++ b/crates/tinymist-query/src/prelude.rs
@@ -7,14 +7,15 @@ pub use std::sync::{Arc, LazyLock, OnceLock};
 pub use ecow::{EcoVec, eco_vec};
 pub use itertools::Itertools;
 pub use lsp_types::{
-    CodeActionKind, CodeLens, ColorInformation, ColorPresentation, Diagnostic,
-    DiagnosticRelatedInformation, DiagnosticSeverity, DocumentHighlight, DocumentLink,
-    DocumentSymbol, DocumentSymbolResponse, Documentation, FoldingRange, GotoDefinitionResponse,
-    Hover, HoverContents, InlayHint, Location as LspLocation, LocationLink, MarkedString,
-    MarkupContent, MarkupKind, ParameterInformation, Position as LspPosition,
-    PrepareRenameResponse, SelectionRange, SemanticTokens, SemanticTokensDelta,
-    SemanticTokensFullDeltaResult, SemanticTokensResult, SignatureHelp, SignatureInformation,
-    SymbolInformation, TextEdit, Url, WorkspaceEdit, request::GotoDeclarationResponse,
+    ActiveParameter, BaseSymbolInformation, CodeActionKind, CodeLens, ColorInformation,
+    ColorPresentation, Contents, DeclarationResponse, DefinitionResponse, Diagnostic,
+    DiagnosticRelatedInformation, DiagnosticSeverity, DocumentChange, DocumentHighlight,
+    DocumentLink, DocumentSymbol, DocumentSymbolResponse, Documentation, FoldingRange, Hover,
+    InlayHint, Location as LspLocation, LocationLink, MarkupContent, MarkupKind,
+    ParameterInformation, Position as LspPosition, PrepareRenamePlaceholder, PrepareRenameResult,
+    SelectionRange, SemanticTokens, SemanticTokensDelta, SemanticTokensDeltaResponse,
+    SignatureHelp, SignatureInformation, SymbolInformation, TextDocumentIdentifier, TextEdit,
+    Uri as Url, WorkspaceEdit,
 };
 pub use serde_json::Value as JsonValue;
 pub use tinymist_project::LspComputeGraph;

--- a/crates/tinymist-query/src/prepare_rename.rs
+++ b/crates/tinymist-query/src/prepare_rename.rs
@@ -32,7 +32,7 @@ pub struct PrepareRenameRequest {
 // todo: rename alias
 // todo: rename import path?
 impl SemanticRequest for PrepareRenameRequest {
-    type Response = PrepareRenameResponse;
+    type Response = PrepareRenameResult;
 
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
@@ -59,10 +59,12 @@ impl SemanticRequest for PrepareRenameRequest {
 
         let name = prepare_renaming(&syntax, &def)?;
 
-        Some(PrepareRenameResponse::RangeWithPlaceholder {
-            range: origin_selection_range,
-            placeholder: name,
-        })
+        Some(PrepareRenameResult::PrepareRenamePlaceholder(
+            PrepareRenamePlaceholder {
+                range: origin_selection_range,
+                placeholder: name,
+            },
+        ))
     }
 }
 

--- a/crates/tinymist-query/src/rename.rs
+++ b/crates/tinymist-query/src/rename.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
-    AnnotatedTextEdit, ChangeAnnotation, DocumentChangeOperation, DocumentChanges, OneOf,
-    OptionalVersionedTextDocumentIdentifier, RenameFile, TextDocumentEdit,
+    AnnotatedTextEdit, ChangeAnnotation, OptionalVersionedTextDocumentIdentifier, RenameFile,
+    TextDocumentEdit,
 };
 use rustc_hash::FxHashSet;
 use tinymist_std::path::{PathClean, unix_slash};
@@ -78,18 +78,16 @@ impl SemanticRequest for RenameRequest {
 
                 let mut document_changes = edits_to_document_changes(edits, None);
 
-                document_changes.push(lsp_types::DocumentChangeOperation::Op(
-                    lsp_types::ResourceOp::Rename(RenameFile {
-                        old_uri,
-                        new_uri,
-                        options: None,
-                        annotation_id: None,
-                    }),
-                ));
+                document_changes.push(lsp_types::DocumentChange::RenameFile(RenameFile {
+                    old_uri,
+                    new_uri,
+                    options: None,
+                    annotation_id: None,
+                }));
 
                 // todo: validate: workspace.workspaceEdit.resourceOperations
                 Some(WorkspaceEdit {
-                    document_changes: Some(DocumentChanges::Operations(document_changes)),
+                    document_changes: Some(document_changes),
                     ..Default::default()
                 })
             }
@@ -128,7 +126,7 @@ impl SemanticRequest for RenameRequest {
                     ));
 
                     Some(WorkspaceEdit {
-                        document_changes: Some(DocumentChanges::Operations(document_changes)),
+                        document_changes: Some(document_changes),
                         change_annotations,
                         ..Default::default()
                     })
@@ -325,23 +323,29 @@ impl RenameFileWorker<'_> {
 pub(crate) fn edits_to_document_changes(
     edits: HashMap<Url, Vec<TextEdit>>,
     change_id: Option<&str>,
-) -> Vec<DocumentChangeOperation> {
+) -> Vec<DocumentChange> {
     let mut document_changes = vec![];
 
     for (uri, edits) in edits {
-        document_changes.push(lsp_types::DocumentChangeOperation::Edit(TextDocumentEdit {
-            text_document: OptionalVersionedTextDocumentIdentifier { uri, version: None },
-            edits: edits
-                .into_iter()
-                .map(|edit| match change_id {
-                    Some(change_id) => OneOf::Right(AnnotatedTextEdit {
-                        text_edit: edit,
-                        annotation_id: change_id.to_owned(),
-                    }),
-                    None => OneOf::Left(edit),
-                })
-                .collect(),
-        }));
+        document_changes.push(lsp_types::DocumentChange::TextDocumentEdit(
+            TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    text_document_identifier: TextDocumentIdentifier { uri },
+                    version: None,
+                },
+                edits: edits
+                    .into_iter()
+                    .map(|edit| match change_id {
+                        Some(change_id) => AnnotatedTextEdit {
+                            text_edit: edit,
+                            annotation_id: change_id.to_owned(),
+                        }
+                        .into(),
+                        None => edit.into(),
+                    })
+                    .collect(),
+            },
+        ));
     }
 
     document_changes

--- a/crates/tinymist-query/src/semantic_tokens_delta.rs
+++ b/crates/tinymist-query/src/semantic_tokens_delta.rs
@@ -24,7 +24,7 @@ pub struct SemanticTokensDeltaRequest {
 }
 
 impl SemanticRequest for SemanticTokensDeltaRequest {
-    type Response = SemanticTokensFullDeltaResult;
+    type Response = SemanticTokensDeltaResponse;
     /// Handles the request to compute the semantic tokens delta for a given
     /// document.
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
@@ -32,7 +32,7 @@ impl SemanticRequest for SemanticTokensDeltaRequest {
         let (tokens, result_id) = ctx.cached_tokens(&source);
 
         Some(match ctx.tokens.as_ref().and_then(|t| t.prev.as_ref()) {
-            Some(cached) => SemanticTokensFullDeltaResult::TokensDelta(SemanticTokensDelta {
+            Some(cached) => SemanticTokensDeltaResponse::SemanticTokensDelta(SemanticTokensDelta {
                 result_id,
                 edits: token_delta(cached, &tokens),
             }),
@@ -42,7 +42,7 @@ impl SemanticRequest for SemanticTokensDeltaRequest {
                     self.path.display(),
                     self.previous_result_id
                 );
-                SemanticTokensFullDeltaResult::Tokens(SemanticTokens {
+                SemanticTokensDeltaResponse::SemanticTokens(SemanticTokens {
                     result_id,
                     data: tokens.as_ref().clone(),
                 })
@@ -73,6 +73,18 @@ fn token_delta(from: &[SemanticToken], to: &[SemanticToken]) -> Vec<SemanticToke
 
     let (from, _) = from.split_at(from.len() - dist_from_end);
     let (to, _) = to.split_at(to.len() - dist_from_end);
+    let data = to
+        .iter()
+        .flat_map(|token| {
+            vec![
+                token.delta_line,
+                token.delta_start,
+                token.length,
+                token.token_type,
+                token.token_modifiers_bitset,
+            ]
+        })
+        .collect();
 
     if from.is_empty() && to.is_empty() {
         vec![]
@@ -80,7 +92,7 @@ fn token_delta(from: &[SemanticToken], to: &[SemanticToken]) -> Vec<SemanticToke
         vec![SemanticTokensEdit {
             start: 5 * start as u32,
             delete_count: 5 * from.len() as u32,
-            data: Some(to.into()),
+            data: Some(data),
         }]
     }
 }

--- a/crates/tinymist-query/src/semantic_tokens_full.rs
+++ b/crates/tinymist-query/src/semantic_tokens_full.rs
@@ -23,17 +23,17 @@ pub struct SemanticTokensFullRequest {
 }
 
 impl SemanticRequest for SemanticTokensFullRequest {
-    type Response = SemanticTokensResult;
+    type Response = SemanticTokens;
 
     /// Handles the request to compute the semantic tokens for a given document.
     fn request(self, ctx: &mut LocalContext) -> Option<Self::Response> {
         let source = ctx.source_by_path(&self.path).ok()?;
         let (tokens, result_id) = ctx.cached_tokens(&source);
 
-        Some(SemanticTokensResult::Tokens(SemanticTokens {
+        Some(SemanticTokens {
             result_id,
             data: tokens.as_ref().clone(),
-        }))
+        })
     }
 }
 
@@ -139,18 +139,9 @@ mod tests {
             let request = SemanticTokensFullRequest { path: path.clone() };
 
             let mut result = request.request(ctx).unwrap();
-            if let SemanticTokensResult::Tokens(tokens) = &mut result {
-                tokens.result_id.take();
-            }
+            result.result_id.take();
 
-            match &result {
-                SemanticTokensResult::Tokens(tokens) => {
-                    check_tokens(tokens);
-                }
-                SemanticTokensResult::Partial(_) => {
-                    panic!("Unexpected partial result");
-                }
-            }
+            check_tokens(&result);
 
             assert_snapshot!(serde_json::to_string(&result).unwrap());
         });

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -89,7 +89,7 @@ impl SemanticRequest for SignatureHelpRequest {
             ));
 
             params.push(ParameterInformation {
-                label: lsp_types::ParameterLabel::Simple(format!("{}:", param.name)),
+                label: lsp_types::ParameterInformationLabel::String(format!("{}:", param.name)),
                 documentation: param.docs.as_ref().map(|docs| {
                     Documentation::MarkupContent(MarkupContent {
                         value: docs.as_ref().into(),
@@ -117,7 +117,7 @@ impl SemanticRequest for SignatureHelpRequest {
                 label: label.to_string(),
                 documentation: sig.primary().docs.as_deref().map(markdown_docs),
                 parameters: Some(params),
-                active_parameter: active_parameter.map(|x| x as u32),
+                active_parameter: active_parameter.map(|x| ActiveParameter::Int(x as u32)),
             }],
             active_signature: Some(0),
             active_parameter: None,

--- a/crates/tinymist-query/src/symbol.rs
+++ b/crates/tinymist-query/src/symbol.rs
@@ -82,15 +82,17 @@ fn filter_document_symbols(
             let rng = to_lsp_range(hierarchy.info.range.clone(), source, position_encoding);
 
             Some(SymbolInformation {
-                name: hierarchy.info.name.to_string(),
-                kind: hierarchy.info.kind.clone().into(),
-                tags: None,
+                base_symbol_information: BaseSymbolInformation {
+                    name: hierarchy.info.name.to_string(),
+                    kind: hierarchy.info.kind.clone().into(),
+                    tags: None,
+                    container_name: None,
+                },
                 deprecated: None,
                 location: LspLocation {
                     uri: uri.clone(),
                     range: rng,
                 },
-                container_name: None,
             })
         })
         .collect()
@@ -120,8 +122,9 @@ mod tests {
             if let Some(result) = &mut result {
                 // Sort the symbols by name for consistent output
                 result.sort_by(|x, y| {
-                    x.name
-                        .cmp(&y.name)
+                    x.base_symbol_information
+                        .name
+                        .cmp(&y.base_symbol_information.name)
                         .then_with(|| x.location.uri.cmp(&y.location.uri))
                 });
             }

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -115,11 +115,11 @@ impl From<LexicalKind> for SymbolKind {
     fn from(value: LexicalKind) -> Self {
         use LexicalVarKind::*;
         match value {
-            LexicalKind::Heading(..) => SymbolKind::NAMESPACE,
-            LexicalKind::Var(ValRef | Variable) => SymbolKind::VARIABLE,
-            LexicalKind::Var(Function) => SymbolKind::FUNCTION,
-            LexicalKind::Var(LabelRef | Label | BibKey) => SymbolKind::CONSTANT,
-            LexicalKind::Block | LexicalKind::CommentGroup => SymbolKind::CONSTANT,
+            LexicalKind::Heading(..) => SymbolKind::Namespace,
+            LexicalKind::Var(ValRef | Variable) => SymbolKind::Variable,
+            LexicalKind::Var(Function) => SymbolKind::Function,
+            LexicalKind::Var(LabelRef | Label | BibKey) => SymbolKind::Constant,
+            LexicalKind::Block | LexicalKind::CommentGroup => SymbolKind::Constant,
         }
     }
 }

--- a/crates/tinymist-query/src/tests.rs
+++ b/crates/tinymist-query/src/tests.rs
@@ -525,10 +525,10 @@ impl Redact for RedactFields {
 }
 
 pub(crate) fn file_uri(uri: &str) -> String {
-    file_uri_(&lsp_types::Url::parse(uri).unwrap())
+    file_uri_(&lsp_types::Uri::parse(uri).unwrap())
 }
 
-pub(crate) fn file_uri_(uri: &lsp_types::Url) -> String {
+pub(crate) fn file_uri_(uri: &lsp_types::Uri) -> String {
     let uri = uri.to_file_path().unwrap();
     file_path_(&uri)
 }

--- a/crates/tinymist-query/src/will_rename_files.rs
+++ b/crates/tinymist-query/src/will_rename_files.rs
@@ -48,7 +48,7 @@ impl SemanticRequest for WillRenameFilesRequest {
 
         Some(WorkspaceEdit {
             changes: None,
-            document_changes: Some(lsp_types::DocumentChanges::Operations(document_changes)),
+            document_changes: Some(document_changes),
             change_annotations,
         })
     }

--- a/crates/tinymist-query/src/workspace_label.rs
+++ b/crates/tinymist-query/src/workspace_label.rs
@@ -63,15 +63,17 @@ fn filter_document_labels(
             let rng = to_lsp_range(hierarchy.info.range.clone(), source, position_encoding);
 
             Some(SymbolInformation {
-                name: hierarchy.info.name.to_string(),
-                kind: hierarchy.info.kind.clone().into(),
-                tags: None,
+                base_symbol_information: BaseSymbolInformation {
+                    name: hierarchy.info.name.to_string(),
+                    kind: hierarchy.info.kind.clone().into(),
+                    tags: None,
+                    container_name: None,
+                },
                 deprecated: None,
                 location: LspLocation {
                     uri: uri.clone(),
                     range: rng,
                 },
-                container_name: None,
             })
         })
         .collect()

--- a/crates/tinymist/src/actor/editor.rs
+++ b/crates/tinymist/src/actor/editor.rs
@@ -3,8 +3,10 @@
 
 use std::collections::HashMap;
 
-use lsp_types::notification::{Notification, PublishDiagnostics as PublishDiagnosticsBase};
-use lsp_types::{Diagnostic, Url};
+use lsp_types::{
+    Diagnostic, LspNotificationMethod, Notification,
+    PublishDiagnosticsNotification as PublishDiagnosticsBase, Uri as Url,
+};
 use reflexo::path::unix_slash;
 use reflexo_typst::typst::prelude::{eco_vec, EcoVec};
 use serde::{Deserialize, Serialize};
@@ -245,9 +247,12 @@ struct StatusAll {
     pub words_count: Option<WordsCount>,
 }
 
-impl lsp_types::notification::Notification for StatusAll {
+impl lsp_types::Notification for StatusAll {
     type Params = Self;
-    const METHOD: &'static str = "tinymist/compileStatus";
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ClientToServer;
+    const METHOD: LspNotificationMethod<'_> =
+        LspNotificationMethod::Custom("tinymist/compileStatus");
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -271,7 +276,9 @@ pub enum PublishDiagnostics {}
 
 impl Notification for PublishDiagnostics {
     type Params = PublishDiagnosticsParams;
-    const METHOD: &'static str = PublishDiagnosticsBase::METHOD;
+    const METHOD: LspNotificationMethod<'_> = PublishDiagnosticsBase::METHOD;
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ServerToClient;
 }
 
 /// A scatter vector that is serialized as a flatten representation.

--- a/crates/tinymist/src/actor/preview.rs
+++ b/crates/tinymist/src/actor/preview.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use lsp_types::notification::Notification;
+use lsp_types::{LspNotificationMethod, Notification};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sync_ls::{internal_error, LspClient, LspResult};
@@ -135,5 +135,8 @@ struct DisposePreview {
 
 impl Notification for DisposePreview {
     type Params = Self;
-    const METHOD: &'static str = "tinymist/preview/dispose";
+    const METHOD: LspNotificationMethod<'_> =
+        LspNotificationMethod::Custom("tinymist/preview/dispose");
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ClientToServer;
 }

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -213,7 +213,14 @@ impl Config {
         font_args: CompileFontArgs,
     ) -> (Self, Option<ResponseError>) {
         // Initialize configurations
-        let roots = match params.workspace_folders.as_ref() {
+        let roots = match params
+            .workspace_folders_initialize_params
+            .workspace_folders
+            .as_ref()
+            .and_then(|folders| match folders {
+                WorkspaceFolders::WorkspaceFolderList(folders) => Some(folders),
+                WorkspaceFolders::Null => None,
+            }) {
             Some(roots) => roots
                 .iter()
                 .map(|root| ImmutPath::from(url_to_path(&root.uri)))
@@ -223,7 +230,15 @@ impl Config {
                 .root_uri
                 .as_ref()
                 .map(|uri| ImmutPath::from(url_to_path(uri)))
-                .or_else(|| Some(Path::new(&params.root_path.as_ref()?).into()))
+                .or_else(|| {
+                    Some(
+                        Path::new(&params.root_path.as_ref().and_then(|p| match p {
+                            RootPath::String(string) => Some(string),
+                            RootPath::Null => None,
+                        })?)
+                        .into(),
+                    )
+                })
                 .into_iter()
                 .collect(),
         };
@@ -1110,11 +1125,15 @@ pub(crate) fn get_semantic_tokens_options() -> SemanticTokensOptions {
         legend: SemanticTokensLegend {
             token_types: TokenType::iter()
                 .filter(|e| *e != TokenType::None)
-                .map(Into::into)
+                .map(|e| SemanticTokenTypes::from(e).into())
                 .collect(),
-            token_modifiers: Modifier::iter().map(Into::into).collect(),
+            token_modifiers: Modifier::iter()
+                .map(|e| SemanticTokenModifiers::from(e).into())
+                .collect(),
         },
-        full: Some(SemanticTokensFullOptions::Delta { delta: Some(true) }),
+        full: Some(Full::SemanticTokensFullDelta(SemanticTokensFullDelta {
+            delta: Some(true),
+        })),
         ..SemanticTokensOptions::default()
     }
 }

--- a/crates/tinymist/src/input.rs
+++ b/crates/tinymist/src/input.rs
@@ -77,15 +77,18 @@ impl ServerState {
             .ok_or_else(|| error_once!("file missing", path: path.display()))?;
 
         for change in content {
-            let replacement = change.text;
-            match change.range {
-                Some(lsp_range) => {
-                    let range = to_typst_range(lsp_range, position_encoding, source)
-                        .expect("invalid range");
-                    source.edit(range, &replacement);
+            match change {
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument { text },
+                ) => {
+                    source.replace(&text);
                 }
-                None => {
-                    source.replace(&replacement);
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { text, range, .. },
+                ) => {
+                    let range =
+                        to_typst_range(range, position_encoding, source).expect("invalid range");
+                    source.edit(range, &text);
                 }
             }
         }
@@ -135,7 +138,7 @@ impl ServerState {
 
         for change in params.inserts {
             let path: ImmutPath =
-                tinymist_query::url_to_path(&Url::parse(&change.uri).unwrap()).into();
+                tinymist_query::url_to_path(&Uri::parse(&change.uri).unwrap()).into();
             let content: FileResult<Bytes> = match change.content {
                 FileChangeResult::Ok { content } => base64::engine::general_purpose::STANDARD
                     .decode(content)
@@ -150,7 +153,7 @@ impl ServerState {
         }
 
         for path in params.removes {
-            removes.push(tinymist_query::url_to_path(&Url::parse(&path).unwrap()).into());
+            removes.push(tinymist_query::url_to_path(&Uri::parse(&path).unwrap()).into());
         }
 
         let update = FilesystemEvent::Update(FileChangeSet { inserts, removes }, params.is_sync);
@@ -344,10 +347,11 @@ impl ServerState {
 /// The file system change request.
 pub enum FsChange {}
 
-impl lsp_types::request::Request for FsChange {
+impl lsp_types::Request for FsChange {
     type Params = FsChangeParams;
     type Result = ();
-    const METHOD: &'static str = "tinymist/fsChange";
+    const METHOD: LspRequestMethod<'_> = LspRequestMethod::Custom("tinymist/fsChange");
+    const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
 }
 
 /// The file system change parameters.

--- a/crates/tinymist/src/input/watch.rs
+++ b/crates/tinymist/src/input/watch.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use lsp_types::request::Request;
+use lsp_types::{LspRequestMethod, Request};
 use reflexo::ImmutPath;
 use reflexo_typst::vfs::{FileChangeSet, PathAccessModel};
 use reflexo_typst::Bytes;
@@ -123,12 +123,14 @@ impl PathAccessModel for WatchAccessModel {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FsWatchRequest {
-    inserts: Vec<lsp_types::Url>,
-    removes: Vec<lsp_types::Url>,
+    inserts: Vec<lsp_types::Uri>,
+    removes: Vec<lsp_types::Uri>,
 }
 
 impl Request for FsWatchRequest {
     type Params = Self;
     type Result = ();
-    const METHOD: &'static str = "tinymist/fs/watch";
+    const METHOD: LspRequestMethod<'_> = LspRequestMethod::Custom("tinymist/fs/watch");
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ServerToClient;
 }

--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -1,5 +1,6 @@
 //! Logging Functionality
 
+use lsp_types::LspNotificationMethod;
 use serde::{Deserialize, Serialize};
 
 use super::*;
@@ -104,7 +105,9 @@ struct Log {
     data: String,
 }
 
-impl lsp_types::notification::Notification for Log {
-    const METHOD: &'static str = "tmLog";
+impl lsp_types::Notification for Log {
+    const METHOD: LspNotificationMethod<'_> = LspNotificationMethod::Custom("tmLog");
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ServerToClient;
     type Params = Self;
 }

--- a/crates/tinymist/src/lsp.rs
+++ b/crates/tinymist/src/lsp.rs
@@ -1,9 +1,7 @@
 use std::sync::OnceLock;
 
-use lsp_types::request::*;
 use lsp_types::*;
 use reflexo::ImmutPath;
-use request::{RegisterCapability, UnregisterCapability};
 use serde_json::{Map, Value as JsonValue};
 use sync_ls::*;
 use tinymist_std::error::{prelude::*, IgnoreLogging};
@@ -112,7 +110,9 @@ impl ServerState {
     }
 
     pub(crate) fn did_change(&mut self, params: DidChangeTextDocumentParams) -> LspResult<()> {
-        let path = as_path_(&params.text_document.uri).as_path().into();
+        let path = as_path_(&params.text_document.text_document_identifier.uri)
+            .as_path()
+            .into();
         let changes = params.content_changes;
 
         self.edit_source(path, changes, self.const_config().position_encoding)
@@ -211,7 +211,7 @@ impl ServerState {
             return self.on_changed_configuration(settings);
         };
 
-        self.client.send_lsp_request::<WorkspaceConfiguration>(
+        self.client.send_lsp_request::<ConfigurationRequest>(
             ConfigurationParams {
                 items: Config::get_items(),
             },
@@ -247,7 +247,7 @@ impl ServerState {
 impl ServerState {
     // todo: handle error
     pub(crate) fn register_capability(&self, registrations: Vec<Registration>) -> Result<()> {
-        self.client.send_lsp_request_::<RegisterCapability>(
+        self.client.send_lsp_request_::<RegistrationRequest>(
             RegistrationParams { registrations },
             |_, resp| {
                 if let Some(err) = resp.error {
@@ -262,7 +262,7 @@ impl ServerState {
         &self,
         unregisterations: Vec<Unregistration>,
     ) -> Result<()> {
-        self.client.send_lsp_request_::<UnregisterCapability>(
+        self.client.send_lsp_request_::<UnregistrationRequest>(
             UnregistrationParams { unregisterations },
             |_, resp| {
                 if let Some(err) = resp.error {
@@ -332,7 +332,7 @@ impl ServerState {
         pub fn get_formatting_registration() -> Registration {
             Registration {
                 id: FORMATTING_REGISTRATION_ID.to_owned(),
-                method: Formatting::METHOD.to_owned(),
+                method: DocumentFormattingRequest::METHOD.to_string(),
                 register_options: None,
             }
         }
@@ -340,7 +340,7 @@ impl ServerState {
         pub fn get_range_formatting_registration() -> Registration {
             Registration {
                 id: RANGE_FORMATTING_REGISTRATION_ID.to_owned(),
-                method: RangeFormatting::METHOD.to_owned(),
+                method: DocumentRangeFormattingRequest::METHOD.to_string(),
                 register_options: None,
             }
         }
@@ -348,14 +348,14 @@ impl ServerState {
         pub fn get_formatting_unregistration() -> Unregistration {
             Unregistration {
                 id: FORMATTING_REGISTRATION_ID.to_owned(),
-                method: Formatting::METHOD.to_owned(),
+                method: DocumentFormattingRequest::METHOD.to_string(),
             }
         }
 
         pub fn get_range_formatting_unregistration() -> Unregistration {
             Unregistration {
                 id: RANGE_FORMATTING_REGISTRATION_ID.to_owned(),
-                method: RangeFormatting::METHOD.to_owned(),
+                method: DocumentRangeFormattingRequest::METHOD.to_string(),
             }
         }
 

--- a/crates/tinymist/src/lsp/init.rs
+++ b/crates/tinymist/src/lsp/init.rs
@@ -97,16 +97,16 @@ impl Initializer for SuperInit {
             return (state, Err(err));
         }
 
-        let semantic_tokens_provider = (!const_config.tokens_dynamic_registration).then(|| {
-            SemanticTokensServerCapabilities::SemanticTokensOptions(get_semantic_tokens_options())
-        });
+        let semantic_tokens_provider = (!const_config.tokens_dynamic_registration)
+            .then(|| SemanticTokensProvider::SemanticTokensOptions(get_semantic_tokens_options()));
         let document_formatting_provider =
-            (!const_config.doc_fmt_dynamic_registration).then_some(OneOf::Left(true));
+            (!const_config.doc_fmt_dynamic_registration).then_some(true.into());
         let document_range_formatting_provider =
-            (!const_config.doc_fmt_dynamic_registration).then_some(OneOf::Left(true));
+            (!const_config.doc_fmt_dynamic_registration).then_some(true.into());
 
-        let file_operations = const_config.notify_will_rename_files.then(|| {
-            WorkspaceFileOperationsServerCapabilities {
+        let file_operations = const_config
+            .notify_will_rename_files
+            .then(|| FileOperationOptions {
                 will_rename: Some(FileOperationRegistrationOptions {
                     filters: vec![FileOperationFilter {
                         scheme: Some("file".to_string()),
@@ -117,14 +117,13 @@ impl Initializer for SuperInit {
                         },
                     }],
                 }),
-                ..WorkspaceFileOperationsServerCapabilities::default()
-            }
-        });
+                ..FileOperationOptions::default()
+            });
 
         let res = InitializeResult {
             capabilities: ServerCapabilities {
                 position_encoding: Some(const_config.position_encoding.into()),
-                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                hover_provider: Some(true.into()),
                 signature_help_provider: Some(SignatureHelpOptions {
                     trigger_characters: Some(vec![
                         String::from("("),
@@ -136,8 +135,8 @@ impl Initializer for SuperInit {
                         work_done_progress: None,
                     },
                 }),
-                definition_provider: Some(OneOf::Left(true)),
-                references_provider: Some(OneOf::Left(true)),
+                definition_provider: Some(true.into()),
+                references_provider: Some(true.into()),
                 completion_provider: Some(CompletionOptions {
                     // Please update the language-configuration.json if you are changing this
                     // setting.
@@ -154,14 +153,15 @@ impl Initializer for SuperInit {
                     ]),
                     ..CompletionOptions::default()
                 }),
-                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                text_document_sync: Some(
                     TextDocumentSyncOptions {
                         open_close: Some(true),
-                        change: Some(TextDocumentSyncKind::INCREMENTAL),
-                        save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                        change: Some(TextDocumentSyncKind::Incremental),
+                        save: Some(true.into()),
                         ..TextDocumentSyncOptions::default()
-                    },
-                )),
+                    }
+                    .into(),
+                ),
                 semantic_tokens_provider,
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: exec_cmds,
@@ -169,37 +169,44 @@ impl Initializer for SuperInit {
                         work_done_progress: None,
                     },
                 }),
-                color_provider: Some(ColorProviderCapability::Simple(true)),
-                document_highlight_provider: Some(OneOf::Left(true)),
-                document_symbol_provider: Some(OneOf::Left(true)),
-                workspace_symbol_provider: Some(OneOf::Left(true)),
-                selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-                rename_provider: Some(OneOf::Right(RenameOptions {
-                    prepare_provider: Some(true),
-                    work_done_progress_options: WorkDoneProgressOptions {
-                        work_done_progress: None,
-                    },
-                })),
+                color_provider: Some(true.into()),
+                document_highlight_provider: Some(true.into()),
+                document_symbol_provider: Some(true.into()),
+                workspace_symbol_provider: Some(true.into()),
+                selection_range_provider: Some(true.into()),
+                rename_provider: Some(
+                    RenameOptions {
+                        prepare_provider: Some(true),
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: None,
+                        },
+                    }
+                    .into(),
+                ),
                 document_link_provider: Some(DocumentLinkOptions {
                     resolve_provider: None,
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: None,
                     },
                 }),
-                folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
-                workspace: Some(WorkspaceServerCapabilities {
+                folding_range_provider: Some(true.into()),
+                workspace: Some(WorkspaceOptions {
                     workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                         supported: Some(true),
-                        change_notifications: Some(OneOf::Left(true)),
+                        change_notifications: Some(true.into()),
                     }),
                     file_operations,
+                    text_document_content: None,
                 }),
                 document_formatting_provider,
                 document_range_formatting_provider,
-                inlay_hint_provider: Some(OneOf::Left(true)),
-                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                inlay_hint_provider: Some(true.into()),
+                code_action_provider: Some(true.into()),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(false),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
                 }),
 
                 experimental: Some(json!({

--- a/crates/tinymist/src/lsp/query.rs
+++ b/crates/tinymist/src/lsp/query.rs
@@ -1,6 +1,6 @@
 //! tinymist's language server
 
-use lsp_types::request::GotoDeclarationParams;
+use lsp_types::DeclarationParams;
 use lsp_types::*;
 use serde::{Deserialize, Serialize};
 use sync_ls::*;
@@ -26,18 +26,18 @@ pub(crate) use run_query;
 
 /// LSP Standard Language Features
 impl ServerState {
-    pub(crate) fn goto_definition(&mut self, params: GotoDefinitionParams) -> ScheduleResult {
+    pub(crate) fn goto_definition(&mut self, params: DefinitionParams) -> ScheduleResult {
         let (path, position) = as_path_pos(params.text_document_position_params);
         run_query!(self.GotoDefinition(path, position))
     }
 
-    pub(crate) fn goto_declaration(&mut self, params: GotoDeclarationParams) -> ScheduleResult {
+    pub(crate) fn goto_declaration(&mut self, params: DeclarationParams) -> ScheduleResult {
         let (path, position) = as_path_pos(params.text_document_position_params);
         run_query!(self.GotoDeclaration(path, position))
     }
 
     pub(crate) fn references(&mut self, params: ReferenceParams) -> ScheduleResult {
-        let (path, position) = as_path_pos(params.text_document_position);
+        let (path, position) = as_path_pos(params.text_document_position_params);
         run_query!(self.References(path, position))
     }
 
@@ -148,10 +148,10 @@ impl ServerState {
     }
 
     pub(crate) fn completion(&mut self, params: CompletionParams) -> ScheduleResult {
-        let (path, position) = as_path_pos(params.text_document_position);
+        let (path, position) = as_path_pos(params.text_document_position_params);
         let context = params.context.as_ref();
         let explicit =
-            context.is_some_and(|context| context.trigger_kind == CompletionTriggerKind::INVOKED);
+            context.is_some_and(|context| context.trigger_kind == CompletionTriggerKind::Invoked);
         let trigger_character = context
             .and_then(|c| c.trigger_character.as_ref())
             .and_then(|c| c.chars().next());
@@ -168,13 +168,13 @@ impl ServerState {
     }
 
     pub(crate) fn rename(&mut self, params: RenameParams) -> ScheduleResult {
-        let (path, position) = as_path_pos(params.text_document_position);
+        let (path, position) = as_path_pos(params.text_document_position_params);
         let new_name = params.new_name;
         run_query!(self.Rename(path, position, new_name))
     }
 
-    pub(crate) fn prepare_rename(&mut self, params: TextDocumentPositionParams) -> ScheduleResult {
-        let (path, position) = as_path_pos(params);
+    pub(crate) fn prepare_rename(&mut self, params: PrepareRenameParams) -> ScheduleResult {
+        let (path, position) = as_path_pos(params.text_document_position_params);
         run_query!(self.PrepareRename(path, position))
     }
 
@@ -197,8 +197,8 @@ impl ServerState {
             .iter()
             .map(|f| {
                 Some((
-                    as_path_(&Url::parse(&f.old_uri).ok()?),
-                    as_path_(&Url::parse(&f.new_uri).ok()?),
+                    as_path_(&Uri::parse(&f.old_uri).ok()?),
+                    as_path_(&Uri::parse(&f.new_uri).ok()?),
                 ))
             })
             .collect::<Option<Vec<_>>>()
@@ -330,8 +330,9 @@ pub struct OnEnterParams {
 }
 
 pub struct OnEnter;
-impl lsp_types::request::Request for OnEnter {
+impl lsp_types::Request for OnEnter {
     type Params = OnEnterParams;
     type Result = Option<Vec<TextEdit>>;
-    const METHOD: &'static str = "experimental/onEnter";
+    const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+    const METHOD: LspRequestMethod<'_> = LspRequestMethod::Custom("experimental/onEnter");
 }

--- a/crates/tinymist/src/lsp/workspace_change_tests.rs
+++ b/crates/tinymist/src/lsp/workspace_change_tests.rs
@@ -270,8 +270,8 @@ impl LspHarness {
         self.root.path().join(rel)
     }
 
-    fn uri(&self, rel: &str) -> Url {
-        Url::from_file_path(self.path(rel)).expect("fixture path should convert to file URL")
+    fn uri(&self, rel: &str) -> Uri {
+        Uri::from_file_path(self.path(rel)).expect("fixture path should convert to file URL")
     }
 
     fn text_document(&self, rel: &str) -> TextDocumentIdentifier {
@@ -372,11 +372,13 @@ impl LspHarness {
         self.server
             .edit_source(
                 self.path(rel).as_path().into(),
-                vec![TextDocumentContentChangeEvent {
-                    range: None,
-                    range_length: None,
-                    text: source.to_owned(),
-                }],
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        TextDocumentContentChangeWholeDocument {
+                            text: source.to_owned(),
+                        },
+                    ),
+                ],
                 encoding,
             )
             .expect("failed to edit open source");
@@ -390,8 +392,8 @@ impl LspHarness {
         self.drain_project_events();
     }
 
-    fn goto_definition_uris(&mut self, rel: &str, position: Position) -> Vec<Url> {
-        let response = self.server.goto_definition(GotoDefinitionParams {
+    fn goto_definition_uris(&mut self, rel: &str, position: Position) -> Vec<Uri> {
+        let response = self.server.goto_definition(DefinitionParams {
             text_document_position_params: self.text_position(
                 rel,
                 position.line,
@@ -400,22 +402,28 @@ impl LspHarness {
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
         });
-        let result: Option<GotoDefinitionResponse> = self.decode_egress_response(response);
+        let result: Option<DefinitionResponse> = self.decode_egress_response(response);
         match result {
-            Some(GotoDefinitionResponse::Scalar(location)) => vec![location.uri],
-            Some(GotoDefinitionResponse::Array(locations)) => {
+            Some(DefinitionResponse::Definition(Definition::Location(location))) => {
+                vec![location.uri]
+            }
+            Some(DefinitionResponse::Definition(Definition::LocationList(locations))) => {
                 locations.into_iter().map(|location| location.uri).collect()
             }
-            Some(GotoDefinitionResponse::Link(links)) => {
+            Some(DefinitionResponse::DefinitionLinkList(links)) => {
                 links.into_iter().map(|link| link.target_uri).collect()
             }
             None => vec![],
         }
     }
 
-    fn reference_uris(&mut self, rel: &str, position: Position) -> Vec<Url> {
+    fn reference_uris(&mut self, rel: &str, position: Position) -> Vec<Uri> {
         let response = self.server.references(ReferenceParams {
-            text_document_position: self.text_position(rel, position.line, position.character),
+            text_document_position_params: self.text_position(
+                rel,
+                position.line,
+                position.character,
+            ),
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
             context: ReferenceContext {
@@ -440,28 +448,33 @@ impl LspHarness {
             work_done_progress_params: WorkDoneProgressParams::default(),
         });
         let result: Option<Hover> = self.decode_egress_response(response);
+        #[allow(deprecated)]
         result.map(|hover| match hover.contents {
-            HoverContents::Scalar(MarkedString::String(text)) => text,
-            HoverContents::Scalar(MarkedString::LanguageString(text)) => text.value,
-            HoverContents::Array(items) => items
+            Contents::MarkedString(MarkedString::String(text)) => text,
+            Contents::MarkedString(MarkedString::MarkedStringWithLanguage(text)) => text.value,
+            Contents::MarkedStringList(items) => items
                 .into_iter()
                 .map(|item| match item {
                     MarkedString::String(text) => text,
-                    MarkedString::LanguageString(text) => text.value,
+                    MarkedString::MarkedStringWithLanguage(text) => text.value,
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
-            HoverContents::Markup(markup) => markup.value,
+            Contents::MarkupContent(markup) => markup.value,
         })
     }
 
     fn completion_labels(&mut self, rel: &str, position: Position) -> BTreeSet<String> {
         let response = self.server.completion(CompletionParams {
-            text_document_position: self.text_position(rel, position.line, position.character),
+            text_document_position_params: self.text_position(
+                rel,
+                position.line,
+                position.character,
+            ),
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
             context: Some(CompletionContext {
-                trigger_kind: CompletionTriggerKind::INVOKED,
+                trigger_kind: CompletionTriggerKind::Invoked,
                 trigger_character: None,
             }),
         });
@@ -470,6 +483,8 @@ impl LspHarness {
             .unwrap_or_else(|| CompletionList {
                 is_incomplete: false,
                 items: vec![],
+                apply_kind: None,
+                item_defaults: None,
             })
             .items
             .into_iter()
@@ -477,7 +492,7 @@ impl LspHarness {
             .collect()
     }
 
-    fn workspace_symbol_uris(&mut self, query: &str) -> Vec<Url> {
+    fn workspace_symbol_uris(&mut self, query: &str) -> Vec<Uri> {
         let response = self.server.symbol(WorkspaceSymbolParams {
             query: query.to_owned(),
             work_done_progress_params: WorkDoneProgressParams::default(),
@@ -499,13 +514,14 @@ impl LspHarness {
         });
         let result: Option<DocumentSymbolResponse> = self.decode_egress_response(response);
         match result {
-            Some(DocumentSymbolResponse::Nested(symbols)) => symbols
+            Some(DocumentSymbolResponse::DocumentSymbolList(symbols)) => symbols
                 .into_iter()
                 .flat_map(flatten_document_symbol)
                 .collect(),
-            Some(DocumentSymbolResponse::Flat(symbols)) => {
-                symbols.into_iter().map(|symbol| symbol.name).collect()
-            }
+            Some(DocumentSymbolResponse::SymbolInformationList(symbols)) => symbols
+                .into_iter()
+                .map(|symbol| symbol.base_symbol_information.name)
+                .collect(),
             None => BTreeSet::new(),
         }
     }
@@ -516,13 +532,8 @@ impl LspHarness {
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
         });
-        let result: Option<SemanticTokensResult> = self.decode_egress_response(response);
-        match result.expect("expected semantic token response") {
-            SemanticTokensResult::Tokens(tokens) => tokens,
-            SemanticTokensResult::Partial(_) => {
-                panic!("unexpected partial semantic token response")
-            }
-        }
+        let result: Option<SemanticTokens> = self.decode_egress_response(response);
+        result.expect("expected semantic token response")
     }
 
     fn semantic_delta_result_id(
@@ -538,17 +549,20 @@ impl LspHarness {
                 work_done_progress_params: WorkDoneProgressParams::default(),
                 partial_result_params: PartialResultParams::default(),
             });
-        let result: Option<SemanticTokensFullDeltaResult> = self.decode_egress_response(response);
+        let result: Option<SemanticTokensDeltaResponse> = self.decode_egress_response(response);
         match result.expect("expected semantic token delta response") {
-            SemanticTokensFullDeltaResult::Tokens(tokens) => tokens.result_id,
-            SemanticTokensFullDeltaResult::TokensDelta(delta) => delta.result_id,
-            SemanticTokensFullDeltaResult::PartialTokensDelta { .. } => None,
+            SemanticTokensDeltaResponse::SemanticTokens(tokens) => tokens.result_id,
+            SemanticTokensDeltaResponse::SemanticTokensDelta(delta) => delta.result_id,
         }
     }
 
     fn rename_edit(&mut self, rel: &str, position: Position, new_name: &str) -> WorkspaceEdit {
         let response = self.server.rename(RenameParams {
-            text_document_position: self.text_position(rel, position.line, position.character),
+            text_document_position_params: self.text_position(
+                rel,
+                position.line,
+                position.character,
+            ),
             new_name: new_name.to_owned(),
             work_done_progress_params: WorkDoneProgressParams::default(),
         });
@@ -632,7 +646,7 @@ impl LspHarness {
         timeout: Duration,
         description: &str,
         pump_events: bool,
-        mut matches: impl FnMut(&DiagnosticPublication, &Url) -> bool,
+        mut matches: impl FnMut(&DiagnosticPublication, &Uri) -> bool,
     ) -> DiagnosticPublication {
         let deadline = Instant::now() + timeout;
         let main_uri = self.uri(MAIN);
@@ -801,7 +815,7 @@ impl LspHarness {
 
 fn diagnostics_are_empty(
     diagnostics: Option<&tinymist_query::DiagnosticsMap>,
-    main_uri: &Url,
+    main_uri: &Uri,
 ) -> bool {
     diagnostics.is_none_or(|diagnostics| {
         diagnostics.values().all(|items| items.is_empty())
@@ -813,7 +827,7 @@ fn diagnostics_are_empty(
 
 fn diagnostics_are_present_on_main(
     diagnostics: Option<&tinymist_query::DiagnosticsMap>,
-    main_uri: &Url,
+    main_uri: &Uri,
 ) -> bool {
     diagnostics
         .and_then(|diagnostics| diagnostics.get(main_uri))
@@ -1495,14 +1509,15 @@ fn assert_workspace_edit_carries_rename_assistance(
     );
 }
 
-fn workspace_edit_resource_renames(edit: &WorkspaceEdit) -> Vec<Url> {
+fn workspace_edit_resource_renames(edit: &WorkspaceEdit) -> Vec<Uri> {
     let mut renames = Vec::new();
-    let Some(DocumentChanges::Operations(operations)) = &edit.document_changes else {
+
+    let Some(changes) = &edit.document_changes else {
         return renames;
     };
 
-    for operation in operations {
-        if let DocumentChangeOperation::Op(ResourceOp::Rename(rename)) = operation {
+    for change in changes {
+        if let DocumentChange::RenameFile(rename) = change {
             renames.push(rename.new_uri.clone());
         }
     }
@@ -1526,7 +1541,7 @@ fn applied_workspace_edit_to_main(harness: &LspHarness, edit: &WorkspaceEdit) ->
     Some(after)
 }
 
-fn workspace_edit_text_edits(edit: &WorkspaceEdit, uri: &Url) -> Vec<TextEdit> {
+fn workspace_edit_text_edits(edit: &WorkspaceEdit, uri: &Uri) -> Vec<TextEdit> {
     let mut edits = Vec::new();
 
     if let Some(changes) = &edit.changes {
@@ -1536,19 +1551,10 @@ fn workspace_edit_text_edits(edit: &WorkspaceEdit, uri: &Url) -> Vec<TextEdit> {
     }
 
     if let Some(document_changes) = &edit.document_changes {
-        match document_changes {
-            DocumentChanges::Edits(document_edits) => {
-                for document_edit in document_edits {
-                    collect_text_document_edit(uri, document_edit, &mut edits);
-                }
-            }
-            DocumentChanges::Operations(operations) => {
-                for operation in operations {
-                    if let DocumentChangeOperation::Edit(document_edit) = operation {
-                        collect_text_document_edit(uri, document_edit, &mut edits);
-                    }
-                }
-            }
+        for change in document_changes {
+            if let DocumentChange::TextDocumentEdit(document_edit) = change {
+                collect_text_document_edit(uri, document_edit, &mut edits);
+            };
         }
     }
 
@@ -1556,18 +1562,19 @@ fn workspace_edit_text_edits(edit: &WorkspaceEdit, uri: &Url) -> Vec<TextEdit> {
 }
 
 fn collect_text_document_edit(
-    uri: &Url,
+    uri: &Uri,
     document_edit: &TextDocumentEdit,
     edits: &mut Vec<TextEdit>,
 ) {
-    if document_edit.text_document.uri != *uri {
+    if document_edit.text_document.text_document_identifier.uri != *uri {
         return;
     }
 
     for edit in &document_edit.edits {
         match edit {
-            OneOf::Left(edit) => edits.push(edit.clone()),
-            OneOf::Right(edit) => edits.push(edit.text_edit.clone()),
+            Edit::TextEdit(edit) => edits.push(edit.clone()),
+            Edit::AnnotatedTextEdit(edit) => edits.push(edit.text_edit.clone()),
+            Edit::SnippetTextEdit(_) => {}
         }
     }
 }

--- a/crates/tinymist/src/project.rs
+++ b/crates/tinymist/src/project.rs
@@ -17,6 +17,7 @@
 //!
 //! The [`CompileHandlerImpl`] will push information to other actors.
 
+use lsp_types::LspNotificationMethod;
 use reflexo_typst::TypstDocument;
 use serde::{Deserialize, Serialize};
 pub use tinymist_project::*;
@@ -816,7 +817,9 @@ pub enum DevEvent {
     Export(DevExportEvent),
 }
 
-impl lsp_types::notification::Notification for DevEvent {
-    const METHOD: &'static str = "tinymist/devEvent";
+impl lsp_types::Notification for DevEvent {
+    const METHOD: LspNotificationMethod<'_> = LspNotificationMethod::Custom("tinymist/devEvent");
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ServerToClient;
     type Params = Self;
 }

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub(crate) use futures::Future;
-use lsp_types::request::ShowMessageRequest;
+use lsp_types::ShowMessageRequest;
 use lsp_types::*;
 use reflexo::debug_loc::LspPosition;
 use sync_ls::*;
@@ -31,7 +31,7 @@ pub(crate) fn as_path(inp: TextDocumentIdentifier) -> PathBuf {
     as_path_(&inp.uri)
 }
 
-pub(crate) fn as_path_(uri: &Url) -> PathBuf {
+pub(crate) fn as_path_(uri: &Uri) -> PathBuf {
     tinymist_query::url_to_path(uri)
 }
 
@@ -248,8 +248,7 @@ impl ServerState {
         provider: LspBuilder<T>,
     ) -> LspBuilder<T> {
         type State = ServerState;
-        use lsp_types::notification::*;
-        use lsp_types::request::*;
+        use lsp_types::*;
 
         #[cfg(feature = "preview")]
         let provider = provider
@@ -277,7 +276,7 @@ impl ServerState {
 
         // todo: .on_sync_mut::<notifs::Cancel>(handlers::handle_cancel)?
         let mut provider = provider
-            .with_request::<Shutdown>(State::shutdown)
+            .with_request::<ShutdownRequest>(State::shutdown)
             // customized event
             .with_event(
                 &LspInterrupt::Compile(ProjectInsId::default()),
@@ -288,18 +287,18 @@ impl ServerState {
                 State::server_event::<T>,
             )
             // lantency sensitive
-            .with_request_::<Completion>(State::completion)
-            .with_request_::<SemanticTokensFullRequest>(State::semantic_tokens_full)
-            .with_request_::<SemanticTokensFullDeltaRequest>(State::semantic_tokens_full_delta)
+            .with_request_::<CompletionRequest>(State::completion)
+            .with_request_::<SemanticTokensRequest>(State::semantic_tokens_full)
+            .with_request_::<SemanticTokensDeltaRequest>(State::semantic_tokens_full_delta)
             .with_request_::<DocumentHighlightRequest>(State::document_highlight)
             .with_request_::<DocumentSymbolRequest>(State::document_symbol)
             // Sync for low latency
-            .with_request_::<Formatting>(State::formatting)
-            .with_request_::<RangeFormatting>(State::range_formatting)
+            .with_request_::<DocumentFormattingRequest>(State::formatting)
+            .with_request_::<DocumentRangeFormattingRequest>(State::range_formatting)
             .with_request_::<SelectionRangeRequest>(State::selection_range)
             // latency insensitive
             .with_request_::<InlayHintRequest>(State::inlay_hint)
-            .with_request_::<DocumentColor>(State::document_color)
+            .with_request_::<DocumentColorRequest>(State::document_color)
             .with_request_::<DocumentLinkRequest>(State::document_link)
             .with_request_::<ColorPresentationRequest>(State::color_presentation)
             .with_request_::<HoverRequest>(State::hover)
@@ -308,21 +307,23 @@ impl ServerState {
             .with_request_::<FoldingRangeRequest>(State::folding_range)
             .with_request_::<SignatureHelpRequest>(State::signature_help)
             .with_request_::<PrepareRenameRequest>(State::prepare_rename)
-            .with_request_::<Rename>(State::rename)
-            .with_request_::<GotoDefinition>(State::goto_definition)
-            .with_request_::<GotoDeclaration>(State::goto_declaration)
-            .with_request_::<References>(State::references)
+            .with_request_::<RenameRequest>(State::rename)
+            .with_request_::<DefinitionRequest>(State::goto_definition)
+            .with_request_::<DeclarationRequest>(State::goto_declaration)
+            .with_request_::<ReferencesRequest>(State::references)
             .with_request_::<WorkspaceSymbolRequest>(State::symbol)
             .with_request_::<OnEnter>(State::on_enter)
-            .with_request_::<WillRenameFiles>(State::will_rename_files)
+            .with_request_::<WillRenameFilesRequest>(State::will_rename_files)
             .with_request_::<FsChange>(State::fs_change)
             // notifications
-            .with_notification::<Initialized>(State::initialized)
-            .with_notification::<DidOpenTextDocument>(State::did_open)
-            .with_notification::<DidCloseTextDocument>(State::did_close)
-            .with_notification::<DidChangeTextDocument>(State::did_change)
-            .with_notification::<DidSaveTextDocument>(State::did_save)
-            .with_notification::<DidChangeConfiguration>(State::did_change_configuration)
+            .with_notification::<InitializedNotification>(State::initialized)
+            .with_notification::<DidOpenTextDocumentNotification>(State::did_open)
+            .with_notification::<DidCloseTextDocumentNotification>(State::did_close)
+            .with_notification::<DidChangeTextDocumentNotification>(State::did_change)
+            .with_notification::<DidSaveTextDocumentNotification>(State::did_save)
+            .with_notification::<DidChangeConfigurationNotification>(
+                State::did_change_configuration,
+            )
             // commands
             .with_command_("tinymist.exportPdf", State::export_pdf)
             .with_command_("tinymist.exportSvg", State::export_svg)
@@ -474,7 +475,7 @@ impl ServerState {
             for warning in self.config.warnings.iter() {
                 self.client.send_lsp_request::<ShowMessageRequest>(
                     ShowMessageRequestParams {
-                        typ: MessageType::WARNING,
+                        kind: MessageType::Warning,
                         message: tinymist_l10n::t!(
                             "tinymist.config.badServerConfig",
                             "bad server configuration: {warning}",
@@ -528,10 +529,10 @@ fn test_as_path() {
     use reflexo::path::PathClean;
     use std::path::Path;
 
-    let uri = Url::parse("untitled:/path/to/file").unwrap();
+    let uri = Uri::parse("untitled:/path/to/file").unwrap();
     assert_eq!(as_path_(&uri), Path::new("/untitled/path/to/file").clean());
 
-    let uri = Url::parse("untitled:/path/to/file%20with%20space").unwrap();
+    let uri = Uri::parse("untitled:/path/to/file%20with%20space").unwrap();
     assert_eq!(
         as_path_(&uri),
         Path::new("/untitled/path/to/file with space").clean()

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -2,6 +2,7 @@
 
 pub use compile::{PreviewCompileView, ProjectPreviewHandler};
 pub use http::{make_http_server, HttpServer};
+use lsp_types::LspNotificationMethod;
 
 mod compile;
 mod http;
@@ -11,8 +12,8 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use clap::{Parser, ValueEnum};
 use futures::{SinkExt, TryStreamExt};
 use hyper_tungstenite::{tungstenite::Message, HyperWebsocket, HyperWebsocketStream};
-use lsp_types::notification::Notification;
-use lsp_types::Url;
+use lsp_types::Notification;
+use lsp_types::Uri as Url;
 use reflexo_typst::error::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -603,14 +604,20 @@ struct ScrollSource;
 
 impl Notification for ScrollSource {
     type Params = DocToSrcJumpInfo;
-    const METHOD: &'static str = "tinymist/preview/scrollSource";
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ClientToServer;
+    const METHOD: LspNotificationMethod<'_> =
+        LspNotificationMethod::Custom("tinymist/preview/scrollSource");
 }
 
 struct NotifDocumentOutline;
 
 impl Notification for NotifDocumentOutline {
     type Params = tinymist_preview::Outline;
-    const METHOD: &'static str = "tinymist/documentOutline";
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ClientToServer;
+    const METHOD: LspNotificationMethod<'_> =
+        LspNotificationMethod::Custom("tinymist/documentOutline");
 }
 
 #[derive(Serialize, Deserialize)]
@@ -624,7 +631,10 @@ struct NotifViewerWindowState;
 
 impl Notification for NotifViewerWindowState {
     type Params = ViewerWindowStateParams;
-    const METHOD: &'static str = "tinymist/preview/windowState";
+    const METHOD: LspNotificationMethod<'static> =
+        LspNotificationMethod::Custom("tinymist/preview/windowState");
+    const MESSAGE_DIRECTION: lsp_types::MessageDirection =
+        lsp_types::MessageDirection::ServerToClient;
 }
 
 fn send_show_document(client: &TypedLspClient<PreviewState>, s: &DocToSrcJumpInfo, tid: &str) {
@@ -654,7 +664,7 @@ fn send_show_document(client: &TypedLspClient<PreviewState>, s: &DocToSrcJumpInf
         }
     };
 
-    client.send_lsp_request::<lsp_types::request::ShowDocument>(
+    client.send_lsp_request::<lsp_types::ShowDocumentRequest>(
         lsp_types::ShowDocumentParams {
             uri,
             external: None,

--- a/crates/tinymist/src/tool/preview/http.rs
+++ b/crates/tinymist/src/tool/preview/http.rs
@@ -8,7 +8,7 @@ use hyper::service::service_fn;
 use hyper_tungstenite::HyperWebsocket;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::graceful::GracefulShutdown;
-use lsp_types::Url;
+use lsp_types::Uri as Url;
 use tinymist_std::error::IgnoreLogging;
 use tokio::sync::{mpsc, oneshot};
 

--- a/tests/e2e/e2e/lsp.rs
+++ b/tests/e2e/e2e/lsp.rs
@@ -105,8 +105,8 @@ impl ReplayBuilder {
             .push(lsp::Message::Request(lsp::Request::new(id, method, req)));
     }
 
-    fn request<R: lsp_types::request::Request>(&mut self, req: Value) {
-        self.request_(R::METHOD.to_owned(), req);
+    fn request<R: lsp_types::Request>(&mut self, req: Value) {
+        self.request_(R::METHOD.to_string(), req);
     }
 
     fn notify_(&mut self, method: String, params: Value) {
@@ -116,8 +116,8 @@ impl ReplayBuilder {
             )));
     }
 
-    fn notify<N: lsp_types::notification::Notification>(&mut self, params: Value) {
-        self.notify_(N::METHOD.to_owned(), params);
+    fn notify<N: lsp_types::Notification>(&mut self, params: Value) {
+        self.notify_(N::METHOD.to_string(), params);
     }
 }
 
@@ -162,14 +162,12 @@ struct SmokeArgs {
 }
 
 fn gen_smoke(args: SmokeArgs) {
-    use lsp_types::notification::*;
-    use lsp_types::request::*;
     use lsp_types::*;
 
     let SmokeArgs { root, init, log } = args;
     gen(&root, |srv| {
-        let root_uri = lsp_types::Url::from_directory_path(&root).unwrap();
-        srv.request::<Initialize>(fixture(&init, |v| {
+        let root_uri = lsp_types::Uri::from_directory_path(&root).unwrap();
+        srv.request::<InitializeRequest>(fixture(&init, |v| {
             v["rootUri"] = json!(root_uri);
             v["rootPath"] = json!(root);
             v["workspaceFolders"] = json!([{
@@ -177,7 +175,7 @@ fn gen_smoke(args: SmokeArgs) {
                 "name": "tinymist",
             }]);
         }));
-        srv.notify::<Initialized>(json!({}));
+        srv.notify::<InitializedNotification>(json!({}));
 
         // open editions/base.log and readlines
         let log = std::fs::read_to_string(&log).unwrap();
@@ -205,7 +203,7 @@ fn gen_smoke(args: SmokeArgs) {
 
             let uri_name = v["params"]["textDocument"]["uri"].as_str().unwrap();
             let url_v = if uri_name.starts_with("file:") || uri_name.starts_with("untitled:") {
-                lsp_types::Url::parse(uri_name).unwrap()
+                lsp_types::Uri::parse(uri_name).unwrap()
             } else {
                 root_uri.join(uri_name).unwrap()
             };
@@ -228,20 +226,20 @@ fn gen_smoke(args: SmokeArgs) {
                     text_document_position_params: pos.clone(),
                 }));
                 if log_lines == idx + 1 || log_lines == idx + 5 || log_lines == idx + 10 {
-                    srv.request::<Completion>(json!(CompletionParams {
-                        text_document_position: pos.clone(),
+                    srv.request::<CompletionRequest>(json!(CompletionParams {
+                        text_document_position_params: pos.clone(),
                         context: None,
                         work_done_progress_params: Default::default(),
                         partial_result_params: Default::default(),
                     }));
                 }
-                srv.request::<GotoDefinition>(json!(GotoDefinitionParams {
+                srv.request::<DefinitionRequest>(json!(DefinitionParams {
                     text_document_position_params: pos.clone(),
                     work_done_progress_params: Default::default(),
                     partial_result_params: Default::default(),
                 }));
-                srv.request::<References>(json!(ReferenceParams {
-                    text_document_position: pos.clone(),
+                srv.request::<ReferencesRequest>(json!(ReferenceParams {
+                    text_document_position_params: pos.clone(),
                     context: ReferenceContext {
                         include_declaration: false,
                     },
@@ -337,7 +335,7 @@ fn gen_smoke(args: SmokeArgs) {
                 }));
 
                 if log_lines == idx + 1 {
-                    srv.request::<SemanticTokensFullRequest>(json!(SemanticTokensParams {
+                    srv.request::<SemanticTokensRequest>(json!(SemanticTokensParams {
                         text_document: TextDocumentIdentifier { uri: u.clone() },
                         work_done_progress_params: Default::default(),
                         partial_result_params: Default::default(),
@@ -479,7 +477,7 @@ fn may_redact_uri(uri: &str) -> Value {
     if uri == "file://" || uri == "file:///" {
         Value::String("".to_owned())
     } else {
-        let uri = lsp_types::Url::parse(uri).unwrap();
+        let uri = lsp_types::Uri::parse(uri).unwrap();
 
         match uri.to_file_path() {
             Ok(path) => {


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93

Closes #1542 (as an alternative solution)