### PR TITLE
fix(viewer): paint default page background

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
         with:
           node-version: 24
           cache: 'yarn'
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfontconfig1-dev libvulkan1 mesa-vulkan-drivers vulkan-tools
+      - name: Check Vulkan software renderer
+        run: |
+          ls -l /usr/share/vulkan/icd.d
+          vulkaninfo --summary || true
+        env:
+          VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.json
+          VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.json
       - name: Install deps
         run: yarn install
       - name: Check and build assets
@@ -76,6 +87,10 @@ jobs:
           path: tinymist-completions.tar.gz
       - name: Test tinymist
         run: cargo test --workspace --features tinymist/system --locked -- --skip=e2e
+        env:
+          WGPU_BACKEND: vulkan
+          VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.json
+          VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.json
       - name: Test real filesystem watcher
         run: cargo test -p tinymist-project -p tinymist --features tinymist-project/system,tinymist-project/mock,tinymist/system --locked real_fs_ -- --ignored
       - name: Test Lockfile (Prepare)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
  "accesskit",
  "accesskit_consumer",
  "hashbrown 0.15.5",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -153,6 +153,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-activity"
@@ -693,7 +699,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -1120,7 +1126,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1225,9 +1231,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
 dependencies = [
  "clipboard-win",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "smithay-clipboard",
  "x11-clipboard",
 ]
@@ -2071,6 +2077,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fontique"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "icu_locale_core",
+ "linebender_resource_handle",
+ "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "read-fonts 0.35.0",
+ "roxmltree 0.21.1",
+ "smallvec",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2488,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.35.0",
+ "smallvec",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2533,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2827,6 +2871,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap 0.8.1",
+ "serde",
  "tinystr 0.8.2",
  "writeable 0.6.2",
  "zerovec 0.11.5",
@@ -3477,6 +3522,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3717,7 @@ dependencies = [
  "console_error_panic_hook",
  "cursor-icon",
  "dpi",
+ "parley",
  "smallvec",
  "time",
  "tracing",
@@ -3665,6 +3729,20 @@ dependencies = [
  "ui-events",
  "vello",
  "web-time",
+]
+
+[[package]]
+name = "masonry_testing"
+version = "0.4.0"
+source = "git+https://github.com/Myriad-dreamin/xilem?rev=abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3#abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3"
+dependencies = [
+ "accesskit_consumer",
+ "futures-intrusive",
+ "image",
+ "masonry_core",
+ "oxipng",
+ "pollster",
+ "tracing",
 ]
 
 [[package]]
@@ -3991,6 +4069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,10 +4086,10 @@ dependencies = [
  "bitflags 2.10.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
 ]
 
@@ -4014,9 +4101,9 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4026,8 +4113,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4038,8 +4125,17 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4049,8 +4145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -4061,9 +4157,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4082,7 +4188,17 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -4092,9 +4208,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4105,8 +4221,8 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4117,8 +4233,8 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -4128,8 +4244,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4140,12 +4256,12 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -4160,8 +4276,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4172,9 +4288,9 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4269,6 +4385,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxipng"
+version = "9.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c613f0f566526a647c7473f6a8556dbce22c91b13485ee4b4ec7ab648e4973"
+dependencies = [
+ "bitvec",
+ "indexmap 2.12.1",
+ "libdeflater",
+ "log",
+ "rgb",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,6 +4449,21 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parley"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+dependencies = [
+ "accesskit",
+ "fontique",
+ "harfrust",
+ "hashbrown 0.16.1",
+ "linebender_resource_handle",
+ "skrifa 0.37.0",
+ "swash",
 ]
 
 [[package]]
@@ -4946,6 +5091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
+ "core_maths",
  "font-types 0.10.1",
 ]
 
