### PR TITLE
fix: ignore notify access events in project watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3120,11 +3120,11 @@ checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "inotify-sys",
  "libc",
 ]
@@ -3763,23 +3763,12 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3876,21 +3865,29 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.10.0",
- "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6972,7 +6969,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -8652,7 +8649,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8844,15 +8841,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8900,21 +8888,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -8967,12 +8940,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8991,12 +8958,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9012,12 +8973,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9051,12 +9006,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9072,12 +9021,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9099,12 +9042,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9120,12 +9057,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dirs = "6"
 fontdb = { version = "0.23", default-features = false }
 half = "=2.6.0"
 libc = "0.2.155"
-notify = "6"
+notify = "8"
 open = { version = "5.3.2" }
 parking_lot = "0.12.1"
 path-clean = "1.0.1"

--- a/crates/tinymist-project/src/watch.rs
+++ b/crates/tinymist-project/src/watch.rs
@@ -425,6 +425,17 @@ impl<F: FnMut(FilesystemEvent) + Send + Sync> NotifyActor<F> {
 
     /// Notify the event from the builtin watcher.
     fn notify_event(&mut self, event: notify::Event) {
+        if matches!(
+            event.kind,
+            notify::EventKind::Access(
+                notify::event::AccessKind::Read
+                    | notify::event::AccessKind::Open(_)
+                    | notify::event::AccessKind::Close(notify::event::AccessMode::Read)
+            )
+        ) {
+            return;
+        }
+
         // Account file updates.
         let mut changeset = FileChangeSet::default();
         for path in event.paths.iter() {
@@ -677,6 +688,7 @@ mod tests {
     #[derive(Debug, Default, Clone)]
     struct TestAccess {
         files: Arc<Mutex<HashMap<PathBuf, TestFile>>>,
+        reads: Arc<Mutex<HashMap<PathBuf, usize>>>,
     }
 
     impl TestAccess {
@@ -712,10 +724,26 @@ mod tests {
                 },
             );
         }
+
+        fn read_count(&self, path: &ImmutPath) -> usize {
+            self.reads
+                .lock()
+                .expect("test read counts poisoned")
+                .get(path.as_ref())
+                .copied()
+                .unwrap_or_default()
+        }
     }
 
     impl NotifyActorAccess for TestAccess {
         fn content(&self, src: &Path) -> FileResult<Bytes> {
+            *self
+                .reads
+                .lock()
+                .expect("test read counts poisoned")
+                .entry(src.to_path_buf())
+                .or_default() += 1;
+
             self.files
                 .lock()
                 .expect("test access poisoned")
@@ -1016,6 +1044,33 @@ mod tests {
 
         harness.assert_no_events();
         assert_eq!(harness.take_commands(), Vec::new());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_access_events_are_ignored_without_rereading_watched_file() {
+        let mut harness = NotifyActorHarness::new();
+        let dep = test_path("access-open.typ");
+
+        harness.access.set_content(&dep, "stable");
+        harness
+            .apply(MatrixInput::SyncDependency(vec![dep.clone()]))
+            .await;
+        harness.take_events();
+        harness.take_commands();
+
+        let reads_after_sync = harness.access.read_count(&dep);
+        harness
+            .apply(MatrixInput::WatcherEvent {
+                kind: notify::EventKind::Access(notify::event::AccessKind::Open(
+                    notify::event::AccessMode::Any,
+                )),
+                paths: vec![dep.clone()],
+            })
+            .await;
+
+        harness.assert_no_events();
+        assert_eq!(harness.take_commands(), Vec::new());
+        assert_eq!(harness.access.read_count(&dep), reads_after_sync);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/tinymist-project/src/watch.rs
+++ b/crates/tinymist-project/src/watch.rs
@@ -425,14 +425,7 @@ impl<F: FnMut(FilesystemEvent) + Send + Sync> NotifyActor<F> {
 
     /// Notify the event from the builtin watcher.
     fn notify_event(&mut self, event: notify::Event) {
-        if matches!(
-            event.kind,
-            notify::EventKind::Access(
-                notify::event::AccessKind::Read
-                    | notify::event::AccessKind::Open(_)
-                    | notify::event::AccessKind::Close(notify::event::AccessMode::Read)
-            )
-        ) {
+        if !is_relevant_event_kind(&event.kind) {
             return;
         }
 
@@ -626,6 +619,24 @@ impl<F: FnMut(FilesystemEvent) + Send + Sync> NotifyActor<F> {
         };
 
         Some(())
+    }
+}
+
+/// Whether a kind of watch event is relevant for compilation.
+fn is_relevant_event_kind(kind: &notify::EventKind) -> bool {
+    match kind {
+        notify::EventKind::Any => true,
+        notify::EventKind::Access(_) => false,
+        notify::EventKind::Create(_) => true,
+        notify::EventKind::Modify(kind) => match kind {
+            notify::event::ModifyKind::Any => true,
+            notify::event::ModifyKind::Data(_) => true,
+            notify::event::ModifyKind::Metadata(_) => false,
+            notify::event::ModifyKind::Name(_) => true,
+            notify::event::ModifyKind::Other => false,
+        },
+        notify::EventKind::Remove(_) => true,
+        notify::EventKind::Other => false,
     }
 }
 
@@ -1047,9 +1058,9 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn read_access_events_are_ignored_without_rereading_watched_file() {
+    async fn irrelevant_events_are_ignored_without_rereading_watched_file() {
         let mut harness = NotifyActorHarness::new();
-        let dep = test_path("access-open.typ");
+        let dep = test_path("irrelevant-events.typ");
 
         harness.access.set_content(&dep, "stable");
         harness
@@ -1058,19 +1069,33 @@ mod tests {
         harness.take_events();
         harness.take_commands();
 
-        let reads_after_sync = harness.access.read_count(&dep);
-        harness
-            .apply(MatrixInput::WatcherEvent {
-                kind: notify::EventKind::Access(notify::event::AccessKind::Open(
-                    notify::event::AccessMode::Any,
-                )),
-                paths: vec![dep.clone()],
-            })
-            .await;
+        let irrelevant_kinds = [
+            notify::EventKind::Access(notify::event::AccessKind::Open(
+                notify::event::AccessMode::Any,
+            )),
+            notify::EventKind::Access(notify::event::AccessKind::Close(
+                notify::event::AccessMode::Read,
+            )),
+            notify::EventKind::Modify(notify::event::ModifyKind::Metadata(
+                notify::event::MetadataKind::Any,
+            )),
+            notify::EventKind::Modify(notify::event::ModifyKind::Other),
+            notify::EventKind::Other,
+        ];
 
-        harness.assert_no_events();
-        assert_eq!(harness.take_commands(), Vec::new());
-        assert_eq!(harness.access.read_count(&dep), reads_after_sync);
+        for kind in irrelevant_kinds {
+            let reads_before_event = harness.access.read_count(&dep);
+            harness
+                .apply(MatrixInput::WatcherEvent {
+                    kind,
+                    paths: vec![dep.clone()],
+                })
+                .await;
+
+            harness.assert_no_events();
+            assert_eq!(harness.take_commands(), Vec::new());
+            assert_eq!(harness.access.read_count(&dep), reads_before_event);
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- Upgrade `notify` to v8 and refresh the related lockfile entries.
- Ignore read/open access events in the project watcher so normal file reads do not retrigger reloads.
- Add a regression test to verify access events are skipped without rereading the watched file.

## Validation
- Added targeted async test coverage in `crates/tinymist-project/src/watch.rs`.
- Updated dependency resolution in `Cargo.toml` and `Cargo.lock`.