### PR TITLE
feat: improve native viewer window state

### DIFF
--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -167,7 +167,7 @@ async function windowLaunchPlanForTask(
     }
 
     return {
-      initialWindowState: sideBySideState ?? storedWindowState,
+      initialWindowState: sideBySideState,
       repairSideBySideLayout: true,
     };
   }

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -167,7 +167,7 @@ async function windowLaunchPlanForTask(
     }
 
     return {
-      initialWindowState: sideBySideState,
+      initialWindowState: sideBySideState ?? storedWindowState,
       repairSideBySideLayout: true,
     };
   }

--- a/openspec/changes/improve-viewer-window-state/.openspec.yaml
+++ b/openspec/changes/improve-viewer-window-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/improve-viewer-window-state/README.md
+++ b/openspec/changes/improve-viewer-window-state/README.md
@@ -1,0 +1,3 @@
+# improve-viewer-window-state
+
+Improve native viewer fit-to-window layout and remember the last viewer window state.

--- a/openspec/changes/improve-viewer-window-state/design.md
+++ b/openspec/changes/improve-viewer-window-state/design.md
@@ -1,0 +1,53 @@
+## Overview
+
+The current viewer already knows the preview content area size through `resize_observer`, which is enough for page fit. The visible gap comes from fitting pages to `window_width - 0.5`; this was intended to avoid a stray scrollbar but now creates a persistent half-pixel inset in side-by-side layouts.
+
+Window state reporting needs lower-level window events than the Xilem app-state callback exposes. Xilem supports an external event-loop integration, so `tinymist-viewer` can wrap the normal Masonry/Xilem driver in a small `ApplicationHandler` that observes winit `Moved` and `Resized` events before delegating them to Masonry.
+
+## Window State
+
+The viewer does not own durable storage. The launching client owns persistence and passes any restored geometry back to the viewer on the next launch.
+
+Viewer startup accepts:
+
+- `--initial-window-inner-size WIDTHxHEIGHT`
+- `--initial-window-position X,Y`
+
+The native viewer already connects to tinymist server's preview data-plane websocket. After accepted move/resize events, it sends one text command over that existing connection:
+
+```text
+viewer-window-state {"schema_version":1,"window":{"inner_width":1280,"inner_height":900,"outer_x":24,"outer_y":48}}
+```
+
+Event payload:
+
+- physical inner size from `WindowEvent::Resized`
+- physical outer position from `WindowEvent::Moved`
+- `schema_version: 1`
+
+Restore:
+
+- initial inner size through `WindowOptions::with_initial_inner_size`
+- initial position through `WindowOptions::with_initial_position`
+
+Tinymist server receives the data-plane text command in `WebviewActor`, forwards it to the internal preview editor actor, and then sends a `tinymist/preview/windowState` LSP notification to the editor client. The VS Code preview integration stores schema-versioned records in `ExtensionContext.globalState` under a versioned key and passes the restored initial state to the configured previewer on the next launch. This avoids inventing cross-process file locking in the viewer and lets multiple same-version viewer processes converge through the client's storage semantics. Multiple viewer/client versions are isolated by `schema_version` and the versioned storage key; an incompatible future schema should use a new key or ignore mismatched records.
+
+Neovim and other clients can implement their own persistence later by passing the same initial geometry arguments and consuming the server-forwarded window-state notification.
+
+## Side-by-side Startup
+
+When `tinymist.gpuViewer.windowLayout` is `sideBySide`, side-by-side layout is the launch strategy. The VS Code provider should try to compute the right-half work-area rectangle and move the VS Code window to the left half before spawning `tinymist-viewer`. The computed right-half rectangle is passed as the viewer's initial size and position so the operating system can create the viewer close to the final side-by-side layout.
+
+Stored window state must not suppress the side-by-side script, because viewer window-state persistence will normally produce a stored record after the first launch. In side-by-side mode, stored state is only a fallback if pre-layout fails before spawn. When `tinymist.gpuViewer.windowLayout` is `disabled`, stored state is the primary initial geometry.
+
+The existing post-spawn arrangement remains as a repair pass in side-by-side mode because native window managers can apply decorations, minimum sizes, DPI conversions, and placement policies differently from the requested initial geometry. If pre-layout fails, the provider falls back to stored state or default placement and still performs the post-spawn repair pass.
+
+## Fit Width
+
+`fitted_page_width` should return the finite available viewport width directly. This removes the fractional blank column while keeping invalid sizes clamped to at least one logical pixel.
+
+If future floating-point rounding causes a stray scrollbar, that should be handled in the scroll container's overflow tolerance rather than by shrinking the rendered page.
+
+## Lifecycle
+
+Window state messages are sent immediately after accepted move/resize events so process termination from the preview provider still leaves a recent state in client storage. Very small resize values are ignored to avoid persisting minimized or transient zero-sized states.

