### PR TITLE
fix(viewer): accept full current preview frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7025,6 +7025,7 @@ dependencies = [
  "tinymist-assets 0.14.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinymist-preview",
  "tinymist-std",
+ "tinymist-tests",
  "tokio",
  "tracing",
  "ttf-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6783,6 +6783,7 @@ dependencies = [
  "serde_json",
  "tinymist-assets 0.14.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinymist-std",
+ "tinymist-tests",
  "tokio",
  "typst",
  "typst-assets",

--- a/crates/tinymist-viewer/Cargo.toml
+++ b/crates/tinymist-viewer/Cargo.toml
@@ -60,6 +60,7 @@ no-content-hint = ["reflexo-typst/no-content-hint"]
 [dev-dependencies]
 masonry_testing.workspace = true
 masonry_winit.workspace = true
+tinymist-tests.workspace = true
 
 [lints]
 workspace = true

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -340,6 +340,14 @@ mod tests {
     use masonry::vello::Scene;
     use masonry::vello::kurbo::Size;
     use masonry_testing::{TestHarness, TestHarnessParams};
+    use reflexo::vector::incr::IncrDocClient;
+    use reflexo::vector::stream::BytesModuleStream;
+    use reflexo_vec2svg::IncrSvgDocServer;
+    use tinymist_preview::protocol::{DIFF_V1_PREFIX, NEW_PREFIX};
+    use tinymist_std::typst::TypstDocument;
+
+    use crate::incr::IncrVelloDocClient;
+    use crate::protocol::preview_update_from_bytes;
 
     use super::PageCanvas;
 
@@ -366,6 +374,114 @@ mod tests {
             center,
             [255, 255, 255, 255],
             "a Typst page with a supplied white background should not reveal the viewer background"
+        );
+    }
+
+    #[test]
+    fn diff_v1_preview_frame_paints_generated_page() {
+        let (frame, _) = generated_preview_frames();
+        assert!(
+            frame.starts_with(DIFF_V1_PREFIX),
+            "the initial backend preview frame should be diff-v1"
+        );
+
+        let center = render_preview_frame_center(&frame);
+
+        assert_black_pixel(
+            center,
+            "a rendered diff-v1 frame should paint the generated black page",
+        );
+    }
+
+    #[test]
+    fn full_current_preview_frame_paints_generated_page_after_reset() {
+        let (_, frame) = generated_preview_frames();
+        assert!(
+            frame.starts_with(NEW_PREFIX),
+            "the backend full-current preview frame should be new"
+        );
+
+        let center = render_preview_frame_center(&frame);
+
+        assert_black_pixel(
+            center,
+            "a rendered new frame should reset, merge, and paint the generated black page",
+        );
+    }
+
+    fn generated_preview_frames() -> (Vec<u8>, Vec<u8>) {
+        const SOURCE: &str = r#"
+#set page(width: 16pt, height: 16pt, margin: 0pt, fill: white)
+#rect(width: 16pt, height: 16pt, fill: black)
+"#;
+
+        tinymist_tests::run_with_sources(SOURCE, |verse, _| {
+            let world = verse.snapshot();
+            let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+                .output
+                .expect("short viewer preview fixture should compile");
+            let document = TypstDocument::Paged(Arc::new(doc));
+            let mut renderer = IncrSvgDocServer::default();
+
+            let diff = renderer.pack_delta(&document);
+            let current = tinymist_preview::protocol::full_current_frame_from_delta(&diff)
+                .expect("full current can be built from an initial incremental frame");
+
+            (diff, current)
+        })
+    }
+
+    fn render_preview_frame_center(frame: &[u8]) -> [u8; 4] {
+        let mut doc = IncrDocClient::default();
+        let mut vello = IncrVelloDocClient::default();
+
+        let update = preview_update_from_bytes(frame).expect("preview frame should be accepted");
+        if update.reset_before_merge {
+            doc = IncrDocClient::default();
+            vello.reset();
+        }
+
+        let delta = BytesModuleStream::from_slice(update.payload).checkout_owned();
+        doc.merge_delta(delta);
+
+        let mut pages = vello
+            .render_pages(&mut doc)
+            .expect("preview frame should render through the viewer");
+        assert_eq!(pages.len(), 1, "preview fixture should render one page");
+
+        let (scene, size) = pages.pop().expect("one rendered page should exist");
+        assert_eq!(size, Size::new(16.0, 16.0));
+
+        render_page_canvas_center(scene, vello.background_color())
+    }
+
+    fn render_page_canvas_center(scene: Arc<Scene>, background_color: Option<Color>) -> [u8; 4] {
+        let page = PageCanvas {
+            alt_text: None,
+            size: Size::ZERO,
+            scene_scale: 1.0,
+            background_color,
+            scene,
+        };
+        let mut params = TestHarnessParams::default();
+        params.window_size = Size::new(32.0, 32.0);
+        params.background_color = Color::from_rgb8(0x29, 0x29, 0x29);
+
+        let mut harness =
+            TestHarness::create_with(default_property_set(), page.with_auto_id(), params);
+        let rendered = harness.render();
+
+        rendered.get_pixel(8, 8).0
+    }
+
+    fn assert_black_pixel(pixel: [u8; 4], message: &str) {
+        assert!(
+            pixel[0] <= 4 && pixel[1] <= 4 && pixel[2] <= 4 && pixel[3] == 255,
+            "{message}; got rgba({},{},{},{})",
+            pixel[0],
+            pixel[1],
+            pixel[2],
+            pixel[3]
         );
     }
 }

