### PR TITLE
fix(viewer): recover websocket connections

### DIFF
--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -1,27 +1,43 @@
 //! Renders and views typst document with Xilem & Vello.
 
 use core::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use ezsockets::ClientConfig;
+use ezsockets::client::ClientCloseMode;
 use masonry::layout::Length;
+use masonry::layout::UnitPoint;
 use reflexo::debug_loc::DocumentPosition;
 use reflexo::vector::incr::IncrDocClient;
 use reflexo::vector::stream::BytesModuleStream;
+use reflexo_vec2svg::IncrSvgDocServer;
+use tinymist_std::typst::TypstDocument;
 use tokio::sync::mpsc;
+use typst::diag::{FileError, FileResult};
+use typst::foundations::{Bytes as TypstBytes, Datetime};
+use typst::layout::PagedDocument;
+use typst::syntax::{FileId, Source, VirtualPath};
+use typst::text::{Font, FontBook};
+use typst::utils::LazyHash;
+use typst::{Library, LibraryExt, World};
 use winit::dpi::LogicalSize;
 use xilem::core::{Edit, MessageProxy, fork};
 use xilem::vello::Scene;
 use xilem::vello::kurbo::Size;
 use xilem::vello::peniko::Color;
-use xilem::view::{flex_col, portal, resize_observer, sized_box, task};
-use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
+use xilem::view::{ZStackExt as _, flex_col, portal, resize_observer, sized_box, task, zstack};
+use xilem::{AppState, EventLoop, WidgetView, WindowId, Xilem, window};
 
 use tinymist_viewer::doc::doc;
 use tinymist_viewer::incr::IncrVelloDocClient;
 use tinymist_viewer::protocol::preview_update_from_bytes;