@@ -6003,6 +6149,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swash"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+dependencies = [
+ "skrifa 0.37.0",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6854,6 +7011,8 @@ dependencies = [
  "indexmap 2.12.1",
  "log",
  "masonry",
+ "masonry_testing",
+ "masonry_winit",
  "parking_lot",
  "reflexo",
  "reflexo-typst",
@@ -9094,9 +9253,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
@@ -9331,6 +9490,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9473,6 +9649,12 @@ dependencies = [
  "zbus_names",
  "zvariant",
 ]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,13 @@ tracing = "0.1"
 # Linebender
 xilem = { git = "https://github.com/Myriad-dreamin/xilem", rev = "abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3", default-features = false }
 masonry = { git = "https://github.com/Myriad-dreamin/xilem", rev = "abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3", default-features = false }
+masonry_testing = { git = "https://github.com/Myriad-dreamin/xilem", rev = "abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3", default-features = false, features = [
+    "default",
+    "text",
+] }
+masonry_winit = { git = "https://github.com/Myriad-dreamin/xilem", rev = "abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3", default-features = false, features = [
+    "text",
+] }
 
 # xilem = { path = "../../../xilem/xilem/", default-features = false }
 # masonry = { path = "../../../xilem/masonry/", default-features = false }

--- a/crates/tinymist-viewer/Cargo.toml
+++ b/crates/tinymist-viewer/Cargo.toml
@@ -57,5 +57,9 @@ cli = []
 # This requires modifying typst.
 no-content-hint = ["reflexo-typst/no-content-hint"]
 
+[dev-dependencies]
+masonry_testing.workspace = true
+masonry_winit.workspace = true
+
 [lints]
 workspace = true

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -12,11 +12,17 @@ use masonry::layout::{LenReq, Length};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Axis, Point, Rect, Size};
+use vello::peniko::{Color, Fill};
 use xilem::core::{Arg, MessageCtx, MessageResult, Mut, View, ViewArgument, ViewMarker};
 use xilem::{Pod, ViewCtx};
 
 /// Accesses a raw vello [`Scene`] within a canvas that fills its parent
-pub fn doc<State, F>(scene: Arc<Scene>, scene_scale: f64, on_click: F) -> TypstDocPage<State, F>
+pub fn doc<State, F>(
+    scene: Arc<Scene>,
+    scene_scale: f64,
+    background_color: Option<Color>,
+    on_click: F,
+) -> TypstDocPage<State, F>
 where
     State: ViewArgument,
     F: Fn(Point, Rect) + 'static,
@@ -24,6 +30,7 @@ where
     TypstDocPage {
         scene,
         scene_scale,
+        background_color,
         on_click,
         alt_text: Option::default(),
         phantom: PhantomData,
@@ -35,6 +42,7 @@ where
 pub struct TypstDocPage<State, F> {
     scene: Arc<Scene>,
     scene_scale: f64,
+    background_color: Option<Color>,
     alt_text: Option<ArcStr>,
     on_click: F,
     phantom: PhantomData<fn() -> State>,
@@ -68,6 +76,7 @@ where
                     alt_text: self.alt_text.clone(),
                     size: Size::default(),
                     scene_scale: self.scene_scale,
+                    background_color: self.background_color,
                     scene: self.scene.clone(),
                 })
             }),
