### PR TITLE
dev(neovim): make spec container self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ARG RUST_VERSION=1.91.0
 
 FROM rust:${RUST_VERSION}-bookworm AS base
 RUN apt-get install -y git
-RUN cargo install sccache --version ^0.7
-RUN cargo install cargo-chef --version ^0.1
+RUN cargo install sccache --version =0.15.0 --locked
+RUN cargo install cargo-chef --version =0.1.77 --locked
 ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 # to download the toolchain
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -24,7 +24,6 @@ FROM base as planner
 WORKDIR app
 # We only pay the installation cost once, 
 # it will be cached from the second build onwards
-RUN cargo install cargo-chef 
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
@@ -32,7 +31,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM base as builder
 WORKDIR app
-RUN cargo install cargo-chef
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \

--- a/editors/neovim/CONTRIBUTING.md
+++ b/editors/neovim/CONTRIBUTING.md
@@ -13,6 +13,45 @@ The Neovim Tinymist plugin serves as the **heavily-documented canonical implemen
 
 ## Development Workflow
 
+### Spec Environment Notes
+
+Neovim specs are container-only in normal development. Do not validate them
+with a host `nvim`, because the spec runner expects the container layout,
+runtime dependencies, and mounted fixtures used by `bootstrap.sh`.
+
+Before editing or running specs, read this file together with
+`docs/dev-guide.md`, then inspect the affected files under `spec/`, `lua/`,
+and `scripts/minimal_init.lua`.
+
+The supported entry point is:
+
+```bash
+./bootstrap.sh test
+```
+
+This builds/runs the `tinymist-nvim-spec-local` Neovim development container, mounts
+`tests/workspaces` as `/home/runner/dev/workspaces`, runs
+`tinymist compile` for the `book` fixture, then runs `spec/main.py` with
+headless Neovim and the `inanis` runner. The container must provide the Lua
+test dependencies on `/home/runner/packpath/*`, especially `inanis.nvim`,
+`plenary.nvim`, and `nvim-lspconfig`.
+
+The Neovim development image intentionally does not bundle `tinymist`.
+`bootstrap.sh` mounts a host-built binary into the container as
+`/usr/local/bin/tinymist`, preferring `target/debug/tinymist` and falling back
+to `target/release/tinymist`. Build one first with `cargo build --bin tinymist`,
+or set `TINYMIST_BIN=/absolute/path/to/tinymist` to override the selection.
+
+If Docker builds need an HTTP proxy, do not use `127.0.0.1` inside the
+container. Point Docker's proxy configuration at the host address visible from
+the default bridge network, usually `172.17.0.1:<port>`. A temporary
+`DOCKER_CONFIG` is preferred over editing the user's global Docker config.
+
+Warnings from newer `nvim-lspconfig` about the deprecated
+`require("lspconfig")` framework do not fail the suite by themselves. Treat a
+zero exit status and the final `passed` summary as the test result. Remove
+transient `.nvimlog` files if headless Neovim leaves them in the worktree.
+
 ### Interactive Editor Mode
 
 ```bash

--- a/editors/neovim/bootstrap.sh
+++ b/editors/neovim/bootstrap.sh
@@ -1,25 +1,62 @@
-# todo: it is in very early stage, so we are doing dirty things.
+#!/usr/bin/env bash
 
-# python3 ./spec/main.py
+set -euo pipefail
 
-DOCKER_ARGS=
-if [ "$1" = "test" ]; then
-    DOCKER_ARGS="python3 ./spec/main.py"
-elif [ "$1" = "bash" ]; then
-    DOCKER_ARGS="bash"
-elif [ "$1" = "editor" ]; then
-    DOCKER_ARGS="nvim ."
-else
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+image_name="${TINYMIST_NVIM_IMAGE:-tinymist-nvim-spec-local}"
+
+case "${1:-}" in
+  test)
+    docker_args=(python3 ./spec/main.py)
+    ;;
+  bash)
+    docker_args=(bash)
+    ;;
+  editor)
+    docker_args=(nvim .)
+    ;;
+  *)
     echo "Usage: $0 [test|bash|editor]"
     exit 1
+    ;;
+esac
+
+if [ -n "${TINYMIST_BIN:-}" ]; then
+  tinymist_bin="$TINYMIST_BIN"
+elif [ -x "$repo_root/target/debug/tinymist" ]; then
+  tinymist_bin="$repo_root/target/debug/tinymist"
+elif [ -x "$repo_root/target/release/tinymist" ]; then
+  tinymist_bin="$repo_root/target/release/tinymist"
+else
+  echo "No tinymist binary found."
+  echo "Build one first with: cargo build --bin tinymist"
+  echo "Or set TINYMIST_BIN=/absolute/path/to/tinymist."
+  exit 1
 fi
 
-(cd ../.. && docker build -t myriaddreamin/tinymist:0.14.18 .)
-(cd samples && docker build -t myriaddreamin/tinymist-nvim:0.14.18 -f lazyvim-dev/Dockerfile .)
-docker run --rm -it \
-  -v $PWD/../../tests/workspaces:/home/runner/dev/workspaces \
-  -v $PWD:/home/runner/dev \
-  -v $PWD/target/.local:/home/runner/.local \
-  -v $PWD/target/.cache:/home/runner/.cache \
-  -w /home/runner/dev myriaddreamin/tinymist-nvim:0.14.18 \
-  $DOCKER_ARGS
+if [ ! -x "$tinymist_bin" ]; then
+  echo "Tinymist binary is not executable: $tinymist_bin"
+  exit 1
+fi
+
+mkdir -p "$script_dir/target/.local" "$script_dir/target/.cache"
+
+(cd "$script_dir/samples" && docker build -t "$image_name" -f lazyvim-dev/Dockerfile .)
+
+docker_run_args=(
+  --rm
+  -v "$repo_root/tests/workspaces:/home/runner/dev/workspaces"
+  -v "$script_dir:/home/runner/dev"
+  -v "$tinymist_bin:/usr/local/bin/tinymist:ro"
+  -v "$script_dir/target/.local:/home/runner/.local"
+  -v "$script_dir/target/.cache:/home/runner/.cache"
+  -w /home/runner/dev
+)
+
+if [ -t 0 ] && [ -t 1 ]; then
+  docker_run_args+=(-it)
+fi
+
+docker run "${docker_run_args[@]}" "$image_name" "${docker_args[@]}"

--- a/editors/neovim/samples/lazyvim-dev/Dockerfile
+++ b/editors/neovim/samples/lazyvim-dev/Dockerfile
@@ -1,50 +1,47 @@
-# Not for end users! This is a Dockerfile to develop the Neovim plugin it self.
-# https://github.com/Julian/lean.nvim/tree/1b2752069d700a3e6c7953f5c117d49c134ec711/.devcontainer/lazyvim
+# Not for end users! This image develops and tests the Neovim plugin itself.
+# It intentionally does not bundle tinymist. Mount the checkout's tinymist
+# binary into /usr/local/bin/tinymist when running the container.
 
-FROM debian:12 AS builder
+FROM debian:12
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    wget \
     git \
-    file \
-    ninja-build gettext cmake unzip curl build-essential
+    ripgrep \
+    build-essential \
+    unzip \
+    python3 && \
+    update-ca-certificates
 
-RUN git clone --filter=blob:none --branch stable https://github.com/neovim/neovim && cd neovim && make CMAKE_BUILD_TYPE=RelWithDebInfo
-USER root
-RUN cd neovim/build && cpack -G DEB && dpkg -i nvim-linux-x86_64.deb
-
-FROM myriaddreamin/tinymist:0.14.18 as tinymist
-
-FROM debian:12
-
-COPY --from=builder /neovim/build/nvim-linux-x86_64.deb /tmp/nvim-linux-x86_64.deb
-
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
-    --mount=target=/var/cache/apt,type=cache,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update && apt-get install -y curl wget git ripgrep build-essential unzip
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
-    --mount=target=/var/cache/apt,type=cache,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update && apt-get install -y python3
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
-    --mount=target=/var/cache/apt,type=cache,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get install -y /tmp/nvim-linux-x86_64.deb \
-    && rm /tmp/nvim-linux-x86_64.deb
+RUN curl -fL https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz -o /tmp/nvim-linux-x86_64.tar.gz && \
+    tar -C /opt -xzf /tmp/nvim-linux-x86_64.tar.gz && \
+    ln -s /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim && \
+    rm /tmp/nvim-linux-x86_64.tar.gz
 
 RUN useradd --create-home --shell /bin/bash runner
 USER runner
 WORKDIR /home/runner
 
-RUN for dependency in AndrewRadev/switch.vim andymass/vim-matchup neovim/nvim-lspconfig nvim-lua/plenary.nvim tomtom/tcomment_vim lewis6991/satellite.nvim; do git clone --quiet --filter=blob:none "https://github.com/$dependency" "packpath/$(basename $dependency)"; done
-RUN for dependency in Julian/inanis.nvim; do git clone --quiet --filter=blob:none "https://github.com/$dependency" "packpath/$(basename $dependency)"; done
-
-USER root
-COPY --from=tinymist /usr/local/bin/tinymist /usr/local/bin/tinymist
-USER runner
+RUN set -eux; \
+    for dependency in \
+      AndrewRadev/switch.vim \
+      andymass/vim-matchup \
+      neovim/nvim-lspconfig \
+      nvim-lua/plenary.nvim \
+      tomtom/tcomment_vim \
+      lewis6991/satellite.nvim \
+      Julian/inanis.nvim; do \
+        for attempt in 1 2 3; do \
+          git clone --quiet --filter=blob:none "https://github.com/$dependency" "packpath/$(basename "$dependency")" && break; \
+          if [ "$attempt" = 3 ]; then exit 1; fi; \
+          sleep 2; \
+        done; \
+    done
 
 ENV XDG_CONFIG_HOME=/home/runner/.config
 ENV XDG_DATA_HOME=/home/runner/.local/share
@@ -57,5 +54,5 @@ COPY lazyvim-dev/plugins/mason-workaround.lua $XDG_CONFIG_HOME/nvim/lua/plugins/
 COPY lazyvim/plugins/lsp-folding.lua $XDG_CONFIG_HOME/nvim/lua/plugins/lsp-folding.lua
 COPY lazyvim/plugins/tinymist.lua $XDG_CONFIG_HOME/nvim/lua/others/tinymist.lua
 
-# SHELL isn't supported by OCI images
+# SHELL isn't supported by OCI images.
 ENTRYPOINT []

--- a/scripts/nightly-utils.mjs
+++ b/scripts/nightly-utils.mjs
@@ -298,35 +298,8 @@ class NightlyUtils {
             console.warn(`Warning: Could not update flake.nix: ${e.message}`);
         }
 
-        // Dockerfile
-        try {
-            const dockerfilePath = path.join(this.rootDir, 'editors/neovim/samples/lazyvim-dev/Dockerfile');
-            let dockerContent = await fs.readFile(dockerfilePath, 'utf-8');
-            dockerContent = dockerContent.replace(
-                /FROM myriaddreamin\/tinymist:[^ ]* as tinymist/g,
-                `FROM myriaddreamin/tinymist:${newVersion} as tinymist`
-            );
-            await fs.writeFile(dockerfilePath, dockerContent);
-        } catch (e) {
-            console.warn(`Warning: Could not update Dockerfile: ${e.message}`);
-        }
-
-        // bootstrap.sh
-        try {
-            const bootstrapPath = path.join(this.rootDir, 'editors/neovim/bootstrap.sh');
-            let bootstrapContent = await fs.readFile(bootstrapPath, 'utf-8');
-            bootstrapContent = bootstrapContent.replace(
-                /myriaddreamin\/tinymist:[^ ]*/g,
-                `myriaddreamin/tinymist:${newVersion}`
-            );
-            bootstrapContent = bootstrapContent.replace(
-                /myriaddreamin\/tinymist-nvim:[^ ]*/g,
-                `myriaddreamin/tinymist-nvim:${newVersion}`
-            );
-            await fs.writeFile(bootstrapPath, bootstrapContent);
-        } catch (e) {
-            console.warn(`Warning: Could not update bootstrap.sh: ${e.message}`);
-        }
+        // The Neovim spec image is intentionally local-only; bootstrap.sh mounts
+        // the host-built tinymist binary instead of embedding a release image tag.
     }
 
     async generateChangelog(newVersion, tinymistBaseCommit, tinymistBaseMessage, typstRev, typstBaseCommit, typstBaseMessage) {

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -48,7 +48,7 @@ const manifestPatches = trackedManifests.flatMap((manifestPath) =>
   }),
 );
 
-const releaseSensitiveFiles = buildReleaseSensitiveFiles(currentVersion, targetVersion);
+const releaseSensitiveFiles = buildReleaseSensitiveFiles(targetVersion);
 const directReleaseSensitivePatches = releaseSensitiveFiles
   .filter((item) => item.kind === "direct-update" && item.command)
   .map((item) => ({
@@ -372,38 +372,10 @@ function formatHunkRange(start, count) {
   return count === 1 ? `${start}` : `${start},${count}`;
 }
 
-function buildReleaseSensitiveFiles(currentVersionValue, targetVersionValue) {
-  const directUpdateFiles = [
-    {
-      path: "editors/neovim/bootstrap.sh",
-      reason: "Neovim bootstrap image tags should match the release version under test.",
-    },
-    {
-      path: "editors/neovim/samples/lazyvim-dev/Dockerfile",
-      reason: "Neovim sample Docker images should reference the matching tinymist release image.",
-    },
-  ];
-
-  const directUpdates = directUpdateFiles.map((item) => {
-    const patch = buildVersionPatch(item.path, currentVersionValue, targetVersionValue, {
-      kind: "simple",
-    })[0];
-
-    return {
-      path: item.path,
-      kind: "direct-update",
-      reason: item.reason,
-      needsUpdate: Boolean(patch),
-      lineUpdates: patch?.lineUpdates ?? [],
-      patch: patch?.patch ?? null,
-      command: patch?.command ?? null,
-    };
-  });
-
+function buildReleaseSensitiveFiles(targetVersionValue) {
   const typliteGeneratedVersion = readGeneratedReleaseVersion("crates/typlite/README.md");
 
   return [
-    ...directUpdates,
     {
       path: "crates/typlite/README.md",
       kind: "generated-document",


### PR DESCRIPTION
## Summary
- Stop tying Neovim spec assets to release image tags and make the spec container rely on a host-built `tinymist` binary instead.
- Refresh the Neovim development Dockerfile and bootstrap flow to build a local spec image, mount the checkout binary, and install dependencies with more explicit, repeatable steps.
- Add contributor guidance for running Neovim specs in containers and update release preflight/nightly scripts to match the new local-only workflow.

## Details
- `editors/neovim/bootstrap.sh` now validates the selected `tinymist` binary, builds the local spec image, mounts workspace/cache directories, and runs the requested container command.
- `editors/neovim/samples/lazyvim-dev/Dockerfile` now installs Neovim from the stable tarball, pulls the Lua plugin dependencies directly, and no longer copies in a packaged `tinymist` image layer.
- `editors/neovim/CONTRIBUTING.md` documents the container-only spec workflow, the `TINYMIST_BIN` override, and the expected container layout.
- `scripts/nightly-utils.mjs` and `scripts/release-preflight.mjs` no longer treat the Neovim Docker assets as release-sensitive files that need version tag updates.
- The root `Dockerfile` now pins `sccache` and `cargo-chef` to exact locked versions for reproducible builds.

## Validation
- Not run here; changes are focused on build/container scripts and docs.