--- a/openspec/changes/improve-viewer-window-state/design.md
+++ b/openspec/changes/improve-viewer-window-state/design.md
@@ -32,15 +32,17 @@ Restore:
 
 Tinymist server receives the data-plane text command in `WebviewActor`, forwards it to the internal preview editor actor, and then sends a `tinymist/preview/windowState` LSP notification to the editor client. The VS Code preview integration stores schema-versioned records in `ExtensionContext.globalState` under a versioned key and passes the restored initial state to the configured previewer on the next launch. This avoids inventing cross-process file locking in the viewer and lets multiple same-version viewer processes converge through the client's storage semantics. Multiple viewer/client versions are isolated by `schema_version` and the versioned storage key; an incompatible future schema should use a new key or ignore mismatched records.
 
+Resize and move gestures can emit many window-state notifications quickly. The VS Code preview integration serializes `globalState` writes in notification arrival order so slower earlier storage writes cannot overwrite a later resize state.
+
 Neovim and other clients can implement their own persistence later by passing the same initial geometry arguments and consuming the server-forwarded window-state notification.
 
 ## Side-by-side Startup
 
-When `tinymist.gpuViewer.windowLayout` is `sideBySide`, side-by-side layout is the launch strategy. The VS Code provider should try to compute the right-half work-area rectangle and move the VS Code window to the left half before spawning `tinymist-viewer`. The computed right-half rectangle is passed as the viewer's initial size and position so the operating system can create the viewer close to the final side-by-side layout.
+When `tinymist.gpuViewer.windowLayout` is `sideBySide`, the VS Code provider should try to prepare the desktop before spawning `tinymist-viewer`. Pre-layout moves VS Code to the left half and computes the right-half work-area rectangle. This keeps the side-by-side script active even after viewer state persistence has produced a stored record.
 
-Stored window state must not suppress the side-by-side script, because viewer window-state persistence will normally produce a stored record after the first launch. In side-by-side mode, stored state is only a fallback if pre-layout fails before spawn. When `tinymist.gpuViewer.windowLayout` is `disabled`, stored state is the primary initial geometry.
+When a valid stored viewer state exists, that stored state remains the viewer's initial geometry because it represents the user's last accepted resize/move. In that path, the provider skips the post-spawn viewer repair pass so the repair script does not overwrite the restored viewer geometry.
 
-The existing post-spawn arrangement remains as a repair pass in side-by-side mode because native window managers can apply decorations, minimum sizes, DPI conversions, and placement policies differently from the requested initial geometry. If pre-layout fails, the provider falls back to stored state or default placement and still performs the post-spawn repair pass.
+When no valid stored viewer state exists, the computed right-half rectangle is passed as the viewer's initial size and position so the operating system can create the viewer close to the final side-by-side layout. The existing post-spawn arrangement remains as a repair pass in this no-stored-state path because native window managers can apply decorations, minimum sizes, DPI conversions, and placement policies differently from the requested initial geometry. If pre-layout fails and no stored state exists, the provider falls back to default placement and still performs the post-spawn repair pass.
 
 ## Fit Width
 

--- a/openspec/changes/improve-viewer-window-state/proposal.md
+++ b/openspec/changes/improve-viewer-window-state/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The native GPU viewer is now commonly launched as a side-by-side preview window. Its fit-to-window page layout still leaves a small visible gap, and every new viewer process starts from the default placement instead of the user's last working window shape.
+
+## What Changes
+
+- Make the viewer's automatic fit-width layout use the full available viewport width instead of keeping a fractional inset.
+- Let editor clients persist the native viewer's last usable window size and position in their own storage.
+- Add `tinymist-viewer` startup arguments for initial window size and position.
+- Reuse the existing preview server path so `tinymist-viewer` can report valid window changes to tinymist server through a schema-versioned `viewer-window-state` data-plane message; tinymist server then forwards the state to the editor client.
+- In the VS Code preview integration, use `globalState` for schema-versioned window state and pre-arrange side-by-side geometry before spawning the viewer when possible.
+
+## Capabilities
+
+### New Capabilities
+
+- `native-viewer-window-state`: Native GPU viewer fit-to-window behavior, client-owned last-window-state persistence, and initial side-by-side placement.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `crates/tinymist-viewer/src/main.rs` will accept initial geometry, observe native movement and resize events, and send schema-versioned `viewer-window-state` text messages over its existing data-plane websocket.
+- `crates/typst-preview`, `crates/tinymist`, and `editors/vscode` will forward the viewer window-state message from tinymist server to the VS Code extension storage layer.
+- `contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts` will accept initial window state from the main preview task and attempt side-by-side pre-layout before launching the viewer.
+- Validation should include targeted Rust tests, VS Code provider type-checking, and formatting checks.

