### PR TITLE
feat(viewer): add AccessKit semantics and text selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6988,6 +6988,7 @@ dependencies = [
 name = "tinymist-viewer"
 version = "0.14.18"
 dependencies = [
+ "accesskit_consumer",
  "anyhow",
  "async-trait",
  "bytes",

--- a/crates/tinymist-viewer/Cargo.toml
+++ b/crates/tinymist-viewer/Cargo.toml
@@ -63,7 +63,12 @@ no-content-hint = ["reflexo-typst/no-content-hint"]
 name = "page_incremental_rendering"
 harness = false
 
+[[bench]]
+name = "a11y_synthetic_tree"
+harness = false
+
 [dev-dependencies]
+accesskit_consumer = "0.31.0"
 criterion.workspace = true
 insta.workspace = true
 masonry_testing.workspace = true

--- a/crates/tinymist-viewer/benches/a11y_synthetic_tree.rs
+++ b/crates/tinymist-viewer/benches/a11y_synthetic_tree.rs
@@ -1,0 +1,435 @@
+#![allow(missing_docs)]
+
+use std::time::Duration;
+
+use accesskit_consumer::{Node as ConsumerNode, Tree as ConsumerTree, TreeChangeHandler};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use masonry::accesskit::{
+    Action, Node, NodeId, Rect, Role, TextDirection, Tree as AccessTree, TreeUpdate,
+};
+
+const PAGE_COUNTS: &[usize] = &[32, 256, 2048];
+const MAX_FULL_TREE_PAGES: usize = 256;
+const VISIBLE_PAGE_WINDOW: usize = 9;
+const PARAGRAPHS_PER_PAGE: usize = 8;
+const RUNS_PER_PARAGRAPH: usize = 4;
+const RUN_TEXT_CHARS: usize = 64;
+
+const DOC_ID: NodeId = NodeId(1);
+const PAGE_ID_BASE: u64 = 1_000_000;
+const PARAGRAPH_ID_BASE: u64 = 2_000_000;
+const RUN_ID_BASE: u64 = 3_000_000;
+
+fn bench_synthetic_accesskit_tree(c: &mut Criterion) {
+    print_shapes();
+
+    let mut group = c.benchmark_group("viewer_a11y_synthetic_tree");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(500));
+
+    for &page_count in PAGE_COUNTS {
+        let shape = Shape::new(page_count);
+
+        group.throughput(Throughput::Elements(
+            shape.adaptive_initial_nodes(VISIBLE_PAGE_WINDOW) as u64,
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("construct_initial_adaptive_tree", page_count),
+            &shape,
+            |b, shape| {
+                b.iter(|| {
+                    let update = initial_adaptive_update(
+                        *shape,
+                        shape.scroll_start_page(),
+                        VISIBLE_PAGE_WINDOW,
+                    );
+                    criterion::black_box(update);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("apply_initial_adaptive_tree", page_count),
+            &shape,
+            |b, shape| {
+                b.iter_batched(
+                    || {
+                        initial_adaptive_update(
+                            *shape,
+                            shape.scroll_start_page(),
+                            VISIBLE_PAGE_WINDOW,
+                        )
+                    },
+                    |update| {
+                        let tree = ConsumerTree::new(update, true);
+                        criterion::black_box(tree);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        if !shape.uses_full_tree() {
+            group.throughput(Throughput::Elements(shape.scroll_update_nodes() as u64));
+
+            group.bench_with_input(
+                BenchmarkId::new("construct_incremental_scroll_adaptive_tree", page_count),
+                &shape,
+                |b, shape| {
+                    let base_start = shape.scroll_start_page();
+                    let mut start = base_start;
+                    b.iter(|| {
+                        let old_start = start;
+                        start = if start == base_start {
+                            base_start + 1
+                        } else {
+                            base_start
+                        };
+                        let update = page_stubs_visible_scroll_update(
+                            *shape,
+                            old_start,
+                            start,
+                            VISIBLE_PAGE_WINDOW,
+                        );
+                        criterion::black_box(update);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new("apply_incremental_scroll_adaptive_tree", page_count),
+                &shape,
+                |b, shape| {
+                    let base_start = shape.scroll_start_page();
+                    let mut tree = ConsumerTree::new(
+                        initial_adaptive_update(*shape, base_start, VISIBLE_PAGE_WINDOW),
+                        true,
+                    );
+                    let mut changes = NoopChanges;
+                    let mut start = base_start;
+                    b.iter(|| {
+                        let old_start = start;
+                        start = if start == base_start {
+                            base_start + 1
+                        } else {
+                            base_start
+                        };
+                        tree.update_and_process_changes(
+                            page_stubs_visible_scroll_update(
+                                *shape,
+                                old_start,
+                                start,
+                                VISIBLE_PAGE_WINDOW,
+                            ),
+                            &mut changes,
+                        );
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+#[derive(Clone, Copy)]
+struct Shape {
+    page_count: usize,
+    paragraphs: usize,
+    runs: usize,
+}
+
+impl Shape {
+    fn new(page_count: usize) -> Self {
+        let paragraphs = page_count * PARAGRAPHS_PER_PAGE;
+        let runs = paragraphs * RUNS_PER_PARAGRAPH;
+        Self {
+            page_count,
+            paragraphs,
+            runs,
+        }
+    }
+
+    fn uses_full_tree(self) -> bool {
+        self.page_count <= MAX_FULL_TREE_PAGES
+    }
+
+    fn scroll_start_page(self) -> usize {
+        100.min(self.page_count.saturating_sub(VISIBLE_PAGE_WINDOW + 1))
+    }
+
+    fn expanded_page_nodes(self) -> usize {
+        1 + self.expanded_page_child_nodes()
+    }
+
+    fn expanded_page_child_nodes(self) -> usize {
+        PARAGRAPHS_PER_PAGE + PARAGRAPHS_PER_PAGE * RUNS_PER_PARAGRAPH
+    }
+
+    fn full_nodes(self) -> usize {
+        1 + self.page_count * self.expanded_page_nodes()
+    }
+
+    fn page_stubs_visible_nodes(self, materialized_page_count: usize) -> usize {
+        1 + self.page_count + materialized_page_count * self.expanded_page_child_nodes()
+    }
+
+    fn adaptive_initial_nodes(self, materialized_page_count: usize) -> usize {
+        if self.uses_full_tree() {
+            self.full_nodes()
+        } else {
+            self.page_stubs_visible_nodes(materialized_page_count)
+        }
+    }
+
+    fn scroll_update_nodes(self) -> usize {
+        1 + self.expanded_page_nodes()
+    }
+}
+
+fn print_shapes() {
+    for &page_count in PAGE_COUNTS {
+        let shape = Shape::new(page_count);
+        let strategy = if shape.uses_full_tree() {
+            "full"
+        } else {
+            "page-stubs-visible"
+        };
+        println!(
+            "synthetic-a11y-adaptive-shape pages={} strategy={} nodes(initial={}, scroll-update={}) paragraphs={} text-runs={}",
+            page_count,
+            strategy,
+            shape.adaptive_initial_nodes(VISIBLE_PAGE_WINDOW),
+            if shape.uses_full_tree() {
+                0
+            } else {
+                shape.scroll_update_nodes()
+            },
+            shape.paragraphs,
+            shape.runs
+        );
+    }
+}
+
+fn initial_adaptive_update(shape: Shape, start_page: usize, page_count: usize) -> TreeUpdate {
+    if shape.uses_full_tree() {
+        initial_full_update(shape)
+    } else {
+        initial_page_stubs_visible_update(shape, start_page, page_count)
+    }
+}
+
+fn initial_full_update(shape: Shape) -> TreeUpdate {
+    let mut nodes = Vec::with_capacity(shape.full_nodes());
+    nodes.push((
+        DOC_ID,
+        document_node_with_children(shape, (0..shape.page_count).map(page_id).collect()),
+    ));
+
+    for page in 0..shape.page_count {
+        push_expanded_page_subtree(&mut nodes, shape, page);
+    }
+
+    TreeUpdate {
+        nodes,
+        tree: Some(AccessTree {
+            root: DOC_ID,
+            toolkit_name: Some("tinymist-viewer synthetic a11y bench".to_owned()),
+            toolkit_version: None,
+        }),
+        focus: DOC_ID,
+    }
+}
+
+fn initial_page_stubs_visible_update(
+    shape: Shape,
+    start_page: usize,
+    page_count: usize,
+) -> TreeUpdate {
+    let mut nodes = Vec::with_capacity(shape.page_stubs_visible_nodes(page_count));
+    nodes.push((
+        DOC_ID,
+        document_node_with_children(shape, (0..shape.page_count).map(page_id).collect()),
+    ));
+
+    let end_page = start_page + page_count;
+    for page in 0..shape.page_count {
+        if (start_page..end_page).contains(&page) {
+            push_expanded_page_subtree(&mut nodes, shape, page);
+        } else {
+            nodes.push((page_id(page), page_index_node(shape, page, Vec::new())));
+        }
+    }
+
+    TreeUpdate {
+        nodes,
+        tree: Some(AccessTree {
+            root: DOC_ID,
+            toolkit_name: Some("tinymist-viewer synthetic a11y bench".to_owned()),
+            toolkit_version: None,
+        }),
+        focus: DOC_ID,
+    }
+}
+
+fn page_stubs_visible_scroll_update(
+    shape: Shape,
+    old_start_page: usize,
+    start_page: usize,
+    page_count: usize,
+) -> TreeUpdate {
+    let (departed_page, added_page) = if start_page > old_start_page {
+        (old_start_page, start_page + page_count - 1)
+    } else {
+        (old_start_page + page_count - 1, start_page)
+    };
+
+    let mut nodes = Vec::with_capacity(shape.scroll_update_nodes());
+    nodes.push((
+        page_id(departed_page),
+        page_index_node(shape, departed_page, Vec::new()),
+    ));
+    push_expanded_page_subtree(&mut nodes, shape, added_page);
+
+    TreeUpdate {
+        nodes,
+        tree: None,
+        focus: DOC_ID,
+    }
+}
+
+fn push_expanded_page_subtree(nodes: &mut Vec<(NodeId, Node)>, shape: Shape, page: usize) {
+    nodes.push((
+        page_id(page),
+        page_index_node(
+            shape,
+            page,
+            (0..PARAGRAPHS_PER_PAGE)
+                .map(|paragraph| paragraph_id(page, paragraph))
+                .collect(),
+        ),
+    ));
+    for paragraph in 0..PARAGRAPHS_PER_PAGE {
+        nodes.push((
+            paragraph_id(page, paragraph),
+            paragraph_node(page, paragraph),
+        ));
+        for run in 0..RUNS_PER_PARAGRAPH {
+            nodes.push((
+                run_id(page, paragraph, run),
+                text_run_node(page, paragraph, run),
+            ));
+        }
+    }
+}
+
+fn document_node_with_children(shape: Shape, children: Vec<NodeId>) -> Node {
+    let mut node = Node::new(Role::Document);
+    node.set_bounds(Rect {
+        x0: 0.0,
+        y0: 0.0,
+        x1: 800.0,
+        y1: shape.page_count as f64 * 1000.0,
+    });
+    node.set_children(children);
+    node
+}
+
+fn page_index_node(shape: Shape, page: usize, children: Vec<NodeId>) -> Node {
+    let mut node = Node::new(Role::Region);
+    node.set_label(format!("Page {}", page + 1));
+    node.set_bounds(Rect {
+        x0: 0.0,
+        y0: page as f64 * 1000.0,
+        x1: 800.0,
+        y1: (page + 1) as f64 * 1000.0,
+    });
+    node.set_position_in_set(page + 1);
+    node.set_size_of_set(shape.page_count);
+    node.add_action(Action::ScrollIntoView);
+    node.set_children(children);
+    node
+}
+
+fn paragraph_node(page: usize, paragraph: usize) -> Node {
+    let y0 = page as f64 * 1000.0 + paragraph as f64 * 96.0;
+    let mut node = Node::new(Role::Paragraph);
+    node.set_bounds(Rect {
+        x0: 48.0,
+        y0,
+        x1: 752.0,
+        y1: y0 + 72.0,
+    });
+    node.set_children(
+        (0..RUNS_PER_PARAGRAPH)
+            .map(|run| run_id(page, paragraph, run))
+            .collect::<Vec<_>>(),
+    );
+    node
+}
+
+fn text_run_node(page: usize, paragraph: usize, run: usize) -> Node {
+    let y0 = page as f64 * 1000.0 + paragraph as f64 * 96.0 + run as f64 * 18.0;
+    let x0 = 48.0 + (run % 2) as f64 * 320.0;
+
+    let mut node = Node::new(Role::TextRun);
+    node.set_bounds(Rect {
+        x0,
+        y0,
+        x1: x0 + 300.0,
+        y1: y0 + 16.0,
+    });
+    node.set_text_direction(TextDirection::LeftToRight);
+    node.set_value(run_text(page, paragraph, run));
+    node.set_character_lengths(vec![1; RUN_TEXT_CHARS]);
+    node.set_character_positions(
+        (0..RUN_TEXT_CHARS)
+            .map(|idx| idx as f32 * 7.0)
+            .collect::<Vec<_>>(),
+    );
+    node.set_character_widths(vec![7.0; RUN_TEXT_CHARS]);
+    node
+}
+
+fn run_text(page: usize, paragraph: usize, run: usize) -> String {
+    let prefix = format!("p{page:04} para{paragraph:02} run{run:02} stable ");
+    let fill = RUN_TEXT_CHARS.saturating_sub(prefix.len());
+    format!("{prefix}{}", "x".repeat(fill))
+}
+
+fn page_id(page: usize) -> NodeId {
+    NodeId(PAGE_ID_BASE + page as u64)
+}
+
+fn paragraph_id(page: usize, paragraph: usize) -> NodeId {
+    NodeId(PARAGRAPH_ID_BASE + (page * PARAGRAPHS_PER_PAGE + paragraph) as u64)
+}
+
+fn run_id(page: usize, paragraph: usize, run: usize) -> NodeId {
+    NodeId(
+        RUN_ID_BASE + ((page * PARAGRAPHS_PER_PAGE + paragraph) * RUNS_PER_PARAGRAPH + run) as u64,
+    )
+}
+
+#[derive(Default)]
+struct NoopChanges;
+
+impl TreeChangeHandler for NoopChanges {
+    fn node_added(&mut self, _node: &ConsumerNode<'_>) {}
+
+    fn node_updated(&mut self, _old_node: &ConsumerNode<'_>, _new_node: &ConsumerNode<'_>) {}
+
+    fn focus_moved(
+        &mut self,
+        _old_node: Option<&ConsumerNode<'_>>,
+        _new_node: Option<&ConsumerNode<'_>>,
+    ) {
+    }
+
+    fn node_removed(&mut self, _node: &ConsumerNode<'_>) {}
+}
+
+criterion_group!(benches, bench_synthetic_accesskit_tree);
+criterion_main!(benches);

--- a/crates/tinymist-viewer/docs/a11y.md
+++ b/crates/tinymist-viewer/docs/a11y.md
@@ -1,280 +1,207 @@
-# Masonry/Xilem 自定义组件的 a11y 支持
+# Masonry/Xilem Accessibility Reference
+
+This document summarizes how accessibility is supported by upstream
+Masonry/Xilem. It is intended as a reference for custom widget authors, not as
+an implementation plan for any specific tinymist-viewer feature.
+
+The APIs described here are based on the `Myriad-Dreamin/xilem` revision pinned
+by this workspace at the time this document was written.
+
+## Overview
+
+Masonry exposes accessibility through [AccessKit](https://accesskit.dev/).
+Accessibility metadata is owned by Masonry widgets. Xilem does not provide a
+separate accessibility description language; it builds and rebuilds Masonry
+widgets, and Masonry produces the AccessKit tree from those widgets during its
+accessibility pass.
+
+For a custom component, the division of responsibility is:
+
+- The Masonry `Widget` implementation declares the role, fills the AccessKit
+  node, exposes supported accessibility actions, and handles accessibility
+  action events.
+- The Xilem `View` creates the widget, updates the widget state during rebuild,
+  and ensures state changes request the correct Masonry pass.
+- AccessKit is the platform-facing tree model. A widget can either expose a
+  single node for itself or add additional synthetic AccessKit nodes for internal
+  semantic structure.
+
+Custom drawing does not expose internal semantics automatically. If painted
+content contains meaningful structure, the widget must provide that structure as
+accessibility metadata.
+
+## Masonry Widget Hooks
+
+Every custom Masonry widget implements `masonry::core::Widget`. The primary
+accessibility-related hooks are:
+
+- `accessibility_role`: returns the AccessKit `Role` for the widget node.
+- `accessibility`: fills additional properties on the generated AccessKit
+  `Node`.
+- `on_access_event`: handles actions requested by assistive technologies.
+- `children_ids`: reports child widget ids in accessibility order.
+- `register_children`: registers child widgets with Masonry.
+
+Masonry creates a fresh AccessKit node for each widget when accessibility is
+updated, then calls the widget's `accessibility` method to let it fill in
+widget-specific metadata. The widget should treat the passed node as ephemeral
+and fully describe its current state each time the method is called.
 
-本文记录 `tinymist-viewer` 继续编写自定义 Masonry/Xilem 组件时，应该如何接入 accessibility。当前 viewer 使用 `Cargo.lock` 中锁定的 `Myriad-Dreamin/xilem` 修订 `abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3`，结论以这个版本的 API 为准。
+## Framework-Provided Metadata
+
+Before `Widget::accessibility` runs, Masonry has already populated framework
+metadata that is derived from widget state and layout:
+
+- The node role from `Widget::accessibility_role`.
+- Bounds from the widget border box.
+- Transform information from layout, placement, scrolling, and scaling.
+- Children from `Widget::children_ids`, with stashed children excluded.
+- Common state such as disabled, clipping, focus, and blur when applicable.
+
+The widget's own `accessibility` method should add semantic properties that
+Masonry cannot infer, such as names, descriptions, values, checked state,
+selected state, text metadata, supported actions, or custom child nodes.
+
+## Roles and Node Properties
+
+`accessibility_role` should describe the semantic role, not the visual shape.
+Common upstream patterns are:
 
-## 结论
+- Purely drawn content with no internal semantic structure uses `Role::Canvas`
+  or `Role::Image`, usually with a description when meaningful.
+- Activatable controls use roles such as `Role::Button`, `Role::CheckBox`, or
+  `Role::Switch`, and expose `Action::Click` when they can be activated.
+- Adjustable controls use roles such as `Role::Slider`, `Role::ScrollBar`, or
+  `Role::Splitter`, along with value, range, orientation, and increment or
+  decrement actions.
+- Scrollable containers use `Role::ScrollView`, scroll ranges, current scroll
+  offsets, and scroll-related actions.
+- Text-oriented widgets use text-capable roles and provide text values,
+  character positions, selections, and supported text actions as needed.
+
+The built-in Masonry widgets are the best reference for idiomatic role and
+property combinations. For example, built-in controls pair their AccessKit role
+with matching state properties and actions instead of relying on role alone.
 
-Masonry 的 accessibility 支持在 `Widget` 层实现，底层模型是 [AccessKit](https://accesskit.dev/)。Xilem 不提供独立的一套 a11y 描述 DSL；Xilem 的职责是把自定义 `Widget` 包成 `Pod<W>`、在 rebuild 时变更 widget 状态，并让 Masonry 在渲染/更新 pass 中生成 AccessKit tree。
+## Accessibility Actions
 
-因此，自定义组件的规则是：
+If a node advertises an AccessKit action, the owning widget must handle the same
+action in `on_access_event`.
+
+Accessibility actions are delivered to Masonry with a target node id. For normal
+widget nodes, the target corresponds to the widget. For synthetic nodes created
+inside a widget, the owner widget is responsible for mapping the target node id
+back to the appropriate internal semantic object.
+
+Typical actions include:
+
+- `Click` for activatable controls and links.
+- `Focus` and blur-related behavior for focusable widgets.
+- `Increment`, `Decrement`, or `SetValue` for adjustable controls.
+- `ScrollIntoView` and scroll actions for scrollable content.
+- Text actions for text editing, selection, and cursor movement when supported
+  by the widget.
 
-- 语义写在 Masonry `Widget` 实现里：`accessibility_role` 返回控件角色，`accessibility` 填充 AccessKit `Node`，需要响应辅助技术动作时实现 `on_access_event`。
-- Xilem `View` 只负责生命周期：`build` 时 `ViewCtx::create_pod`，有 action 的 widget 用 `ViewCtx::with_action_widget` 注册 action 路由，`rebuild` 时通过 `WidgetMut` helper 修改 widget 并请求对应 pass。
-- 只改变 a11y 语义时调用 `ctx.request_accessibility_update()`；绘制和 a11y 都改变时调用 `ctx.request_render()`；纯视觉状态改变才用 `ctx.request_paint_only()`。
-- Vello `Scene` 或 Typst 渲染结果不会自动变成可读文本。`Role::Canvas` 加描述只是最低限度支持；要让 screen reader 按段落、链接、图片等导航，需要额外从 Typst 的文本/语义数据生成 AccessKit 子节点。
-
-## Masonry 侧
-
-每个 Masonry widget 都实现 `masonry::core::Widget`。和 a11y 直接相关的方法包括：
-
-```rust
-fn on_access_event(
-    &mut self,
-    ctx: &mut EventCtx<'_>,
-    props: &mut PropertiesMut<'_>,
-    event: &AccessEvent,
-);
-
-fn accessibility_role(&self) -> Role;
-
-fn accessibility(
-    &mut self,
-    ctx: &mut AccessCtx<'_>,
-    props: &PropertiesRef<'_>,
-    node: &mut Node,
-);
-
-fn children_ids(&self) -> ChildrenIds;
-fn register_children(&mut self, ctx: &mut RegisterCtx<'_>);
-```
-
-Masonry 的 accessibility pass 会为 widget 构造一个新的 `accesskit::Node`，再调用 widget 的 `accessibility` 方法补充语义。这个初始节点已经由框架填好了一些通用信息：
-
-- `Role` 来自 `Widget::accessibility_role()`。
-- bounds 来自 widget 的 border box。
-- transform 来自 widget 的布局、滚动和缩放状态。
-- children 来自 `Widget::children_ids()`，并会过滤掉 stashed child。
-- disabled、clip、focus/blur 等通用状态由 Masonry 根据 widget state 自动设置。
-
-`accessibility` 拿到的是一次性节点。Masonry 每次重新构造节点时都会重新调用这个方法，所以 widget 需要每次都把自己的语义重新写进去，不能依赖上一次对 `node` 的修改还存在。
-
-### 角色和节点属性
-
-`accessibility_role` 应该返回最接近真实语义的 AccessKit role，而不是最接近视觉外观的 role。常见例子：
-
-- 只有绘制内容、无法拆出内部结构：`Role::Canvas` 或 `Role::Image`，并用 `node.set_description(...)` 提供替代文本。
-- 可点击控件：`Role::Button`、`Role::CheckBox`、`Role::Switch` 等，并用 `node.add_action(accesskit::Action::Click)` 暴露 click 动作。
-- 可调值控件：`Role::Slider`、`Role::ScrollBar`、`Role::Splitter` 等，同时设置 value/range/orientation，并暴露 `Increment`、`Decrement` 或 `SetValue`。
-- 滚动容器：`Role::ScrollView`，设置 scroll range、当前位置、可用 scroll action，并对子节点暴露 `ScrollIntoView`。
-- 文档或文本区域：`Role::Document`、`Role::TextInput`、`Role::MultilineTextInput` 等，并考虑生成文本子节点。
-
-Masonry 自带 widget 是最可靠的参考。比如内置 `Canvas` 的做法是 `Role::Canvas` 加可选 description；`Checkbox` 是 `Role::CheckBox`、`Action::Click` 和 `Toggled` 状态；`Portal` 是 `Role::ScrollView`，并设置 scroll x/y 范围和方向。
-
-### 动作事件
-
-如果 `accessibility` 里给节点添加了 action，widget 需要在 `on_access_event` 里处理对应 `accesskit::Action`。例如按钮式组件通常把 accessibility click 转成和鼠标点击相同的 Masonry action：
-
-```rust
-fn on_access_event(
-    &mut self,
-    ctx: &mut EventCtx<'_>,
-    _props: &mut PropertiesMut<'_>,
-    event: &AccessEvent,
-) {
-    if event.action == accesskit::Action::Click {
-        ctx.submit_action::<Self::Action>(MyAction::Pressed);
-    }
-}
-
-fn accessibility_role(&self) -> Role {
-    Role::Button
-}
-
-fn accessibility(
-    &mut self,
-    _ctx: &mut AccessCtx<'_>,
-    _props: &PropertiesRef<'_>,
-    node: &mut Node,
-) {
-    node.add_action(accesskit::Action::Click);
-}
-```
-
-动作事件会以 widget id 为目标进入 Masonry，并向父级冒泡。对于复合控件，父容器可以处理自己暴露的动作，也可以让子 widget 处理自己的动作。
-
-### 何时请求更新
-
-Masonry 会缓存 paint 和 accessibility 结果，状态改变后必须请求对应 pass：
-
-- `request_accessibility_update()`：只改了 screen reader 可见语义，例如 alt text、checked/toggled 状态、aria-like value、可用 action。
-- `request_render()`：视觉和 a11y 都变了，例如 checked 状态同时影响图形和 `Toggled`，或者滚动位置同时影响画面和 scroll value。
-- `request_paint_only()`：只改了视觉状态，例如 pointer capture、hover 高亮，并且 a11y 节点内容不变。
-- `request_layout()`：尺寸、children 或布局相关信息变了。布局和 compose pass 会进一步标记 a11y 需要更新，因为 bounds/transform/children 可能改变。
-
-当前 `PageCanvas` 里这些判断已经按这个思路写：
-
-- `PageCanvas::request_render` 在 scene、scale 或 background 改变时调用 `request_render()`。
-- `PageCanvas::set_alt_text` 只改变描述文本，所以调用 `request_accessibility_update()`。
-- pointer capture 只影响绘制状态，所以用 `request_paint_only()`。
-
-### children 和复合节点
-
-叶子 widget 返回 `ChildrenIds::new()`，容器 widget 必须保证三件事一致：
-
-- `register_children` 注册所有子 widget。
-- `layout` 对所有子 widget 执行 layout/place。
-- `children_ids` 返回同一批 child id，顺序就是 accessibility tree 中的顺序。
-
-如果动态增删子 widget，父级需要通过上下文的 `children_changed()` 通知 Masonry children 发生变化；用 `remove_child(...)` 移除子 widget 时当前 API 会顺带标记 children changed。stashed child 不会被 paint，也不会出现在 accessibility tree 里。
-
-如果一个 leaf widget 需要生成额外的非 widget 子节点，例如把一段文本拆成行、字形或 span，可以在 `accessibility` 里通过 `AccessCtx::tree_update()` 写入额外 AccessKit node，并用 `AccessCtx::next_node_id()` 分配不会和 widget id 冲突的 node id。Masonry 的 `Label` 和 `TextArea` 就是这样把 Parley 文本布局暴露给 AccessKit 的。这个接口目前比较底层，应只在确实需要构造内部语义树时使用。
-
-## Xilem 侧
-
-Xilem 的 `WidgetView` 本质上是：
-
-```rust
-View<State, Action, ViewCtx, Element = Pod<impl Widget>>
-```
-
-所以自定义组件通常分成两层：
-
-- Masonry widget：保存实际控件状态，实现绘制、事件、layout 和 a11y。
-- Xilem view：保存声明式输入，在 `build` 创建 widget，在 `rebuild` diff 输入并通过 `WidgetMut` helper 更新 widget。
-
-`crates/tinymist-viewer/src/doc.rs` 的 `TypstDocPage` 和 `PageCanvas` 就是这个结构。
-
-```rust
-fn build(&self, ctx: &mut ViewCtx, _: Arg<'_, State>) -> (Pod<PageCanvas>, ()) {
-    (
-        ctx.with_action_widget(|ctx| {
-            ctx.create_pod(PageCanvas {
-                alt_text: self.alt_text.clone(),
-                size: Size::default(),
-                scene_scale: self.scene_scale,
-                background_color: self.background_color,
-                scene: self.scene.clone(),
-            })
-        }),
-        (),
-    )
-}
-
-fn rebuild(
-    &self,
-    prev: &Self,
-    (): &mut (),
-    _ctx: &mut ViewCtx,
-    mut element: Mut<'_, Pod<PageCanvas>>,
-    _state: Arg<'_, State>,
-) {
-    PageCanvas::request_render(
-        &mut element,
-        self.scene.clone(),
-        self.scene_scale,
-        self.background_color,
-    );
-    if self.alt_text != prev.alt_text {
-        PageCanvas::set_alt_text(&mut element, self.alt_text.clone());
-    }
-}
-```
-
-`with_action_widget` 很重要：它把 widget id 记录到 Xilem 的 view path 上，这样 widget 用 `ctx.submit_action::<Self::Action>(...)` 提交的 Masonry action 才能路由到这个 view 的 `message` 方法。没有 action 的纯展示 widget 可以只用 `create_pod`。
-
-Xilem view 本身不应该重复描述 a11y。它只需要保证 rebuild 里所有影响 a11y 的输入变化最终会调用 widget helper，而 helper 再调用正确的 Masonry request 方法。
-
-## `PageCanvas` 当前状态
-
-`PageCanvas` 当前是一个把 Typst 页面 Vello scene 画出来的自定义 canvas：
-
-```rust
-fn accessibility_role(&self) -> Role {
-    Role::Canvas
-}
-
-fn accessibility(
-    &mut self,
-    _ctx: &mut AccessCtx<'_>,
-    _props: &PropertiesRef<'_>,
-    node: &mut Node,
-) {
-    if let Some(alt_text) = &self.alt_text {
-        node.set_description(&**alt_text);
-    }
-}
-```
-
-这能让辅助技术知道“这里有一个 canvas”，并在有 `alt_text` 时读出描述。它不能让用户：
-
-- 按段落、标题、链接或图片在 Typst 页面内部导航；
-- 选择/朗读页面中的实际文本；
-- 操作页面内部的链接或表单式元素；
-- 获取光标位置对应的 Typst 源位置信息。
-
-也就是说，当前实现适合“页面预览缩略图/画布”的最低限度 a11y，不等价于完整文档可访问性。
-
-## Adaptive synthetic tree benchmark
-
-`crates/tinymist-viewer/benches/a11y_synthetic_tree.rs` 只保留当前建议实现的 adaptive 策略 benchmark：
-
-- `page_count <= 256`：构造完整 `Document -> Page -> Paragraph -> TextRun` tree。
-- `page_count > 256`：所有页面常驻轻量 page index node，只展开 visible 附近 9 页的 `Paragraph -> TextRun` subtree。
-- 每页 8 个 paragraph，每个 paragraph 4 个 text run。
-- 每个 text run 64 个字符，并设置 `value`、`character_lengths`、`character_positions` 和 `character_widths`。
-
-这个 benchmark 只测当前准备落地的行为：adaptive 初始 tree，以及大文档滚动一页时离开页收缩为 page stub、进入页展开完整 subtree 的增量 update。
-
-在本机 `cargo bench -p tinymist-viewer --bench a11y_synthetic_tree adaptive_tree` 的 Criterion median 结果如下：
-
-| 页数 | 策略 | 初始节点数 | 初始构造 | 初始 apply | 滚动一页节点数 | 滚动一页构造 | 滚动一页 apply |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 32 | full tree | 1,313 | 314.8 us | 458.6 us | n/a | n/a | n/a |
-| 256 | full tree | 10,497 | 4.1 ms | 4.9 ms | n/a | n/a | n/a |
-| 2048 | page stubs + 9 页完整 subtree | 2,409 | 376.7 us | 551.0 us | 42 | 12.8 us | 25.0 us |
-
-超过 256 页时，page stubs + 9 页完整 subtree 的初始节点数计算方式是：
-
-```text
-1 document
-+ page_count page index nodes
-+ 9 * (8 paragraph + 32 text run)
-```
-
-滚动一页的 update 不更新 document root，只提交：
-
-- 离开窗口的 page node，children 变为空。
-- 新进入窗口的 page node，加上 8 个 paragraph 和 32 个 text run。
-
-因此滚动 update 固定是 42 个节点，和总页数无关。真实实现中还需要把 `focused_page + selection_anchor_page + selection_focus_page` 加进 materialized set；跨页选择时，selection endpoint 页必须强制 materialize，避免 AccessKit `TextSelection` 引用当前 tree 中不存在的 text run node。
-
-## 对 tinymist-viewer 的建议路线
-
-短期可以继续沿用 canvas 级别描述：
-
-- 每个 `PageCanvas` 保持 `Role::Canvas`。
-- 有页面上下文时设置稳定、简短的 `alt_text`，例如页码、文档标题、渲染错误摘要或“Typst page preview”。
-- 装饰性 canvas 可以设置空字符串描述；如果确实无法提供有意义描述，则保持 `None`，让辅助技术知道没有 accessible description。
-- 所有 alt text 变化都通过 `PageCanvas::set_alt_text` 进入 widget，并只请求 accessibility update。
-
-中期如果 viewer 要支持“可读页面”，需要新增一层独立的 page a11y model，而不是试图从 Vello scene 反推语义：
-
-1. 从 Typst 编译产物或 tinymist 的分析层提取页面文本、图片替代文本、链接、标题层级和源位置。
-2. 给 `PageCanvas` 或新的 page widget 增加语义树输入，例如 `Arc<PageAccessibilityTree>`。
-3. 在 widget 的 `accessibility` 中把 `Role::Canvas` 升级为更合适的容器角色，或保留 canvas 节点并生成可导航子节点。
-4. 用稳定 id 映射页面内部对象，避免每帧生成完全不同的 node id 导致 screen reader 焦点跳动。
-5. 为链接、跳转、滚动到选区等操作添加 `accesskit::Action`，并在 `on_access_event` 中转成 viewer action。
-6. 用 `masonry_testing::TestHarness` 断言 accessibility node 的 role、description、child ids 和 supported actions，而不是只做截图测试。
-
-这个路线的关键是语义数据来自 Typst/tinymist 的文档模型，而不是来自像素或 Vello path。a11y tree 应该描述用户能理解和操作的文档结构，绘制 scene 只负责视觉呈现。
-
-## 实现检查清单
-
-给 tinymist-viewer 新增或修改自定义组件时，逐项检查：
-
-- 这个 widget 的真实语义是什么？是否已有内置 Masonry widget 更合适？
-- `accessibility_role` 是否选择了最接近语义的 `Role`？
-- `accessibility` 是否每次都完整设置 name/description/value/state/action/children 相关信息？
-- 如果暴露了 `node.add_action(...)`，`on_access_event` 是否处理了同一个 action？
-- 状态变化时调用的是 `request_accessibility_update`、`request_render` 还是 `request_paint_only`？
-- 容器的 `register_children`、`layout`、`children_ids` 是否一致？children 顺序是否符合朗读顺序？
-- 是否需要 `accepts_focus`、`accepts_text_input` 或 keyboard path，避免只能用鼠标操作？
-- 是否有 `masonry_testing` 覆盖 role、description、state、actions、child ids 或 focus 行为？
-
-## 参考资料
-
-- 当前锁定源码：`Cargo.lock` 中 `masonry`、`masonry_core`、`masonry_winit`、`xilem` 来自 `Myriad-Dreamin/xilem` 修订 `abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3`。
-- Masonry `Widget` trait 文档：<https://docs.rs/masonry_core/latest/masonry_core/core/trait.Widget.html>
-- Masonry 自定义 widget 教程：<https://docs.rs/masonry/latest/masonry/doc/doc_02_implementing_widget/index.html>
-- AccessKit 项目：<https://accesskit.dev/>
-- ARIA roles 参考：<https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles>
+Action handling should produce the same observable behavior as the equivalent
+keyboard or pointer interaction whenever possible.
+
+## Requesting Updates
+
+Masonry caches rendering and accessibility state. A widget must request the
+appropriate pass when its state changes:
+
+- `request_accessibility_update` when only accessibility metadata changed, such
+  as a label, description, value, state, selection, or supported action.
+- `request_render` when both visual output and accessibility metadata may have
+  changed.
+- `request_paint_only` when only paint output changed and the accessibility tree
+  is still valid.
+- `request_layout` when size, placement, or child structure changed. Layout
+  changes can also affect accessibility because bounds, transforms, and children
+  may change.
+
+Choosing the narrowest correct request keeps Masonry's cached work valid without
+skipping necessary accessibility updates.
+
+## Children and Containers
+
+A container widget must keep child registration, layout, and accessibility child
+order consistent:
+
+- `register_children` registers the child widgets.
+- `layout` lays out and places the same children.
+- `children_ids` returns the ids that should appear in the accessibility tree,
+  in the order assistive technologies should traverse them.
+
+If the set of child widgets changes dynamically, the parent must notify Masonry
+that its children changed. Stashed children are not painted and are not exposed
+in the accessibility tree.
+
+## Synthetic AccessKit Nodes
+
+A widget is not limited to one AccessKit node. When a single widget represents
+structured content internally, it can create additional synthetic nodes during
+the accessibility pass.
+
+The upstream mechanism is:
+
+- Allocate stable non-widget node ids through `AccessCtx`.
+- Submit extra nodes through the AccessKit tree update available from
+  `AccessCtx`.
+- Attach the synthetic node ids as children of the widget node or of other
+  synthetic nodes.
+- Keep ids stable for semantic objects across updates so assistive technology
+  focus and selection do not jump unnecessarily.
+
+Synthetic nodes are useful when the visual implementation is a single custom
+widget but the accessible representation needs finer structure, such as text
+lines, text runs, list items, inline controls, or other semantic regions.
+
+The owner widget remains responsible for update granularity, node id stability,
+and action routing for any synthetic nodes it creates.
+
+## Xilem Integration
+
+Xilem `WidgetView` values build and rebuild Masonry widgets. Accessibility
+metadata should still live in the Masonry widget, not in a parallel Xilem-only
+model.
+
+In Xilem, a custom view typically:
+
+- Creates the widget pod during `build`.
+- Registers action-capable widgets with the view context when Masonry actions
+  should be routed back into the Xilem view tree.
+- Compares old and new view inputs during `rebuild`.
+- Calls widget helper methods through `WidgetMut` so the widget updates its
+  state and requests the correct Masonry pass.
+
+The view should pass accessibility-relevant input into the widget in the same
+way it passes visual input. The widget then decides whether the change requires
+layout, render, paint-only, or accessibility update work.
+
+## Testing
+
+Masonry accessibility behavior can be tested without relying only on screenshots.
+Tests can inspect the produced accessibility tree and assert:
+
+- Node roles.
+- Names, descriptions, values, and state properties.
+- Child ids and traversal order.
+- Supported actions.
+- Focusability and focus transitions.
+- Tree changes after widget state updates.
+- Action event behavior.
+
+For custom widgets, these tests should cover the accessibility contract directly:
+what assistive technologies see, what actions are exposed, and how the tree
+changes when the widget state changes.
+
+## References
+
+- AccessKit: <https://accesskit.dev/>
+- Masonry `Widget` trait:
+  <https://docs.rs/masonry_core/latest/masonry_core/core/trait.Widget.html>
+- Masonry custom widget tutorial:
+  <https://docs.rs/masonry/latest/masonry/doc/doc_02_implementing_widget/index.html>
+- ARIA roles reference:
+  <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles>

--- a/crates/tinymist-viewer/docs/a11y.md
+++ b/crates/tinymist-viewer/docs/a11y.md
@@ -1,0 +1,280 @@
+# Masonry/Xilem 自定义组件的 a11y 支持
+
+本文记录 `tinymist-viewer` 继续编写自定义 Masonry/Xilem 组件时，应该如何接入 accessibility。当前 viewer 使用 `Cargo.lock` 中锁定的 `Myriad-Dreamin/xilem` 修订 `abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3`，结论以这个版本的 API 为准。
+
+## 结论
+
+Masonry 的 accessibility 支持在 `Widget` 层实现，底层模型是 [AccessKit](https://accesskit.dev/)。Xilem 不提供独立的一套 a11y 描述 DSL；Xilem 的职责是把自定义 `Widget` 包成 `Pod<W>`、在 rebuild 时变更 widget 状态，并让 Masonry 在渲染/更新 pass 中生成 AccessKit tree。
+
+因此，自定义组件的规则是：
+
+- 语义写在 Masonry `Widget` 实现里：`accessibility_role` 返回控件角色，`accessibility` 填充 AccessKit `Node`，需要响应辅助技术动作时实现 `on_access_event`。
+- Xilem `View` 只负责生命周期：`build` 时 `ViewCtx::create_pod`，有 action 的 widget 用 `ViewCtx::with_action_widget` 注册 action 路由，`rebuild` 时通过 `WidgetMut` helper 修改 widget 并请求对应 pass。
+- 只改变 a11y 语义时调用 `ctx.request_accessibility_update()`；绘制和 a11y 都改变时调用 `ctx.request_render()`；纯视觉状态改变才用 `ctx.request_paint_only()`。
+- Vello `Scene` 或 Typst 渲染结果不会自动变成可读文本。`Role::Canvas` 加描述只是最低限度支持；要让 screen reader 按段落、链接、图片等导航，需要额外从 Typst 的文本/语义数据生成 AccessKit 子节点。
+
+## Masonry 侧
+
+每个 Masonry widget 都实现 `masonry::core::Widget`。和 a11y 直接相关的方法包括：
+
+```rust
+fn on_access_event(
+    &mut self,
+    ctx: &mut EventCtx<'_>,
+    props: &mut PropertiesMut<'_>,
+    event: &AccessEvent,
+);
+
+fn accessibility_role(&self) -> Role;
+
+fn accessibility(
+    &mut self,
+    ctx: &mut AccessCtx<'_>,
+    props: &PropertiesRef<'_>,
+    node: &mut Node,
+);
+
+fn children_ids(&self) -> ChildrenIds;
+fn register_children(&mut self, ctx: &mut RegisterCtx<'_>);
+```
+
+Masonry 的 accessibility pass 会为 widget 构造一个新的 `accesskit::Node`，再调用 widget 的 `accessibility` 方法补充语义。这个初始节点已经由框架填好了一些通用信息：
+
+- `Role` 来自 `Widget::accessibility_role()`。
+- bounds 来自 widget 的 border box。
+- transform 来自 widget 的布局、滚动和缩放状态。
+- children 来自 `Widget::children_ids()`，并会过滤掉 stashed child。
+- disabled、clip、focus/blur 等通用状态由 Masonry 根据 widget state 自动设置。
+
+`accessibility` 拿到的是一次性节点。Masonry 每次重新构造节点时都会重新调用这个方法，所以 widget 需要每次都把自己的语义重新写进去，不能依赖上一次对 `node` 的修改还存在。
+
+### 角色和节点属性
+
+`accessibility_role` 应该返回最接近真实语义的 AccessKit role，而不是最接近视觉外观的 role。常见例子：
+
+- 只有绘制内容、无法拆出内部结构：`Role::Canvas` 或 `Role::Image`，并用 `node.set_description(...)` 提供替代文本。
+- 可点击控件：`Role::Button`、`Role::CheckBox`、`Role::Switch` 等，并用 `node.add_action(accesskit::Action::Click)` 暴露 click 动作。
+- 可调值控件：`Role::Slider`、`Role::ScrollBar`、`Role::Splitter` 等，同时设置 value/range/orientation，并暴露 `Increment`、`Decrement` 或 `SetValue`。
+- 滚动容器：`Role::ScrollView`，设置 scroll range、当前位置、可用 scroll action，并对子节点暴露 `ScrollIntoView`。
+- 文档或文本区域：`Role::Document`、`Role::TextInput`、`Role::MultilineTextInput` 等，并考虑生成文本子节点。
+
+Masonry 自带 widget 是最可靠的参考。比如内置 `Canvas` 的做法是 `Role::Canvas` 加可选 description；`Checkbox` 是 `Role::CheckBox`、`Action::Click` 和 `Toggled` 状态；`Portal` 是 `Role::ScrollView`，并设置 scroll x/y 范围和方向。
+
+### 动作事件
+
+如果 `accessibility` 里给节点添加了 action，widget 需要在 `on_access_event` 里处理对应 `accesskit::Action`。例如按钮式组件通常把 accessibility click 转成和鼠标点击相同的 Masonry action：
+
+```rust
+fn on_access_event(
+    &mut self,
+    ctx: &mut EventCtx<'_>,
+    _props: &mut PropertiesMut<'_>,
+    event: &AccessEvent,
+) {
+    if event.action == accesskit::Action::Click {
+        ctx.submit_action::<Self::Action>(MyAction::Pressed);
+    }
+}
+
+fn accessibility_role(&self) -> Role {
+    Role::Button
+}
+
+fn accessibility(
+    &mut self,
+    _ctx: &mut AccessCtx<'_>,
+    _props: &PropertiesRef<'_>,
+    node: &mut Node,
+) {
+    node.add_action(accesskit::Action::Click);
+}
+```
+
+动作事件会以 widget id 为目标进入 Masonry，并向父级冒泡。对于复合控件，父容器可以处理自己暴露的动作，也可以让子 widget 处理自己的动作。
+
+### 何时请求更新
+
+Masonry 会缓存 paint 和 accessibility 结果，状态改变后必须请求对应 pass：
+
+- `request_accessibility_update()`：只改了 screen reader 可见语义，例如 alt text、checked/toggled 状态、aria-like value、可用 action。
+- `request_render()`：视觉和 a11y 都变了，例如 checked 状态同时影响图形和 `Toggled`，或者滚动位置同时影响画面和 scroll value。
+- `request_paint_only()`：只改了视觉状态，例如 pointer capture、hover 高亮，并且 a11y 节点内容不变。
+- `request_layout()`：尺寸、children 或布局相关信息变了。布局和 compose pass 会进一步标记 a11y 需要更新，因为 bounds/transform/children 可能改变。
+
+当前 `PageCanvas` 里这些判断已经按这个思路写：
+
+- `PageCanvas::request_render` 在 scene、scale 或 background 改变时调用 `request_render()`。
+- `PageCanvas::set_alt_text` 只改变描述文本，所以调用 `request_accessibility_update()`。
+- pointer capture 只影响绘制状态，所以用 `request_paint_only()`。
+
+### children 和复合节点
+
+叶子 widget 返回 `ChildrenIds::new()`，容器 widget 必须保证三件事一致：
+
+- `register_children` 注册所有子 widget。
+- `layout` 对所有子 widget 执行 layout/place。
+- `children_ids` 返回同一批 child id，顺序就是 accessibility tree 中的顺序。
+
+如果动态增删子 widget，父级需要通过上下文的 `children_changed()` 通知 Masonry children 发生变化；用 `remove_child(...)` 移除子 widget 时当前 API 会顺带标记 children changed。stashed child 不会被 paint，也不会出现在 accessibility tree 里。
+
+如果一个 leaf widget 需要生成额外的非 widget 子节点，例如把一段文本拆成行、字形或 span，可以在 `accessibility` 里通过 `AccessCtx::tree_update()` 写入额外 AccessKit node，并用 `AccessCtx::next_node_id()` 分配不会和 widget id 冲突的 node id。Masonry 的 `Label` 和 `TextArea` 就是这样把 Parley 文本布局暴露给 AccessKit 的。这个接口目前比较底层，应只在确实需要构造内部语义树时使用。
+
+## Xilem 侧
+
+Xilem 的 `WidgetView` 本质上是：
+
+```rust
+View<State, Action, ViewCtx, Element = Pod<impl Widget>>
+```
+
+所以自定义组件通常分成两层：
+
+- Masonry widget：保存实际控件状态，实现绘制、事件、layout 和 a11y。
+- Xilem view：保存声明式输入，在 `build` 创建 widget，在 `rebuild` diff 输入并通过 `WidgetMut` helper 更新 widget。
+
+`crates/tinymist-viewer/src/doc.rs` 的 `TypstDocPage` 和 `PageCanvas` 就是这个结构。
+
+```rust
+fn build(&self, ctx: &mut ViewCtx, _: Arg<'_, State>) -> (Pod<PageCanvas>, ()) {
+    (
+        ctx.with_action_widget(|ctx| {
+            ctx.create_pod(PageCanvas {
+                alt_text: self.alt_text.clone(),
+                size: Size::default(),
+                scene_scale: self.scene_scale,
+                background_color: self.background_color,
+                scene: self.scene.clone(),
+            })
+        }),
+        (),
+    )
+}
+
+fn rebuild(
+    &self,
+    prev: &Self,
+    (): &mut (),
+    _ctx: &mut ViewCtx,
+    mut element: Mut<'_, Pod<PageCanvas>>,
+    _state: Arg<'_, State>,
+) {
+    PageCanvas::request_render(
+        &mut element,
+        self.scene.clone(),
+        self.scene_scale,
+        self.background_color,
+    );
+    if self.alt_text != prev.alt_text {
+        PageCanvas::set_alt_text(&mut element, self.alt_text.clone());
+    }
+}
+```
+
+`with_action_widget` 很重要：它把 widget id 记录到 Xilem 的 view path 上，这样 widget 用 `ctx.submit_action::<Self::Action>(...)` 提交的 Masonry action 才能路由到这个 view 的 `message` 方法。没有 action 的纯展示 widget 可以只用 `create_pod`。
+
+Xilem view 本身不应该重复描述 a11y。它只需要保证 rebuild 里所有影响 a11y 的输入变化最终会调用 widget helper，而 helper 再调用正确的 Masonry request 方法。
+
+## `PageCanvas` 当前状态
+
+`PageCanvas` 当前是一个把 Typst 页面 Vello scene 画出来的自定义 canvas：
+
+```rust
+fn accessibility_role(&self) -> Role {
+    Role::Canvas
+}
+
+fn accessibility(
+    &mut self,
+    _ctx: &mut AccessCtx<'_>,
+    _props: &PropertiesRef<'_>,
+    node: &mut Node,
+) {
+    if let Some(alt_text) = &self.alt_text {
+        node.set_description(&**alt_text);
+    }
+}
+```
+
+这能让辅助技术知道“这里有一个 canvas”，并在有 `alt_text` 时读出描述。它不能让用户：
+
+- 按段落、标题、链接或图片在 Typst 页面内部导航；
+- 选择/朗读页面中的实际文本；
+- 操作页面内部的链接或表单式元素；
+- 获取光标位置对应的 Typst 源位置信息。
+
+也就是说，当前实现适合“页面预览缩略图/画布”的最低限度 a11y，不等价于完整文档可访问性。
+
+## Adaptive synthetic tree benchmark
+
+`crates/tinymist-viewer/benches/a11y_synthetic_tree.rs` 只保留当前建议实现的 adaptive 策略 benchmark：
+
+- `page_count <= 256`：构造完整 `Document -> Page -> Paragraph -> TextRun` tree。
+- `page_count > 256`：所有页面常驻轻量 page index node，只展开 visible 附近 9 页的 `Paragraph -> TextRun` subtree。
+- 每页 8 个 paragraph，每个 paragraph 4 个 text run。
+- 每个 text run 64 个字符，并设置 `value`、`character_lengths`、`character_positions` 和 `character_widths`。
+
+这个 benchmark 只测当前准备落地的行为：adaptive 初始 tree，以及大文档滚动一页时离开页收缩为 page stub、进入页展开完整 subtree 的增量 update。
+
+在本机 `cargo bench -p tinymist-viewer --bench a11y_synthetic_tree adaptive_tree` 的 Criterion median 结果如下：
+
+| 页数 | 策略 | 初始节点数 | 初始构造 | 初始 apply | 滚动一页节点数 | 滚动一页构造 | 滚动一页 apply |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 | full tree | 1,313 | 314.8 us | 458.6 us | n/a | n/a | n/a |
+| 256 | full tree | 10,497 | 4.1 ms | 4.9 ms | n/a | n/a | n/a |
+| 2048 | page stubs + 9 页完整 subtree | 2,409 | 376.7 us | 551.0 us | 42 | 12.8 us | 25.0 us |
+
+超过 256 页时，page stubs + 9 页完整 subtree 的初始节点数计算方式是：
+
+```text
+1 document
++ page_count page index nodes
++ 9 * (8 paragraph + 32 text run)
+```
+
+滚动一页的 update 不更新 document root，只提交：
+
+- 离开窗口的 page node，children 变为空。
+- 新进入窗口的 page node，加上 8 个 paragraph 和 32 个 text run。
+
+因此滚动 update 固定是 42 个节点，和总页数无关。真实实现中还需要把 `focused_page + selection_anchor_page + selection_focus_page` 加进 materialized set；跨页选择时，selection endpoint 页必须强制 materialize，避免 AccessKit `TextSelection` 引用当前 tree 中不存在的 text run node。
+
+## 对 tinymist-viewer 的建议路线
+
+短期可以继续沿用 canvas 级别描述：
+
+- 每个 `PageCanvas` 保持 `Role::Canvas`。
+- 有页面上下文时设置稳定、简短的 `alt_text`，例如页码、文档标题、渲染错误摘要或“Typst page preview”。
+- 装饰性 canvas 可以设置空字符串描述；如果确实无法提供有意义描述，则保持 `None`，让辅助技术知道没有 accessible description。
+- 所有 alt text 变化都通过 `PageCanvas::set_alt_text` 进入 widget，并只请求 accessibility update。
+
+中期如果 viewer 要支持“可读页面”，需要新增一层独立的 page a11y model，而不是试图从 Vello scene 反推语义：
+
+1. 从 Typst 编译产物或 tinymist 的分析层提取页面文本、图片替代文本、链接、标题层级和源位置。
+2. 给 `PageCanvas` 或新的 page widget 增加语义树输入，例如 `Arc<PageAccessibilityTree>`。
+3. 在 widget 的 `accessibility` 中把 `Role::Canvas` 升级为更合适的容器角色，或保留 canvas 节点并生成可导航子节点。
+4. 用稳定 id 映射页面内部对象，避免每帧生成完全不同的 node id 导致 screen reader 焦点跳动。
+5. 为链接、跳转、滚动到选区等操作添加 `accesskit::Action`，并在 `on_access_event` 中转成 viewer action。
+6. 用 `masonry_testing::TestHarness` 断言 accessibility node 的 role、description、child ids 和 supported actions，而不是只做截图测试。
+
+这个路线的关键是语义数据来自 Typst/tinymist 的文档模型，而不是来自像素或 Vello path。a11y tree 应该描述用户能理解和操作的文档结构，绘制 scene 只负责视觉呈现。
+
+## 实现检查清单
+
+给 tinymist-viewer 新增或修改自定义组件时，逐项检查：
+
+- 这个 widget 的真实语义是什么？是否已有内置 Masonry widget 更合适？
+- `accessibility_role` 是否选择了最接近语义的 `Role`？
+- `accessibility` 是否每次都完整设置 name/description/value/state/action/children 相关信息？
+- 如果暴露了 `node.add_action(...)`，`on_access_event` 是否处理了同一个 action？
+- 状态变化时调用的是 `request_accessibility_update`、`request_render` 还是 `request_paint_only`？
+- 容器的 `register_children`、`layout`、`children_ids` 是否一致？children 顺序是否符合朗读顺序？
+- 是否需要 `accepts_focus`、`accepts_text_input` 或 keyboard path，避免只能用鼠标操作？
+- 是否有 `masonry_testing` 覆盖 role、description、state、actions、child ids 或 focus 行为？
+
+## 参考资料
+
+- 当前锁定源码：`Cargo.lock` 中 `masonry`、`masonry_core`、`masonry_winit`、`xilem` 来自 `Myriad-Dreamin/xilem` 修订 `abe7da9eae473d4f09a7e69a058c31cfe6d3b2e3`。
+- Masonry `Widget` trait 文档：<https://docs.rs/masonry_core/latest/masonry_core/core/trait.Widget.html>
+- Masonry 自定义 widget 教程：<https://docs.rs/masonry/latest/masonry/doc/doc_02_implementing_widget/index.html>
+- AccessKit 项目：<https://accesskit.dev/>
+- ARIA roles 参考：<https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles>

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -355,7 +355,7 @@ fn is_copy_shortcut(event: &KeyboardEvent) -> bool {
         && matches!(&event.key, Key::Character(key) if key.as_str().eq_ignore_ascii_case("c"))
 }
 
-const TEXT_SELECTION_COLOR: Color = Color::from_rgba8(70, 130, 255, 96);
+const TEXT_SELECTION_COLOR: Color = Color::from_rgba8(0x7d, 0xb9, 0xde, 0xa0);
 
 fn scale_access_rect(rect: masonry::accesskit::Rect, scale: f64) -> Rect {
     Rect::new(
@@ -525,6 +525,7 @@ impl Widget for PageCanvas {
                 &self.size.to_rect(),
             );
         }
+        scene.append(&self.scene, Some(Affine::scale(self.scene_scale)));
         if let Some(selection) = self.selection {
             for rect in self.accessibility.selection_rects(selection) {
                 scene.fill(
@@ -536,7 +537,6 @@ impl Widget for PageCanvas {
                 );
             }
         }
-        scene.append(&self.scene, Some(Affine::scale(self.scene_scale)));
     }
 
     fn accessibility_role(&self) -> Role {
@@ -587,10 +587,10 @@ mod tests {
         CursorIcon, KeyboardEvent, Modifiers, NewWidget, PointerButton, TextEvent, Widget,
         WidgetTag,
     };
-    use masonry::peniko::Color;
+    use masonry::peniko::{Color, Fill};
     use masonry::theme::default_property_set;
     use masonry::vello::Scene;
-    use masonry::vello::kurbo::{Point, Size};
+    use masonry::vello::kurbo::{Affine, Point, Size};
     use masonry_testing::{TestHarness, TestHarnessParams};
     use reflexo::vector::incr::IncrDocClient;
     use reflexo::vector::stream::BytesModuleStream;
@@ -600,7 +600,7 @@ mod tests {
 
     use crate::incr::IncrVelloDocClient;
     use crate::protocol::preview_update_from_bytes;
-    use crate::{PageAccessibility, PageTextRun};
+    use crate::{PageAccessibility, PageTextPosition, PageTextRun, PageTextSelection};
 
     use super::{PageCanvas, ZoomAction, zoom_action_from_keyboard};
 
@@ -870,6 +870,56 @@ mod tests {
         harness.process_text_event(TextEvent::Keyboard(keyboard_event("c", copy_modifiers())));
 
         assert_eq!(harness.clipboard_contents(), "hello");
+    }
+
+    #[test]
+    fn page_canvas_paints_selection_overlay_above_scene() {
+        let page_accessibility = Arc::new(text_accessibility());
+        let mut scene = Scene::new();
+        scene.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            Color::WHITE,
+            None,
+            &Size::new(50.0, 10.0).to_rect(),
+        );
+        let page = PageCanvas {
+            alt_text: None,
+            size: Size::ZERO,
+            scene_scale: 1.0,
+            background_color: None,
+            scene: Arc::new(scene),
+            accessibility: page_accessibility,
+            selection: Some(PageTextSelection {
+                anchor: PageTextPosition {
+                    run_index: 0,
+                    character_index: 0,
+                },
+                focus: PageTextPosition {
+                    run_index: 0,
+                    character_index: 5,
+                },
+            }),
+            selection_drag_anchor: None,
+            selection_dragged: false,
+        };
+        let mut params = TestHarnessParams::default();
+        params.window_size = Size::new(64.0, 32.0);
+        params.background_color = Color::from_rgb8(0x29, 0x29, 0x29);
+
+        let mut harness =
+            TestHarness::create_with(default_property_set(), page.with_auto_id(), params);
+        let rendered = harness.render();
+        let selected_pixel = rendered.get_pixel(5, 5).0;
+
+        assert!(
+            selected_pixel[2] > selected_pixel[0],
+            "selection overlay should tint an opaque page scene blue; got rgba({},{},{},{})",
+            selected_pixel[0],
+            selected_pixel[1],
+            selected_pixel[2],
+            selected_pixel[3],
+        );
     }
 
     fn text_accessibility() -> PageAccessibility {

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -17,6 +17,8 @@ use vello::peniko::{Color, Fill};
 use xilem::core::{Arg, MessageCtx, MessageResult, Mut, View, ViewArgument, ViewMarker};
 use xilem::{Pod, ViewCtx};
 
+use crate::PageAccessibility;
+
 /// Accesses a raw vello [`Scene`] within a canvas that fills its parent
 pub fn doc<State, Action, F, G>(
     scene: Arc<Scene>,
@@ -37,6 +39,7 @@ where
         on_click,
         on_zoom,
         alt_text: Option::default(),
+        accessibility: Arc::new(PageAccessibility::default()),
         phantom: PhantomData,
     }
 }
@@ -59,6 +62,7 @@ pub struct TypstDocPage<State, Action, F, G> {
     scene_scale: f64,
     background_color: Option<Color>,
     alt_text: Option<ArcStr>,
+    accessibility: Arc<PageAccessibility>,
     on_click: F,
     on_zoom: G,
     phantom: PhantomData<fn() -> (State, Action)>,
@@ -71,6 +75,12 @@ impl<State, Action, F, G> TypstDocPage<State, Action, F, G> {
     /// tools to use.
     pub fn alt_text(mut self, alt_text: impl Into<ArcStr>) -> Self {
         self.alt_text = Some(alt_text.into());
+        self
+    }
+
+    /// Sets synthetic AccessKit nodes for the page contents.
+    pub fn accessibility(mut self, accessibility: Arc<PageAccessibility>) -> Self {
+        self.accessibility = accessibility;
         self
     }
 }
@@ -96,6 +106,7 @@ where
                     scene_scale: self.scene_scale,
                     background_color: self.background_color,
                     scene: self.scene.clone(),
+                    accessibility: self.accessibility.clone(),
                 })
             }),
             (),
@@ -118,6 +129,9 @@ where
         );
         if self.alt_text != prev.alt_text {
             PageCanvas::set_alt_text(&mut element, self.alt_text.clone());
+        }
+        if !Arc::ptr_eq(&self.accessibility, &prev.accessibility) {
+            PageCanvas::set_accessibility(&mut element, self.accessibility.clone());
         }
     }
 
@@ -172,6 +186,7 @@ pub struct PageCanvas {
     scene_scale: f64,
     background_color: Option<Color>,
     scene: Arc<Scene>,
+    accessibility: Arc<PageAccessibility>,
 }
 
 // --- MARK: BUILDERS
@@ -184,6 +199,7 @@ impl PageCanvas {
             scene_scale,
             background_color,
             scene,
+            accessibility: Arc::new(PageAccessibility::default()),
         }
     }
 
@@ -199,6 +215,12 @@ impl PageCanvas {
     /// accessible description of the canvas content.
     pub fn with_alt_text(mut self, alt_text: impl Into<ArcStr>) -> Self {
         self.alt_text = Some(alt_text.into());
+        self
+    }
+
+    /// Sets synthetic AccessKit nodes for this page canvas.
+    pub fn with_accessibility(mut self, accessibility: Arc<PageAccessibility>) -> Self {
+        self.accessibility = accessibility;
         self
     }
 }
@@ -238,6 +260,15 @@ impl PageCanvas {
     /// See [`Canvas::with_alt_text`] for details.
     pub fn set_alt_text(this: &mut WidgetMut<'_, Self>, alt_text: Option<impl Into<ArcStr>>) {
         this.widget.alt_text = alt_text.map(Into::into);
+        this.ctx.request_accessibility_update();
+    }
+
+    /// Sets synthetic AccessKit nodes for this page canvas.
+    pub fn set_accessibility(
+        this: &mut WidgetMut<'_, Self>,
+        accessibility: Arc<PageAccessibility>,
+    ) {
+        this.widget.accessibility = accessibility;
         this.ctx.request_accessibility_update();
     }
 }
@@ -374,18 +405,28 @@ impl Widget for PageCanvas {
     }
 
     fn accessibility_role(&self) -> Role {
-        Role::Canvas
+        if self.accessibility.is_empty() {
+            Role::Canvas
+        } else {
+            Role::Document
+        }
     }
 
     fn accessibility(
         &mut self,
-        _ctx: &mut AccessCtx<'_>,
+        ctx: &mut AccessCtx<'_>,
         _props: &PropertiesRef<'_>,
         node: &mut Node,
     ) {
         if let Some(alt_text) = &self.alt_text {
             node.set_description(&**alt_text);
         }
+        self.accessibility.push_accesskit_nodes(
+            ctx.tree_update(),
+            node,
+            AccessCtx::next_node_id,
+            self.scene_scale,
+        );
     }
 
     fn children_ids(&self) -> ChildrenIds {
@@ -405,8 +446,9 @@ impl Widget for PageCanvas {
 mod tests {
     use std::sync::Arc;
 
+    use masonry::accesskit::{Action, Rect as AccessRect, Role};
     use masonry::core::keyboard::{Code, Key, KeyState};
-    use masonry::core::{KeyboardEvent, Modifiers, Widget};
+    use masonry::core::{KeyboardEvent, Modifiers, NewWidget, Widget, WidgetTag};
     use masonry::peniko::Color;
     use masonry::theme::default_property_set;
     use masonry::vello::Scene;
@@ -418,6 +460,7 @@ mod tests {
     use tinymist_preview::protocol::{DIFF_V1_PREFIX, NEW_PREFIX};
     use tinymist_std::typst::TypstDocument;
 
+    use crate::PageAccessibility;
     use crate::incr::IncrVelloDocClient;
     use crate::protocol::preview_update_from_bytes;
 
@@ -431,6 +474,7 @@ mod tests {
             scene_scale: 1.0,
             background_color: Some(Color::WHITE),
             scene: Arc::new(Scene::new()),
+            accessibility: Arc::new(PageAccessibility::default()),
         };
         let mut params = TestHarnessParams::default();
         params.window_size = Size::new(64.0, 64.0);
@@ -572,6 +616,7 @@ mod tests {
             scene_scale: 1.0,
             background_color,
             scene,
+            accessibility: Arc::new(PageAccessibility::default()),
         };
         let mut params = TestHarnessParams::default();
         params.window_size = Size::new(32.0, 32.0);
@@ -582,6 +627,40 @@ mod tests {
         let rendered = harness.render();
 
         rendered.get_pixel(8, 8).0
+    }
+
+    #[test]
+    fn page_canvas_exposes_synthetic_accesskit_link_nodes() {
+        let page_accessibility = Arc::new(PageAccessibility::new([PageAccessibility::link_node(
+            "https://example.com",
+            AccessRect::new(1.0, 2.0, 7.0, 10.0),
+        )]));
+        let page = PageCanvas::new(Arc::new(Scene::new()), 2.0, None)
+            .with_accessibility(page_accessibility);
+        let tag = WidgetTag::named("page");
+        let widget = NewWidget::new_with_tag(page, tag);
+        let mut harness = TestHarness::create(default_property_set(), widget);
+
+        let _ = harness.render();
+        let page_id = harness.get_widget(tag).id();
+        let page_node = harness
+            .access_node(page_id)
+            .expect("page canvas should have an AccessKit node");
+        assert_eq!(page_node.role(), Role::Document);
+
+        let link_node = page_node
+            .children()
+            .next()
+            .expect("page canvas should contain synthetic link node");
+        assert_eq!(link_node.role(), Role::Link);
+        assert_eq!(link_node.value().as_deref(), Some("https://example.com"));
+        assert!(link_node.supports_action(Action::Click, &|_| {
+            accesskit_consumer::FilterResult::Include
+        }));
+        assert_eq!(
+            link_node.raw_bounds(),
+            Some(AccessRect::new(2.0, 4.0, 14.0, 20.0))
+        );
     }
 
     fn assert_black_pixel(pixel: [u8; 4], message: &str) {

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use masonry::accesskit::{Node, Role};
 use masonry::core::keyboard::Key;
 use masonry::core::{
-    AccessCtx, ArcStr, ChildrenIds, KeyboardEvent, LayoutCtx, MeasureCtx, Modifiers, PaintCtx,
-    PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
+    AccessCtx, ArcStr, ChildrenIds, CursorIcon, KeyboardEvent, LayoutCtx, MeasureCtx, Modifiers,
+    PaintCtx, PointerButton, PointerButtonEvent, PointerEvent, PointerUpdate, PropertiesMut,
+    PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
 };
 use masonry::layout::{LenReq, Length};
 use tracing::{Span, trace_span};
@@ -17,7 +18,7 @@ use vello::peniko::{Color, Fill};
 use xilem::core::{Arg, MessageCtx, MessageResult, Mut, View, ViewArgument, ViewMarker};
 use xilem::{Pod, ViewCtx};
 
-use crate::PageAccessibility;
+use crate::{PageAccessibility, PageTextPosition, PageTextSelection};
 
 /// Accesses a raw vello [`Scene`] within a canvas that fills its parent
 pub fn doc<State, Action, F, G>(
@@ -107,6 +108,9 @@ where
                     background_color: self.background_color,
                     scene: self.scene.clone(),
                     accessibility: self.accessibility.clone(),
+                    selection: None,
+                    selection_drag_anchor: None,
+                    selection_dragged: false,
                 })
             }),
             (),
@@ -187,6 +191,9 @@ pub struct PageCanvas {
     background_color: Option<Color>,
     scene: Arc<Scene>,
     accessibility: Arc<PageAccessibility>,
+    selection: Option<PageTextSelection>,
+    selection_drag_anchor: Option<PageTextPosition>,
+    selection_dragged: bool,
 }
 
 // --- MARK: BUILDERS
@@ -200,6 +207,9 @@ impl PageCanvas {
             background_color,
             scene,
             accessibility: Arc::new(PageAccessibility::default()),
+            selection: None,
+            selection_drag_anchor: None,
+            selection_dragged: false,
         }
     }
 
@@ -231,6 +241,24 @@ impl PageCanvas {
     /// size.
     pub fn size(&self) -> Size {
         self.size
+    }
+
+    fn page_point_from_local(&self, pos: Point) -> Option<Point> {
+        if self.scene_scale <= 0.0 || !self.scene_scale.is_finite() {
+            return None;
+        }
+        Some(Point::new(
+            pos.x / self.scene_scale,
+            pos.y / self.scene_scale,
+        ))
+    }
+
+    fn selection_is_valid(&self) -> bool {
+        let Some(selection) = self.selection else {
+            return true;
+        };
+        selection.anchor.run_index < self.accessibility.text_runs().len()
+            && selection.focus.run_index < self.accessibility.text_runs().len()
     }
 }
 
@@ -269,6 +297,11 @@ impl PageCanvas {
         accessibility: Arc<PageAccessibility>,
     ) {
         this.widget.accessibility = accessibility;
+        if !this.widget.selection_is_valid() {
+            this.widget.selection = None;
+            this.widget.selection_drag_anchor = None;
+            this.widget.selection_dragged = false;
+        }
         this.ctx.request_accessibility_update();
     }
 }
@@ -309,6 +342,30 @@ fn zoom_action_from_keyboard(event: &KeyboardEvent) -> Option<ZoomAction> {
     }
 }
 
+fn is_copy_shortcut(event: &KeyboardEvent) -> bool {
+    if !event.state.is_down() {
+        return false;
+    }
+    let action_modifier = if cfg!(target_os = "macos") {
+        event.modifiers.meta()
+    } else {
+        event.modifiers.ctrl()
+    };
+    action_modifier
+        && matches!(&event.key, Key::Character(key) if key.as_str().eq_ignore_ascii_case("c"))
+}
+
+const TEXT_SELECTION_COLOR: Color = Color::from_rgba8(70, 130, 255, 96);
+
+fn scale_access_rect(rect: masonry::accesskit::Rect, scale: f64) -> Rect {
+    Rect::new(
+        rect.x0 * scale,
+        rect.y0 * scale,
+        rect.x1 * scale,
+        rect.y1 * scale,
+    )
+}
+
 // --- MARK: IMPL WIDGET
 impl Widget for PageCanvas {
     type Action = PageAction;
@@ -316,18 +373,57 @@ impl Widget for PageCanvas {
     fn on_pointer_event(
         &mut self,
         ctx: &mut masonry::core::EventCtx<'_>,
-        _props: &mut masonry::core::PropertiesMut<'_>,
-        event: &masonry::core::PointerEvent,
+        _props: &mut PropertiesMut<'_>,
+        event: &PointerEvent,
     ) {
         match event {
-            masonry::core::PointerEvent::Down(..) => {
+            PointerEvent::Down(PointerButtonEvent {
+                button: None | Some(PointerButton::Primary),
+                state,
+                ..
+            }) => {
+                let cursor_pos = ctx.local_position(state.position);
+                let new_selection = self
+                    .page_point_from_local(cursor_pos)
+                    .and_then(|point| self.accessibility.hit_test_text(point))
+                    .map(PageTextSelection::collapsed);
+                let selection_changed = self.selection != new_selection;
+                self.selection = new_selection;
+                self.selection_drag_anchor = new_selection.map(|selection| selection.anchor);
+                self.selection_dragged = false;
+
                 ctx.request_focus();
                 ctx.capture_pointer();
-                // Changes in pointer capture impact appearance, but not accessibility node
                 ctx.request_paint_only();
+                if selection_changed {
+                    ctx.request_accessibility_update();
+                }
             }
-            masonry::core::PointerEvent::Up(event) => {
-                if ctx.is_active() && ctx.is_hovered() {
+            PointerEvent::Move(PointerUpdate { current, .. }) => {
+                if ctx.is_active()
+                    && let Some(anchor) = self.selection_drag_anchor
+                    && let Some(focus) = self
+                        .page_point_from_local(ctx.local_position(current.position))
+                        .and_then(|point| self.accessibility.hit_test_text(point))
+                {
+                    let new_selection = PageTextSelection { anchor, focus };
+                    if self.selection != Some(new_selection) {
+                        self.selection_dragged = true;
+                        self.selection = Some(new_selection);
+                        ctx.request_paint_only();
+                        ctx.request_accessibility_update();
+                    }
+                }
+            }
+            PointerEvent::Up(event) => {
+                let suppress_click = self.selection_dragged
+                    && self
+                        .selection
+                        .is_some_and(|selection| !selection.is_collapsed());
+                self.selection_drag_anchor = None;
+                self.selection_dragged = false;
+
+                if ctx.is_active() && ctx.is_hovered() && !suppress_click {
                     let content_box = ctx.content_box();
                     let cursor_pos = ctx.local_position(event.state.position);
                     ctx.submit_action::<Self::Action>(PageAction::Click {
@@ -335,7 +431,11 @@ impl Widget for PageCanvas {
                         cursor_pos,
                     });
                 }
-                // Changes in pointer capture impact appearance, but not accessibility node
+                ctx.request_paint_only();
+            }
+            PointerEvent::Cancel(_) => {
+                self.selection_drag_anchor = None;
+                self.selection_dragged = false;
                 ctx.request_paint_only();
             }
             _ => (),
@@ -353,12 +453,36 @@ impl Widget for PageCanvas {
         {
             ctx.submit_action::<Self::Action>(PageAction::Zoom(action));
             ctx.set_handled();
+        } else if let TextEvent::Keyboard(event) = event
+            && is_copy_shortcut(event)
+        {
+            if let Some(selection) = self.selection {
+                let selected_text = self.accessibility.selected_text(selection);
+                if !selected_text.is_empty() {
+                    ctx.set_clipboard(selected_text);
+                }
+            }
+            ctx.set_handled();
         }
     }
 
     // TODO - Do we want the Canvas to be transparent to pointer events?
     fn accepts_pointer_interaction(&self) -> bool {
         true
+    }
+
+    fn get_cursor(&self, ctx: &QueryCtx<'_>, pos: Point) -> CursorIcon {
+        let local_pos = ctx.to_local(pos);
+        let Some(page_pos) = self.page_point_from_local(local_pos) else {
+            return CursorIcon::Default;
+        };
+        if self.accessibility.hit_test_link(page_pos).is_some() {
+            CursorIcon::Pointer
+        } else if self.accessibility.hit_test_text(page_pos).is_some() {
+            CursorIcon::Text
+        } else {
+            CursorIcon::Default
+        }
     }
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx<'_>) {}
@@ -400,6 +524,17 @@ impl Widget for PageCanvas {
                 None,
                 &self.size.to_rect(),
             );
+        }
+        if let Some(selection) = self.selection {
+            for rect in self.accessibility.selection_rects(selection) {
+                scene.fill(
+                    Fill::NonZero,
+                    Affine::IDENTITY,
+                    TEXT_SELECTION_COLOR,
+                    None,
+                    &scale_access_rect(rect, self.scene_scale),
+                );
+            }
         }
         scene.append(&self.scene, Some(Affine::scale(self.scene_scale)));
     }
@@ -448,11 +583,14 @@ mod tests {
 
     use masonry::accesskit::{Action, Rect as AccessRect, Role};
     use masonry::core::keyboard::{Code, Key, KeyState};
-    use masonry::core::{KeyboardEvent, Modifiers, NewWidget, Widget, WidgetTag};
+    use masonry::core::{
+        CursorIcon, KeyboardEvent, Modifiers, NewWidget, PointerButton, TextEvent, Widget,
+        WidgetTag,
+    };
     use masonry::peniko::Color;
     use masonry::theme::default_property_set;
     use masonry::vello::Scene;
-    use masonry::vello::kurbo::Size;
+    use masonry::vello::kurbo::{Point, Size};
     use masonry_testing::{TestHarness, TestHarnessParams};
     use reflexo::vector::incr::IncrDocClient;
     use reflexo::vector::stream::BytesModuleStream;
@@ -460,9 +598,9 @@ mod tests {
     use tinymist_preview::protocol::{DIFF_V1_PREFIX, NEW_PREFIX};
     use tinymist_std::typst::TypstDocument;
 
-    use crate::PageAccessibility;
     use crate::incr::IncrVelloDocClient;
     use crate::protocol::preview_update_from_bytes;
+    use crate::{PageAccessibility, PageTextRun};
 
     use super::{PageCanvas, ZoomAction, zoom_action_from_keyboard};
 
@@ -475,6 +613,9 @@ mod tests {
             background_color: Some(Color::WHITE),
             scene: Arc::new(Scene::new()),
             accessibility: Arc::new(PageAccessibility::default()),
+            selection: None,
+            selection_drag_anchor: None,
+            selection_dragged: false,
         };
         let mut params = TestHarnessParams::default();
         params.window_size = Size::new(64.0, 64.0);
@@ -617,6 +758,9 @@ mod tests {
             background_color,
             scene,
             accessibility: Arc::new(PageAccessibility::default()),
+            selection: None,
+            selection_drag_anchor: None,
+            selection_dragged: false,
         };
         let mut params = TestHarnessParams::default();
         params.window_size = Size::new(32.0, 32.0);
@@ -661,6 +805,92 @@ mod tests {
             link_node.raw_bounds(),
             Some(AccessRect::new(2.0, 4.0, 14.0, 20.0))
         );
+    }
+
+    #[test]
+    fn page_canvas_uses_pointer_cursor_over_links() {
+        let page_accessibility = Arc::new(PageAccessibility::new([PageAccessibility::link_node(
+            "https://example.com",
+            AccessRect::new(0.0, 0.0, 20.0, 20.0),
+        )]));
+        let page = PageCanvas::new(Arc::new(Scene::new()), 1.0, None)
+            .with_accessibility(page_accessibility);
+        let tag = WidgetTag::named("page");
+        let widget = NewWidget::new_with_tag(page, tag);
+        let mut harness = TestHarness::create(default_property_set(), widget);
+
+        let _ = harness.render();
+        harness.mouse_move(Point::new(10.0, 10.0));
+        assert_eq!(harness.cursor_icon(), CursorIcon::Pointer);
+    }
+
+    #[test]
+    fn page_canvas_exposes_synthetic_accesskit_text_runs() {
+        let page_accessibility = Arc::new(text_accessibility());
+        let page = PageCanvas::new(Arc::new(Scene::new()), 2.0, None)
+            .with_accessibility(page_accessibility);
+        let tag = WidgetTag::named("page");
+        let widget = NewWidget::new_with_tag(page, tag);
+        let mut harness = TestHarness::create(default_property_set(), widget);
+
+        let _ = harness.render();
+        let page_id = harness.get_widget(tag).id();
+        let page_node = harness
+            .access_node(page_id)
+            .expect("page canvas should have an AccessKit node");
+        assert_eq!(page_node.role(), Role::Document);
+
+        let text_node = page_node
+            .children()
+            .next()
+            .expect("page canvas should contain synthetic text node");
+        assert_eq!(text_node.role(), Role::TextRun);
+        assert_eq!(text_node.value().as_deref(), Some("hello"));
+        assert_eq!(text_node.data().character_lengths(), &[1, 1, 1, 1, 1]);
+        assert_eq!(
+            text_node.raw_bounds(),
+            Some(AccessRect::new(0.0, 0.0, 100.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn page_canvas_selects_and_copies_text() {
+        let page_accessibility = Arc::new(text_accessibility());
+        let page = PageCanvas::new(Arc::new(Scene::new()), 1.0, None)
+            .with_accessibility(page_accessibility);
+        let widget = NewWidget::new(page);
+        let mut harness = TestHarness::create(default_property_set(), widget);
+
+        let _ = harness.render();
+        harness.mouse_move(Point::new(1.0, 5.0));
+        assert_eq!(harness.cursor_icon(), CursorIcon::Text);
+        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_move(Point::new(49.0, 5.0));
+        harness.mouse_button_release(PointerButton::Primary);
+        harness.process_text_event(TextEvent::Keyboard(keyboard_event("c", copy_modifiers())));
+
+        assert_eq!(harness.clipboard_contents(), "hello");
+    }
+
+    fn text_accessibility() -> PageAccessibility {
+        let mut accessibility = PageAccessibility::default();
+        accessibility.push_text_run(PageTextRun::new(
+            "hello",
+            AccessRect::new(0.0, 0.0, 50.0, 10.0),
+            (0..5).map(|index| {
+                let x0 = index as f64 * 10.0;
+                AccessRect::new(x0, 0.0, x0 + 10.0, 10.0)
+            }),
+        ));
+        accessibility
+    }
+
+    fn copy_modifiers() -> Modifiers {
+        if cfg!(target_os = "macos") {
+            Modifiers::META
+        } else {
+            Modifiers::CONTROL
+        }
     }
 
     fn assert_black_pixel(pixel: [u8; 4], message: &str) {

--- a/crates/tinymist-viewer/src/incr.rs
+++ b/crates/tinymist-viewer/src/incr.rs
@@ -555,6 +555,52 @@ mod tests {
     }
 
     #[test]
+    fn render_pages_preserves_text_accessibility_run() {
+        let mut doc = compile_incremental_doc(
+            r#"
+#set page(width: 96pt, height: 48pt, margin: 0pt)
+hello
+"#,
+        );
+
+        let mut client = IncrVelloDocClient::default();
+        let rendered = client
+            .render_pages_with_accessibility(&mut doc)
+            .expect("text accessibility fixture should render");
+
+        assert_eq!(rendered.len(), 1);
+        let text_runs = rendered[0].accessibility.text_runs();
+        assert!(
+            text_runs.iter().any(|run| run.text() == "hello"),
+            "expected rendered text runs to include the source text, got {text_runs:?}"
+        );
+        let run = text_runs
+            .iter()
+            .find(|run| run.text() == "hello")
+            .expect("text run should exist");
+        assert_eq!(run.character_bounds().len(), 5);
+
+        let first = run.character_bounds()[0];
+        let last = run.character_bounds()[4];
+        let first_x = first.x0 + (first.x1 - first.x0) * 0.1;
+        let last_x = last.x1 - (last.x1 - last.x0) * 0.1;
+        let anchor = rendered[0]
+            .accessibility
+            .hit_test_text(Point::new(first_x, (first.y0 + first.y1) / 2.0))
+            .expect("first character should be selectable");
+        let focus = rendered[0]
+            .accessibility
+            .hit_test_text(Point::new(last_x, (last.y0 + last.y1) / 2.0))
+            .expect("last character should be selectable");
+        assert_eq!(
+            rendered[0]
+                .accessibility
+                .selected_text(crate::PageTextSelection { anchor, focus }),
+            "hello"
+        );
+    }
+
+    #[test]
     fn renderer_emits_expected_scene_encoding_for_typst_primitives() {
         struct Case {
             name: &'static str,

--- a/crates/tinymist-viewer/src/incr.rs
+++ b/crates/tinymist-viewer/src/incr.rs
@@ -17,17 +17,17 @@ use vello::{
     peniko::{Color, color::parse_color},
 };
 
-use crate::{PageSemantics, SvgResourceResolver, VecPage};
+use crate::{PageAccessibility, SvgResourceResolver, VecPage};
 
-/// A rendered page with its semantic metadata.
+/// A rendered page with its accessibility metadata.
 #[derive(Clone)]
 pub struct RenderedPage {
     /// The flushed Vello scene.
     pub scene: Arc<Scene>,
     /// The page size in Typst page coordinates.
     pub size: Size,
-    /// The page semantic layer.
-    pub semantics: PageSemantics,
+    /// The page AccessKit nodes.
+    pub accessibility: PageAccessibility,
 }
 
 /// Incremental pass from vector to vello scene.
@@ -84,11 +84,11 @@ impl IncrVelloPass {
 
                 let size = Vec2::new(size.x.0 as f64, size.y.0 as f64);
                 let elem = ct.render_item(content);
-                let semantics = elem.page_semantics();
+                let accessibility = elem.page_accessibility();
                 VecPage {
                     size,
                     elem,
-                    semantics,
+                    accessibility,
                     content_hash: *content,
                 }
             })
@@ -99,17 +99,17 @@ impl IncrVelloPass {
 
     /// Flushes a page to the canvas with the given transform.
     pub fn flush_page(&mut self, idx: usize) -> (Arc<Scene>, Vec2) {
-        let page = self.flush_page_with_semantics(idx);
+        let page = self.flush_page_with_accessibility(idx);
         (page.scene, size_to_vec2(page.size))
     }
 
-    fn flush_page_with_semantics(&mut self, idx: usize) -> RenderedPage {
+    fn flush_page_with_accessibility(&mut self, idx: usize) -> RenderedPage {
         if idx >= self.pages.len() {
             log::warn!("Index out of bounds: {idx}");
             return RenderedPage {
                 scene: Arc::new(vello::Scene::new()),
                 size: Size::ZERO,
-                semantics: PageSemantics::default(),
+                accessibility: PageAccessibility::default(),
             };
         }
 
@@ -131,13 +131,13 @@ impl IncrVelloPass {
 
     #[cfg(test)]
     fn flush_pages(&mut self) -> Vec<(Arc<Scene>, Vec2)> {
-        self.flush_pages_with_semantics()
+        self.flush_pages_with_accessibility()
             .into_iter()
             .map(|page| (page.scene, size_to_vec2(page.size)))
             .collect()
     }
 
-    fn flush_pages_with_semantics(&mut self) -> Vec<RenderedPage> {
+    fn flush_pages_with_accessibility(&mut self) -> Vec<RenderedPage> {
         let mut pages = Vec::with_capacity(self.pages.len());
         let mut flushed_pages = Vec::with_capacity(self.pages.len());
         let mut reusable_flushed_pages =
@@ -209,7 +209,7 @@ impl IncrVelloPass {
         RenderedPage {
             scene: Arc::new(elem_scene),
             size: vec2_to_size(*size),
-            semantics: page.semantics.clone(),
+            accessibility: page.accessibility.clone(),
         }
     }
 }
@@ -360,14 +360,14 @@ impl IncrVelloDocClient {
     /// Renders a specific page of the document in the given window.
     pub fn render_pages(&mut self, kern: &mut IncrDocClient) -> Result<Vec<(Arc<Scene>, Size)>> {
         Ok(self
-            .render_pages_with_semantics(kern)?
+            .render_pages_with_accessibility(kern)?
             .into_iter()
             .map(|page| (page.scene, page.size))
             .collect())
     }
 
-    /// Renders pages with their semantic metadata.
-    pub fn render_pages_with_semantics(
+    /// Renders pages with their accessibility metadata.
+    pub fn render_pages_with_accessibility(
         &mut self,
         kern: &mut IncrDocClient,
     ) -> Result<Vec<RenderedPage>> {
@@ -384,7 +384,7 @@ impl IncrVelloDocClient {
         // let ts = sk::Transform::from_scale(s, s);
         // let ts = Affine::scale(s as f64);
 
-        let res = self.vec2vello.flush_pages_with_semantics();
+        let res = self.vec2vello.flush_pages_with_accessibility();
         Ok(res)
     }
 }
@@ -393,6 +393,7 @@ impl IncrVelloDocClient {
 mod tests {
     use std::sync::Arc;
 
+    use masonry::accesskit::{Action, Role};
     use reflexo::{
         hash::Fingerprint,
         vector::{
@@ -505,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn render_pages_preserves_link_semantics() {
+    fn render_pages_preserves_link_accessibility_node() {
         let link_id = Fingerprint::from_pair(41, 0);
         let mut module = Module::default();
         module.items.insert(
@@ -526,25 +527,28 @@ mod tests {
 
         let mut client = IncrVelloDocClient::default();
         let rendered = client
-            .render_pages_with_semantics(&mut doc)
-            .expect("link semantics fixture should render");
+            .render_pages_with_accessibility(&mut doc)
+            .expect("link accessibility fixture should render");
 
         assert_eq!(rendered.len(), 1);
-        let links = rendered[0].semantics.links();
-        assert_eq!(links.len(), 1);
-        assert_eq!(links[0].href, "https://example.com");
-        assert_eq!(links[0].rect.width(), 6.0);
-        assert_eq!(links[0].rect.height(), 8.0);
+        let [link] = rendered[0].accessibility.nodes() else {
+            panic!("expected one AccessKit link node");
+        };
+        assert_eq!(link.role(), Role::Link);
+        assert_eq!(link.value(), Some("https://example.com"));
+        assert!(link.supports_action(Action::Click));
+        let bounds = link.bounds().expect("link node should have bounds");
+        assert_eq!(bounds.width(), 6.0);
+        assert_eq!(bounds.height(), 8.0);
         assert_eq!(
             rendered[0]
-                .semantics
-                .hit_test_link(Point::new(3.0, 4.0))
-                .map(|link| link.href.as_str()),
+                .accessibility
+                .hit_test_link(Point::new(3.0, 4.0)),
             Some("https://example.com")
         );
         assert!(
             rendered[0]
-                .semantics
+                .accessibility
                 .hit_test_link(Point::new(12.0, 12.0))
                 .is_none()
         );

--- a/crates/tinymist-viewer/src/lib.rs
+++ b/crates/tinymist-viewer/src/lib.rs
@@ -7,9 +7,10 @@
 use std::fmt;
 
 use ecow::EcoVec;
+use masonry::accesskit::{Action, Node, NodeId, Rect as AccessRect, Role, TreeUpdate};
 use reflexo::hash::Fingerprint;
 use std::sync::Arc;
-use vello::kurbo::{self, Affine, Point, Rect};
+use vello::kurbo::{self, Affine, Point};
 use vello::peniko;
 
 pub mod doc;
@@ -68,59 +69,96 @@ pub trait SvgResourceResolver: Send + Sync {
 pub struct VecPage {
     size: kurbo::Vec2,
     elem: Arc<VecScene>,
-    semantics: PageSemantics,
+    accessibility: PageAccessibility,
     content_hash: Fingerprint,
 }
 
-/// Semantic metadata for a rendered page.
+/// AccessKit nodes for a rendered page.
 #[derive(Debug, Clone, Default)]
-pub struct PageSemantics {
-    links: EcoVec<SemanticLink>,
+pub struct PageAccessibility {
+    nodes: EcoVec<Node>,
 }
 
-impl PageSemantics {
-    /// Returns all semantic links in paint order.
-    pub fn links(&self) -> &[SemanticLink] {
-        &self.links
+impl PageAccessibility {
+    /// Creates a page accessibility tree from AccessKit nodes in paint order.
+    pub fn new(nodes: impl IntoIterator<Item = Node>) -> Self {
+        Self {
+            nodes: nodes.into_iter().collect(),
+        }
     }
 
-    /// Returns the topmost link at the provided page-coordinate point.
-    pub fn hit_test_link(&self, point: Point) -> Option<&SemanticLink> {
-        self.links
+    /// Returns the page AccessKit nodes in paint order.
+    pub fn nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+
+    /// Returns whether this page has no synthetic AccessKit nodes.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Returns the topmost link href at the provided page-coordinate point.
+    pub fn hit_test_link(&self, point: Point) -> Option<&str> {
+        self.nodes
             .iter()
             .rev()
-            .find(|link| link.rect.contains(point))
+            .find(|node| {
+                node.role() == Role::Link
+                    && node.supports_action(Action::Click)
+                    && node
+                        .bounds()
+                        .is_some_and(|bounds| access_rect_contains(bounds, point))
+            })
+            .and_then(Node::value)
     }
 
-    fn push_link(&mut self, link: SemanticLink) {
-        self.links.push(link);
+    /// Adds synthetic nodes to the active AccessKit update and attaches them to
+    /// the owner widget node.
+    pub fn push_accesskit_nodes(
+        &self,
+        tree_update: &mut TreeUpdate,
+        owner: &mut Node,
+        mut next_node_id: impl FnMut() -> NodeId,
+        scale: f64,
+    ) {
+        let mut child_ids = Vec::with_capacity(self.nodes.len());
+        for page_node in self.nodes.iter() {
+            let node_id = next_node_id();
+            child_ids.push(node_id);
+            tree_update
+                .nodes
+                .push((node_id, scaled_access_node(page_node, scale)));
+        }
+        owner.set_children(child_ids);
+    }
+
+    pub(crate) fn push_node(&mut self, node: Node) {
+        self.nodes.push(node);
+    }
+
+    pub(crate) fn link_node(href: impl Into<String>, bounds: AccessRect) -> Node {
+        let href = href.into();
+        let mut node = Node::new(Role::Link);
+        node.set_bounds(bounds);
+        node.set_label(href.clone());
+        node.set_value(href);
+        node.add_action(Action::Click);
+        node
     }
 }
 
-/// A semantic link hit area in page coordinates.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SemanticLink {
-    /// The link destination.
-    pub href: String,
-    /// The clickable page-coordinate rectangle.
-    pub rect: Rect,
+fn scaled_access_node(node: &Node, scale: f64) -> Node {
+    let mut node = node.clone();
+    if scale != 1.0
+        && let Some(bounds) = node.bounds()
+    {
+        node.set_bounds(transform_access_rect_bbox(Affine::scale(scale), bounds));
+    }
+    node
 }
 
-impl SemanticLink {
-    /// Creates a semantic link.
-    pub fn new(href: impl Into<String>, rect: Rect) -> Self {
-        Self {
-            href: href.into(),
-            rect,
-        }
-    }
-
-    fn transformed(&self, transform: Affine) -> Self {
-        Self {
-            href: self.href.clone(),
-            rect: transform_rect_bbox(transform, self.rect),
-        }
-    }
+fn access_rect_contains(rect: AccessRect, point: Point) -> bool {
+    point.x >= rect.x0 && point.x < rect.x1 && point.y >= rect.y0 && point.y < rect.y1
 }
 
 /// A scene that can be rendered to a [`vello::Scene`].
@@ -162,16 +200,16 @@ impl VecScene {
         }
     }
 
-    /// Collects semantic metadata in page coordinates.
-    pub fn page_semantics(&self) -> PageSemantics {
-        let mut semantics = PageSemantics::default();
-        self.collect_semantics(Affine::IDENTITY, &mut semantics);
-        semantics
+    /// Collects AccessKit nodes in page coordinates.
+    pub fn page_accessibility(&self) -> PageAccessibility {
+        let mut accessibility = PageAccessibility::default();
+        self.collect_accessibility(Affine::IDENTITY, &mut accessibility);
+        accessibility
     }
 
-    fn collect_semantics(&self, transform: Affine, semantics: &mut PageSemantics) {
+    fn collect_accessibility(&self, transform: Affine, accessibility: &mut PageAccessibility) {
         match self {
-            VecScene::Group(group) => group.collect_semantics(transform, semantics),
+            VecScene::Group(group) => group.collect_accessibility(transform, accessibility),
             VecScene::Path(..) | VecScene::Scene(..) => {}
         }
     }
@@ -182,8 +220,21 @@ impl VecScene {
 pub struct GroupScene {
     clip: Option<kurbo::BezPath>,
     ts: Affine,
-    scenes: EcoVec<(kurbo::Vec2, Arc<VecScene>)>,
-    semantic_links: EcoVec<SemanticLink>,
+    items: EcoVec<GroupSceneItem>,
+}
+
+/// An item inside a [`GroupScene`], ordered as emitted by the renderer.
+#[derive(Debug, Clone)]
+pub enum GroupSceneItem {
+    /// A visual scene drawn at the given group-local position.
+    Scene {
+        /// The group-local position of the scene.
+        pos: kurbo::Vec2,
+        /// The scene to render.
+        scene: Arc<VecScene>,
+    },
+    /// An AccessKit node associated with the group.
+    Accessibility(Node),
 }
 
 impl GroupScene {
@@ -193,30 +244,46 @@ impl GroupScene {
             scene.push_clip_layer(peniko::Fill::NonZero, self.ts, clip);
         }
         let ts = self.ts;
-        for (pos, elem) in self.scenes.iter() {
-            let ts = ts.pre_translate(*pos);
-            let mut sub_scene = vello::Scene::new();
-            elem.render(&mut sub_scene);
-            scene.append(&sub_scene, Some(ts));
+        for item in self.items.iter() {
+            if let GroupSceneItem::Scene {
+                pos,
+                scene: child_scene,
+            } = item
+            {
+                let ts = ts.pre_translate(*pos);
+                let mut sub_scene = vello::Scene::new();
+                child_scene.render(&mut sub_scene);
+                scene.append(&sub_scene, Some(ts));
+            }
         }
         if self.clip.is_some() {
             scene.pop_layer();
         }
     }
 
-    fn collect_semantics(&self, transform: Affine, semantics: &mut PageSemantics) {
+    fn collect_accessibility(&self, transform: Affine, accessibility: &mut PageAccessibility) {
         let transform = transform * self.ts;
-        for link in self.semantic_links.iter() {
-            semantics.push_link(link.transformed(transform));
-        }
-
-        for (pos, elem) in self.scenes.iter() {
-            elem.collect_semantics(transform.pre_translate(*pos), semantics);
+        for item in self.items.iter() {
+            match item {
+                GroupSceneItem::Scene {
+                    pos,
+                    scene: child_scene,
+                } => {
+                    child_scene.collect_accessibility(transform.pre_translate(*pos), accessibility);
+                }
+                GroupSceneItem::Accessibility(node) => {
+                    let mut node = node.clone();
+                    if let Some(bounds) = node.bounds() {
+                        node.set_bounds(transform_access_rect_bbox(transform, bounds));
+                    }
+                    accessibility.push_node(node);
+                }
+            }
         }
     }
 }
 
-fn transform_rect_bbox(transform: Affine, rect: Rect) -> Rect {
+fn transform_access_rect_bbox(transform: Affine, rect: AccessRect) -> AccessRect {
     let points = [
         Point::new(rect.x0, rect.y0),
         Point::new(rect.x1, rect.y0),
@@ -236,69 +303,121 @@ fn transform_rect_bbox(transform: Affine, rect: Rect) -> Rect {
         y1 = y1.max(point.y);
     }
 
-    Rect::new(x0, y0, x1, y1)
+    AccessRect::new(x0, y0, x1, y1)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn page_semantics_hit_tests_topmost_link() {
-        let mut semantics = PageSemantics::default();
-        semantics.push_link(SemanticLink::new(
-            "https://bottom.example",
-            Rect::new(0.0, 0.0, 20.0, 20.0),
-        ));
-        semantics.push_link(SemanticLink::new(
-            "https://top.example",
-            Rect::new(10.0, 10.0, 30.0, 30.0),
-        ));
-
-        assert_eq!(
-            semantics
-                .hit_test_link(Point::new(12.0, 12.0))
-                .map(|link| link.href.as_str()),
-            Some("https://top.example")
-        );
-        assert_eq!(
-            semantics
-                .hit_test_link(Point::new(5.0, 5.0))
-                .map(|link| link.href.as_str()),
-            Some("https://bottom.example")
-        );
-        assert!(semantics.hit_test_link(Point::new(40.0, 40.0)).is_none());
+    fn access_rect(x0: f64, y0: f64, x1: f64, y1: f64) -> AccessRect {
+        AccessRect::new(x0, y0, x1, y1)
     }
 
     #[test]
-    fn page_semantics_collects_transformed_nested_links() {
-        let mut links = EcoVec::new();
-        links.push(SemanticLink::new(
-            "https://example.com",
-            Rect::new(0.0, 0.0, 5.0, 10.0),
+    fn page_accessibility_hit_tests_topmost_link_node() {
+        let mut accessibility = PageAccessibility::default();
+        accessibility.push_node(PageAccessibility::link_node(
+            "https://bottom.example",
+            access_rect(0.0, 0.0, 20.0, 20.0),
         ));
+        accessibility.push_node(PageAccessibility::link_node(
+            "https://top.example",
+            access_rect(10.0, 10.0, 30.0, 30.0),
+        ));
+
+        assert_eq!(
+            accessibility.hit_test_link(Point::new(12.0, 12.0)),
+            Some("https://top.example")
+        );
+        assert_eq!(
+            accessibility.hit_test_link(Point::new(5.0, 5.0)),
+            Some("https://bottom.example")
+        );
+        assert!(
+            accessibility
+                .hit_test_link(Point::new(40.0, 40.0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn page_accessibility_collects_transformed_nested_link_nodes() {
+        let mut child_items = EcoVec::new();
+        child_items.push(GroupSceneItem::Accessibility(PageAccessibility::link_node(
+            "https://example.com",
+            access_rect(0.0, 0.0, 5.0, 10.0),
+        )));
         let child = Arc::new(VecScene::Group(GroupScene {
             clip: None,
             ts: Affine::scale(2.0),
-            scenes: EcoVec::new(),
-            semantic_links: links,
+            items: child_items,
         }));
 
-        let mut scenes = EcoVec::new();
-        scenes.push((kurbo::Vec2::new(10.0, 20.0), child));
+        let mut items = EcoVec::new();
+        items.push(GroupSceneItem::Scene {
+            pos: kurbo::Vec2::new(10.0, 20.0),
+            scene: child,
+        });
         let scene = VecScene::Group(GroupScene {
             clip: None,
             ts: Affine::IDENTITY,
-            scenes,
-            semantic_links: EcoVec::new(),
+            items,
         });
 
-        let semantics = scene.page_semantics();
-        assert_eq!(semantics.links().len(), 1);
-        let link = &semantics.links()[0];
-        assert_eq!(link.href, "https://example.com");
-        assert_eq!(link.rect, Rect::new(10.0, 20.0, 20.0, 40.0));
-        assert!(semantics.hit_test_link(Point::new(15.0, 30.0)).is_some());
-        assert!(semantics.hit_test_link(Point::new(25.0, 30.0)).is_none());
+        let accessibility = scene.page_accessibility();
+        let [link] = accessibility.nodes() else {
+            panic!("expected one AccessKit link node");
+        };
+        assert_eq!(link.role(), Role::Link);
+        assert_eq!(link.value(), Some("https://example.com"));
+        assert_eq!(link.bounds(), Some(access_rect(10.0, 20.0, 20.0, 40.0)));
+        assert!(link.supports_action(Action::Click));
+        assert!(
+            accessibility
+                .hit_test_link(Point::new(15.0, 30.0))
+                .is_some()
+        );
+        assert!(
+            accessibility
+                .hit_test_link(Point::new(25.0, 30.0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn page_accessibility_hit_tests_links_in_group_item_order() {
+        let mut child_items = EcoVec::new();
+        child_items.push(GroupSceneItem::Accessibility(PageAccessibility::link_node(
+            "https://bottom.example",
+            access_rect(0.0, 0.0, 20.0, 20.0),
+        )));
+        let child = Arc::new(VecScene::Group(GroupScene {
+            clip: None,
+            ts: Affine::IDENTITY,
+            items: child_items,
+        }));
+
+        let mut items = EcoVec::new();
+        items.push(GroupSceneItem::Scene {
+            pos: kurbo::Vec2::ZERO,
+            scene: child,
+        });
+        items.push(GroupSceneItem::Accessibility(PageAccessibility::link_node(
+            "https://top.example",
+            access_rect(0.0, 0.0, 20.0, 20.0),
+        )));
+        let scene = VecScene::Group(GroupScene {
+            clip: None,
+            ts: Affine::IDENTITY,
+            items,
+        });
+
+        assert_eq!(
+            scene
+                .page_accessibility()
+                .hit_test_link(Point::new(10.0, 10.0)),
+            Some("https://top.example")
+        );
     }
 }

--- a/crates/tinymist-viewer/src/lib.rs
+++ b/crates/tinymist-viewer/src/lib.rs
@@ -77,6 +77,7 @@ pub struct VecPage {
 #[derive(Debug, Clone, Default)]
 pub struct PageAccessibility {
     nodes: EcoVec<Node>,
+    text_runs: EcoVec<PageTextRun>,
 }
 
 impl PageAccessibility {
@@ -84,6 +85,7 @@ impl PageAccessibility {
     pub fn new(nodes: impl IntoIterator<Item = Node>) -> Self {
         Self {
             nodes: nodes.into_iter().collect(),
+            text_runs: EcoVec::new(),
         }
     }
 
@@ -92,9 +94,14 @@ impl PageAccessibility {
         &self.nodes
     }
 
+    /// Returns selectable text runs in page coordinates.
+    pub fn text_runs(&self) -> &[PageTextRun] {
+        &self.text_runs
+    }
+
     /// Returns whether this page has no synthetic AccessKit nodes.
     pub fn is_empty(&self) -> bool {
-        self.nodes.is_empty()
+        self.nodes.is_empty() && self.text_runs.is_empty()
     }
 
     /// Returns the topmost link href at the provided page-coordinate point.
@@ -112,6 +119,83 @@ impl PageAccessibility {
             .and_then(Node::value)
     }
 
+    /// Returns whether the provided page-coordinate point is over selectable text.
+    pub fn hit_test_text(&self, point: Point) -> Option<PageTextPosition> {
+        self.text_runs
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(run_index, run)| {
+                run.character_index_at_point(point)
+                    .map(|character_index| PageTextPosition {
+                        run_index,
+                        character_index,
+                    })
+            })
+    }
+
+    /// Returns text covered by a selection.
+    pub fn selected_text(&self, selection: PageTextSelection) -> String {
+        let Some((start, end)) = selection.normalized() else {
+            return String::new();
+        };
+        if start.run_index >= self.text_runs.len()
+            || end.run_index >= self.text_runs.len()
+            || start == end
+        {
+            return String::new();
+        }
+
+        let mut selected = String::new();
+        for run_index in start.run_index..=end.run_index {
+            let run = &self.text_runs[run_index];
+            let start_index = if run_index == start.run_index {
+                start.character_index
+            } else {
+                0
+            };
+            let end_index = if run_index == end.run_index {
+                end.character_index
+            } else {
+                run.character_count()
+            };
+            selected.push_str(run.text_slice(start_index, end_index));
+        }
+        selected
+    }
+
+    /// Returns page-coordinate rectangles covered by a text selection.
+    pub fn selection_rects(&self, selection: PageTextSelection) -> Vec<AccessRect> {
+        let Some((start, end)) = selection.normalized() else {
+            return Vec::new();
+        };
+        if start.run_index >= self.text_runs.len()
+            || end.run_index >= self.text_runs.len()
+            || start == end
+        {
+            return Vec::new();
+        }
+
+        let mut rects = Vec::new();
+        for run_index in start.run_index..=end.run_index {
+            let run = &self.text_runs[run_index];
+            let start_index = if run_index == start.run_index {
+                start.character_index
+            } else {
+                0
+            };
+            let end_index = if run_index == end.run_index {
+                end.character_index
+            } else {
+                run.character_count()
+            };
+            if let Some(rect) = run.selection_rect(start_index, end_index) {
+                rects.push(rect);
+            }
+        }
+        rects
+    }
+
     /// Adds synthetic nodes to the active AccessKit update and attaches them to
     /// the owner widget node.
     pub fn push_accesskit_nodes(
@@ -121,7 +205,7 @@ impl PageAccessibility {
         mut next_node_id: impl FnMut() -> NodeId,
         scale: f64,
     ) {
-        let mut child_ids = Vec::with_capacity(self.nodes.len());
+        let mut child_ids = Vec::with_capacity(self.nodes.len() + self.text_runs.len());
         for page_node in self.nodes.iter() {
             let node_id = next_node_id();
             child_ids.push(node_id);
@@ -129,11 +213,22 @@ impl PageAccessibility {
                 .nodes
                 .push((node_id, scaled_access_node(page_node, scale)));
         }
+        for text_run in self.text_runs.iter() {
+            let node_id = next_node_id();
+            child_ids.push(node_id);
+            tree_update
+                .nodes
+                .push((node_id, text_run.accesskit_node(scale)));
+        }
         owner.set_children(child_ids);
     }
 
     pub(crate) fn push_node(&mut self, node: Node) {
         self.nodes.push(node);
+    }
+
+    pub(crate) fn push_text_run(&mut self, text_run: PageTextRun) {
+        self.text_runs.push(text_run);
     }
 
     pub(crate) fn link_node(href: impl Into<String>, bounds: AccessRect) -> Node {
@@ -147,18 +242,245 @@ impl PageAccessibility {
     }
 }
 
+/// A selectable text run in page coordinates.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageTextRun {
+    text: String,
+    bounds: AccessRect,
+    character_bounds: EcoVec<AccessRect>,
+}
+
+impl PageTextRun {
+    /// Creates a page text run from text and per-character page-coordinate boxes.
+    pub fn new(
+        text: impl Into<String>,
+        bounds: AccessRect,
+        character_bounds: impl IntoIterator<Item = AccessRect>,
+    ) -> Self {
+        let text = text.into();
+        let character_count = text.chars().count();
+        let mut character_bounds: EcoVec<_> = character_bounds.into_iter().collect();
+        if character_count == 0 {
+            character_bounds.clear();
+        } else if character_bounds.len() != character_count {
+            character_bounds = split_access_rect_horizontally(bounds, character_count);
+        }
+
+        Self {
+            text,
+            bounds,
+            character_bounds,
+        }
+    }
+
+    /// Returns the plain text for this run.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the page-coordinate run bounds.
+    pub fn bounds(&self) -> AccessRect {
+        self.bounds
+    }
+
+    /// Returns page-coordinate per-character bounds.
+    pub fn character_bounds(&self) -> &[AccessRect] {
+        &self.character_bounds
+    }
+
+    /// Returns the number of selectable characters in this run.
+    pub fn character_count(&self) -> usize {
+        self.text.chars().count().min(self.character_bounds.len())
+    }
+
+    fn transformed(&self, transform: Affine) -> Self {
+        Self {
+            text: self.text.clone(),
+            bounds: transform_access_rect_bbox(transform, self.bounds),
+            character_bounds: self
+                .character_bounds
+                .iter()
+                .map(|bounds| transform_access_rect_bbox(transform, *bounds))
+                .collect(),
+        }
+    }
+
+    fn accesskit_node(&self, scale: f64) -> Node {
+        let mut node = Node::new(Role::TextRun);
+        node.set_bounds(scale_access_rect(self.bounds, scale));
+        node.set_value(self.text.clone());
+        node.set_character_lengths(
+            self.text
+                .chars()
+                .map(|c| c.len_utf8() as u8)
+                .collect::<Vec<_>>(),
+        );
+
+        let character_count = self.character_count();
+        let scaled_bounds = scale_access_rect(self.bounds, scale);
+        let mut positions = Vec::with_capacity(character_count);
+        let mut widths = Vec::with_capacity(character_count);
+        for character_bounds in self.character_bounds.iter().take(character_count) {
+            let character_bounds = scale_access_rect(*character_bounds, scale);
+            positions.push((character_bounds.x0 - scaled_bounds.x0) as f32);
+            widths.push((character_bounds.x1 - character_bounds.x0) as f32);
+        }
+        node.set_character_positions(positions);
+        node.set_character_widths(widths);
+        node
+    }
+
+    fn character_index_at_point(&self, point: Point) -> Option<usize> {
+        if !access_rect_contains(self.bounds, point) {
+            return None;
+        }
+
+        let character_count = self.character_count();
+        if character_count == 0 {
+            return Some(0);
+        }
+
+        for (index, bounds) in self
+            .character_bounds
+            .iter()
+            .take(character_count)
+            .enumerate()
+        {
+            if point.x >= bounds.x0 && point.x < bounds.x1 {
+                let midpoint = (bounds.x0 + bounds.x1) / 2.0;
+                return Some(if point.x < midpoint { index } else { index + 1 });
+            }
+        }
+
+        if point.x < self.character_bounds[0].x0 {
+            Some(0)
+        } else {
+            Some(character_count)
+        }
+    }
+
+    fn selection_rect(&self, start: usize, end: usize) -> Option<AccessRect> {
+        let character_count = self.character_count();
+        let start = start.min(character_count);
+        let end = end.min(character_count);
+        if start >= end {
+            return None;
+        }
+
+        self.character_bounds
+            .iter()
+            .skip(start)
+            .take(end - start)
+            .copied()
+            .reduce(access_rect_union)
+    }
+
+    fn text_slice(&self, start: usize, end: usize) -> &str {
+        let character_count = self.character_count();
+        let start = start.min(character_count);
+        let end = end.min(character_count);
+        if start >= end {
+            return "";
+        }
+
+        let start_byte = char_to_byte_index(&self.text, start);
+        let end_byte = char_to_byte_index(&self.text, end);
+        &self.text[start_byte..end_byte]
+    }
+}
+
+/// A position inside the page text semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageTextPosition {
+    /// Index into [`PageAccessibility::text_runs`].
+    pub run_index: usize,
+    /// Character index inside the run.
+    pub character_index: usize,
+}
+
+/// A text selection inside the page text semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageTextSelection {
+    /// Fixed end of the selection.
+    pub anchor: PageTextPosition,
+    /// Active end of the selection.
+    pub focus: PageTextPosition,
+}
+
+impl PageTextSelection {
+    /// Creates a collapsed selection at a text position.
+    pub fn collapsed(position: PageTextPosition) -> Self {
+        Self {
+            anchor: position,
+            focus: position,
+        }
+    }
+
+    /// Returns whether the selection is collapsed.
+    pub fn is_collapsed(self) -> bool {
+        self.anchor == self.focus
+    }
+
+    fn normalized(self) -> Option<(PageTextPosition, PageTextPosition)> {
+        if self.is_collapsed() {
+            None
+        } else if self.anchor <= self.focus {
+            Some((self.anchor, self.focus))
+        } else {
+            Some((self.focus, self.anchor))
+        }
+    }
+}
+
 fn scaled_access_node(node: &Node, scale: f64) -> Node {
     let mut node = node.clone();
     if scale != 1.0
         && let Some(bounds) = node.bounds()
     {
-        node.set_bounds(transform_access_rect_bbox(Affine::scale(scale), bounds));
+        node.set_bounds(scale_access_rect(bounds, scale));
     }
     node
 }
 
+fn scale_access_rect(rect: AccessRect, scale: f64) -> AccessRect {
+    if scale == 1.0 {
+        rect
+    } else {
+        transform_access_rect_bbox(Affine::scale(scale), rect)
+    }
+}
+
 fn access_rect_contains(rect: AccessRect, point: Point) -> bool {
     point.x >= rect.x0 && point.x < rect.x1 && point.y >= rect.y0 && point.y < rect.y1
+}
+
+fn access_rect_union(a: AccessRect, b: AccessRect) -> AccessRect {
+    AccessRect::new(
+        a.x0.min(b.x0),
+        a.y0.min(b.y0),
+        a.x1.max(b.x1),
+        a.y1.max(b.y1),
+    )
+}
+
+fn split_access_rect_horizontally(rect: AccessRect, count: usize) -> EcoVec<AccessRect> {
+    if count == 0 {
+        return EcoVec::new();
+    }
+
+    let width = rect.width() / count as f64;
+    (0..count)
+        .map(|index| {
+            let x0 = rect.x0 + width * index as f64;
+            AccessRect::new(x0, rect.y0, x0 + width, rect.y1)
+        })
+        .collect()
+}
+
+fn char_to_byte_index(text: &str, character_index: usize) -> usize {
+    text.char_indices()
+        .nth(character_index)
+        .map_or(text.len(), |(byte_index, _)| byte_index)
 }
 
 /// A scene that can be rendered to a [`vello::Scene`].
@@ -235,6 +557,8 @@ pub enum GroupSceneItem {
     },
     /// An AccessKit node associated with the group.
     Accessibility(Node),
+    /// A selectable text run associated with the group.
+    Text(PageTextRun),
 }
 
 impl GroupScene {
@@ -277,6 +601,9 @@ impl GroupScene {
                         node.set_bounds(transform_access_rect_bbox(transform, bounds));
                     }
                     accessibility.push_node(node);
+                }
+                GroupSceneItem::Text(text_run) => {
+                    accessibility.push_text_run(text_run.transformed(transform));
                 }
             }
         }
@@ -418,6 +745,67 @@ mod tests {
                 .page_accessibility()
                 .hit_test_link(Point::new(10.0, 10.0)),
             Some("https://top.example")
+        );
+    }
+
+    #[test]
+    fn page_accessibility_collects_transformed_text_runs() {
+        let text_run = PageTextRun::new(
+            "hi",
+            access_rect(0.0, 0.0, 20.0, 10.0),
+            [
+                access_rect(0.0, 0.0, 10.0, 10.0),
+                access_rect(10.0, 0.0, 20.0, 10.0),
+            ],
+        );
+
+        let mut items = EcoVec::new();
+        items.push(GroupSceneItem::Text(text_run));
+        let scene = VecScene::Group(GroupScene {
+            clip: None,
+            ts: Affine::translate((5.0, 10.0)) * Affine::scale(2.0),
+            items,
+        });
+
+        let accessibility = scene.page_accessibility();
+        let [run] = accessibility.text_runs() else {
+            panic!("expected one text run");
+        };
+        assert_eq!(run.text(), "hi");
+        assert_eq!(run.bounds(), access_rect(5.0, 10.0, 45.0, 30.0));
+        assert_eq!(
+            run.character_bounds(),
+            &[
+                access_rect(5.0, 10.0, 25.0, 30.0),
+                access_rect(25.0, 10.0, 45.0, 30.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn page_accessibility_selects_text_by_page_point() {
+        let mut accessibility = PageAccessibility::default();
+        accessibility.push_text_run(PageTextRun::new(
+            "hello",
+            access_rect(0.0, 0.0, 50.0, 10.0),
+            (0..5).map(|index| {
+                let x0 = index as f64 * 10.0;
+                access_rect(x0, 0.0, x0 + 10.0, 10.0)
+            }),
+        ));
+
+        let anchor = accessibility
+            .hit_test_text(Point::new(1.0, 5.0))
+            .expect("left edge should hit text");
+        let focus = accessibility
+            .hit_test_text(Point::new(49.0, 5.0))
+            .expect("right edge should hit text");
+        let selection = PageTextSelection { anchor, focus };
+
+        assert_eq!(accessibility.selected_text(selection), "hello");
+        assert_eq!(
+            accessibility.selection_rects(selection),
+            [access_rect(0.0, 0.0, 50.0, 10.0)]
         );
     }
 }

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -281,7 +281,7 @@ impl PreviewState {
             .map(|(idx, page)| {
                 let tx = self.tx.clone();
                 let page_scene = page.scene.clone();
-                let page_semantics = page.semantics.clone();
+                let page_accessibility = Arc::new(page.accessibility.clone());
                 let background_color = self.background_color;
                 let width = page.size.width;
                 let height = page.size.height;
@@ -298,32 +298,39 @@ impl PreviewState {
                 };
                 let elem_height = elem_scale * height;
                 // The sized box is necessary to avoid collapsing the canvas.
-                sized_box(doc(
-                    page_scene,
-                    elem_scale,
-                    background_color,
-                    move |pos, bbox| {
-                        if bbox.width() == 0. || bbox.height() == 0. {
-                            return;
-                        }
-
-                        let x = pos.x / bbox.width() * width;
-                        let y = pos.y / bbox.height() * height;
-
-                        if let Some(link) = page_semantics.hit_test_link(Point::new(x, y))
-                            && open_supported_external_link(&link.href)
+                sized_box(
+                    doc(
+                        page_scene,
+                        elem_scale,
+                        background_color,
                         {
-                            return;
-                        }
+                            let page_accessibility = page_accessibility.clone();
+                            move |pos, bbox| {
+                                if bbox.width() == 0. || bbox.height() == 0. {
+                                    return;
+                                }
 
-                        let _ = tx.send(PreviewEvent::Click {
-                            page_idx: idx + 1,
-                            x: x as f32,
-                            y: y as f32,
-                        });
-                    },
-                    |state: &mut PreviewState, action| state.apply_zoom(action),
-                ))
+                                let x = pos.x / bbox.width() * width;
+                                let y = pos.y / bbox.height() * height;
+
+                                if let Some(href) =
+                                    page_accessibility.hit_test_link(Point::new(x, y))
+                                    && open_supported_external_link(href)
+                                {
+                                    return;
+                                }
+
+                                let _ = tx.send(PreviewEvent::Click {
+                                    page_idx: idx + 1,
+                                    x: x as f32,
+                                    y: y as f32,
+                                });
+                            }
+                        },
+                        |state: &mut PreviewState, action| state.apply_zoom(action),
+                    )
+                    .accessibility(page_accessibility),
+                )
                 .fixed_width(Length::const_px(elem_width))
                 .fixed_height(Length::const_px(elem_height))
             })
@@ -686,7 +693,7 @@ impl ezsockets::ClientExt for Client {
 
             self.doc.merge_delta(delta);
 
-            let pages = match self.vello.render_pages_with_semantics(&mut self.doc) {
+            let pages = match self.vello.render_pages_with_accessibility(&mut self.doc) {
                 Ok(scene) => scene,
                 Err(err) => {
                     log::error!("Error rendering pages: {err}");

--- a/crates/tinymist-viewer/src/render.rs
+++ b/crates/tinymist-viewer/src/render.rs
@@ -32,7 +32,7 @@ use vello::{
 };
 
 use crate::{
-    GroupScene, GroupSceneItem, PageAccessibility, SvgResource, SvgResourceFormat,
+    GroupScene, GroupSceneItem, PageAccessibility, PageTextRun, SvgResource, SvgResourceFormat,
     SvgResourceResolver, VecScene,
 };
 
@@ -72,6 +72,7 @@ impl<'m> RenderVm<'m> for Renderer<'m> {
             ts: Affine::IDENTITY,
             clipper: None,
             glyph_style: None,
+            pending_text: None,
             items: EcoVec::new(),
         }
     }
@@ -84,6 +85,9 @@ impl<'m> RenderVm<'m> for Renderer<'m> {
             .map(|font| f64::from(font.units_per_em.0) / f64::from(text.shape.size.0))
             .filter(|scale| scale.is_finite())
             .unwrap_or(1.0);
+        if let Some(font) = self.get_font(&text.shape.font) {
+            g.pending_text = text_run_for_item(text, font);
+        }
         g.glyph_style = Some(resolve_draw_style(self, &text.shape.styles, stroke_scale));
         g
     }
@@ -150,6 +154,8 @@ pub struct RenderStack {
     pub clipper: Option<ir::PathItem>,
     /// The draw style for glyph outlines in text groups.
     glyph_style: Option<DrawStyle>,
+    /// Text semantics emitted after the text transform is applied.
+    pending_text: Option<PageTextRun>,
     /// The ordered visual and semantic items.
     pub items: EcoVec<GroupSceneItem>,
     // /// The bounding box of the group.
@@ -163,13 +169,115 @@ pub enum GroupKind {
 }
 
 impl From<RenderStack> for Arc<VecScene> {
-    fn from(s: RenderStack) -> Self {
+    fn from(mut s: RenderStack) -> Self {
+        if let Some(text_run) = s.pending_text.take() {
+            s.items.push(GroupSceneItem::Text(text_run));
+        }
         Arc::new(VecScene::Group(GroupScene {
             // todo: detect whether there is a failure converting paths.
             clip: s.clipper.and_then(|it| svg_path(&it.d)),
             ts: s.ts,
             items: s.items,
         }))
+    }
+}
+
+fn text_run_for_item(text: &ir::TextItem, font: &FontItem) -> Option<PageTextRun> {
+    let content = text.content.content.as_ref();
+    if content.is_empty() || text.shape.size.0 == 0.0 || font.units_per_em.0 == 0.0 {
+        return None;
+    }
+
+    let upem = font.units_per_em.0 as f64;
+    let inv_ppem = upem / text.shape.size.0 as f64;
+    if !inv_ppem.is_finite() {
+        return None;
+    }
+
+    let ascender = font.ascender.0 as f64 * upem;
+    let descender = font.descender.0 as f64 * upem;
+    let y0 = descender.min(ascender);
+    let y1 = descender.max(ascender);
+    if y0 == y1 {
+        return None;
+    }
+
+    let width = text.width().0 as f64 * inv_ppem;
+    if width <= 0.0 || !width.is_finite() {
+        return None;
+    }
+
+    let character_count = content.chars().count();
+    if character_count == 0 {
+        return None;
+    }
+
+    let mut character_bounds = text_run_character_bounds(text, font, inv_ppem, y0, y1);
+    if character_bounds.len() != character_count {
+        character_bounds = evenly_spaced_character_bounds(character_count, width, y0, y1);
+    }
+
+    Some(PageTextRun::new(
+        content,
+        masonry::accesskit::Rect::new(0.0, y0, width, y1),
+        character_bounds,
+    ))
+}
+
+fn text_run_character_bounds(
+    text: &ir::TextItem,
+    font: &FontItem,
+    inv_ppem: f64,
+    y0: f64,
+    y1: f64,
+) -> Vec<masonry::accesskit::Rect> {
+    let character_count = text.content.content.chars().count();
+    let mut character_bounds = Vec::with_capacity(character_count);
+    let mut remaining = character_count;
+    let mut cursor = 0.0;
+
+    for (_, advance, glyph) in text.content.glyphs.iter() {
+        if remaining == 0 {
+            break;
+        }
+
+        let cluster_len = glyph_ligature_len(font, *glyph).clamp(1, remaining);
+        let advance = advance.x.0 as f64 * inv_ppem;
+        if !advance.is_finite() {
+            return Vec::new();
+        }
+        let character_advance = advance / cluster_len as f64;
+        for _ in 0..cluster_len {
+            let next = cursor + character_advance;
+            character_bounds.push(masonry::accesskit::Rect::new(cursor, y0, next, y1));
+            cursor = next;
+        }
+        remaining -= cluster_len;
+    }
+
+    character_bounds
+}
+
+fn evenly_spaced_character_bounds(
+    character_count: usize,
+    width: f64,
+    y0: f64,
+    y1: f64,
+) -> Vec<masonry::accesskit::Rect> {
+    let character_width = width / character_count as f64;
+    (0..character_count)
+        .map(|index| {
+            let x0 = character_width * index as f64;
+            masonry::accesskit::Rect::new(x0, y0, x0 + character_width, y1)
+        })
+        .collect()
+}
+
+fn glyph_ligature_len(font: &FontItem, glyph: u32) -> usize {
+    match font.get_glyph(glyph).map(|glyph| glyph.as_ref()) {
+        Some(ir::FlatGlyphItem::Image(glyph)) => glyph.ligature_len.into(),
+        Some(ir::FlatGlyphItem::Outline(glyph)) => glyph.ligature_len.into(),
+        Some(ir::FlatGlyphItem::None) | None => 1,
     }
 }
 

--- a/crates/tinymist-viewer/src/render.rs
+++ b/crates/tinymist-viewer/src/render.rs
@@ -32,7 +32,8 @@ use vello::{
 };
 
 use crate::{
-    GroupScene, SemanticLink, SvgResource, SvgResourceFormat, SvgResourceResolver, VecScene,
+    GroupScene, GroupSceneItem, PageAccessibility, SvgResource, SvgResourceFormat,
+    SvgResourceResolver, VecScene,
 };
 
 pub struct Renderer<'a> {
@@ -71,8 +72,7 @@ impl<'m> RenderVm<'m> for Renderer<'m> {
             ts: Affine::IDENTITY,
             clipper: None,
             glyph_style: None,
-            inner: EcoVec::new(),
-            semantic_links: EcoVec::new(),
+            items: EcoVec::new(),
         }
     }
 
@@ -150,10 +150,8 @@ pub struct RenderStack {
     pub clipper: Option<ir::PathItem>,
     /// The draw style for glyph outlines in text groups.
     glyph_style: Option<DrawStyle>,
-    /// The inner elements.
-    pub inner: EcoVec<(Vec2, Arc<VecScene>)>,
-    /// Semantic links in this group.
-    pub semantic_links: EcoVec<SemanticLink>,
+    /// The ordered visual and semantic items.
+    pub items: EcoVec<GroupSceneItem>,
     // /// The bounding box of the group.
     // pub rect: CanvasBBox,
 }
@@ -170,8 +168,7 @@ impl From<RenderStack> for Arc<VecScene> {
             // todo: detect whether there is a failure converting paths.
             clip: s.clipper.and_then(|it| svg_path(&it.d)),
             ts: s.ts,
-            scenes: s.inner,
-            semantic_links: s.semantic_links,
+            items: s.items,
         }))
     }
 }
@@ -224,10 +221,10 @@ impl<'m, C: RenderVm<'m, Resultant = Arc<VecScene>> + GlyphFactory> GroupContext
         let style = resolve_draw_style(ctx, &path.styles, 1.0);
         render_path_with_style(ctx, &mut scene, &path_data, &style);
 
-        self.inner.push((
-            Vec2::new(0., 0.),
-            Arc::new(VecScene::Scene(Box::new(scene), None)),
-        ));
+        self.items.push(GroupSceneItem::Scene {
+            pos: Vec2::new(0., 0.),
+            scene: Arc::new(VecScene::Scene(Box::new(scene), None)),
+        });
     }
 
     fn render_link(&mut self, _ctx: &mut C, link: &ir::LinkItem) {
@@ -235,10 +232,16 @@ impl<'m, C: RenderVm<'m, Resultant = Arc<VecScene>> + GlyphFactory> GroupContext
             return;
         }
 
-        self.semantic_links.push(SemanticLink::new(
-            link.href.as_ref(),
-            Rect::from_origin_size((0.0, 0.0), (link.size.x.0 as f64, link.size.y.0 as f64)),
-        ));
+        self.items
+            .push(GroupSceneItem::Accessibility(PageAccessibility::link_node(
+                link.href.as_ref(),
+                masonry::accesskit::Rect {
+                    x0: 0.0,
+                    y0: 0.0,
+                    x1: link.size.x.0 as f64,
+                    y1: link.size.y.0 as f64,
+                },
+            )));
     }
 
     fn render_image(&mut self, ctx: &mut C, image_item: &ir::ImageItem) {
@@ -255,17 +258,17 @@ impl<'m, C: RenderVm<'m, Resultant = Arc<VecScene>> + GlyphFactory> GroupContext
             return;
         };
 
-        self.inner.push((
-            Vec2::new(0., 0.),
-            Arc::new(VecScene::Scene(Box::new(scene), Some(transform))),
-        ));
+        self.items.push(GroupSceneItem::Scene {
+            pos: Vec2::new(0., 0.),
+            scene: Arc::new(VecScene::Scene(Box::new(scene), Some(transform))),
+        });
     }
 
     fn render_item_at(&mut self, ctx: &mut C, pos: ir::Point, item: &Fingerprint) {
-        self.inner.push((
-            Vec2::new(pos.x.0 as f64, pos.y.0 as f64),
-            ctx.render_item(item),
-        ));
+        self.items.push(GroupSceneItem::Scene {
+            pos: Vec2::new(pos.x.0 as f64, pos.y.0 as f64),
+            scene: ctx.render_item(item),
+        });
     }
 
     fn render_glyph(&mut self, ctx: &mut C, pos: Axes<Scalar>, font: &FontItem, glyph: u32) {
@@ -273,7 +276,7 @@ impl<'m, C: RenderVm<'m, Resultant = Arc<VecScene>> + GlyphFactory> GroupContext
         if let Some(style) = &self.glyph_style
             && let Some(glyph) = ctx.get_glyph(font, glyph, style, pos)
         {
-            self.inner.push((pos, glyph));
+            self.items.push(GroupSceneItem::Scene { pos, scene: glyph });
         }
     }
 }


### PR DESCRIPTION

- add synthetic AccessKit semantics for native viewer pages, including link nodes and text runs
- make native viewer links feel interactive with pointer cursor hit-testing and click handling
- support text hit-testing, drag selection, selection highlighting, and copy shortcuts in `tinymist-viewer`
- add renderer/incremental coverage for preserving page accessibility metadata across rendered pages
- add the synthetic AccessKit tree benchmark and document the current Masonry/Xilem accessibility approach
