### PR TITLE
feat(vscode): add Tinymist GPU viewer extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,22 @@
             "preLaunchTask": "VS Code Extension Prelaunch"
         },
         {
+            "name": "Run Extension [GPU Viewer]",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode",
+                "--extensionDevelopmentPath=${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode",
+                "${workspaceFolder}/editors/vscode/e2e-workspaces/gpu-viewer"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/editors/vscode/out/**/*.js",
+                "${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode/out/**/*.js"
+            ],
+            "preLaunchTask": "VS Code Extension Prelaunch [GPU Viewer]"
+        },
+        {
             "name": "Run Extension [Web]",
             "type": "extensionHost",
             "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,16 @@
 			"group": "build"
 		},
 		{
+			"label": "VS Code Extension Prelaunch [GPU Viewer]",
+			"dependsOn": [
+				"VS Code Extension Prelaunch",
+				"Compile Tinymist GPU Viewer Extension",
+				"Build Tinymist GPU Viewer Binary",
+				"Install Tinymist GPU Viewer Binary"
+			],
+			"dependsOrder": "sequence",
+		},
+		{
 			"label": "VS Code Extension Prelaunch Preview",
 			"dependsOn": [
 				  "Compile Typst Preview Extension",
@@ -70,6 +80,55 @@
 			"script": "compile",
 			"path": "contrib/typst-preview/editors/vscode",
 			"group": "build",
+		},
+		{
+			"label": "Compile Tinymist GPU Viewer Extension",
+			"type": "npm",
+			"script": "compile",
+			"path": "contrib/tinymist-gpu-viewer/editors/vscode",
+			"group": "build",
+		},
+		{
+			"label": "Build Tinymist GPU Viewer Binary",
+			"type": "cargo",
+			"command": "build",
+			"args": [
+				"--bin",
+				"tinymist-viewer"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "Install Tinymist GPU Viewer Binary",
+			"type": "shell",
+			"windows": {
+				"command": "powershell",
+				"args": [
+					"-NoProfile",
+					"-ExecutionPolicy",
+					"Bypass",
+					"-Command",
+					"New-Item -ItemType Directory -Force -Path \"${workspaceFolder}\\contrib\\tinymist-gpu-viewer\\editors\\vscode\\bin\" | Out-Null; Copy-Item -Force -Path \"${workspaceFolder}\\target\\debug\\tinymist-viewer.exe\" -Destination \"${workspaceFolder}\\contrib\\tinymist-gpu-viewer\\editors\\vscode\\bin\\tinymist-viewer.exe\""
+				]
+			},
+			"linux": {
+				"command": "sh",
+				"args": [
+					"-c",
+					"mkdir -p \"${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode/bin\" && cp \"${workspaceFolder}/target/debug/tinymist-viewer\" \"${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode/bin/tinymist-viewer\""
+				]
+			},
+			"osx": {
+				"command": "sh",
+				"args": [
+					"-c",
+					"mkdir -p \"${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode/bin\" && cp \"${workspaceFolder}/target/debug/tinymist-viewer\" \"${workspaceFolder}/contrib/tinymist-gpu-viewer/editors/vscode/bin/tinymist-viewer\""
+				]
+			},
+			"group": "build"
 		},
 		{
 			"label": "Generate Typst Preview Extension Bundle",

--- a/contrib/tinymist-gpu-viewer/editors/vscode/.gitignore
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/out/
+*.vsix

--- a/contrib/tinymist-gpu-viewer/editors/vscode/.vscodeignore
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+src/**
+tsconfig.json
+*.vsix
+node_modules/**
+out/**/*.map

--- a/contrib/tinymist-gpu-viewer/editors/vscode/CHANGELOG.md
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.14.18
+
+- Add the Tinymist GPU Viewer previewer-provider extension package.

--- a/contrib/tinymist-gpu-viewer/editors/vscode/LICENSE
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023-2025 Myriad Dreamin, Nathan Varner
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/contrib/tinymist-gpu-viewer/editors/vscode/README.md
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/README.md
@@ -1,0 +1,52 @@
+# Tinymist GPU Viewer
+
+Tinymist GPU Viewer is a previewer-provider extension for Tinymist. It launches the native GPU previewer from `crates/tinymist-viewer` through Tinymist's `tinymist.previewer` extension-provider contract.
+
+## Usage
+
+Install both extensions:
+
+- `myriad-dreamin.tinymist`
+- `myriad-dreamin.tinymist-gpu-viewer`
+
+Then configure Tinymist:
+
+```json
+{
+  "tinymist.previewer": "myriad-dreamin.tinymist-gpu-viewer"
+}
+```
+
+Tinymist will activate this extension, start the regular preview server, and pass the preview data-plane websocket address to the native `tinymist-viewer` process. No VS Code webview preview panel is created for this provider.
+
+For local development, the repository debug task builds the native viewer and copies the debug binary into this extension's `bin/` directory before launching the Extension Development Host:
+
+```sh
+cargo build --bin tinymist-viewer
+```
+
+The provider version is expected to match the Tinymist extension version because the preview websocket protocol is versioned with Tinymist.
+
+If the executable is not bundled and cannot be found on PATH, configure:
+
+```json
+{
+  "tinymist.gpuViewer.executable": "/path/to/tinymist-viewer"
+}
+```
+
+## Window layout
+
+By default the provider tries to place VS Code on the left and the native viewer on the right after starting preview. To disable this desktop window automation, configure:
+
+```json
+{
+  "tinymist.gpuViewer.windowLayout": "disabled"
+}
+```
+
+Window layout is best-effort and does not affect the preview task if the operating system blocks it. Check the `Tinymist GPU Viewer` output channel for layout diagnostics.
+
+- Windows uses PowerShell with Win32 window APIs.
+- macOS uses AppleScript through `osascript` and may require Accessibility permission.
+- Linux uses `wmctrl`; it works on many X11/EWMH window managers and is commonly blocked or unsupported on Wayland.

--- a/contrib/tinymist-gpu-viewer/editors/vscode/package.json
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/package.json
@@ -26,10 +26,9 @@
   "extensionDependencies": [
     "myriad-dreamin.tinymist"
   ],
-  "extensionKind": [
-    "workspace",
-    "ui"
-  ],
+    "extensionKind": [
+      "ui"
+    ],
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {

--- a/contrib/tinymist-gpu-viewer/editors/vscode/package.json
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "tinymist-gpu-viewer",
+  "displayName": "Tinymist GPU Viewer",
+  "description": "GPU-backed Typst previewer provider for Tinymist.",
+  "publisher": "myriad-dreamin",
+  "version": "0.14.18",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/tinymist.git"
+  },
+  "keywords": [
+    "typst",
+    "tinymist",
+    "preview",
+    "previewer",
+    "gpu",
+    "vello"
+  ],
+  "categories": [
+    "Other"
+  ],
+  "engines": {
+    "vscode": "^1.97.0"
+  },
+  "extensionDependencies": [
+    "myriad-dreamin.tinymist"
+  ],
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Tinymist GPU Viewer",
+      "properties": {
+        "tinymist.gpuViewer.executable": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Path to the `tinymist-viewer` executable. When unset, the extension uses a bundled binary under `bin` or `tinymist-viewer` from PATH."
+        },
+        "tinymist.gpuViewer.windowLayout": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "sideBySide"
+          ],
+          "default": "sideBySide",
+          "markdownDescription": "Controls desktop window arrangement after launching the native GPU viewer. `sideBySide` places VS Code on the left and Tinymist GPU Viewer on the right when the platform allows window automation. Set to `disabled` to leave windows where the operating system places them."
+        }
+      }
+    }
+  },
+  "files": [
+    "out",
+    "bin",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "compile": "tsc -p .",
+    "vscode:prepublish": "yarn run compile",
+    "package": "npx @vscode/vsce package --yarn",
+    "type-check": "tsc --noEmit -p ."
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.4",
+    "@types/vscode": "^1.97.0",
+    "@vscode/vsce": "^2.22.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -1,0 +1,521 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  execFile,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+  type ExecFileOptionsWithStringEncoding,
+} from "child_process";
+
+const VIEWER_BINARY_NAME = process.platform === "win32" ? "tinymist-viewer.exe" : "tinymist-viewer";
+const VIEWER_WINDOW_TITLE = "Tinymist View";
+const WINDOW_LAYOUT_DELAY_MS = 700;
+const WINDOW_LAYOUT_TIMEOUT_MS = 10_000;
+const WINDOW_LAYOUT_POLL_MS = 250;
+
+type WindowLayoutMode = "disabled" | "sideBySide";
+
+interface TinymistPreviewer {
+  compatibleTinymistVersion: string;
+  isCompatible?(tinymistVersion: string): Promise<boolean> | boolean;
+  handlePreview(task: TinymistPreviewTask): Promise<vscode.Disposable> | vscode.Disposable;
+}
+
+interface TinymistPreviewTask {
+  taskId: string;
+  documentPath: string;
+  dataPlaneHost: string;
+}
+
+interface TinymistPreviewerProvider {
+  providePreviewer(): Promise<TinymistPreviewer> | TinymistPreviewer;
+}
+
+let outputChannel: vscode.OutputChannel | undefined;
+const activeViewers = new Map<string, ChildProcessWithoutNullStreams>();
+
+export function activate(context: vscode.ExtensionContext): TinymistPreviewerProvider {
+  const compatibleTinymistVersion = String(context.extension.packageJSON.version ?? "0.0.0");
+  outputChannel = vscode.window.createOutputChannel("Tinymist GPU Viewer");
+  context.subscriptions.push(outputChannel, {
+    dispose() {
+      for (const viewer of activeViewers.values()) {
+        viewer.kill();
+      }
+      activeViewers.clear();
+    },
+  });
+
+  return {
+    providePreviewer() {
+      return {
+        compatibleTinymistVersion,
+        isCompatible(tinymistVersion: string) {
+          return tinymistVersion === compatibleTinymistVersion;
+        },
+        handlePreview(task: TinymistPreviewTask) {
+          return launchViewer(context, task);
+        },
+      };
+    },
+  };
+}
+
+export function deactivate() {}
+
+function launchViewer(context: vscode.ExtensionContext, task: TinymistPreviewTask): vscode.Disposable {
+  activeViewers.get(task.taskId)?.kill();
+
+  const executable = resolveViewerExecutable(context);
+  const args = ["--data-plane-host", task.dataPlaneHost];
+  const cwd = path.dirname(task.documentPath);
+  appendLog(`Starting ${executable} ${args.join(" ")}`);
+
+  const viewer = spawn(executable, args, {
+    cwd,
+    env: {
+      ...process.env,
+      RUST_BACKTRACE: "1",
+    },
+    windowsHide: false,
+  });
+
+  activeViewers.set(task.taskId, viewer);
+  scheduleWindowLayout(viewer);
+  viewer.stdout.on("data", (data: Buffer) => appendLog(data.toString()));
+  viewer.stderr.on("data", (data: Buffer) => appendLog(data.toString()));
+  viewer.on("error", (error) => {
+    const message = `Failed to start Tinymist GPU Viewer: ${error.message}`;
+    appendLog(message);
+    void vscode.window.showErrorMessage(message, "Show Logs").then((selection) => {
+      if (selection === "Show Logs") {
+        outputChannel?.show();
+      }
+    });
+  });
+  viewer.on("exit", (code, signal) => {
+    activeViewers.delete(task.taskId);
+    appendLog(`Tinymist GPU Viewer exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
+  });
+
+  return {
+    dispose() {
+      activeViewers.delete(task.taskId);
+      if (!viewer.killed) {
+        viewer.kill();
+      }
+    },
+  };
+}
+
+function resolveViewerExecutable(context: vscode.ExtensionContext): string {
+  const configured = vscode.workspace
+    .getConfiguration("tinymist.gpuViewer")
+    .get<string | null>("executable");
+  const candidates = [
+    configured,
+    path.join(context.extensionUri.fsPath, "bin", VIEWER_BINARY_NAME),
+    VIEWER_BINARY_NAME,
+  ].filter((candidate): candidate is string => !!candidate && candidate.trim() !== "");
+
+  for (const candidate of candidates) {
+    if (candidate === VIEWER_BINARY_NAME || fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Cannot find ${VIEWER_BINARY_NAME}. Configure tinymist.gpuViewer.executable, bundle it under bin, or add it to PATH.`,
+  );
+}
+
+function scheduleWindowLayout(viewer: ChildProcessWithoutNullStreams) {
+  if (getWindowLayoutMode() !== "sideBySide") {
+    appendLog("Skipping side-by-side window layout: tinymist.gpuViewer.windowLayout is disabled.");
+    return;
+  }
+
+  const viewerPid = viewer.pid;
+  if (viewerPid === undefined) {
+    appendLog("Skipping side-by-side window layout: viewer process id is unavailable.");
+    return;
+  }
+
+  appendLog(`Scheduling side-by-side window layout for viewer pid ${viewerPid}.`);
+  void arrangeWindowsSideBySide(viewerPid).catch((error) => {
+    appendLog(`Could not arrange GPU viewer windows: ${errorMessage(error)}`);
+  });
+}
+
+function getWindowLayoutMode(): WindowLayoutMode {
+  const configured = vscode.workspace
+    .getConfiguration("tinymist.gpuViewer")
+    .get<string>("windowLayout", "sideBySide");
+
+  return configured === "sideBySide" ? "sideBySide" : "disabled";
+}
+
+async function arrangeWindowsSideBySide(viewerPid: number) {
+  await delay(WINDOW_LAYOUT_DELAY_MS);
+
+  switch (process.platform) {
+    case "win32":
+      await arrangeWindowsSideBySideWin32(viewerPid);
+      return;
+    case "darwin":
+      await arrangeWindowsSideBySideMacOS();
+      return;
+    case "linux":
+      await arrangeWindowsSideBySideLinux(viewerPid);
+      return;
+    default:
+      appendLog(`Skipping side-by-side window layout: unsupported platform ${process.platform}.`);
+  }
+}
+
+async function arrangeWindowsSideBySideWin32(viewerPid: number) {
+  const script = `
+$viewerPid = ${viewerPid}
+$viewerTitle = '${VIEWER_WINDOW_TITLE}'
+$codeProcessNames = @('Code', 'Code - Insiders', 'VSCodium', 'Code - OSS')
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class TinymistWindowApi {
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll")]
+    public static extern bool MoveWindow(IntPtr hWnd, int x, int y, int width, int height, bool repaint);
+
+    [DllImport("user32.dll")]
+    public static extern bool ShowWindowAsync(IntPtr hWnd, int command);
+}
+'@
+
+function Get-VisibleTopLevelWindows {
+    $script:tinymistWindows = New-Object 'System.Collections.Generic.List[object]'
+    $callback = [TinymistWindowApi+EnumWindowsProc]{
+        param([IntPtr] $handle, [IntPtr] $param)
+
+        if (-not [TinymistWindowApi]::IsWindowVisible($handle)) {
+            return $true
+        }
+
+        $titleBuilder = New-Object System.Text.StringBuilder 512
+        [void][TinymistWindowApi]::GetWindowText($handle, $titleBuilder, $titleBuilder.Capacity)
+        $title = $titleBuilder.ToString()
+        if ([string]::IsNullOrWhiteSpace($title)) {
+            return $true
+        }
+
+        [uint32] $windowPid = 0
+        [void][TinymistWindowApi]::GetWindowThreadProcessId($handle, [ref] $windowPid)
+        $script:tinymistWindows.Add([pscustomobject]@{
+            Handle = $handle
+            ProcessId = [int] $windowPid
+            Title = $title
+        })
+
+        return $true
+    }
+
+    [void][TinymistWindowApi]::EnumWindows($callback, [IntPtr]::Zero)
+    return $script:tinymistWindows
+}
+
+function Test-CodeWindow($window) {
+    try {
+        $processName = (Get-Process -Id $window.ProcessId -ErrorAction Stop).ProcessName
+    } catch {
+        $processName = ''
+    }
+
+    return (($codeProcessNames -contains $processName) -or ($window.Title -like '*Visual Studio Code*') -or ($window.Title -like '*VSCodium*') -or ($window.Title -like '*Code - OSS*'))
+}
+
+$deadline = (Get-Date).AddMilliseconds(${WINDOW_LAYOUT_TIMEOUT_MS})
+$codeWindow = $null
+$viewerWindow = $null
+
+do {
+    $windows = Get-VisibleTopLevelWindows
+    $viewerWindow = $windows | Where-Object { $_.ProcessId -eq $viewerPid -or $_.Title -eq $viewerTitle } | Select-Object -First 1
+    $codeWindow = $windows | Where-Object { Test-CodeWindow $_ } | Select-Object -First 1
+
+    if ($codeWindow -and $viewerWindow) {
+        break
+    }
+
+    Start-Sleep -Milliseconds ${WINDOW_LAYOUT_POLL_MS}
+} while ((Get-Date) -lt $deadline)
+
+if (-not $codeWindow) {
+    throw 'Could not find a visible VS Code window.'
+}
+if (-not $viewerWindow) {
+    throw 'Could not find the Tinymist GPU Viewer window.'
+}
+
+$workArea = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+$halfWidth = [Math]::Floor($workArea.Width / 2)
+$rightWidth = $workArea.Width - $halfWidth
+
+[void][TinymistWindowApi]::ShowWindowAsync($codeWindow.Handle, 9)
+[void][TinymistWindowApi]::ShowWindowAsync($viewerWindow.Handle, 9)
+[void][TinymistWindowApi]::MoveWindow($codeWindow.Handle, $workArea.Left, $workArea.Top, $halfWidth, $workArea.Height, $true)
+[void][TinymistWindowApi]::MoveWindow($viewerWindow.Handle, $workArea.Left + $halfWidth, $workArea.Top, $rightWidth, $workArea.Height, $true)
+`;
+
+  await runFile("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]);
+}
+
+async function arrangeWindowsSideBySideMacOS() {
+  const script = `
+set viewerTitle to "${VIEWER_WINDOW_TITLE}"
+set codeProcessNames to {"Code", "Visual Studio Code", "Code - Insiders", "VSCodium", "Code - OSS"}
+tell application "Finder"
+  set desktopBounds to bounds of window of desktop
+end tell
+
+set screenLeft to item 1 of desktopBounds
+set screenTop to item 2 of desktopBounds
+set screenRight to item 3 of desktopBounds
+set screenBottom to item 4 of desktopBounds
+set screenWidth to screenRight - screenLeft
+set screenHeight to screenBottom - screenTop
+set halfWidth to screenWidth div 2
+set rightWidth to screenWidth - halfWidth
+
+tell application "System Events"
+  set codeProcess to missing value
+  repeat with processName in codeProcessNames
+    if exists process (contents of processName) then
+      set codeProcess to process (contents of processName)
+      exit repeat
+    end if
+  end repeat
+
+  if codeProcess is missing value then
+    error "Could not find a VS Code process."
+  end if
+
+  set deadline to (current date) + 10
+  set viewerWindow to missing value
+  repeat while viewerWindow is missing value and (current date) < deadline
+    repeat with candidateProcess in processes
+      repeat with candidateWindow in windows of candidateProcess
+        if name of candidateWindow is viewerTitle then
+          set viewerWindow to candidateWindow
+          exit repeat
+        end if
+      end repeat
+      if viewerWindow is not missing value then exit repeat
+    end repeat
+
+    if viewerWindow is missing value then delay 0.25
+  end repeat
+
+  if viewerWindow is missing value then
+    error "Could not find the Tinymist GPU Viewer window."
+  end if
+  if not (exists window 1 of codeProcess) then
+    error "Could not find a VS Code window."
+  end if
+
+  set position of window 1 of codeProcess to {screenLeft, screenTop}
+  set size of window 1 of codeProcess to {halfWidth, screenHeight}
+  set position of viewerWindow to {screenLeft + halfWidth, screenTop}
+  set size of viewerWindow to {rightWidth, screenHeight}
+end tell
+`;
+
+  await runFile("osascript", ["-e", script]);
+}
+
+async function arrangeWindowsSideBySideLinux(viewerPid: number) {
+  const pair = await waitForWindowPair(viewerPid);
+  const workArea = await getLinuxWorkArea();
+  const halfWidth = Math.floor(workArea.width / 2);
+  const rightWidth = workArea.width - halfWidth;
+
+  await moveLinuxWindow(pair.code.id, workArea.x, workArea.y, halfWidth, workArea.height);
+  await moveLinuxWindow(
+    pair.viewer.id,
+    workArea.x + halfWidth,
+    workArea.y,
+    rightWidth,
+    workArea.height,
+  );
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+function runFile(
+  file: string,
+  args: string[],
+  timeout = WINDOW_LAYOUT_TIMEOUT_MS,
+): Promise<CommandResult> {
+  const options: ExecFileOptionsWithStringEncoding = {
+    encoding: "utf8",
+    timeout,
+    windowsHide: true,
+  };
+
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        const details = stderr.trim() ? `${error.message}: ${stderr.trim()}` : error.message;
+        reject(new Error(`${file} failed: ${details}`));
+        return;
+      }
+
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+interface LinuxWindow {
+  id: string;
+  pid: number;
+  title: string;
+}
+
+interface LinuxWorkArea {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+async function waitForWindowPair(
+  viewerPid: number,
+): Promise<{ code: LinuxWindow; viewer: LinuxWindow }> {
+  const started = Date.now();
+  while (Date.now() - started < WINDOW_LAYOUT_TIMEOUT_MS) {
+    const windows = await getLinuxWindows();
+    const viewer = windows.find(
+      (window) => window.pid === viewerPid || window.title.includes(VIEWER_WINDOW_TITLE),
+    );
+    const code = windows.find(isLinuxCodeWindow);
+
+    if (viewer && code) {
+      return { code, viewer };
+    }
+
+    await delay(WINDOW_LAYOUT_POLL_MS);
+  }
+
+  throw new Error("Could not find both VS Code and Tinymist GPU Viewer windows.");
+}
+
+async function getLinuxWindows(): Promise<LinuxWindow[]> {
+  const { stdout } = await runFile("wmctrl", ["-l", "-p", "-G"]);
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .flatMap(parseLinuxWindowLine);
+}
+
+function parseLinuxWindowLine(line: string): LinuxWindow[] {
+  const match = line.match(/^(\S+)\s+\S+\s+(-?\d+)\s+-?\d+\s+-?\d+\s+\d+\s+\d+\s+\S+\s*(.*)$/);
+  if (!match) {
+    return [];
+  }
+
+  return [
+    {
+      id: match[1],
+      pid: Number(match[2]),
+      title: match[3] ?? "",
+    },
+  ];
+}
+
+function isLinuxCodeWindow(window: LinuxWindow): boolean {
+  return (
+    window.title.includes("Visual Studio Code") ||
+    window.title.includes("VSCodium") ||
+    window.title.includes("Code - OSS") ||
+    window.title.endsWith(" - Code")
+  );
+}
+
+async function getLinuxWorkArea(): Promise<LinuxWorkArea> {
+  const { stdout } = await runFile("wmctrl", ["-d"]);
+  const desktop =
+    stdout.split(/\r?\n/).find((line) => line.includes("*")) ??
+    stdout.split(/\r?\n/).find((line) => line.trim());
+  if (!desktop) {
+    throw new Error("Could not read desktop geometry from wmctrl.");
+  }
+
+  const workAreaMatch = desktop.match(/WA:\s*(-?\d+),(-?\d+)\s+(\d+)x(\d+)/);
+  if (workAreaMatch) {
+    return {
+      x: Number(workAreaMatch[1]),
+      y: Number(workAreaMatch[2]),
+      width: Number(workAreaMatch[3]),
+      height: Number(workAreaMatch[4]),
+    };
+  }
+
+  const desktopGeometryMatch = desktop.match(/DG:\s*(\d+)x(\d+)/);
+  if (desktopGeometryMatch) {
+    return {
+      x: 0,
+      y: 0,
+      width: Number(desktopGeometryMatch[1]),
+      height: Number(desktopGeometryMatch[2]),
+    };
+  }
+
+  throw new Error("Could not parse desktop work area from wmctrl.");
+}
+
+async function moveLinuxWindow(
+  windowId: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) {
+  await runFile("wmctrl", ["-ir", windowId, "-b", "remove,maximized_vert,maximized_horz"]);
+  await runFile("wmctrl", ["-ir", windowId, "-e", `0,${x},${y},${width},${height}`]);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function appendLog(message: string) {
+  outputChannel?.append(message.endsWith("\n") ? message : `${message}\n`);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -95,18 +95,24 @@ function launchViewer(context: vscode.ExtensionContext, task: TinymistPreviewTas
     });
   });
   viewer.on("exit", (code, signal) => {
-    activeViewers.delete(task.taskId);
+    deleteActiveViewer(task.taskId, viewer);
     appendLog(`Tinymist GPU Viewer exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
   });
 
   return {
     dispose() {
-      activeViewers.delete(task.taskId);
+      deleteActiveViewer(task.taskId, viewer);
       if (!viewer.killed) {
         viewer.kill();
       }
     },
   };
+}
+
+function deleteActiveViewer(taskId: string, viewer: ChildProcessWithoutNullStreams) {
+  if (activeViewers.get(taskId) === viewer) {
+    activeViewers.delete(taskId);
+  }
 }
 
 function resolveViewerExecutable(context: vscode.ExtensionContext): string {

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -119,11 +119,21 @@ function resolveViewerExecutable(context: vscode.ExtensionContext): string {
   const configured = vscode.workspace
     .getConfiguration("tinymist.gpuViewer")
     .get<string | null>("executable");
+  const configuredPath = configured?.trim();
+  if (configuredPath) {
+    if (configuredPath === VIEWER_BINARY_NAME || fs.existsSync(configuredPath)) {
+      return configuredPath;
+    }
+
+    throw new Error(
+      `Configured tinymist.gpuViewer.executable does not exist: ${configuredPath}. Unset the setting to use the bundled viewer or ${VIEWER_BINARY_NAME} from PATH.`,
+    );
+  }
+
   const candidates = [
-    configured,
     path.join(context.extensionUri.fsPath, "bin", VIEWER_BINARY_NAME),
     VIEWER_BINARY_NAME,
-  ].filter((candidate): candidate is string => !!candidate && candidate.trim() !== "");
+  ];
 
   for (const candidate of candidates) {
     if (candidate === VIEWER_BINARY_NAME || fs.existsSync(candidate)) {

--- a/contrib/tinymist-gpu-viewer/editors/vscode/tsconfig.json
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node", "vscode"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/editors/vscode/e2e-workspaces/gpu-viewer/.vscode/settings.json
+++ b/editors/vscode/e2e-workspaces/gpu-viewer/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "tinymist.previewFeature": "enable",
+  "tinymist.previewer": "myriad-dreamin.tinymist-gpu-viewer",
+  "tinymist.preview.refresh": "onType",
+  "tinymist.exportPdf": "never"
+}

--- a/editors/vscode/e2e-workspaces/gpu-viewer/README.md
+++ b/editors/vscode/e2e-workspaces/gpu-viewer/README.md
@@ -1,0 +1,16 @@
+# GPU Viewer Debug Workspace
+
+This workspace is configured to use the Tinymist GPU Viewer previewer provider:
+
+```json
+{
+  "tinymist.previewer": "myriad-dreamin.tinymist-gpu-viewer"
+}
+```
+
+From the repository root, start the `Run Extension [GPU Viewer]` debug configuration. It opens this folder in the Extension Development Host and loads both development extensions:
+
+- `editors/vscode`
+- `contrib/tinymist-gpu-viewer/editors/vscode`
+
+Open `main.typ`, then run the `typst-preview.preview` command or use the preview editor title action. The preview should open in a native Tinymist GPU Viewer window, not in a VS Code webview panel.

--- a/editors/vscode/e2e-workspaces/gpu-viewer/main.typ
+++ b/editors/vscode/e2e-workspaces/gpu-viewer/main.typ
@@ -1,0 +1,23 @@
+
+#set page(width: 12cm, height: 16cm, margin: 1cm, fill: black)
+#set text(white)
+
+= Tinymist GPU Viewer 1
+
+This workspace configures Tinymist to load the GPU previewer provider extension.
+
+#rect(
+  width: 100%,
+  inset: 12pt,
+  radius: 4pt,
+  stroke: blue,
+)[
+  The active previewer should resolve from
+  `myriad-dreamin.tinymist-gpu-viewer`.
+]
+
+#grid(
+  columns: (1fr, 1fr),
+  gutter: 8pt,
+  [#strong[Mode]\ Document preview], [#strong[Renderer]\ GPU viewer provider],
+)

--- a/openspec/changes/add-gpu-viewer-window-layout/.openspec.yaml
+++ b/openspec/changes/add-gpu-viewer-window-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/add-gpu-viewer-window-layout/design.md
+++ b/openspec/changes/add-gpu-viewer-window-layout/design.md
@@ -1,0 +1,44 @@
+## Overview
+
+The GPU viewer provider already receives `handlePreview(task)` after Tinymist has started the preview server. The layout helper will run from the provider extension after spawning `tinymist-viewer`, using the spawned process id and the known viewer window title (`Tinymist View`) to find the native viewer window.
+
+This keeps window automation outside Tinymist's core VS Code extension and outside the Rust viewer rendering loop. Tinymist continues to manage preview lifecycle and data-plane communication; the provider owns the optional desktop side effect.
+
+## Configuration
+
+`tinymist.gpuViewer.windowLayout`:
+
+- `sideBySide`: move VS Code to the left half of the primary work area and the viewer to the right half.
+- `disabled`: do not move any windows.
+
+The default is `sideBySide` for this provider because the native viewer opens outside VS Code and the expected workflow is source on the left with preview on the right. Users can set `disabled` on tiling window managers, remote sessions, or multi-monitor setups where desktop window movement is unwanted.
+
+## Platform Helpers
+
+### Windows
+
+The extension invokes PowerShell with embedded C# P/Invoke declarations for `user32.dll`. The helper enumerates top-level visible windows, finds a VS Code window by process name (`Code`, `Code - Insiders`, or `VSCodium`) and the viewer window by the spawned process id, then calls `ShowWindowAsync` and `MoveWindow`.
+
+The helper uses the primary screen work area via `System.Windows.Forms.Screen.PrimaryScreen.WorkingArea` to avoid covering the taskbar.
+
+### macOS
+
+The extension invokes `osascript`. AppleScript uses System Events to find the Code process and `Tinymist View`, then sets the front window positions and sizes to the visible desktop bounds. This requires the usual macOS Accessibility permission for the controlling application. If permission is missing, the helper fails softly and logs the error.
+
+### Linux
+
+The extension uses `wmctrl` when available. It queries the desktop work area and visible windows, finds VS Code and the viewer process/window, then moves them with `wmctrl -ir ... -e`. This is expected to work on X11/EWMH window managers. Wayland compositors commonly block global window management; in that case the provider logs that layout was skipped.
+
+## Error Handling
+
+Window layout is best-effort. It must not fail preview launch or kill the viewer. The provider logs the helper command failure, stderr, or timeout to the GPU viewer output channel.
+
+## Lifecycle
+
+The layout helper runs once shortly after spawn. It does not continuously enforce layout and does not watch for later monitor changes. Disposal remains unchanged: Tinymist preview task disposal kills the viewer process.
+
+## Alternatives Considered
+
+- Embedding the native viewer into a VS Code webview: not viable because VS Code cannot host arbitrary native windows in editor tabs.
+- Moving window layout into `tinymist-viewer`: the viewer can control its own window size, but it cannot reliably move VS Code's window across all platforms.
+- Shipping separate native helper binaries: more robust long-term, but increases packaging complexity. Script-backed helpers are sufficient for an opt-in first implementation.

--- a/openspec/changes/add-gpu-viewer-window-layout/proposal.md
+++ b/openspec/changes/add-gpu-viewer-window-layout/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Tinymist GPU Viewer provider launches a native preview window outside VS Code. Users who use it as their primary Typst preview often want the same predictable editing layout they get from a VS Code preview tab: source on the left and preview on the right. Today the provider starts the viewer process but leaves both the VS Code and viewer windows wherever the operating system or window manager places them.
+
+We need an opt-in desktop layout helper for the native viewer provider so opening preview can automatically arrange VS Code and the viewer side by side without changing Tinymist's preview server protocol or forcing webview-based previewers to participate.
+
+## What Changes
+
+- Add a `tinymist.gpuViewer.windowLayout` setting for the GPU viewer provider.
+- Enable side-by-side layout by default for the GPU viewer provider, with a setting to disable it.
+- After launching `tinymist-viewer`, run a platform-specific layout helper that places the VS Code window on the left and the viewer window on the right.
+- Support Windows through Win32 window APIs invoked from PowerShell, macOS through AppleScript, and Linux through common EWMH/X11 helpers when available.
+- Log layout failures to the GPU viewer output channel without failing the preview task.
+
+## Capabilities
+
+### New Capabilities
+
+- `gpu-viewer-window-layout`: Let the Tinymist GPU Viewer provider arrange the active VS Code window and native GPU viewer window side by side after preview launch, with an explicit opt-out setting.
+
+### Modified Capabilities
+
+- `previewer-provider`: Native document preview handlers may perform provider-local desktop window arrangement after Tinymist starts the preview server and calls `handlePreview`.
+
+## Impact
+
+- `contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts` will gain provider-local window layout orchestration.
+- `contrib/tinymist-gpu-viewer/editors/vscode/package.json` will expose the layout setting.
+- `contrib/tinymist-gpu-viewer/editors/vscode/README.md` will document prerequisites and platform behavior.
+- Validation should cover TypeScript compilation for the GPU viewer extension.

--- a/openspec/changes/add-gpu-viewer-window-layout/specs/previewer-provider/spec.md
+++ b/openspec/changes/add-gpu-viewer-window-layout/specs/previewer-provider/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Native GPU viewer arranges windows side by side by default
+
+The Tinymist GPU Viewer previewer provider SHALL arrange the active VS Code window and native GPU viewer window side by side after launching a document preview unless window layout is disabled.
+
+#### Scenario: Default side-by-side layout moves VS Code and viewer
+
+- **WHEN** `tinymist.gpuViewer.windowLayout` is unset or set to `sideBySide`
+- **AND** the GPU viewer provider launches `tinymist-viewer` for a preview task
+- **THEN** the provider attempts to place the VS Code window on the left side of the primary work area
+- **AND** the provider attempts to place the native GPU viewer window on the right side of the primary work area
+
+#### Scenario: Layout disabled preserves operating system placement
+
+- **WHEN** `tinymist.gpuViewer.windowLayout` is set to `disabled`
+- **THEN** the provider launches `tinymist-viewer` without moving the VS Code or viewer windows
+
+#### Scenario: Layout helper failure does not fail preview
+
+- **WHEN** side-by-side layout is enabled
+- **AND** the operating system, desktop environment, permissions, or helper command prevents window movement
+- **THEN** the provider logs the layout failure
+- **AND** the preview task remains running

--- a/openspec/changes/add-gpu-viewer-window-layout/tasks.md
+++ b/openspec/changes/add-gpu-viewer-window-layout/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec
+
+- [x] 1.1 Add proposal, design, tasks, and previewer-provider spec delta for GPU viewer window layout.
+
+## 2. GPU Viewer Provider
+
+- [x] 2.1 Add `tinymist.gpuViewer.windowLayout` configuration with a side-by-side default and disabled opt-out.
+- [x] 2.2 Add provider-side layout orchestration after spawning `tinymist-viewer`.
+- [x] 2.3 Implement Windows, macOS, and Linux helper paths with soft-failure logging.
+- [x] 2.4 Preserve viewer lifecycle behavior and keep preview task errors limited to launch failures.
+
+## 3. Documentation And Validation
+
+- [x] 3.1 Document layout configuration, platform support, and Linux/macOS prerequisites in the GPU viewer README.
+- [x] 3.2 Run TypeScript type-checking for the GPU viewer extension.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "editors/vscode",
     "contrib/typst-preview/editors/vscode",
     "contrib/html/editors/vscode",
+    "contrib/tinymist-gpu-viewer/editors/vscode",
     "contrib/previewer-provider/editors/vscode",
     "tools/editor-tools",
     "tools/typst-dom",


### PR DESCRIPTION
## Summary
- Add contrib/tinymist-gpu-viewer as a VS Code previewer-provider extension for the native GPU viewer.
- Launch tinymist-viewer through the document preview handler with the Tinymist data-plane websocket address, without creating a VS Code webview panel.
- Resolve the viewer executable from tinymist.gpuViewer.executable, bundled bin/, or PATH; local debug tasks copy target/debug/tinymist-viewer into bin/ instead of relying on production repo-layout fallback.
- Add tinymist.gpuViewer.windowLayout with default side-by-side desktop layout and a disabled opt-out, plus OpenSpec coverage.
- Add a local GPU viewer e2e workspace and VS Code debug configuration that loads Tinymist and the GPU viewer extension together.

## Validation
- yarn workspace tinymist-gpu-viewer run type-check
- yarn workspace tinymist run compile:system
- cargo build --bin tinymist-viewer