--- a/openspec/changes/improve-viewer-window-state/specs/native-viewer-window-state/spec.md
+++ b/openspec/changes/improve-viewer-window-state/specs/native-viewer-window-state/spec.md
@@ -57,6 +57,12 @@ The VS Code preview integration SHALL persist and restore viewer window state th
 - **WHEN** the preview integration receives a valid schema-versioned viewer window-state notification from tinymist server
 - **THEN** the integration writes that state to VS Code extension storage for future launches
 
+#### Scenario: Rapid resize updates are stored in notification order
+
+- **WHEN** the preview integration receives multiple valid viewer window-state notifications from one resize gesture
+- **AND** earlier extension-storage writes complete slower than later writes
+- **THEN** the stored viewer window state still reflects the latest notification arrival order
+
 #### Scenario: Positionless updates preserve stored position
 
 - **WHEN** VS Code extension storage contains a valid viewer window-state record with position
@@ -73,16 +79,18 @@ The VS Code preview integration SHALL persist and restore viewer window state th
 
 The VS Code GPU viewer provider SHALL attempt to prepare side-by-side geometry before spawning the native viewer when side-by-side layout is enabled.
 
-#### Scenario: Side-by-side layout has priority over stored state
+#### Scenario: Stored state keeps viewer geometry while pre-layout still runs
 
 - **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
 - **AND** VS Code extension storage contains a valid schema-versioned viewer window-state record
 - **THEN** the provider still attempts side-by-side pre-layout before launch
-- **AND** still schedules the post-spawn side-by-side repair pass
+- **AND** passes the stored geometry as the viewer's initial window size and position
+- **AND** skips the post-spawn viewer layout repair pass
 
 #### Scenario: Side-by-side pre-layout succeeds
 
 - **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
+- **AND** no valid stored viewer window state is available
 - **AND** the provider can compute and apply the platform work-area split before launch
 - **THEN** the provider moves VS Code to the left side
 - **AND** passes the right-side rectangle as the viewer's initial window size and position
@@ -90,6 +98,7 @@ The VS Code GPU viewer provider SHALL attempt to prepare side-by-side geometry b
 #### Scenario: Side-by-side pre-layout fails
 
 - **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
+- **AND** no valid stored viewer window state is available
 - **AND** the provider cannot compute or apply side-by-side geometry before launch
-- **THEN** the provider falls back to stored window state or default placement
+- **THEN** the provider falls back to default placement
 - **AND** the post-spawn side-by-side repair pass can still arrange the windows

--- a/openspec/changes/improve-viewer-window-state/specs/native-viewer-window-state/spec.md
+++ b/openspec/changes/improve-viewer-window-state/specs/native-viewer-window-state/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Native viewer fit-width layout uses the full viewport width
+
+The native GPU viewer SHALL fit pages to the available viewer viewport width without leaving an intentional fractional inset.
+
+#### Scenario: Finite viewport width is preserved
+
+- **WHEN** the viewer computes automatic fit width for a finite viewport width
+- **THEN** the fit width equals that viewport width clamped only by the minimum supported width
+
+#### Scenario: Invalid viewport width remains safe
+
+- **WHEN** the viewer computes automatic fit width for a non-finite viewport width
+- **THEN** the fit width falls back to a safe positive width
+
+### Requirement: Native viewer accepts initial window state
+
+The native GPU viewer SHALL accept client-provided initial window size and position and apply them to the native window attributes at startup.
+
+#### Scenario: Client-provided state is applied on launch
+
+- **WHEN** `tinymist-viewer` starts with `--initial-window-inner-size WIDTHxHEIGHT`
+- **AND** `--initial-window-position X,Y` is provided
+- **THEN** the viewer applies that inner size and position to the initial native window attributes
+
+### Requirement: Native viewer reports window state changes through tinymist server
+
+The native GPU viewer SHALL report valid window movement and resize changes to tinymist server through the existing preview data-plane websocket, and tinymist server SHALL forward the latest state to the editor client.
+
+#### Scenario: Window changes are emitted
+
+- **WHEN** `tinymist-viewer` is connected to the preview data-plane server
+- **AND** the native viewer window is moved or resized to a valid size
+- **THEN** the viewer sends a `viewer-window-state` text message with `schema_version: 1` and the latest window geometry to tinymist server
+- **AND** tinymist server forwards the state to the editor client
+
+#### Scenario: Direct viewer launches do not require a client
+
+- **WHEN** `tinymist-viewer` starts without a reachable preview data-plane server
+- **AND** the native viewer window is moved or resized
+- **THEN** the viewer keeps running without requiring client-owned window-state persistence
+
+### Requirement: VS Code preview integration owns window state persistence
+
+The VS Code preview integration SHALL persist and restore viewer window state through VS Code extension storage instead of a viewer-owned state file.
+
+#### Scenario: Stored state is restored on launch
+
+- **WHEN** VS Code extension storage contains a valid schema-versioned viewer window-state record
+- **AND** the GPU viewer provider launches `tinymist-viewer` through the previewer task contract
+- **THEN** the preview integration passes the stored geometry to the provider
+- **AND** the provider passes the geometry through the viewer's initial window arguments
+
+#### Scenario: Server-forwarded window messages update extension storage
+
+- **WHEN** the preview integration receives a valid schema-versioned viewer window-state notification from tinymist server
+- **THEN** the integration writes that state to VS Code extension storage for future launches
+
+#### Scenario: Positionless updates preserve stored position
+
+- **WHEN** VS Code extension storage contains a valid viewer window-state record with position
+- **AND** the preview integration receives a valid window-state notification with size but without position
+- **THEN** the integration updates the stored size
+- **AND** keeps the previous stored position
+
+#### Scenario: Incompatible stored state is ignored
+
+- **WHEN** the stored viewer window-state record has an unsupported schema version or invalid geometry
+- **THEN** the provider ignores the record and launches the viewer without that stored geometry
+
+### Requirement: VS Code side-by-side launch pre-arranges windows
+
+The VS Code GPU viewer provider SHALL attempt to prepare side-by-side geometry before spawning the native viewer when side-by-side layout is enabled.
+
+#### Scenario: Side-by-side layout has priority over stored state
+
+- **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
+- **AND** VS Code extension storage contains a valid schema-versioned viewer window-state record
+- **THEN** the provider still attempts side-by-side pre-layout before launch
+- **AND** still schedules the post-spawn side-by-side repair pass
+
+#### Scenario: Side-by-side pre-layout succeeds
+
+- **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
+- **AND** the provider can compute and apply the platform work-area split before launch
+- **THEN** the provider moves VS Code to the left side
+- **AND** passes the right-side rectangle as the viewer's initial window size and position
+
+#### Scenario: Side-by-side pre-layout fails
+
+- **WHEN** `tinymist.gpuViewer.windowLayout` is `sideBySide`
+- **AND** the provider cannot compute or apply side-by-side geometry before launch
+- **THEN** the provider falls back to stored window state or default placement
+- **AND** the post-spawn side-by-side repair pass can still arrange the windows