--- a/crates/tinymist-viewer/src/incr.rs
+++ b/crates/tinymist-viewer/src/incr.rs
@@ -92,7 +92,14 @@ pub struct IncrVelloDocClient {
 
 impl IncrVelloDocClient {
     /// Resets the state of the incremental rendering.
-    pub fn reset(&mut self) {}
+    pub fn reset(&mut self) {
+        let fill = self.vec2vello.fill.clone();
+        self.vec2vello = IncrVelloPass {
+            fill,
+            pages: vec![],
+        };
+        self.doc_view = None;
+    }
 
     /// Sets canvas's background color
     pub fn set_fill(&mut self, fill: ImmutStr) {
@@ -149,5 +156,23 @@ impl IncrVelloDocClient {
             })
             .collect();
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncrVelloDocClient;
+
+    #[test]
+    fn reset_clears_cached_view_state_without_losing_fill() {
+        let mut client = IncrVelloDocClient::default();
+        client.set_fill("#101010".into());
+        client.doc_view = Some(vec![]);
+
+        client.reset();
+
+        assert_eq!(client.vec2vello.fill.as_ref(), "#101010");
+        assert!(client.vec2vello.pages.is_empty());
+        assert!(client.doc_view.is_none());
     }
 }

--- a/crates/tinymist-viewer/src/lib.rs
+++ b/crates/tinymist-viewer/src/lib.rs
@@ -14,6 +14,7 @@ use vello::peniko;
 
 pub mod doc;
 pub mod incr;
+pub mod protocol;
 mod render;
 
 /// A vello scene corresponding to a typst page.

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -21,6 +21,7 @@ use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
 
 use tinymist_viewer::doc::doc;
 use tinymist_viewer::incr::IncrVelloDocClient;
+use tinymist_viewer::protocol::preview_update_from_bytes;
 
 #[derive(Debug, Clone, Parser)]
 struct Args {
@@ -222,13 +223,13 @@ impl ezsockets::ClientExt for Client {
     }
 
     async fn on_binary(&mut self, bytes: ezsockets::Bytes) -> Result<(), ezsockets::Error> {
-        const DIFF_V1_PREFIX: &[u8] = b"diff-v1,";
-
-        if bytes.starts_with(DIFF_V1_PREFIX) {
-            let diff = bytes.slice(DIFF_V1_PREFIX.len()..);
-
+        if let Some(update) = preview_update_from_bytes(bytes.as_ref()) {
+            if update.reset_before_merge {
+                self.doc = IncrDocClient::default();
+                self.vello.reset();
+            }
             // todo: cloned on unaligned data.
-            let delta = BytesModuleStream::from_slice(&diff).checkout_owned();
+            let delta = BytesModuleStream::from_slice(update.payload).checkout_owned();
 
             self.doc.merge_delta(delta);
 

--- a/crates/tinymist-viewer/src/protocol.rs
+++ b/crates/tinymist-viewer/src/protocol.rs
@@ -1,0 +1,50 @@
+//! Preview data-plane protocol handling for the Vello viewer.
+
+use tinymist_preview::protocol::{PreviewDataFrame, split_preview_data_frame};
+
+/// A preview vector document update ready to merge into the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreviewUpdate<'a> {
+    /// Whether the viewer must reset client-side state before merging.
+    pub reset_before_merge: bool,
+    /// The serialized vector document payload without the data-plane prefix.
+    pub payload: &'a [u8],
+}
+
+/// Parses a preview data-plane frame into a viewer update.
+pub fn preview_update_from_bytes(bytes: &[u8]) -> Option<PreviewUpdate<'_>> {
+    match split_preview_data_frame(bytes)? {
+        PreviewDataFrame::DiffV1(payload) => Some(PreviewUpdate {
+            reset_before_merge: false,
+            payload,
+        }),
+        PreviewDataFrame::FullCurrent(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tinymist_preview::protocol::{DIFF_V1_PREFIX, NEW_PREFIX};
+
+    use super::preview_update_from_bytes;
+
+    #[test]
+    fn diff_v1_frame_merges_without_reset() {
+        let frame = [DIFF_V1_PREFIX, b"x"].concat();
+
+        let update = preview_update_from_bytes(&frame).expect("diff-v1 should be accepted");
+
+        assert!(!update.reset_before_merge);
+        assert_eq!(update.payload, b"x");
+    }
+
+    #[test]
+    fn full_current_frame_resets_before_merge() {
+        let frame = [NEW_PREFIX, b"x"].concat();
+
+        let update = preview_update_from_bytes(&frame).expect("new should be accepted");
+
+        assert!(update.reset_before_merge);
+        assert_eq!(update.payload, b"x");
+    }
+}

--- a/crates/tinymist-viewer/src/protocol.rs
+++ b/crates/tinymist-viewer/src/protocol.rs
@@ -18,7 +18,10 @@ pub fn preview_update_from_bytes(bytes: &[u8]) -> Option<PreviewUpdate<'_>> {
             reset_before_merge: false,
             payload,
         }),
-        PreviewDataFrame::FullCurrent(_) => None,
+        PreviewDataFrame::FullCurrent(payload) => Some(PreviewUpdate {
+            reset_before_merge: true,
+            payload,
+        }),
     }
 }
 

--- a/crates/typst-preview/Cargo.toml
+++ b/crates/typst-preview/Cargo.toml
@@ -32,6 +32,8 @@ typst-macros.workspace = true
 typst-timing.workspace = true
 typst-assets.workspace = true
 
+[dev-dependencies]
+tinymist-tests.workspace = true
 
 [features]
 

--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -11,6 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 use super::{editor::EditorActorRequest, webview::WebviewActorRequest};
 use crate::debug_loc::SpanInterner;
 use crate::outline::Outline;
+use crate::protocol;
 use crate::{ChangeCursorPositionRequest, CompileView, DocToSrcJumpInfo, ResolveSourceLocRequest};
 
 #[derive(Debug, Clone)]
@@ -58,16 +59,20 @@ impl RenderActor {
         svg_sender: mpsc::UnboundedSender<Vec<u8>>,
         webview_sender: broadcast::Sender<WebviewActorRequest>,
     ) -> Self {
-        let mut res = Self {
+        Self {
             mailbox,
             view,
-            renderer: IncrSvgDocServer::default(),
+            renderer: Self::new_renderer(),
             editor_conn_sender,
             svg_sender,
             webview_sender,
-        };
-        res.renderer.set_should_attach_debug_info(true);
-        res
+        }
+    }
+
+    fn new_renderer() -> IncrSvgDocServer {
+        let mut renderer = IncrSvgDocServer::default();
+        renderer.set_should_attach_debug_info(true);
+        renderer
     }
 
     async fn process_message(&mut self, msg: RenderActorRequest) -> bool {
@@ -162,19 +167,24 @@ impl RenderActor {
 
     fn render(&mut self, has_full_render: bool, document: &TypstDocument) -> Vec<u8> {
         if has_full_render {
-            if let Some(data) = self.render_full() {
-                data
-            } else {
-                self.render_delta(document)
-            }
+            self.render_full(document)
         } else {
             self.render_delta(document)
         }
     }
 
     #[typst_macros::time]
-    fn render_full(&mut self) -> Option<Vec<u8>> {
-        self.renderer.pack_current()
+    fn render_full(&mut self, document: &TypstDocument) -> Vec<u8> {
+        let mut renderer = Self::new_renderer();
+        let delta = renderer.pack_delta(document);
+        self.renderer = renderer;
+        match protocol::full_current_frame_from_delta(&delta) {
+            Some(frame) => frame,
+            None => {
+                log::warn!("fresh preview renderer did not produce a diff-v1 frame");
+                delta
+            }
+        }
     }
 
     #[typst_macros::time]

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -4,6 +4,7 @@
 mod actor;
 mod debug_loc;
 mod outline;
+pub mod protocol;
 
 pub use crate::actor::editor::{
     CompileStatus, ControlPlaneMessage, ControlPlaneResponse, ControlPlaneRx, ControlPlaneTx,
@@ -360,12 +361,50 @@ pub type SourceLocation = reflexo_typst::debug_loc::SourceLocation;
 
 #[cfg(test)]
 mod tests {
-    use super::escape_html_text;
+    use std::sync::Arc;
+
+    use reflexo_vec2svg::IncrSvgDocServer;
+    use tinymist_std::typst::TypstDocument;
+
+    use super::{escape_html_text, protocol};
 
     #[test]
     fn escapes_html_text_without_breaking_multibyte_code_points() {
         assert_eq!(escape_html_text("☃<>&"), "☃&lt;&gt;&amp;");
         assert_eq!(escape_html_text("plain text"), "plain text");
+    }
+
+    #[test]
+    fn full_current_event_uses_new_prefix_after_incremental_render() {
+        tinymist_tests::run_with_sources(
+            "#set page(width: 1pt, height: 1pt, margin: 0pt)",
+            |verse, _| {
+                let world = verse.snapshot();
+                let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+                    .output
+                    .expect("short preview fixture should compile");
+                let document = TypstDocument::Paged(Arc::new(doc));
+                let mut renderer = IncrSvgDocServer::default();
+
+                let first = renderer.pack_delta(&document);
+                assert!(
+                    first.starts_with(protocol::DIFF_V1_PREFIX),
+                    "initial preview update should be diff-v1"
+                );
+
+                let current = renderer
+                    .pack_current()
+                    .expect("full current is available after the renderer has state");
+                assert!(
+                    current.starts_with(protocol::NEW_PREFIX),
+                    "full current preview update should use the new, prefix"
+                );
+                assert!(
+                    current.len() > protocol::NEW_PREFIX.len(),
+                    "full current frame should include a payload"
+                );
+            },
+        );
     }
 }
 

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -392,9 +392,8 @@ mod tests {
                     "initial preview update should be diff-v1"
                 );
 
-                let current = renderer
-                    .pack_current()
-                    .expect("full current is available after the renderer has state");
+                let current = protocol::full_current_frame_from_delta(&first)
+                    .expect("full current can be built from an initial incremental frame");
                 assert!(
                     current.starts_with(protocol::NEW_PREFIX),
                     "full current preview update should use the new, prefix"

--- a/crates/typst-preview/src/protocol.rs
+++ b/crates/typst-preview/src/protocol.rs
@@ -26,3 +26,13 @@ pub fn split_preview_data_frame(bytes: &[u8]) -> Option<PreviewDataFrame<'_>> {
             .map(PreviewDataFrame::FullCurrent)
     }
 }
+
+/// Converts a complete initial incremental update into a full-current update.
+///
+/// A fresh incremental renderer emits a self-contained `diff-v1,` payload. The
+/// full-current data-plane event uses the same payload format with a `new,`
+/// prefix so clients reset their local state before merging it.
+pub fn full_current_frame_from_delta(delta_frame: &[u8]) -> Option<Vec<u8>> {
+    let payload = delta_frame.strip_prefix(DIFF_V1_PREFIX)?;
+    Some([NEW_PREFIX, payload].concat())
+}

--- a/crates/typst-preview/src/protocol.rs
+++ b/crates/typst-preview/src/protocol.rs
@@ -1,0 +1,28 @@
+//! Preview data-plane protocol helpers.
+
+/// Prefix for incremental vector document updates.
+pub const DIFF_V1_PREFIX: &[u8] = b"diff-v1,";
+
+/// Prefix for a full current vector document update.
+pub const NEW_PREFIX: &[u8] = b"new,";
+
+/// A preview data-plane frame with its prefix stripped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewDataFrame<'a> {
+    /// An incremental update.
+    DiffV1(&'a [u8]),
+    /// A full current update. Clients must reset their render state before
+    /// merging the payload.
+    FullCurrent(&'a [u8]),
+}
+
+/// Splits a preview data-plane binary frame into its event kind and payload.
+pub fn split_preview_data_frame(bytes: &[u8]) -> Option<PreviewDataFrame<'_>> {
+    if let Some(payload) = bytes.strip_prefix(DIFF_V1_PREFIX) {
+        Some(PreviewDataFrame::DiffV1(payload))
+    } else {
+        bytes
+            .strip_prefix(NEW_PREFIX)
+            .map(PreviewDataFrame::FullCurrent)
+    }
+}


### PR DESCRIPTION
This PR is opened in two phases.

Phase 1 intentionally adds the regression coverage first:
- tinymist-preview proves the backend can produce a full-current data-plane frame prefixed with `new,` after an incremental render
- tinymist-viewer consumes that confirmed frame shape in a protocol test and currently fails because it only accepts `diff-v1,`.

Expected current CI result: failing viewer test. The next push will implement `new,` support and reset the viewer client state before merging full-current payloads.