+
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(1);
+const STATUS_BANNER_HEIGHT: f64 = 28.0;
+const EMPTY_STATUS_BANNER_HEIGHT: f64 = 34.0;
 
 #[derive(Debug, Clone, Parser)]
 struct Args {
@@ -45,17 +61,21 @@ fn main() -> Result<()> {
     let (tx, rx) = mpsc::unbounded_channel();
 
     let default_size = Size::new(800.0, 800.0);
-    let app = Xilem::new_simple(
+    let data_plane_host = args.data_plane_host;
+    let app = Xilem::new(
         PreviewState {
-            data_plane_host: args.data_plane_host,
+            data_plane_host,
+            window_id: WindowId::next(),
+            running: true,
             pages: vec![],
             background_color: None,
             window_size: default_size,
+            connection: ConnectionStatus::Connecting,
+            status_scene: None,
             tx,
             rx: Some(rx),
         },
-        PreviewState::view,
-        WindowOptions::new("Tinymist View").with_min_inner_size(LogicalSize::new(800.0, 800.0)),
+        PreviewState::windows,
     );
     app.run_in(EventLoop::with_user_event())
         .context("Couldn't run event loop")?;
@@ -64,23 +84,75 @@ fn main() -> Result<()> {
 
 struct PreviewState {
     data_plane_host: String,
+    window_id: WindowId,
+    running: bool,
     pages: Vec<(Arc<Scene>, Size)>,
     background_color: Option<Color>,
     window_size: Size,
+    connection: ConnectionStatus,
+    status_scene: Option<StatusScene>,
     tx: mpsc::UnboundedSender<PreviewEvent>,
     rx: Option<mpsc::UnboundedReceiver<PreviewEvent>>,
 }
 
+impl AppState for PreviewState {
+    fn keep_running(&self) -> bool {
+        self.running
+    }
+}
+
 impl PreviewState {
+    fn windows(&mut self) -> impl Iterator<Item = xilem::WindowView<Self>> + use<> {
+        let window_id = self.window_id;
+        let title = self.window_title();
+        let root = self.view();
+        std::iter::once(window(window_id, title, root).with_options(|options| {
+            options
+                .with_min_inner_size(LogicalSize::new(800.0, 800.0))
+                .on_close(|state: &mut PreviewState| {
+                    state.running = false;
+                })
+        }))
+    }
+
+    fn window_title(&self) -> String {
+        match self.connection.title_suffix() {
+            Some(suffix) => format!("Tinymist View - {suffix}"),
+            None => "Tinymist View".to_owned(),
+        }
+    }
+
+    fn status_scene(&mut self, message: &str, width: f64, height: f64) -> (Arc<Scene>, Size) {
+        if let Some(scene) = &self.status_scene
+            && scene.matches(message, width, height)
+        {
+            return (scene.scene.clone(), scene.size);
+        }
+
+        let (scene, size) = match render_status_scene(message, width, height) {
+            Ok(scene) => scene,
+            Err(err) => {
+                log::warn!("failed to render websocket status with Typst: {err}");
+                (Arc::new(Scene::new()), Size::new(width, height))
+            }
+        };
+        self.status_scene = Some(StatusScene {
+            message: message.to_owned(),
+            width,
+            height,
+            scene,
+            size,
+        });
+
+        let scene = self.status_scene.as_ref().expect("status scene just set");
+        (scene.scene.clone(), scene.size)
+    }
+
     fn view(&mut self) -> impl WidgetView<Edit<Self>> + use<> {
         // Uses an effect that connects to the websocket and receives the document data.
         let effect = task(
             |proxy, args: &mut PreviewState| {
-                let address = if args.data_plane_host.contains("ws://") {
-                    args.data_plane_host.clone()
-                } else {
-                    format!("ws://{}", args.data_plane_host)
-                };
+                let address = websocket_address(&args.data_plane_host);
                 let rx = args.rx.take();
                 async move {
                     let Some(mut rx) = rx else {
@@ -88,44 +160,78 @@ impl PreviewState {
                         return;
                     };
 
+                    send_connection_status(&proxy, ConnectionStatus::Connecting);
+
                     let config = ClientConfig::new(address.as_str())
-                        .header("Origin", "http://localhost:23625");
+                        .header("Origin", "http://localhost:23625")
+                        .reconnect_interval(RECONNECT_INTERVAL);
+                    let client_proxy = proxy.clone();
                     let (handle, future) = ezsockets::connect(
                         |client| Client {
-                            proxy,
+                            proxy: client_proxy,
                             client,
                             doc: IncrDocClient::default(),
                             vello: IncrVelloDocClient::default(),
+                            connect_attempts: 0,
                         },
                         config,
                     )
                     .await;
+                    let mut future = std::pin::pin!(future);
 
-                    while let Some(event) = rx.recv().await {
-                        match event {
-                            PreviewEvent::Click { page_idx, x, y } => {
-                                log::debug!("client click: [{page_idx}] {x}, {y}");
-                                let frame_loc = DocumentPosition {
-                                    page_no: page_idx,
-                                    x,
-                                    y,
+                    loop {
+                        tokio::select! {
+                            event = rx.recv() => {
+                                let Some(event) = event else {
+                                    break;
                                 };
-                                let frame_loc = match serde_json::to_string(&frame_loc) {
-                                    Ok(frame_loc) => frame_loc,
-                                    Err(err) => {
-                                        log::error!("Error serializing frame location: {err}");
-                                        return;
+                                match event {
+                                    PreviewEvent::Click { page_idx, x, y } => {
+                                        log::debug!("client click: [{page_idx}] {x}, {y}");
+                                        let frame_loc = DocumentPosition {
+                                            page_no: page_idx,
+                                            x,
+                                            y,
+                                        };
+                                        let frame_loc = match serde_json::to_string(&frame_loc) {
+                                            Ok(frame_loc) => frame_loc,
+                                            Err(err) => {
+                                                log::error!("Error serializing frame location: {err}");
+                                                return;
+                                            }
+                                        };
+
+                                        if let Err(err) = handle.text(format!("src-point {frame_loc}")) {
+                                            log::warn!("Error sending click position to websocket: {err}");
+                                        }
                                     }
-                                };
-
-                                let _ = handle.text(format!("src-point {frame_loc}"));
+                                }
+                            }
+                            res = &mut future => {
+                                match res {
+                                    Ok(()) => {
+                                        log::warn!("websocket client stopped");
+                                        send_connection_status(
+                                            &proxy,
+                                            ConnectionStatus::Stopped {
+                                                reason: "WebSocket client stopped".into(),
+                                            },
+                                        );
+                                    }
+                                    Err(err) => {
+                                        let reason = truncate_message(err.to_string(), 180);
+                                        log::error!("Error connecting to websocket: {reason}");
+                                        send_connection_status(
+                                            &proxy,
+                                            ConnectionStatus::Stopped {
+                                                reason: format!("WebSocket client stopped: {reason}"),
+                                            },
+                                        );
+                                    }
+                                }
+                                break;
                             }
                         }
-                    }
-
-                    let res = future.await;
-                    if let Err(err) = res {
-                        log::error!("Error connecting to websocket: {err}");
                     }
                 }
             },
@@ -138,6 +244,9 @@ impl PreviewState {
                     } => {
                         arg.pages = pages;
                         arg.background_color = background_color;
+                    }
+                    RenderRequest::Connection(connection) => {
+                        arg.connection = connection;
                     }
                 }
             },
@@ -190,6 +299,36 @@ impl PreviewState {
                 .fixed_height(Length::const_px(elem_height))
             })
             .collect::<Vec<_>>();
+        let status_overlay = if let Some(message) =
+            self.connection.status_message(&self.data_plane_host)
+        {
+            let color = self.connection.status_color().unwrap_or(Color::TRANSPARENT);
+            let overlay_width = self.window_size.width.max(1.0).ceil();
+            let overlay_height = if self.pages.is_empty() {
+                EMPTY_STATUS_BANNER_HEIGHT
+            } else {
+                STATUS_BANNER_HEIGHT
+            };
+            let (scene, scene_size) = self.status_scene(&message, overlay_width, overlay_height);
+            let scene_scale = if scene_size.width > 0. {
+                overlay_width / scene_size.width
+            } else {
+                1.0
+            };
+
+            Some(
+                sized_box(doc(scene, scene_scale, Some(color), |_pos, _bbox| {}).alt_text(message))
+                    .fixed_width(Length::const_px(overlay_width))
+                    .fixed_height(Length::const_px(overlay_height))
+                    .alignment(if self.pages.is_empty() {
+                        UnitPoint::CENTER
+                    } else {
+                        UnitPoint::TOP
+                    }),
+            )
+        } else {
+            None
+        };
 
         // Listens to window size changes and renders the scene.
         resize_observer(
@@ -197,8 +336,222 @@ impl PreviewState {
                 state.window_size = size;
             },
             // Adds a scroll bar
-            fork(portal(flex_col(page_list)), effect),
+            fork(
+                zstack((portal(flex_col(page_list)), status_overlay)),
+                effect,
+            ),
         )
+    }
+}
+
+struct StatusScene {
+    message: String,
+    width: f64,
+    height: f64,
+    scene: Arc<Scene>,
+    size: Size,
+}
+
+impl StatusScene {
+    fn matches(&self, message: &str, width: f64, height: f64) -> bool {
+        self.message == message && self.width == width && self.height == height
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ConnectionStatus {
+    Connecting,
+    Connected,
+    Reconnecting { reason: String },
+    WaitingForRetry { attempt: usize, reason: String },
+    Stopped { reason: String },
+}
+
+impl ConnectionStatus {
+    fn status_message(&self, data_plane_host: &str) -> Option<String> {
+        match self {
+            Self::Connecting => {
+                let address = truncate_message(websocket_address(data_plane_host), 80);
+                Some(format!("Connecting to preview server at {address}..."))
+            }
+            Self::Connected => None,
+            Self::Reconnecting { reason } => Some(format!("{reason}. Reconnecting...")),
+            Self::WaitingForRetry { attempt, reason } => Some(format!(
+                "{reason}. Retrying in {}s (attempt {attempt})...",
+                RECONNECT_INTERVAL.as_secs()
+            )),
+            Self::Stopped { reason } => Some(reason.clone()),
+        }
+    }
+
+    fn title_suffix(&self) -> Option<String> {
+        match self {
+            Self::Connecting => Some("Connecting".into()),
+            Self::Connected => None,
+            Self::Reconnecting { reason } => Some(format!(
+                "Reconnecting - {}",
+                truncate_message(reason.clone(), 60)
+            )),
+            Self::WaitingForRetry { attempt, reason } => Some(format!(
+                "Retrying ({attempt}) - {}",
+                truncate_message(reason.clone(), 60)
+            )),
+            Self::Stopped { reason } => Some(format!(
+                "Disconnected - {}",
+                truncate_message(reason.clone(), 60)
+            )),
+        }
+    }
+
+    fn status_color(&self) -> Option<Color> {
+        match self {
+            Self::Connecting => Some(Color::from_rgba8(0x2f, 0x80, 0xed, 0xe6)),
+            Self::Connected => None,
+            Self::Reconnecting { .. } | Self::WaitingForRetry { .. } => {
+                Some(Color::from_rgba8(0xb4, 0x53, 0x09, 0xe6))
+            }
+            Self::Stopped { .. } => Some(Color::from_rgba8(0xb9, 0x1c, 0x1c, 0xe6)),
+        }
+    }
+}
+
+fn render_status_scene(message: &str, width: f64, height: f64) -> Result<(Arc<Scene>, Size)> {
+    let source = Source::new(
+        FileId::new(None, VirtualPath::new("/tinymist-viewer-status.typ")),
+        status_typst_source(message, width, height),
+    );
+    let world = StatusWorld { main: source };
+    let compiled = typst::compile::<PagedDocument>(&world);
+    for warning in compiled.warnings {
+        log::debug!("Typst status render warning: {warning:?}");
+    }
+    let doc = compiled
+        .output
+        .map_err(|errors| anyhow!("failed to compile status text: {errors:?}"))?;
+    let document = TypstDocument::Paged(Arc::new(doc));
+    let mut renderer = IncrSvgDocServer::default();
+    let frame = renderer.pack_delta(&document);
+    let update = preview_update_from_bytes(&frame).context("status preview frame is invalid")?;
+
+    let mut doc = IncrDocClient::default();
+    let mut vello = IncrVelloDocClient::default();
+    if update.reset_before_merge {
+        doc = IncrDocClient::default();
+        vello.reset();
+    }
+    let delta = BytesModuleStream::from_slice(update.payload).checkout_owned();
+    doc.merge_delta(delta);
+
+    let mut pages = vello.render_pages(&mut doc)?;
+    pages.pop().context("Typst status render produced no pages")
+}
+
+fn status_typst_source(message: &str, width: f64, height: f64) -> String {
+    let message = typst_string_literal(message);
+    format!(
+        r#"#set page(width: {width}pt, height: {height}pt, margin: 0pt)
+#set text(font: "New Computer Modern", size: 10pt, fill: white)
+#place(center + horizon, text({message}))
+"#
+    )
+}
+
+fn typst_string_literal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for c in text.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' | '\r' | '\t' => out.push(' '),
+            c if c.is_control() => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+struct StatusWorld {
+    main: Source,
+}
+
+impl World for StatusWorld {
+    fn library(&self) -> &LazyHash<Library> {
+        &status_typst_base().library
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        &status_typst_base().book
+    }
+
+    fn main(&self) -> FileId {
+        self.main.id()
+    }
+
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.main.id() {
+            Ok(self.main.clone())
+        } else {
+            Err(FileError::NotFound(id.vpath().as_rooted_path().to_owned()))
+        }
+    }
+
+    fn file(&self, id: FileId) -> FileResult<TypstBytes> {
+        Err(FileError::NotFound(id.vpath().as_rooted_path().to_owned()))
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        status_typst_base().fonts.get(index).cloned()
+    }
+
+    fn today(&self, _: Option<i64>) -> Option<Datetime> {
+        Some(Datetime::from_ymd(1970, 1, 1).expect("valid deterministic date"))
+    }
+}
+
+struct StatusTypstBase {
+    library: LazyHash<Library>,
+    book: LazyHash<FontBook>,
+    fonts: Vec<Font>,
+}
+
+fn status_typst_base() -> &'static StatusTypstBase {
+    static BASE: OnceLock<StatusTypstBase> = OnceLock::new();
+    BASE.get_or_init(|| {
+        let fonts = typst_assets::fonts()
+            .flat_map(|data| Font::iter(TypstBytes::new(data)))
+            .collect::<Vec<_>>();
+
+        StatusTypstBase {
+            library: LazyHash::new(Library::builder().build()),
+            book: LazyHash::new(FontBook::from_fonts(&fonts)),
+            fonts,
+        }
+    })
+}
+
+fn websocket_address(data_plane_host: &str) -> String {
+    if data_plane_host.starts_with("ws://") || data_plane_host.starts_with("wss://") {
+        data_plane_host.to_owned()
+    } else {
+        format!("ws://{data_plane_host}")
+    }
+}
+
+fn send_connection_status(proxy: &MessageProxy<RenderRequest>, connection: ConnectionStatus) {
+    if let Err(err) = proxy.message(RenderRequest::Connection(connection)) {
+        log::debug!("failed to send websocket status to viewer: {err}");
+    }
+}
+
+fn truncate_message(message: String, max_chars: usize) -> String {
+    let mut chars = message.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        message
     }
 }
 
@@ -211,6 +564,7 @@ struct Client {
     client: ezsockets::Client<Self>,
     doc: IncrDocClient,
     vello: IncrVelloDocClient,
+    connect_attempts: usize,
 }
 
 #[async_trait::async_trait]
@@ -255,12 +609,62 @@ impl ezsockets::ClientExt for Client {
 
     async fn on_connect(&mut self) -> Result<(), ezsockets::Error> {
         log::info!("connected to websocket");
+        self.connect_attempts = 0;
+        self.doc = IncrDocClient::default();
+        self.vello.reset();
+        send_connection_status(&self.proxy, ConnectionStatus::Connected);
 
         let res = self.client.text("current");
         if let Err(err) = res {
             log::error!("Error sending message to websocket: {err}");
         }
         Ok(())
+    }
+
+    async fn on_connect_fail(
+        &mut self,
+        error: ezsockets::WSError,
+    ) -> Result<ClientCloseMode, ezsockets::Error> {
+        self.connect_attempts += 1;
+        let reason = truncate_message(format!("WebSocket connection failed: {error}"), 120);
+        log::warn!("{reason}");
+        send_connection_status(
+            &self.proxy,
+            ConnectionStatus::WaitingForRetry {
+                attempt: self.connect_attempts,
+                reason,
+            },
+        );
+        Ok(ClientCloseMode::Reconnect)
+    }
+
+    async fn on_close(
+        &mut self,
+        frame: Option<ezsockets::CloseFrame>,
+    ) -> Result<ClientCloseMode, ezsockets::Error> {
+        let reason = truncate_message(
+            match frame {
+                Some(frame) if frame.reason.is_empty() => {
+                    format!("WebSocket closed by server ({:?})", frame.code)
+                }
+                Some(frame) => format!(
+                    "WebSocket closed by server ({:?}: {})",
+                    frame.code, frame.reason
+                ),
+                None => "WebSocket closed by server".into(),
+            },
+            120,
+        );
+        log::warn!("{reason}");
+        send_connection_status(&self.proxy, ConnectionStatus::Reconnecting { reason });
+        Ok(ClientCloseMode::Reconnect)
+    }
+
+    async fn on_disconnect(&mut self) -> Result<ClientCloseMode, ezsockets::Error> {
+        let reason = "WebSocket disconnected".to_owned();
+        log::warn!("{reason}");
+        send_connection_status(&self.proxy, ConnectionStatus::Reconnecting { reason });
+        Ok(ClientCloseMode::Reconnect)
     }
 
     async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
@@ -274,12 +678,31 @@ enum RenderRequest {
         pages: Vec<(Arc<Scene>, Size)>,
         background_color: Option<Color>,
     },
+    Connection(ConnectionStatus),
 }
 
 impl fmt::Debug for RenderRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::New { pages, .. } => write!(f, "New(pages = {:?})", pages.len()),
+            Self::Connection(connection) => write!(f, "Connection({connection:?})"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typst_status_scene_renders() {
+        let (scene, size) = render_status_scene("Retrying websocket connection", 320.0, 28.0)
+            .expect("status text should render through Typst");
+
+        assert_eq!(size, Size::new(320.0, 28.0));
+        assert!(
+            !scene.encoding().is_empty(),
+            "status scene should contain glyphs"
+        );
     }
 }


### PR DESCRIPTION
- Add resilient websocket recovery for `tinymist-viewer`: retry failed, closed, and disconnected sessions with a 1s reconnect interval.
- Reset the incremental document and Vello render state after reconnect, then request `current` so server restarts recover cleanly.
- Surface connection state in the native window title and an in-window Typst-rendered status banner.
- Keep the banner off Xilem/Masonry text support, so normal artifact builds do not pull the fontconfig cross-compile dependency.
