### PR TITLE
feat: add tinymist lint command

### DIFF
--- a/crates/tinymist-cli/src/cmd/lint.rs
+++ b/crates/tinymist-cli/src/cmd/lint.rs
@@ -1,0 +1,68 @@
+use tinymist::project::CompiledArtifact;
+use tinymist::world::DiagnosticFormat;
+use tinymist::world::system::print_diagnostics;
+use tinymist_project::WorldProvider;
+use tinymist_std::error::prelude::*;
+use typlite::CompileOnceArgs;
+
+/// Run Tinymist lint checks.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct LintArgs {
+    /// Compile a document once before linting.
+    #[clap(flatten)]
+    pub compile: CompileOnceArgs,
+
+    /// Configure how diagnostics are printed.
+    #[clap(long = "diagnostic-format", value_enum, default_value_t)]
+    pub diagnostic_format: LintDiagnosticFormat,
+}
+
+#[derive(Debug, Copy, Clone, Default, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum LintDiagnosticFormat {
+    /// Human-readable diagnostics.
+    #[default]
+    Human,
+    /// Short Unix-style diagnostics.
+    Short,
+}
+
+impl From<LintDiagnosticFormat> for DiagnosticFormat {
+    fn from(format: LintDiagnosticFormat) -> Self {
+        match format {
+            LintDiagnosticFormat::Human => DiagnosticFormat::Human,
+            LintDiagnosticFormat::Short => DiagnosticFormat::Short,
+        }
+    }
+}
+
+/// Runs Tinymist lint checks.
+pub fn lint_main(args: LintArgs) -> Result<()> {
+    let analysis = crate::query::default_analysis();
+    let verse = args.compile.resolve()?;
+    let graph = verse.computation();
+    let compiled = CompiledArtifact::from_graph(graph, false);
+    let compiler_diagnostics = compiled.diagnostics().cloned().collect::<Vec<_>>();
+
+    let lint_diagnostics = analysis
+        .query_snapshot(compiled.graph.clone(), None)
+        .run_analysis(|ctx| {
+            tinymist_query::collect_lint_diagnostics(ctx, compiler_diagnostics.iter())
+        })?;
+    let has_lint_diagnostics = !lint_diagnostics.is_empty();
+
+    let mut diagnostics = compiler_diagnostics;
+    diagnostics.extend(lint_diagnostics);
+    print_diagnostics(
+        compiled.world(),
+        diagnostics.iter(),
+        args.diagnostic_format.into(),
+    )
+    .context_ut("print diagnostics")?;
+
+    if compiled.has_errors() || has_lint_diagnostics {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/crates/tinymist-cli/src/cmd/query.rs
+++ b/crates/tinymist-cli/src/cmd/query.rs
@@ -62,12 +62,11 @@ pub struct PackageDocsArgs {
     // pub format: Option<QueryDocsFormat>,
 }
 
-/// The main entry point for language server queries.
-pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
-    use tinymist_project::package::PackageRegistry;
+/// Creates the default analysis context for CLI query-style commands.
+pub fn default_analysis() -> Arc<Analysis> {
     let (config, _) = Config::extract_lsp_params(Default::default(), Default::default());
     let const_config = &config.const_config;
-    let analysis = Arc::new(Analysis {
+    Arc::new(Analysis {
         position_encoding: const_config.position_encoding,
         allow_overlapping_token: const_config.tokens_overlapping_token_support,
         allow_multiline_token: const_config.tokens_multiline_token_support,
@@ -87,7 +86,13 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
         caches: Default::default(),
         analysis_rev_cache: Arc::default(),
         stats: Arc::default(),
-    });
+    })
+}
+
+/// The main entry point for language server queries.
+pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
+    use tinymist_project::package::PackageRegistry;
+    let analysis = default_analysis();
 
     let compile = match &mut cmds {
         QueryCommands::Lsif(args) => &mut args.compile,

--- a/crates/tinymist-cli/src/main.rs
+++ b/crates/tinymist-cli/src/main.rs
@@ -10,6 +10,7 @@ mod cmd {
     #[cfg(feature = "dap")]
     pub mod dap;
     pub mod generate_script;
+    pub mod lint;
     pub mod lsp;
     #[cfg(feature = "preview")]
     pub mod preview;
@@ -34,6 +35,7 @@ use crate::cmd::*;
 #[cfg(feature = "export")]
 use crate::compile::CompileArgs;
 use crate::conn::client_root;
+use crate::lint::LintArgs;
 use crate::utils::*;
 
 #[cfg(feature = "dhat-heap")]
@@ -97,6 +99,8 @@ enum Commands {
     #[cfg(feature = "export")]
     #[clap(alias = "c")]
     Compile(CompileArgs),
+    /// Run Tinymist lint checks
+    Lint(LintArgs),
 
     /// Generate completion script to stdout
     Completion(crate::completion::ShellCompletionArgs),
@@ -148,6 +152,7 @@ fn main() -> Result<()> {
         Commands::Completion(..) | Commands::Probe => false,
         #[cfg(feature = "export")]
         Commands::Compile(..) => false,
+        Commands::Lint(..) => false,
 
         // Long-running commands, usually run from the CLI.
         Commands::Test(test) => test.verbose,
@@ -183,6 +188,7 @@ fn main() -> Result<()> {
         Commands::Preview(args) => block_on(crate::preview::preview_main(args)),
         #[cfg(feature = "export")]
         Commands::Compile(args) => block_on(crate::compile::compile_main(args)),
+        Commands::Lint(args) => crate::lint::lint_main(args),
 
         Commands::Completion(args) => crate::completion::completion_main(args),
         Commands::GenerateScript(args) => crate::generate_script::generate_script_main(args),

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -14,6 +14,41 @@ pub type DiagnosticsMap = HashMap<Url, EcoVec<Diagnostic>>;
 type TypstDiagnostic = typst::diag::SourceDiagnostic;
 type TypstSeverity = typst::diag::Severity;
 
+/// Collects Tinymist lint diagnostics for the current compilation dependencies.
+pub fn collect_lint_diagnostics<'a>(
+    ctx: &mut LocalContext,
+    compiler_diagnostics: impl IntoIterator<Item = &'a TypstDiagnostic>,
+) -> EcoVec<TypstDiagnostic> {
+    let known_issues = KnownIssues::from_compiler_diagnostics(compiler_diagnostics.into_iter());
+    collect_lint_diagnostics_with_known(ctx, &known_issues)
+}
+
+fn collect_lint_diagnostics_with_known(
+    ctx: &mut LocalContext,
+    known_issues: &KnownIssues,
+) -> EcoVec<TypstDiagnostic> {
+    let mut diagnostics = EcoVec::new();
+    for dep in ctx.world().depended_files() {
+        if WorkspaceResolver::is_package_file(dep)
+            || dep
+                .vpath()
+                .as_rooted_path()
+                .extension()
+                .is_none_or(|e| e != "typ")
+        {
+            continue;
+        }
+
+        let Ok(source) = ctx.world().source(dep) else {
+            continue;
+        };
+
+        diagnostics.extend(ctx.lint(&source, known_issues));
+    }
+
+    diagnostics
+}
+
 /// Converts a list of Typst diagnostics to LSP diagnostics,
 /// with potential refinements on the error messages.
 pub fn convert_diagnostics<'a>(
@@ -52,24 +87,8 @@ impl<'w> DiagWorker<'w> {
     pub fn check(mut self, known_issues: &KnownIssues) -> Self {
         let source = self.source;
         self.source = "tinymist-lint";
-        for dep in self.ctx.world().depended_files() {
-            if WorkspaceResolver::is_package_file(dep)
-                || dep
-                    .vpath()
-                    .as_rooted_path()
-                    .extension()
-                    .is_none_or(|e| e != "typ")
-            {
-                continue;
-            }
-
-            let Ok(source) = self.ctx.world().source(dep) else {
-                continue;
-            };
-
-            for diag in self.ctx.lint(&source, known_issues) {
-                self.handle(&diag);
-            }
+        for diag in collect_lint_diagnostics_with_known(self.ctx, known_issues) {
+            self.handle(&diag);
         }
         self.source = source;
 

--- a/tests/e2e/e2e/cli.rs
+++ b/tests/e2e/e2e/cli.rs
@@ -41,6 +41,7 @@ fn test_help() {
       dap         Run debug adapter
       preview     Run preview server
       compile     Run compile command like `typst-cli compile`
+      lint        Run Tinymist lint checks
       completion  Generate completion script to stdout
       test        Test a document and give summary
       help        Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
## Summary
- add a top-level `tinymist lint` command that builds the query analysis context and runs existing lint checks
- print compiler and lint diagnostics with the same diagnostic printer used by `tinymist compile`, with configurable `--diagnostic-format <human|short>`
- keep lint entry resolution on normal compile-once args without implicitly defaulting to `main.typ`
- update top-level CLI help coverage

## Validation
- `cargo fmt --check --all`
- `git diff --check`
- `cargo check -p tinymist-cli`
- `RUSTFLAGS='-Dwarnings' cargo check -p tinymist-cli`
- `cargo test -p tinymist-query lint_tests::test`
- `cargo run --quiet -p tinymist-cli -- lint` (exits with `entry file must be provided`)
- `cargo run --quiet -p tinymist-cli -- lint --diagnostic-format short crates/tinymist-query/src/fixtures/lint/break_top.typ`
- `cargo run --quiet -p tinymist-cli -- lint crates/tinymist-query/src/fixtures/lint/break_top.typ`
- `cargo run --quiet -p tinymist-cli -- lint tests/workspaces/individuals/tiny.typ`