@@ -83,7 +92,12 @@ where
         mut element: Mut<'_, Self::Element>,
         _state: Arg<'_, State>,
     ) {
-        PageCanvas::request_render(&mut element, self.scene.clone(), self.scene_scale);
+        PageCanvas::request_render(
+            &mut element,
+            self.scene.clone(),
+            self.scene_scale,
+            self.background_color,
+        );
         if self.alt_text != prev.alt_text {
             PageCanvas::set_alt_text(&mut element, self.alt_text.clone());
         }
@@ -135,6 +149,7 @@ pub struct PageCanvas {
     /// The drawable area size, which matches the widget's content-box.
     size: Size,
     scene_scale: f64,
+    background_color: Option<Color>,
     scene: Arc<Scene>,
 }
 
@@ -168,9 +183,15 @@ impl PageCanvas {
 // --- MARK: WIDGETMUT
 impl PageCanvas {
     /// Requests a render of the canvas.
-    pub fn request_render(this: &mut WidgetMut<'_, Self>, scene: Arc<Scene>, scene_scale: f64) {
+    pub fn request_render(
+        this: &mut WidgetMut<'_, Self>,
+        scene: Arc<Scene>,
+        scene_scale: f64,
+        background_color: Option<Color>,
+    ) {
         this.widget.scene = scene;
         this.widget.scene_scale = scene_scale;
+        this.widget.background_color = background_color;
         this.ctx.request_render();
     }
 
@@ -269,6 +290,15 @@ impl Widget for PageCanvas {
     }
 
     fn paint(&mut self, _: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+        if let Some(background_color) = self.background_color {
+            scene.fill(
+                Fill::NonZero,
+                Affine::IDENTITY,
+                background_color,
+                None,
+                &self.size.to_rect(),
+            );
+        }
         scene.append(&self.scene, Some(Affine::scale(self.scene_scale)));
     }
 
@@ -297,5 +327,45 @@ impl Widget for PageCanvas {
 
     fn get_debug_text(&self) -> Option<String> {
         self.alt_text.as_ref().map(ToString::to_string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use masonry::core::Widget;
+    use masonry::peniko::Color;
+    use masonry::theme::default_property_set;
+    use masonry::vello::Scene;
+    use masonry::vello::kurbo::Size;
+    use masonry_testing::{TestHarness, TestHarnessParams};
+
+    use super::PageCanvas;
+
+    #[test]
+    fn page_canvas_paints_supplied_white_background() {
+        let page = PageCanvas {
+            alt_text: None,
+            size: Size::ZERO,
+            scene_scale: 1.0,
+            background_color: Some(Color::WHITE),
+            scene: Arc::new(Scene::new()),
+        };
+        let mut params = TestHarnessParams::default();
+        params.window_size = Size::new(64.0, 64.0);
+        params.background_color = Color::from_rgb8(0x29, 0x29, 0x29);
+
+        let mut harness =
+            TestHarness::create_with(default_property_set(), page.with_auto_id(), params);
+
+        let rendered = harness.render();
+        let center = rendered.get_pixel(32, 32).0;
+
+        assert_eq!(
+            center,
+            [255, 255, 255, 255],
+            "a Typst page with a supplied white background should not reveal the viewer background"
+        );
     }
 }

--- a/crates/tinymist-viewer/src/incr.rs
+++ b/crates/tinymist-viewer/src/incr.rs
@@ -13,6 +13,7 @@ use reflexo::{
 use vello::{
     Scene,
     kurbo::{Size, Vec2},
+    peniko::{Color, color::parse_color},
 };
 
 use crate::VecPage;
@@ -96,6 +97,22 @@ impl IncrVelloDocClient {
     /// Sets canvas's background color
     pub fn set_fill(&mut self, fill: ImmutStr) {
         self.vec2vello.fill = fill;
+    }
+
+    /// Returns the configured default page background color.
+    pub fn background_color(&self) -> Option<Color> {
+        let fill = self.vec2vello.fill.as_ref();
+        if fill.is_empty() {
+            return None;
+        }
+
+        match parse_color(fill) {
+            Ok(color) => Some(color.to_alpha_color()),
+            Err(err) => {
+                log::warn!("Invalid page background color {fill:?}: {err}");
+                None
+            }
+        }
     }
 
     /// Patches the delta of the incremental rendering.

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -15,6 +15,7 @@ use winit::dpi::LogicalSize;
 use xilem::core::{Edit, MessageProxy, fork};
 use xilem::vello::Scene;
 use xilem::vello::kurbo::Size;
+use xilem::vello::peniko::Color;
 use xilem::view::{flex_col, portal, resize_observer, sized_box, task};
 use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
 
@@ -47,6 +48,7 @@ fn main() -> Result<()> {
         PreviewState {
             data_plane_host: args.data_plane_host,
             pages: vec![],
+            background_color: None,
             window_size: default_size,
             tx,
             rx: Some(rx),
@@ -62,6 +64,7 @@ fn main() -> Result<()> {
 struct PreviewState {
     data_plane_host: String,
     pages: Vec<(Arc<Scene>, Size)>,
+    background_color: Option<Color>,
     window_size: Size,
     tx: mpsc::UnboundedSender<PreviewEvent>,
     rx: Option<mpsc::UnboundedReceiver<PreviewEvent>>,
@@ -128,8 +131,12 @@ impl PreviewState {
             |arg: &mut PreviewState, req: RenderRequest| {
                 // s.tick();
                 match req {
-                    RenderRequest::New(pages) => {
+                    RenderRequest::New {
+                        pages,
+                        background_color,
+                    } => {
                         arg.pages = pages;
+                        arg.background_color = background_color;
                     }
                 }
             },
@@ -148,6 +155,7 @@ impl PreviewState {
             .map(|(idx, (page_scene, scene_size))| {
                 let tx = self.tx.clone();
                 let page_scene = page_scene.clone();
+                let background_color = self.background_color;
                 let width = scene_size.width;
                 let height = scene_size.height;
 
@@ -158,20 +166,25 @@ impl PreviewState {
                 let elem_scale = if width > 0. { elem_width / width } else { 1.0 };
                 let elem_height = elem_scale * height;
                 // The sized box is necessary to avoid collapsing the canvas.
-                sized_box(doc(page_scene, elem_scale, move |pos, bbox| {
-                    if bbox.width() == 0. || bbox.height() == 0. {
-                        return;
-                    }
+                sized_box(doc(
+                    page_scene,
+                    elem_scale,
+                    background_color,
+                    move |pos, bbox| {
+                        if bbox.width() == 0. || bbox.height() == 0. {
+                            return;
+                        }
 
-                    let x = pos.x / bbox.width() * width;
-                    let y = pos.y / bbox.height() * height;
+                        let x = pos.x / bbox.width() * width;
+                        let y = pos.y / bbox.height() * height;
 
-                    let _ = tx.send(PreviewEvent::Click {
-                        page_idx: idx + 1,
-                        x: x as f32,
-                        y: y as f32,
-                    });
-                }))
+                        let _ = tx.send(PreviewEvent::Click {
+                            page_idx: idx + 1,
+                            x: x as f32,
+                            y: y as f32,
+                        });
+                    },
+                ))
                 .fixed_width(Length::const_px(elem_width))
                 .fixed_height(Length::const_px(elem_height))
             })
@@ -226,8 +239,12 @@ impl ezsockets::ClientExt for Client {
                     return Ok(());
                 }
             };
+            let background_color = self.vello.background_color();
 
-            let _ = self.proxy.message(RenderRequest::New(pages));
+            let _ = self.proxy.message(RenderRequest::New {
+                pages,
+                background_color,
+            });
         } else {
             log::info!("received bytes: {bytes:?}");
         }
@@ -252,13 +269,16 @@ impl ezsockets::ClientExt for Client {
 }
 
 enum RenderRequest {
-    New(Vec<(Arc<Scene>, Size)>),
+    New {
+        pages: Vec<(Arc<Scene>, Size)>,
+        background_color: Option<Color>,
+    },
 }
 
 impl fmt::Debug for RenderRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::New(scenes) => write!(f, "New(pages = {:?})", scenes.len()),
+            Self::New { pages, .. } => write!(f, "New(pages = {:?})", pages.len()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a Masonry headless render regression test for the tinymist viewer page canvas.
- Paint the viewer page background from the previewer's configured default fill before appending the Vello page scene, so an empty/default page no longer reveals the window background.
- Keep transparent backgrounds possible by representing the canvas background as `Option<Color>`.
- Configure Linux CI with fontconfig and Mesa lavapipe Vulkan so `masonry_testing` render tests can run headlessly.

## Validation
- `cargo fmt --check --all`
- `cargo test -p tinymist-viewer page_canvas_paints_supplied_white_background`
- `cargo test -p tinymist-viewer`
- GitHub Actions: Linux CI job and full PR checks passed