--- a/openspec/changes/improve-viewer-window-state/tasks.md
+++ b/openspec/changes/improve-viewer-window-state/tasks.md
@@ -15,8 +15,9 @@
 - [x] 3.3 Store and restore window state in the VS Code preview integration with `globalState`.
 - [x] 3.4 Add side-by-side pre-layout before spawning the viewer, with post-spawn repair retained.
 - [x] 3.5 Add targeted tests for geometry parsing, validation, and window-state payloads.
-- [x] 3.6 Keep side-by-side layout active even when stored window state exists.
+- [x] 3.6 Keep side-by-side pre-layout active while preserving stored viewer geometry.
 - [x] 3.7 Preserve stored window position across positionless size updates.
+- [x] 3.8 Serialize VS Code window-state storage writes in notification order.
 
 ## 4. Validation
 

--- a/openspec/changes/improve-viewer-window-state/tasks.md
+++ b/openspec/changes/improve-viewer-window-state/tasks.md
@@ -1,0 +1,25 @@
+## 1. OpenSpec
+
+- [x] 1.1 Add proposal, design, tasks, and native-viewer-window-state spec.
+- [x] 1.2 Update artifacts for client-owned storage, server-forwarded viewer window-state messages, and side-by-side pre-layout.
+
+## 2. Viewer Layout
+
+- [x] 2.1 Remove the fractional fit-width inset so auto-fit pages occupy the full viewer viewport.
+- [x] 2.2 Add targeted tests for fit-width behavior.
+
+## 3. Window State Persistence
+
+- [x] 3.1 Add viewer CLI arguments for initial window size and position.
+- [x] 3.2 Observe native move/resize events and send schema-versioned window-state messages through tinymist server.
+- [x] 3.3 Store and restore window state in the VS Code preview integration with `globalState`.
+- [x] 3.4 Add side-by-side pre-layout before spawning the viewer, with post-spawn repair retained.
+- [x] 3.5 Add targeted tests for geometry parsing, validation, and window-state payloads.
+- [x] 3.6 Keep side-by-side layout active even when stored window state exists.
+- [x] 3.7 Preserve stored window position across positionless size updates.
+
+## 4. Validation
+
+- [x] 4.1 Run targeted `tinymist-viewer` tests.
+- [x] 4.2 Run VS Code GPU viewer type-checking.
+- [x] 4.3 Run formatting and diff checks.


### PR DESCRIPTION
- add a decorationless native title bar with window controls and document-specific titles
- persist and restore the GPU viewer's last usable window size and position
- remove the fractional fit-width inset so pages use the full available viewport
- keep viewport and scrollbar painting aligned with the new native window chrome
