### PR TITLE
feat(viewer): add native window title bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,6 +7033,7 @@ dependencies = [
  "typst-syntax 0.14.2",
  "vello",
  "walkdir",
+ "windows-sys 0.61.2",
  "winit",
  "xilem",
 ]

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -35,6 +35,13 @@ interface TinymistPreviewerProvider {
   providePreviewer(): Promise<TinymistPreviewer> | TinymistPreviewer;
 }
 
+interface WindowRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 let outputChannel: vscode.OutputChannel | undefined;
 const activeViewers = new Map<string, ChildProcessWithoutNullStreams>();
 
@@ -68,14 +75,17 @@ export function activate(context: vscode.ExtensionContext): TinymistPreviewerPro
 
 export function deactivate() {}
 
-function launchViewer(
+async function launchViewer(
   context: vscode.ExtensionContext,
   task: TinymistPreviewTask,
-): vscode.Disposable {
+): Promise<vscode.Disposable> {
   activeViewers.get(task.taskId)?.kill();
 
   const executable = resolveViewerExecutable(context);
-  const args = ["--data-plane-host", task.dataPlaneHost];
+  const documentTitle = documentTitleForPath(task.documentPath);
+  const viewerTitle = viewerWindowTitle(documentTitle);
+  const layoutMode = getWindowLayoutMode();
+  const args = ["--data-plane-host", task.dataPlaneHost, "--document-title", documentTitle];
   const cwd = path.dirname(task.documentPath);
   appendLog(`Starting ${executable} ${args.join(" ")}`);
 
@@ -89,7 +99,7 @@ function launchViewer(
   });
 
   activeViewers.set(task.taskId, viewer);
-  scheduleWindowLayout(viewer);
+  scheduleWindowLayout(viewer, viewerTitle, layoutMode === "sideBySide");
   viewer.stdout.on("data", (data: Buffer) => appendLog(data.toString()));
   viewer.stderr.on("data", (data: Buffer) => appendLog(data.toString()));
   viewer.on("error", (error) => {
@@ -101,7 +111,7 @@ function launchViewer(
       }
     });
   });
-  viewer.on("exit", (code, signal) => {
+  viewer.on("close", (code, signal) => {
     deleteActiveViewer(task.taskId, viewer);
     appendLog(`Tinymist GPU Viewer exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
   });
@@ -153,9 +163,23 @@ function resolveViewerExecutable(context: vscode.ExtensionContext): string {
   );
 }
 
-function scheduleWindowLayout(viewer: ChildProcessWithoutNullStreams) {
-  if (getWindowLayoutMode() !== "sideBySide") {
-    appendLog("Skipping side-by-side window layout: tinymist.gpuViewer.windowLayout is disabled.");
+function documentTitleForPath(documentPath: string): string {
+  const title = path.basename(documentPath).trim();
+  return title || documentPath.trim() || VIEWER_WINDOW_TITLE;
+}
+
+function viewerWindowTitle(documentTitle: string): string {
+  const title = documentTitle.trim();
+  return title ? `${title} - ${VIEWER_WINDOW_TITLE}` : VIEWER_WINDOW_TITLE;
+}
+
+function scheduleWindowLayout(
+  viewer: ChildProcessWithoutNullStreams,
+  viewerTitle: string,
+  repairSideBySideLayout: boolean,
+) {
+  if (!repairSideBySideLayout) {
+    appendLog("Skipping side-by-side window layout repair.");
     return;
   }
 
@@ -165,8 +189,8 @@ function scheduleWindowLayout(viewer: ChildProcessWithoutNullStreams) {
     return;
   }
 
-  appendLog(`Scheduling side-by-side window layout for viewer pid ${viewerPid}.`);
-  void arrangeWindowsSideBySide(viewerPid).catch((error) => {
+  appendLog(`Scheduling side-by-side window layout repair for viewer pid ${viewerPid}.`);
+  void arrangeWindowsSideBySide(viewerPid, viewerTitle).catch((error) => {
     appendLog(`Could not arrange GPU viewer windows: ${errorMessage(error)}`);
   });
 }
@@ -179,15 +203,15 @@ function getWindowLayoutMode(): WindowLayoutMode {
   return configured === "sideBySide" ? "sideBySide" : "disabled";
 }
 
-async function arrangeWindowsSideBySide(viewerPid: number) {
+async function arrangeWindowsSideBySide(viewerPid: number, viewerTitle: string) {
   await delay(WINDOW_LAYOUT_DELAY_MS);
 
   switch (process.platform) {
     case "win32":
-      await arrangeWindowsSideBySideWin32(viewerPid);
+      await arrangeWindowsSideBySideWin32(viewerPid, viewerTitle);
       return;
     case "darwin":
-      await arrangeWindowsSideBySideMacOS();
+      await arrangeWindowsSideBySideMacOS(viewerTitle);
       return;
     case "linux":
       await arrangeWindowsSideBySideLinux(viewerPid);
@@ -197,10 +221,11 @@ async function arrangeWindowsSideBySide(viewerPid: number) {
   }
 }
 
-async function arrangeWindowsSideBySideWin32(viewerPid: number) {
+async function arrangeWindowsSideBySideWin32(viewerPid: number, viewerTitle: string) {
+  const viewerTitleLiteral = powershellSingleQuotedString(viewerTitle);
   const script = `
 $viewerPid = ${viewerPid}
-$viewerTitle = '${VIEWER_WINDOW_TITLE}'
+$viewerTitle = ${viewerTitleLiteral}
 $codeProcessNames = @('Code', 'Code - Insiders', 'VSCodium', 'Code - OSS')
 
 Add-Type -AssemblyName System.Windows.Forms
@@ -309,9 +334,10 @@ $rightWidth = $workArea.Width - $halfWidth
   await runFile("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]);
 }
 
-async function arrangeWindowsSideBySideMacOS() {
+async function arrangeWindowsSideBySideMacOS(viewerTitle: string) {
+  const viewerTitleLiteral = appleScriptStringLiteral(viewerTitle);
   const script = `
-set viewerTitle to "${VIEWER_WINDOW_TITLE}"
+set viewerTitle to ${viewerTitleLiteral}
 set codeProcessNames to {"Code", "Visual Studio Code", "Code - Insiders", "VSCodium", "Code - OSS"}
 tell application "Finder"
   set desktopBounds to bounds of window of desktop
@@ -344,7 +370,7 @@ tell application "System Events"
   repeat while viewerWindow is missing value and (current date) < deadline
     repeat with candidateProcess in processes
       repeat with candidateWindow in windows of candidateProcess
-        if name of candidateWindow is viewerTitle then
+        if name of candidateWindow contains viewerTitle then
           set viewerWindow to candidateWindow
           exit repeat
         end if
@@ -372,20 +398,51 @@ end tell
   await runFile("osascript", ["-e", script]);
 }
 
+function powershellSingleQuotedString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function appleScriptStringLiteral(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
 async function arrangeWindowsSideBySideLinux(viewerPid: number) {
   const pair = await waitForWindowPair(viewerPid);
-  const workArea = await getLinuxWorkArea();
-  const halfWidth = Math.floor(workArea.width / 2);
-  const rightWidth = workArea.width - halfWidth;
+  const rects = splitSideBySideWorkArea(await getLinuxWorkArea());
 
-  await moveLinuxWindow(pair.code.id, workArea.x, workArea.y, halfWidth, workArea.height);
+  await moveLinuxWindow(
+    pair.code.id,
+    rects.code.x,
+    rects.code.y,
+    rects.code.width,
+    rects.code.height,
+  );
   await moveLinuxWindow(
     pair.viewer.id,
-    workArea.x + halfWidth,
-    workArea.y,
-    rightWidth,
-    workArea.height,
+    rects.viewer.x,
+    rects.viewer.y,
+    rects.viewer.width,
+    rects.viewer.height,
   );
+}
+
+function splitSideBySideWorkArea(workArea: WindowRect): { code: WindowRect; viewer: WindowRect } {
+  const halfWidth = Math.floor(workArea.width / 2);
+  const rightWidth = workArea.width - halfWidth;
+  return {
+    code: {
+      x: workArea.x,
+      y: workArea.y,
+      width: halfWidth,
+      height: workArea.height,
+    },
+    viewer: {
+      x: workArea.x + halfWidth,
+      y: workArea.y,
+      width: rightWidth,
+      height: workArea.height,
+    },
+  };
 }
 
 interface CommandResult {
@@ -421,13 +478,6 @@ interface LinuxWindow {
   id: string;
   pid: number;
   title: string;
-}
-
-interface LinuxWorkArea {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
 }
 
 async function waitForWindowPair(
@@ -484,7 +534,7 @@ function isLinuxCodeWindow(window: LinuxWindow): boolean {
   );
 }
 
-async function getLinuxWorkArea(): Promise<LinuxWorkArea> {
+async function getLinuxWorkArea(): Promise<WindowRect> {
   const { stdout } = await runFile("wmctrl", ["-d"]);
   const desktop =
     stdout.split(/\r?\n/).find((line) => line.includes("*")) ??

--- a/crates/tinymist-viewer/Cargo.toml
+++ b/crates/tinymist-viewer/Cargo.toml
@@ -27,6 +27,7 @@ image.workspace = true
 indexmap.workspace = true
 log.workspace = true
 masonry.workspace = true
+masonry_winit.workspace = true
 open.workspace = true
 parking_lot.workspace = true
 reflexo-vec2svg.workspace = true
@@ -49,6 +50,16 @@ ttf-parser.workspace = true
 vello.workspace = true
 winit.workspace = true
 xilem.workspace = true
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_HiDpi",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [features]
 

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -10,6 +10,9 @@ use ezsockets::ClientConfig;
 use ezsockets::client::ClientCloseMode;
 use masonry::layout::Length;
 use masonry::layout::UnitPoint;
+use masonry::properties::Gap;
+use masonry::theme::default_property_set;
+use masonry_winit::app::{AppDriver, MasonryState, MasonryUserEvent};
 use reflexo::debug_loc::DocumentPosition;
 use reflexo::vector::incr::IncrDocClient;
 use reflexo::vector::stream::BytesModuleStream;
@@ -23,18 +26,29 @@ use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt, World};
+use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
+use winit::event::{DeviceEvent, StartCause, WindowEvent as WinitWindowEvent};
+use winit::event_loop::ActiveEventLoop;
+use winit::window::WindowId as WinitWindowId;
 use xilem::core::{Edit, MessageProxy, fork};
+use xilem::style::Style as _;
 use xilem::vello::Scene;
 use xilem::vello::kurbo::{Point, Size};
 use xilem::vello::peniko::Color;
-use xilem::view::{ZStackExt as _, flex_col, resize_observer, sized_box, task, zstack};
+use xilem::view::{
+    FlexExt as _, ZStackExt as _, flex_col, resize_observer, sized_box, task, zstack,
+};
 use xilem::{AppState, EventLoop, WidgetView, WindowId, Xilem, window};
+
+mod native_title_bar;
+mod title_bar;
 
 use tinymist_viewer::doc::{ZoomAction, doc};
 use tinymist_viewer::incr::{IncrVelloDocClient, RenderedPage};
 use tinymist_viewer::protocol::preview_update_from_bytes;
 use tinymist_viewer::zoom_portal::zoom_portal;
+use title_bar::{TITLE_BAR_HEIGHT, TitleBarAction, title_bar};
 
 const DEFAULT_ZOOM_SCALE: f64 = 1.0;
 const MIN_ZOOM_SCALE: f64 = 0.1;
@@ -48,6 +62,10 @@ const ZOOM_FACTORS: [f64; 31] = [
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(1);
 const STATUS_BANNER_HEIGHT: f64 = 28.0;
 const EMPTY_STATUS_BANNER_HEIGHT: f64 = 34.0;
+const DEFAULT_VIEWER_INNER_WIDTH: u32 = 800;
+const DEFAULT_VIEWER_CONTENT_HEIGHT: u32 = 800;
+const MIN_VIEWER_INNER_WIDTH: u32 = 800;
+const MIN_VIEWER_INNER_HEIGHT: u32 = DEFAULT_VIEWER_CONTENT_HEIGHT + TITLE_BAR_HEIGHT as u32;
 
 #[derive(Debug, Clone, Parser)]
 struct Args {
@@ -59,6 +77,10 @@ struct Args {
         hide(true)
     )]
     pub data_plane_host: String,
+
+    /// The document title shown in the viewer window.
+    #[clap(long = "document-title", value_name = "TITLE")]
+    pub document_title: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -70,11 +92,16 @@ fn main() -> Result<()> {
 
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let default_size = Size::new(800.0, 800.0);
+    let default_size = Size::new(
+        f64::from(DEFAULT_VIEWER_INNER_WIDTH),
+        f64::from(DEFAULT_VIEWER_CONTENT_HEIGHT),
+    );
     let data_plane_host = args.data_plane_host;
+    let document_title = normalize_document_title(args.document_title);
     let app = Xilem::new(
         PreviewState {
             data_plane_host,
+            document_title,
             window_id: WindowId::next(),
             running: true,
             pages: vec![],
@@ -82,19 +109,102 @@ fn main() -> Result<()> {
             window_size: default_size,
             connection: ConnectionStatus::Connecting,
             status_scene: None,
+            help_overlay_visible: false,
+            help_overlay_scene: None,
             zoom_scale: DEFAULT_ZOOM_SCALE,
             tx,
             rx: Some(rx),
         },
         PreviewState::windows,
     );
-    app.run_in(EventLoop::with_user_event())
+
+    let event_loop = EventLoop::with_user_event()
+        .build()
+        .context("Couldn't build event loop")?;
+    let proxy = event_loop.create_proxy();
+    let (driver, windows) =
+        app.into_driver_and_windows(move |event| proxy.send_event(event).map_err(|err| err.0));
+    let masonry_state =
+        MasonryState::new(event_loop.create_proxy(), windows, default_property_set());
+    let mut app = ViewerEventLoopApp {
+        masonry_state,
+        app_driver: Box::new(driver),
+    };
+    event_loop
+        .run_app(&mut app)
         .context("Couldn't run event loop")?;
     Ok(())
 }
 
+struct ViewerEventLoopApp {
+    masonry_state: MasonryState<'static>,
+    app_driver: Box<dyn AppDriver>,
+}
+
+impl ApplicationHandler<MasonryUserEvent> for ViewerEventLoopApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.masonry_state
+            .handle_resumed(event_loop, self.app_driver.as_mut());
+    }
+
+    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        self.masonry_state.handle_suspended(event_loop);
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.masonry_state.handle_about_to_wait(event_loop);
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WinitWindowId,
+        event: WinitWindowEvent,
+    ) {
+        native_title_bar::install_for_window_id(window_id);
+        self.masonry_state.handle_window_event(
+            event_loop,
+            window_id,
+            event,
+            self.app_driver.as_mut(),
+        );
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: MasonryUserEvent) {
+        self.masonry_state
+            .handle_user_event(event_loop, event, self.app_driver.as_mut());
+    }
+
+    fn device_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: DeviceEvent,
+    ) {
+        self.masonry_state.handle_device_event(
+            event_loop,
+            device_id,
+            event,
+            self.app_driver.as_mut(),
+        );
+    }
+
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
+        self.masonry_state.handle_new_events(event_loop, cause);
+    }
+
+    fn exiting(&mut self, event_loop: &ActiveEventLoop) {
+        self.masonry_state.handle_exiting(event_loop);
+    }
+
+    fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
+        self.masonry_state.handle_memory_warning(event_loop);
+    }
+}
+
 struct PreviewState {
     data_plane_host: String,
+    document_title: Option<String>,
     window_id: WindowId,
     running: bool,
     pages: Vec<RenderedPage>,
@@ -102,6 +212,8 @@ struct PreviewState {
     window_size: Size,
     connection: ConnectionStatus,
     status_scene: Option<StatusScene>,
+    help_overlay_visible: bool,
+    help_overlay_scene: Option<HelpOverlayScene>,
     zoom_scale: f64,
     tx: mpsc::UnboundedSender<PreviewEvent>,
     rx: Option<mpsc::UnboundedReceiver<PreviewEvent>>,
@@ -120,7 +232,11 @@ impl PreviewState {
         let root = self.view();
         std::iter::once(window(window_id, title, root).with_options(|options| {
             options
-                .with_min_inner_size(LogicalSize::new(800.0, 800.0))
+                .with_decorations(false)
+                .with_min_inner_size(LogicalSize::new(
+                    f64::from(MIN_VIEWER_INNER_WIDTH),
+                    f64::from(MIN_VIEWER_INNER_HEIGHT),
+                ))
                 .on_close(|state: &mut PreviewState| {
                     state.running = false;
                 })
@@ -128,9 +244,10 @@ impl PreviewState {
     }
 
     fn window_title(&self) -> String {
+        let base = viewer_window_title(self.document_title.as_deref());
         match self.connection.title_suffix() {
-            Some(suffix) => format!("Tinymist View - {suffix}"),
-            None => "Tinymist View".to_owned(),
+            Some(suffix) => format!("{base} - {suffix}"),
+            None => base,
         }
     }
 
@@ -162,6 +279,42 @@ impl PreviewState {
 
     fn apply_zoom(&mut self, action: ZoomAction) {
         self.zoom_scale = zoom_scale_after_action(self.zoom_scale, action);
+    }
+
+    fn handle_title_bar_action(&mut self, action: TitleBarAction) {
+        match action {
+            TitleBarAction::ToggleHelp => {
+                self.help_overlay_visible = !self.help_overlay_visible;
+            }
+        }
+    }
+
+    fn help_overlay_scene(&mut self, width: f64, height: f64) -> (Arc<Scene>, Size) {
+        if let Some(scene) = &self.help_overlay_scene
+            && scene.matches(width, height)
+        {
+            return (scene.scene.clone(), scene.size);
+        }
+
+        let (scene, size) = match render_help_overlay_scene(width, height) {
+            Ok(scene) => scene,
+            Err(err) => {
+                log::warn!("failed to render help overlay with Typst: {err}");
+                (Arc::new(Scene::new()), Size::new(width, height))
+            }
+        };
+        self.help_overlay_scene = Some(HelpOverlayScene {
+            width,
+            height,
+            scene,
+            size,
+        });
+
+        let scene = self
+            .help_overlay_scene
+            .as_ref()
+            .expect("help overlay scene just set");
+        (scene.scene.clone(), scene.size)
     }
 
     fn view(&mut self) -> impl WidgetView<Edit<Self>> + use<> {
@@ -374,9 +527,36 @@ impl PreviewState {
         } else {
             None
         };
+        let help_overlay = if self.help_overlay_visible {
+            let overlay_width = self.window_size.width.max(1.0).ceil();
+            let overlay_height = self.window_size.height.max(1.0).ceil();
+            let (scene, scene_size) = self.help_overlay_scene(overlay_width, overlay_height);
+            let scene_scale = if scene_size.width > 0.0 {
+                overlay_width / scene_size.width
+            } else {
+                1.0
+            };
 
-        // Listens to window size changes and renders the scene.
-        resize_observer(
+            Some(
+                sized_box(
+                    doc(
+                        scene,
+                        scene_scale,
+                        None,
+                        |_pos, _bbox| {},
+                        |state: &mut PreviewState, action| state.apply_zoom(action),
+                    )
+                    .alt_text("Tinymist preview key bindings"),
+                )
+                .fixed_width(Length::const_px(overlay_width))
+                .fixed_height(Length::const_px(overlay_height))
+                .alignment(UnitPoint::CENTER),
+            )
+        } else {
+            None
+        };
+
+        let preview_content = resize_observer(
             |state: &mut PreviewState, size: Size| {
                 state.window_size = size;
             },
@@ -389,10 +569,19 @@ impl PreviewState {
                         |state: &mut PreviewState, action| state.apply_zoom(action),
                     ),
                     status_overlay,
+                    help_overlay,
                 )),
                 effect,
             ),
-        )
+        );
+
+        flex_col((
+            title_bar(self.window_title(), |state: &mut PreviewState, action| {
+                state.handle_title_bar_action(action)
+            }),
+            preview_content.flex(1.0),
+        ))
+        .gap(Gap::ZERO)
     }
 }
 
@@ -407,6 +596,19 @@ struct StatusScene {
 impl StatusScene {
     fn matches(&self, message: &str, width: f64, height: f64) -> bool {
         self.message == message && self.width == width && self.height == height
+    }
+}
+
+struct HelpOverlayScene {
+    width: f64,
+    height: f64,
+    scene: Arc<Scene>,
+    size: Size,
+}
+
+impl HelpOverlayScene {
+    fn matches(&self, width: f64, height: f64) -> bool {
+        self.width == width && self.height == height
     }
 }
 
@@ -472,18 +674,31 @@ fn render_status_scene(message: &str, width: f64, height: f64) -> Result<(Arc<Sc
         FileId::new(None, VirtualPath::new("/tinymist-viewer-status.typ")),
         status_typst_source(message, width, height),
     );
+    render_typst_scene(source, "status")
+}
+
+fn render_help_overlay_scene(width: f64, height: f64) -> Result<(Arc<Scene>, Size)> {
+    let source = Source::new(
+        FileId::new(None, VirtualPath::new("/tinymist-viewer-help-overlay.typ")),
+        help_overlay_typst_source(width, height),
+    );
+    render_typst_scene(source, "help overlay")
+}
+
+fn render_typst_scene(source: Source, scene_name: &str) -> Result<(Arc<Scene>, Size)> {
     let world = StatusWorld { main: source };
     let compiled = typst::compile::<PagedDocument>(&world);
     for warning in compiled.warnings {
-        log::debug!("Typst status render warning: {warning:?}");
+        log::debug!("Typst {scene_name} render warning: {warning:?}");
     }
     let doc = compiled
         .output
-        .map_err(|errors| anyhow!("failed to compile status text: {errors:?}"))?;
+        .map_err(|errors| anyhow!("failed to compile {scene_name}: {errors:?}"))?;
     let document = TypstDocument::Paged(Arc::new(doc));
     let mut renderer = IncrSvgDocServer::default();
     let frame = renderer.pack_delta(&document);
-    let update = preview_update_from_bytes(&frame).context("status preview frame is invalid")?;
+    let update = preview_update_from_bytes(&frame)
+        .with_context(|| format!("{scene_name} preview frame is invalid"))?;
 
     let mut doc = IncrDocClient::default();
     let mut vello = IncrVelloDocClient::default();
@@ -495,7 +710,9 @@ fn render_status_scene(message: &str, width: f64, height: f64) -> Result<(Arc<Sc
     doc.merge_delta(delta);
 
     let mut pages = vello.render_pages(&mut doc)?;
-    pages.pop().context("Typst status render produced no pages")
+    pages
+        .pop()
+        .with_context(|| format!("Typst {scene_name} render produced no pages"))
 }
 
 fn status_typst_source(message: &str, width: f64, height: f64) -> String {
@@ -506,6 +723,66 @@ fn status_typst_source(message: &str, width: f64, height: f64) -> String {
 #place(center + horizon, text({message}))
 "#
     )
+}
+
+fn help_overlay_typst_source(width: f64, height: f64) -> String {
+    let panel_width = help_overlay_panel_width(width);
+    let key_column_width = (panel_width * 0.4)
+        .clamp(190.0, 270.0)
+        .min(panel_width * 0.48);
+
+    format!(
+        r##"#set page(width: {width}pt, height: {height}pt, margin: 0pt)
+#set text(font: "New Computer Modern", size: 21pt, fill: rgb("#d9d9d9"))
+#let key(body) = box(
+  fill: rgb("#3a3a3a"),
+  stroke: 0.65pt + rgb("#626262"),
+  radius: 4pt,
+  inset: (x: 11pt, y: 5pt),
+  text(size: 18pt, fill: rgb("#f7f7f7"), body),
+)
+#let sep = text(fill: rgb("#858585"))[/]
+#let desc(body) = text(size: 21pt, fill: rgb("#d9d9d9"), body)
+
+#place(center + horizon)[
+  #block(
+    width: {panel_width}pt,
+    fill: rgb("#252525"),
+    stroke: 0.8pt + rgb("#505050"),
+    radius: 8pt,
+    inset: (x: 32pt, y: 30pt),
+  )[
+    #text(size: 27pt, weight: "semibold", fill: rgb("#ffffff"))[Key Bindings]
+    #v(20pt)
+    #grid(
+      columns: ({key_column_width}pt, 1fr),
+      column-gutter: 28pt,
+      row-gutter: 13pt,
+      align: (right + horizon, left + horizon),
+      [#key[Ctrl/Cmd] #key[Wheel]],
+      desc[Zoom around cursor],
+      [#key[Ctrl/Cmd] #key[+] #sep #key[-]],
+      desc[Zoom in or out],
+      [#key[Ctrl/Cmd] #key[0]],
+      desc[Reset zoom],
+      [#key[Arrow keys]],
+      desc[Scroll by line],
+      [#key[Page Up] #sep #key[Page Down]],
+      desc[Scroll by page],
+      [#key[Home] #sep #key[End]],
+      desc[Jump to document edges],
+      [#key[Click page]],
+      desc[Sync source position],
+    )
+  ]
+]
+"##
+    )
+}
+
+fn help_overlay_panel_width(width: f64) -> f64 {
+    let available = (width - 64.0).max(1.0);
+    available.min(760.0).max(420.0).min(width.max(1.0))
 }
 
 fn typst_string_literal(text: &str) -> String {
@@ -591,6 +868,19 @@ fn websocket_address(data_plane_host: &str) -> String {
     }
 }
 
+fn normalize_document_title(title: Option<String>) -> Option<String> {
+    title
+        .map(|title| title.trim().to_owned())
+        .filter(|title| !title.is_empty())
+}
+
+fn viewer_window_title(document_title: Option<&str>) -> String {
+    match document_title {
+        Some(title) if !title.trim().is_empty() => format!("{} - Tinymist View", title.trim()),
+        _ => "Tinymist View".to_owned(),
+    }
+}
+
 fn send_connection_status(proxy: &MessageProxy<RenderRequest>, connection: ConnectionStatus) {
     if let Err(err) = proxy.message(RenderRequest::Connection(connection)) {
         log::debug!("failed to send websocket status to viewer: {err}");
@@ -609,7 +899,7 @@ fn truncate_message(message: String, max_chars: usize) -> String {
 
 fn fitted_page_width(window_width: f64) -> f64 {
     if window_width.is_finite() {
-        (window_width - 0.5).max(1.0)
+        window_width.max(1.0)
     } else {
         1.0
     }
@@ -838,6 +1128,18 @@ mod tests {
     }
 
     #[test]
+    fn fitted_page_width_uses_full_finite_width() {
+        assert_eq!(fitted_page_width(400.5), 400.5);
+        assert_eq!(fitted_page_width(0.25), 1.0);
+    }
+
+    #[test]
+    fn fitted_page_width_uses_safe_width_for_invalid_values() {
+        assert_eq!(fitted_page_width(f64::NAN), 1.0);
+        assert_eq!(fitted_page_width(f64::INFINITY), 1.0);
+    }
+
+    #[test]
     fn zoom_actions_update_and_reset_scale() {
         assert_eq!(zoom_scale_after_action(1.0, ZoomAction::In), 1.1);
         assert_eq!(zoom_scale_after_action(1.1, ZoomAction::In), 1.3);
@@ -887,6 +1189,16 @@ mod tests {
     }
 
     #[test]
+    fn viewer_window_title_uses_document_title_when_available() {
+        assert_eq!(
+            viewer_window_title(Some("main.typ")),
+            "main.typ - Tinymist View"
+        );
+        assert_eq!(viewer_window_title(Some("  ")), "Tinymist View");
+        assert_eq!(viewer_window_title(None), "Tinymist View");
+    }
+
+    #[test]
     fn typst_status_scene_renders() {
         let (scene, size) = render_status_scene("Retrying websocket connection", 320.0, 28.0)
             .expect("status text should render through Typst");
@@ -895,6 +1207,18 @@ mod tests {
         assert!(
             !scene.encoding().is_empty(),
             "status scene should contain glyphs"
+        );
+    }
+
+    #[test]
+    fn typst_help_overlay_scene_renders() {
+        let (scene, size) =
+            render_help_overlay_scene(800.0, 600.0).expect("help overlay should render");
+
+        assert_eq!(size, Size::new(800.0, 600.0));
+        assert!(
+            !scene.encoding().is_empty(),
+            "help overlay scene should contain panel content"
         );
     }
 }

--- a/crates/tinymist-viewer/src/native_title_bar.rs
+++ b/crates/tinymist-viewer/src/native_title_bar.rs
@@ -1,0 +1,613 @@
+//! Native title-bar hit testing for decorationless windows.
+
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use winit::window::WindowId;
+
+#[cfg(any(test, target_os = "windows"))]
+use vello::kurbo::{Point, Size};
+
+#[cfg(any(test, target_os = "windows"))]
+use crate::title_bar::{TITLE_BAR_HEIGHT, TitleBarButton, button_at_pos};
+
+/// Installs native title-bar behavior for the given winit window.
+#[cfg(target_os = "windows")]
+pub fn install_for_window_id(window_id: WindowId) {
+    windows::install_for_window_id(window_id);
+}
+
+/// Installs native title-bar behavior for the given winit window.
+#[cfg(not(target_os = "windows"))]
+pub fn install_for_window_id(_window_id: WindowId) {}
+
+/// Consumes a native maximize-button activation that has already been handled by Windows.
+#[cfg(target_os = "windows")]
+pub(crate) fn take_native_maximize_activation() -> bool {
+    NATIVE_MAXIMIZE_ACTIVATION.swap(false, Ordering::AcqRel)
+}
+
+/// Consumes a native maximize-button activation that has already been handled by Windows.
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn take_native_maximize_activation() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+static NATIVE_MAXIMIZE_ACTIVATION: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(any(test, target_os = "windows"))]
+enum NativeTitleBarHit {
+    Client,
+    Caption,
+    MaximizeButton,
+    Resize(ResizeEdge),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(any(test, target_os = "windows"))]
+enum ResizeEdge {
+    Left,
+    Right,
+    Top,
+    Bottom,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn native_title_bar_hit_test(
+    logical_size: Size,
+    logical_pos: Point,
+    primary_button_down: bool,
+    resize_border: Size,
+) -> Option<NativeTitleBarHit> {
+    if logical_pos.x < 0.0
+        || logical_pos.x >= logical_size.width
+        || logical_pos.y < 0.0
+        || logical_pos.y >= logical_size.height
+    {
+        return None;
+    }
+
+    if let Some(edge) = resize_edge_at_pos(logical_size, logical_pos, resize_border)
+        && !primary_button_down
+    {
+        return Some(NativeTitleBarHit::Resize(edge));
+    }
+
+    if logical_pos.y >= TITLE_BAR_HEIGHT {
+        return None;
+    }
+
+    match button_at_pos(logical_size, logical_pos) {
+        Some(TitleBarButton::Maximize) => Some(NativeTitleBarHit::MaximizeButton),
+        Some(_) => Some(NativeTitleBarHit::Client),
+        None => Some(NativeTitleBarHit::Caption),
+    }
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn resize_edge_at_pos(size: Size, pos: Point, border: Size) -> Option<ResizeEdge> {
+    if border.width <= 0.0 || border.height <= 0.0 {
+        return None;
+    }
+
+    let border_x = border.width.min(size.width * 0.5);
+    let border_y = border.height.min(size.height * 0.5);
+    let left = pos.x < border_x;
+    let right = pos.x >= size.width - border_x;
+    let top = pos.y < border_y;
+    let bottom = pos.y >= size.height - border_y;
+
+    match (left, right, top, bottom) {
+        (true, _, true, _) => Some(ResizeEdge::TopLeft),
+        (_, true, true, _) => Some(ResizeEdge::TopRight),
+        (true, _, _, true) => Some(ResizeEdge::BottomLeft),
+        (_, true, _, true) => Some(ResizeEdge::BottomRight),
+        (true, _, _, _) => Some(ResizeEdge::Left),
+        (_, true, _, _) => Some(ResizeEdge::Right),
+        (_, _, true, _) => Some(ResizeEdge::Top),
+        (_, _, _, true) => Some(ResizeEdge::Bottom),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use std::collections::HashSet;
+    use std::mem;
+    use std::sync::atomic::Ordering;
+    use std::sync::{Mutex, OnceLock};
+
+    use super::{
+        NATIVE_MAXIMIZE_ACTIVATION, NativeTitleBarHit, ResizeEdge, native_title_bar_hit_test,
+    };
+    use vello::kurbo::{Point, Size};
+    use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
+    use windows_sys::Win32::Graphics::Gdi::ScreenToClient;
+    use windows_sys::Win32::UI::HiDpi::{GetDpiForWindow, GetSystemMetricsForDpi};
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+        GetKeyState, TME_LEAVE, TME_NONCLIENT, TRACKMOUSEEVENT, TrackMouseEvent, VK_LBUTTON,
+    };
+    use windows_sys::Win32::UI::Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetClientRect, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT,
+        HTMAXBUTTON, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT, IsZoomed, SM_CXPADDEDBORDER,
+        SM_CXSIZEFRAME, SM_CYSIZEFRAME, SW_MAXIMIZE, SW_RESTORE, SendMessageW, ShowWindow,
+        WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_NCDESTROY, WM_NCHITTEST, WM_NCLBUTTONDOWN,
+        WM_NCLBUTTONUP, WM_NCMOUSELEAVE, WM_NCMOUSEMOVE,
+    };
+    use winit::window::WindowId;
+
+    const SUBCLASS_ID: usize = 0x544d_5654;
+    const BASE_DPI: f64 = 96.0;
+    const FALLBACK_RESIZE_BORDER_WIDTH: f64 = 8.0;
+    const WM_MOUSELEAVE: u32 = 0x02A3;
+
+    pub(super) fn install_for_window_id(window_id: WindowId) {
+        let Ok(hwnd_value) = usize::try_from(u64::from(window_id)) else {
+            return;
+        };
+        if hwnd_value == 0 {
+            return;
+        }
+
+        let Ok(mut installed) = installed_windows().lock() else {
+            return;
+        };
+        if !installed.insert(hwnd_value) {
+            return;
+        }
+        drop(installed);
+
+        let hwnd = hwnd_value as HWND;
+        // SAFETY: `window_id` comes from winit for a live Windows window on the event loop thread.
+        let installed =
+            unsafe { SetWindowSubclass(hwnd, Some(title_bar_subclass_proc), SUBCLASS_ID, 0) != 0 };
+        if !installed && let Ok(mut installed_windows) = installed_windows().lock() {
+            installed_windows.remove(&hwnd_value);
+        }
+    }
+
+    unsafe extern "system" fn title_bar_subclass_proc(
+        hwnd: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+        _subclass_id: usize,
+        _ref_data: usize,
+    ) -> LRESULT {
+        if message == WM_NCDESTROY {
+            remove_subclass(hwnd);
+            // SAFETY: Forwarding the original window message to the next subclass/default proc.
+            return unsafe { DefSubclassProc(hwnd, message, wparam, lparam) };
+        }
+
+        if message != WM_NCHITTEST {
+            if message == WM_NCMOUSEMOVE && wparam == HTMAXBUTTON as WPARAM {
+                set_maximize_button_hovered(hwnd, true);
+                // SAFETY: Forwarding keeps Windows 11 snap-layout hover behavior active.
+                let result = unsafe { DefSubclassProc(hwnd, message, wparam, lparam) };
+                bridge_maximize_mouse_move(hwnd, lparam);
+                return result;
+            }
+
+            if message == WM_NCMOUSELEAVE {
+                set_maximize_button_hovered(hwnd, false);
+                bridge_maximize_mouse_leave(hwnd);
+                // SAFETY: Forwarding messages we do not handle to the next subclass/default proc.
+                return unsafe { DefSubclassProc(hwnd, message, wparam, lparam) };
+            }
+
+            if message == WM_MOUSELEAVE && is_maximize_button_hovered(hwnd) {
+                return 0;
+            }
+
+            if message == WM_NCLBUTTONDOWN && wparam == HTMAXBUTTON as WPARAM {
+                set_maximize_button_hovered(hwnd, true);
+                set_maximize_button_pressed(hwnd, true);
+                bridge_maximize_mouse_move(hwnd, lparam);
+                send_client_mouse_message(hwnd, WM_LBUTTONDOWN, lparam);
+                return 0;
+            }
+
+            if message == WM_NCLBUTTONUP && take_maximize_button_pressed(hwnd) {
+                bridge_maximize_mouse_move(hwnd, lparam);
+                let released_on_maximize =
+                    hit_test(hwnd, lparam, false) == Some(NativeTitleBarHit::MaximizeButton);
+                set_maximize_button_hovered(hwnd, released_on_maximize);
+                send_client_mouse_up(hwnd, lparam, released_on_maximize);
+                if released_on_maximize {
+                    toggle_window_maximized(hwnd);
+                }
+                return 0;
+            }
+
+            // SAFETY: Forwarding messages we do not handle to the next subclass/default proc.
+            return unsafe { DefSubclassProc(hwnd, message, wparam, lparam) };
+        }
+
+        // SAFETY: Forwarding first preserves winit/DefWindowProc resize-border hit tests.
+        let default_hit = unsafe { DefSubclassProc(hwnd, message, wparam, lparam) };
+        if default_hit != HTCLIENT as LRESULT {
+            return default_hit;
+        }
+
+        match hit_test(hwnd, lparam, is_primary_button_down()) {
+            Some(NativeTitleBarHit::Caption) => HTCAPTION as LRESULT,
+            Some(NativeTitleBarHit::MaximizeButton) => HTMAXBUTTON as LRESULT,
+            Some(NativeTitleBarHit::Resize(edge)) => resize_edge_to_hit(edge) as LRESULT,
+            Some(NativeTitleBarHit::Client) | None => default_hit,
+        }
+    }
+
+    fn hit_test(
+        hwnd: HWND,
+        lparam: LPARAM,
+        primary_button_down: bool,
+    ) -> Option<NativeTitleBarHit> {
+        let scale_factor = scale_factor_for_window(hwnd);
+        let client_size = client_size(hwnd)?;
+        let client_pos = client_position_from_lparam(hwnd, lparam)?;
+        let resize_border = resize_border_size(hwnd, scale_factor);
+        let logical_size = Size::new(
+            f64::from(client_size.0) / scale_factor,
+            f64::from(client_size.1) / scale_factor,
+        );
+        let logical_pos = Point::new(
+            f64::from(client_pos.x) / scale_factor,
+            f64::from(client_pos.y) / scale_factor,
+        );
+
+        native_title_bar_hit_test(
+            logical_size,
+            logical_pos,
+            primary_button_down,
+            resize_border,
+        )
+    }
+
+    fn installed_windows() -> &'static Mutex<HashSet<usize>> {
+        static INSTALLED: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+        INSTALLED.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    fn pressed_maximize_windows() -> &'static Mutex<HashSet<usize>> {
+        static PRESSED: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+        PRESSED.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    fn hovered_maximize_windows() -> &'static Mutex<HashSet<usize>> {
+        static HOVERED: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+        HOVERED.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    fn remove_subclass(hwnd: HWND) {
+        if let Ok(mut installed) = installed_windows().lock() {
+            installed.remove(&(hwnd as usize));
+        }
+        if let Ok(mut pressed) = pressed_maximize_windows().lock() {
+            pressed.remove(&(hwnd as usize));
+        }
+        if let Ok(mut hovered) = hovered_maximize_windows().lock() {
+            hovered.remove(&(hwnd as usize));
+        }
+
+        // SAFETY: The subclass was installed by `install_for_window_id` with this proc and id.
+        unsafe {
+            RemoveWindowSubclass(hwnd, Some(title_bar_subclass_proc), SUBCLASS_ID);
+        }
+    }
+
+    fn set_maximize_button_pressed(hwnd: HWND, pressed: bool) {
+        let Ok(mut pressed_windows) = pressed_maximize_windows().lock() else {
+            return;
+        };
+
+        if pressed {
+            pressed_windows.insert(hwnd as usize);
+        } else {
+            pressed_windows.remove(&(hwnd as usize));
+        }
+    }
+
+    fn take_maximize_button_pressed(hwnd: HWND) -> bool {
+        let Ok(mut pressed_windows) = pressed_maximize_windows().lock() else {
+            return false;
+        };
+        pressed_windows.remove(&(hwnd as usize))
+    }
+
+    fn set_maximize_button_hovered(hwnd: HWND, hovered: bool) {
+        let Ok(mut hovered_windows) = hovered_maximize_windows().lock() else {
+            return;
+        };
+
+        if hovered {
+            hovered_windows.insert(hwnd as usize);
+        } else {
+            hovered_windows.remove(&(hwnd as usize));
+        }
+    }
+
+    fn is_maximize_button_hovered(hwnd: HWND) -> bool {
+        let Ok(hovered_windows) = hovered_maximize_windows().lock() else {
+            return false;
+        };
+        hovered_windows.contains(&(hwnd as usize))
+    }
+
+    fn scale_factor_for_window(hwnd: HWND) -> f64 {
+        // SAFETY: `hwnd` is the window currently being processed by the subclass callback.
+        let dpi = unsafe { GetDpiForWindow(hwnd) };
+        if dpi == 0 {
+            1.0
+        } else {
+            f64::from(dpi) / BASE_DPI
+        }
+    }
+
+    fn bridge_maximize_mouse_move(hwnd: HWND, screen_lparam: LPARAM) {
+        send_client_mouse_message(hwnd, WM_MOUSEMOVE, screen_lparam);
+        track_non_client_mouse_leave(hwnd);
+    }
+
+    fn bridge_maximize_mouse_leave(hwnd: HWND) {
+        // SAFETY: Sending a client leave lets winit/Masonry clear the custom button hover state.
+        unsafe {
+            SendMessageW(hwnd, WM_MOUSELEAVE, 0, 0);
+        }
+    }
+
+    fn send_client_mouse_message(hwnd: HWND, message: u32, screen_lparam: LPARAM) {
+        let Some(client_lparam) = client_mouse_lparam_from_screen_lparam(hwnd, screen_lparam)
+        else {
+            return;
+        };
+
+        // SAFETY: `hwnd` is the current window; the sent message is processed by winit's
+        // regular client-area mouse path, keeping the Xilem title-bar widget visuals in sync.
+        unsafe {
+            SendMessageW(hwnd, message, 0, client_lparam);
+        }
+    }
+
+    fn send_client_mouse_up(hwnd: HWND, screen_lparam: LPARAM, suppress_activation: bool) {
+        if suppress_activation {
+            NATIVE_MAXIMIZE_ACTIVATION.store(true, Ordering::Release);
+        }
+
+        send_client_mouse_message(hwnd, WM_LBUTTONUP, screen_lparam);
+
+        if suppress_activation {
+            NATIVE_MAXIMIZE_ACTIVATION.store(false, Ordering::Release);
+        }
+    }
+
+    fn toggle_window_maximized(hwnd: HWND) {
+        // SAFETY: `hwnd` is the window currently being processed by the subclass callback.
+        let is_maximized = unsafe { IsZoomed(hwnd) } != 0;
+        let command = if is_maximized {
+            SW_RESTORE
+        } else {
+            SW_MAXIMIZE
+        };
+        // SAFETY: `hwnd` is the window currently being processed by the subclass callback.
+        unsafe {
+            ShowWindow(hwnd, command);
+        }
+    }
+
+    fn track_non_client_mouse_leave(hwnd: HWND) {
+        let mut event = TRACKMOUSEEVENT {
+            cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
+            dwFlags: TME_LEAVE | TME_NONCLIENT,
+            hwndTrack: hwnd,
+            dwHoverTime: 0,
+        };
+        // SAFETY: `event` is fully initialized and refers to the current window.
+        unsafe {
+            TrackMouseEvent(&mut event);
+        }
+    }
+
+    fn client_mouse_lparam_from_screen_lparam(hwnd: HWND, screen_lparam: LPARAM) -> Option<LPARAM> {
+        let point = client_position_from_lparam(hwnd, screen_lparam)?;
+        Some(pack_signed_words(point.x, point.y))
+    }
+
+    fn resize_border_size(hwnd: HWND, scale_factor: f64) -> Size {
+        // SAFETY: `hwnd` is the window currently being processed by the subclass callback.
+        if unsafe { IsZoomed(hwnd) } != 0 {
+            return Size::ZERO;
+        }
+
+        // SAFETY: `hwnd` is the window currently being processed by the subclass callback.
+        let dpi = unsafe { GetDpiForWindow(hwnd) };
+        let dpi = if dpi == 0 { BASE_DPI as u32 } else { dpi };
+
+        // SAFETY: GetSystemMetricsForDpi reads process-global system metrics for this DPI.
+        let frame_x = unsafe { GetSystemMetricsForDpi(SM_CXSIZEFRAME, dpi) };
+        // SAFETY: GetSystemMetricsForDpi reads process-global system metrics for this DPI.
+        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYSIZEFRAME, dpi) };
+        // SAFETY: GetSystemMetricsForDpi reads process-global system metrics for this DPI.
+        let padded = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi) };
+
+        let fallback = (FALLBACK_RESIZE_BORDER_WIDTH * scale_factor).round() as i32;
+        let width = (frame_x + padded).max(fallback).max(0);
+        let height = (frame_y + padded).max(fallback).max(0);
+
+        Size::new(
+            f64::from(width) / scale_factor,
+            f64::from(height) / scale_factor,
+        )
+    }
+
+    fn resize_edge_to_hit(edge: ResizeEdge) -> u32 {
+        match edge {
+            ResizeEdge::Left => HTLEFT,
+            ResizeEdge::Right => HTRIGHT,
+            ResizeEdge::Top => HTTOP,
+            ResizeEdge::Bottom => HTBOTTOM,
+            ResizeEdge::TopLeft => HTTOPLEFT,
+            ResizeEdge::TopRight => HTTOPRIGHT,
+            ResizeEdge::BottomLeft => HTBOTTOMLEFT,
+            ResizeEdge::BottomRight => HTBOTTOMRIGHT,
+        }
+    }
+
+    fn client_size(hwnd: HWND) -> Option<(i32, i32)> {
+        let mut rect = RECT::default();
+        // SAFETY: `rect` is a valid out pointer and `hwnd` is owned by the current callback.
+        let ok = unsafe { GetClientRect(hwnd, &mut rect) } != 0;
+        if !ok {
+            return None;
+        }
+
+        let width = rect.right - rect.left;
+        let height = rect.bottom - rect.top;
+        (width > 0 && height > 0).then_some((width, height))
+    }
+
+    fn client_position_from_lparam(hwnd: HWND, lparam: LPARAM) -> Option<POINT> {
+        let mut point = POINT {
+            x: signed_low_word(lparam),
+            y: signed_high_word(lparam),
+        };
+        // SAFETY: `point` is a valid in/out pointer and `hwnd` is owned by the current callback.
+        let ok = unsafe { ScreenToClient(hwnd, &mut point) } != 0;
+        ok.then_some(point)
+    }
+
+    fn signed_low_word(value: LPARAM) -> i32 {
+        (value as u32 as u16 as i16).into()
+    }
+
+    fn signed_high_word(value: LPARAM) -> i32 {
+        ((value as u32 >> 16) as u16 as i16).into()
+    }
+
+    fn pack_signed_words(low: i32, high: i32) -> LPARAM {
+        let low = u32::from(low as i16 as u16);
+        let high = u32::from(high as i16 as u16) << 16;
+        (low | high) as LPARAM
+    }
+
+    fn is_primary_button_down() -> bool {
+        // SAFETY: GetKeyState reads the calling thread's keyboard state and has no pointer input.
+        unsafe { GetKeyState(i32::from(VK_LBUTTON)) < 0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_title_bar_hit_test_promotes_empty_title_area_to_caption() {
+        assert_eq!(
+            native_title_bar_hit_test(
+                Size::new(800.0, 600.0),
+                Point::new(200.0, 20.0),
+                false,
+                Size::new(8.0, 8.0),
+            ),
+            Some(NativeTitleBarHit::Caption),
+        );
+    }
+
+    #[test]
+    fn native_title_bar_hit_test_promotes_maximize_button_to_native_hit() {
+        assert_eq!(
+            native_title_bar_hit_test(
+                Size::new(800.0, 600.0),
+                Point::new(730.0, 20.0),
+                false,
+                Size::new(8.0, 8.0),
+            ),
+            Some(NativeTitleBarHit::MaximizeButton),
+        );
+    }
+
+    #[test]
+    fn native_title_bar_hit_test_keeps_pressed_maximize_as_native_hit() {
+        assert_eq!(
+            native_title_bar_hit_test(
+                Size::new(800.0, 600.0),
+                Point::new(730.0, 20.0),
+                true,
+                Size::new(8.0, 8.0),
+            ),
+            Some(NativeTitleBarHit::MaximizeButton),
+        );
+    }
+
+    #[test]
+    fn native_title_bar_hit_test_keeps_other_buttons_in_client_area() {
+        assert_eq!(
+            native_title_bar_hit_test(
+                Size::new(800.0, 600.0),
+                Point::new(775.0, 20.0),
+                false,
+                Size::new(8.0, 8.0),
+            ),
+            Some(NativeTitleBarHit::Client),
+        );
+    }
+
+    #[test]
+    fn native_title_bar_hit_test_ignores_body_area() {
+        assert_eq!(
+            native_title_bar_hit_test(
+                Size::new(800.0, 600.0),
+                Point::new(200.0, 60.0),
+                false,
+                Size::new(8.0, 8.0),
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn native_title_bar_hit_test_promotes_window_edges_to_resize_hits() {
+        let size = Size::new(800.0, 600.0);
+        let border = Size::new(8.0, 8.0);
+
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(2.0, 2.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::TopLeft)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(797.0, 2.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::TopRight)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(2.0, 597.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::BottomLeft)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(797.0, 597.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::BottomRight)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(2.0, 200.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::Left)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(797.0, 200.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::Right)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(200.0, 2.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::Top)),
+        );
+        assert_eq!(
+            native_title_bar_hit_test(size, Point::new(200.0, 597.0), false, border),
+            Some(NativeTitleBarHit::Resize(ResizeEdge::Bottom)),
+        );
+    }
+}

--- a/crates/tinymist-viewer/src/title_bar.rs
+++ b/crates/tinymist-viewer/src/title_bar.rs
@@ -1,0 +1,1012 @@
+//! Viewer-owned title bar for decorationless native windows.
+
+use std::any::type_name;
+use std::marker::PhantomData;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use masonry::accesskit::{Node, Role};
+use masonry::core::{
+    AccessCtx, ChildrenIds, CursorIcon, EventCtx, LayoutCtx, MeasureCtx, PaintCtx, PointerButton,
+    PointerButtonEvent, PointerEvent, PointerUpdate, PropertiesMut, PropertiesRef, QueryCtx,
+    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+};
+use masonry::dpi::{LogicalPosition, PhysicalPosition};
+use masonry::layout::LenReq;
+use reflexo::vector::incr::IncrDocClient;
+use reflexo::vector::stream::BytesModuleStream;
+use reflexo_vec2svg::IncrSvgDocServer;
+use tinymist_std::typst::TypstDocument;
+use tracing::{Span, trace_span};
+use typst::diag::{FileError, FileResult};
+use typst::foundations::{Bytes as TypstBytes, Datetime};
+use typst::layout::PagedDocument;
+use typst::syntax::{FileId, Source, VirtualPath};
+use typst::text::{Font, FontBook};
+use typst::utils::LazyHash;
+use typst::{Library, LibraryExt, World};
+use vello::Scene;
+use vello::kurbo::{Affine, Axis, BezPath, Point, Rect, Shape, Size};
+use vello::peniko::{Color, Fill};
+use xilem::core::{Arg, MessageCtx, MessageResult, Mut, View, ViewArgument, ViewMarker};
+use xilem::{Pod, ViewCtx};
+
+use tinymist_viewer::incr::IncrVelloDocClient;
+use tinymist_viewer::protocol::preview_update_from_bytes;
+
+/// Height of the viewer-owned title bar, in logical pixels.
+pub const TITLE_BAR_HEIGHT: f64 = 44.0;
+
+const TITLE_TEXT_SIZE_PT: f64 = 14.0;
+const TITLE_PADDING_X: f64 = 16.0;
+const BUTTON_WIDTH: f64 = 46.0;
+const BUTTON_GROUP_WIDTH: f64 = BUTTON_WIDTH * 4.0;
+const AVG_TITLE_CHAR_WIDTH: f64 = 8.4;
+const TITLE_BAR_BG: Color = Color::from_rgb8(0x29, 0x29, 0x29);
+const BUTTON_ICON_COLOR: Color = Color::from_rgba8(0xf6, 0xf6, 0xf6, 0xdf);
+const BUTTON_HOVER_ALPHA: f32 = 0.11;
+const BUTTON_ACTIVE_ALPHA: f32 = 0.17;
+const CLOSE_HOVER_ALPHA: f32 = 0.93;
+const BUTTON_TRANSITION_MS: f32 = 130.0;
+const BUTTON_ALPHA_EPSILON: f32 = 0.001;
+const TITLE_BAR_BUTTON_COUNT: usize = 4;
+const TITLE_BAR_DOUBLE_CLICK_MAX_DELAY: Duration = Duration::from_millis(500);
+const TITLE_BAR_DOUBLE_CLICK_MAX_DISTANCE: f64 = 5.0;
+
+const FA_ICON_SIZE: f64 = 13.5;
+const FA_XMARK_PATH: &str = "M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z";
+const FA_MINUS_PATH: &str = "M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z";
+const FA_WINDOW_MAXIMIZE_PATH: &str = "M32 32C14.3 32 0 46.3 0 64l0 384c0 17.7 14.3 32 32 32l448 0c17.7 0 32-14.3 32-32l0-384c0-17.7-14.3-32-32-32L32 32zM96 96l320 0 0 320L96 416 96 96z";
+const FA_CIRCLE_QUESTION_PATH: &str = "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3l58.3 0c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24l0-13.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1l-58.3 0c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z";
+
+/// Creates a viewer title bar with document title and window controls.
+pub fn title_bar<State, Action, F>(
+    title: impl Into<String>,
+    on_action: F,
+) -> TitleBar<State, Action, F>
+where
+    State: ViewArgument,
+    F: Fn(Arg<'_, State>, TitleBarAction) -> Action + 'static,
+{
+    TitleBar {
+        title: title.into(),
+        on_action,
+        phantom: PhantomData,
+    }
+}
+
+/// An app-level action emitted by the viewer title bar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TitleBarAction {
+    /// Toggle the in-app help overlay.
+    ToggleHelp,
+}
+
+/// The Xilem view for [`TitleBarWidget`].
+#[must_use = "View values do nothing unless provided to Xilem."]
+pub struct TitleBar<State, Action, F> {
+    title: String,
+    on_action: F,
+    phantom: PhantomData<fn(State) -> Action>,
+}
+
+impl<State, Action, F> ViewMarker for TitleBar<State, Action, F> {}
+
+impl<State, Action, F> View<State, Action, ViewCtx> for TitleBar<State, Action, F>
+where
+    State: ViewArgument,
+    Action: 'static,
+    F: Fn(Arg<'_, State>, TitleBarAction) -> Action + 'static,
+{
+    type Element = Pod<TitleBarWidget>;
+    type ViewState = ();
+
+    fn build(&self, ctx: &mut ViewCtx, _: Arg<'_, State>) -> (Self::Element, Self::ViewState) {
+        (
+            ctx.with_action_widget(|ctx| ctx.create_pod(TitleBarWidget::new(self.title.clone()))),
+            (),
+        )
+    }
+
+    fn rebuild(
+        &self,
+        prev: &Self,
+        (): &mut Self::ViewState,
+        _ctx: &mut ViewCtx,
+        mut element: Mut<'_, Self::Element>,
+        _: Arg<'_, State>,
+    ) {
+        if self.title != prev.title {
+            TitleBarWidget::set_title(&mut element, self.title.clone());
+        }
+    }
+
+    fn teardown(
+        &self,
+        (): &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        element: Mut<'_, Self::Element>,
+    ) {
+        ctx.teardown_action_source(element);
+    }
+
+    fn message(
+        &self,
+        (): &mut Self::ViewState,
+        message: &mut MessageCtx,
+        _element: Mut<'_, Self::Element>,
+        app_state: Arg<'_, State>,
+    ) -> MessageResult<Action> {
+        match message.take_message::<TitleBarAction>() {
+            Some(action) => MessageResult::Action((self.on_action)(app_state, *action)),
+            None => {
+                tracing::error!(
+                    "Wrong message type in TitleBar::message: {message:?} expected {}",
+                    type_name::<TitleBarAction>()
+                );
+                MessageResult::Stale
+            }
+        }
+    }
+}
+
+/// A decorationless-window title bar.
+pub struct TitleBarWidget {
+    title: String,
+    size: Size,
+    title_scene: Option<TitleScene>,
+    hovered_button: Option<TitleBarButton>,
+    active_button: Option<TitleBarButton>,
+    button_visuals: [ButtonVisual; TITLE_BAR_BUTTON_COUNT],
+    last_title_bar_click: Option<TitleBarClick>,
+}
+
+#[derive(Clone)]
+struct TitleScene {
+    title: String,
+    width: f64,
+    height: f64,
+    scene: Arc<Scene>,
+}
+
+#[derive(Clone, Copy)]
+struct TitleBarClick {
+    time: Instant,
+    pos: Point,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TitleBarButton {
+    Help,
+    Close,
+    Maximize,
+    Minimize,
+}
+
+impl TitleBarButton {
+    fn paint_order() -> [Self; 4] {
+        [Self::Help, Self::Minimize, Self::Maximize, Self::Close]
+    }
+
+    fn visual_index(self) -> usize {
+        match self {
+            Self::Help => 0,
+            Self::Minimize => 1,
+            Self::Maximize => 2,
+            Self::Close => 3,
+        }
+    }
+
+    fn right_index(self) -> f64 {
+        match self {
+            Self::Close => 0.0,
+            Self::Maximize => 1.0,
+            Self::Minimize => 2.0,
+            Self::Help => 3.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ButtonVisual {
+    alpha: f32,
+    target_alpha: f32,
+    alpha_per_ms: f32,
+}
+
+impl Default for ButtonVisual {
+    fn default() -> Self {
+        Self {
+            alpha: 0.0,
+            target_alpha: 0.0,
+            alpha_per_ms: 0.0,
+        }
+    }
+}
+
+impl ButtonVisual {
+    fn move_to(&mut self, target_alpha: f32) -> bool {
+        let target_alpha = target_alpha.clamp(0.0, 1.0);
+        if (self.target_alpha - target_alpha).abs() <= BUTTON_ALPHA_EPSILON {
+            if !self.is_stable() && self.alpha_per_ms.abs() <= BUTTON_ALPHA_EPSILON {
+                self.alpha_per_ms = (self.target_alpha - self.alpha) / BUTTON_TRANSITION_MS;
+            }
+
+            if !self.is_stable() {
+                return true;
+            }
+
+            return false;
+        }
+
+        self.target_alpha = target_alpha;
+        self.alpha_per_ms = (self.target_alpha - self.alpha) / BUTTON_TRANSITION_MS;
+        true
+    }
+
+    fn advance(&mut self, millis: f32) -> bool {
+        if self.is_stable() {
+            return false;
+        }
+
+        let previous = self.alpha;
+        self.alpha += self.alpha_per_ms * millis.max(0.0);
+        let passed_target = (previous <= self.target_alpha && self.alpha >= self.target_alpha)
+            || (previous >= self.target_alpha && self.alpha <= self.target_alpha);
+        if passed_target || (self.alpha - self.target_alpha).abs() <= BUTTON_ALPHA_EPSILON {
+            self.alpha = self.target_alpha;
+            self.alpha_per_ms = 0.0;
+        }
+
+        (self.alpha - previous).abs() > BUTTON_ALPHA_EPSILON
+    }
+
+    fn is_stable(self) -> bool {
+        (self.alpha - self.target_alpha).abs() <= BUTTON_ALPHA_EPSILON
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FontAwesomeIcon {
+    CircleQuestion,
+    Xmark,
+    WindowMaximize,
+    Minus,
+}
+
+impl FontAwesomeIcon {
+    fn path(self) -> &'static BezPath {
+        match self {
+            Self::CircleQuestion => {
+                static PATH: OnceLock<BezPath> = OnceLock::new();
+                PATH.get_or_init(|| parse_font_awesome_path(FA_CIRCLE_QUESTION_PATH))
+            }
+            Self::Xmark => {
+                static PATH: OnceLock<BezPath> = OnceLock::new();
+                PATH.get_or_init(|| parse_font_awesome_path(FA_XMARK_PATH))
+            }
+            Self::WindowMaximize => {
+                static PATH: OnceLock<BezPath> = OnceLock::new();
+                PATH.get_or_init(|| parse_font_awesome_path(FA_WINDOW_MAXIMIZE_PATH))
+            }
+            Self::Minus => {
+                static PATH: OnceLock<BezPath> = OnceLock::new();
+                PATH.get_or_init(|| parse_font_awesome_path(FA_MINUS_PATH))
+            }
+        }
+    }
+
+    fn target_size(self) -> f64 {
+        match self {
+            Self::CircleQuestion => 14.5,
+            Self::WindowMaximize => 13.5,
+            Self::Minus | Self::Xmark => FA_ICON_SIZE,
+        }
+    }
+}
+
+fn parse_font_awesome_path(path: &'static str) -> BezPath {
+    BezPath::from_svg(path).expect("embedded Font Awesome SVG path must parse")
+}
+
+impl TitleBarWidget {
+    /// Creates a title bar widget.
+    pub fn new(title: String) -> Self {
+        Self {
+            title,
+            size: Size::ZERO,
+            title_scene: None,
+            hovered_button: None,
+            active_button: None,
+            button_visuals: [ButtonVisual::default(); TITLE_BAR_BUTTON_COUNT],
+            last_title_bar_click: None,
+        }
+    }
+
+    /// Updates the visible title text.
+    pub fn set_title(this: &mut WidgetMut<'_, Self>, title: String) {
+        if this.widget.title == title {
+            return;
+        }
+
+        this.widget.title = title;
+        this.widget.title_scene = None;
+        this.ctx.request_render();
+        this.ctx.request_accessibility_update();
+    }
+
+    fn update_hovered_button(&mut self, ctx: &mut EventCtx<'_>, pos: Point) {
+        let hovered = button_at_pos(self.size, pos);
+        if self.hovered_button != hovered {
+            self.hovered_button = hovered;
+            self.update_button_visual_targets_event_ctx(ctx);
+        }
+    }
+
+    fn activate_button(&mut self, ctx: &mut EventCtx<'_>, button: TitleBarButton) {
+        match button {
+            TitleBarButton::Help => {
+                ctx.submit_action::<TitleBarAction>(TitleBarAction::ToggleHelp);
+            }
+            TitleBarButton::Close => ctx.exit(),
+            TitleBarButton::Maximize => {
+                if !crate::native_title_bar::take_native_maximize_activation() {
+                    ctx.toggle_maximized();
+                }
+            }
+            TitleBarButton::Minimize => ctx.minimize(),
+        }
+    }
+
+    fn update_button_visual_targets_event_ctx(&mut self, ctx: &mut EventCtx<'_>) {
+        if self.update_button_visual_targets() {
+            ctx.request_paint_only();
+            ctx.request_anim_frame();
+        }
+    }
+
+    fn update_button_visual_targets_update_ctx(&mut self, ctx: &mut UpdateCtx<'_>) {
+        if self.update_button_visual_targets() {
+            ctx.request_paint_only();
+            ctx.request_anim_frame();
+        }
+    }
+
+    fn update_button_visual_targets(&mut self) -> bool {
+        let mut changed = false;
+        for button in TitleBarButton::paint_order() {
+            let target = button_background_alpha(
+                button,
+                self.hovered_button == Some(button),
+                self.active_button == Some(button),
+            );
+            changed |= self.button_visuals[button.visual_index()].move_to(target);
+        }
+        changed
+    }
+
+    fn clear_active_button_event_ctx(&mut self, ctx: &mut EventCtx<'_>) -> bool {
+        if self.active_button.take().is_some() {
+            ctx.release_pointer();
+            self.update_button_visual_targets_event_ctx(ctx);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn handle_title_bar_primary_down(&mut self, ctx: &mut EventCtx<'_>, pos: Point) {
+        let now = Instant::now();
+        if is_title_bar_double_click(self.last_title_bar_click, now, pos) {
+            self.last_title_bar_click = None;
+            ctx.toggle_maximized();
+        } else {
+            self.last_title_bar_click = Some(TitleBarClick { time: now, pos });
+            ctx.drag_window();
+        }
+    }
+
+    fn title_scene(&mut self) -> Option<&Scene> {
+        let width = title_available_width(self.size);
+        let height = self.size.height;
+        if width <= 1.0 || height <= 1.0 {
+            return None;
+        }
+
+        let title = truncate_title_for_width(&self.title, width);
+        let reuse = self.title_scene.as_ref().is_some_and(|scene| {
+            scene.title == title && scene.width == width && scene.height == height
+        });
+        if !reuse {
+            match render_title_scene(&title, width, height) {
+                Ok(scene) => {
+                    self.title_scene = Some(TitleScene {
+                        title,
+                        width,
+                        height,
+                        scene,
+                    });
+                }
+                Err(err) => {
+                    log::warn!("failed to render title bar text with Typst: {err}");
+                    self.title_scene = None;
+                    return None;
+                }
+            }
+        }
+
+        self.title_scene.as_ref().map(|scene| &*scene.scene)
+    }
+}
+
+impl Widget for TitleBarWidget {
+    type Action = TitleBarAction;
+
+    fn on_pointer_event(
+        &mut self,
+        ctx: &mut EventCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        event: &PointerEvent,
+    ) {
+        match event {
+            PointerEvent::Down(PointerButtonEvent {
+                button: Some(PointerButton::Secondary),
+                state,
+                ..
+            }) => {
+                let pos = ctx.local_position(state.position);
+                if button_at_pos(self.size, pos).is_none() {
+                    self.last_title_bar_click = None;
+                    ctx.show_window_menu(window_menu_position(
+                        state.position,
+                        ctx.get_scale_factor(),
+                    ));
+                    ctx.set_handled();
+                }
+            }
+            PointerEvent::Down(PointerButtonEvent {
+                button: None | Some(PointerButton::Primary),
+                state,
+                ..
+            }) => {
+                let pos = ctx.local_position(state.position);
+                if let Some(button) = button_at_pos(self.size, pos) {
+                    self.last_title_bar_click = None;
+                    self.active_button = Some(button);
+                    self.hovered_button = Some(button);
+                    ctx.capture_pointer();
+                    self.update_button_visual_targets_event_ctx(ctx);
+                } else {
+                    self.handle_title_bar_primary_down(ctx, pos);
+                }
+                ctx.set_handled();
+            }
+            PointerEvent::Move(PointerUpdate { current, .. }) => {
+                let pos = ctx.local_position(current.position);
+                self.update_hovered_button(ctx, pos);
+            }
+            PointerEvent::Up(event) => {
+                let pos = ctx.local_position(event.state.position);
+                let hovered = button_at_pos(self.size, pos);
+                if let Some(active) = self.active_button.take() {
+                    ctx.release_pointer();
+                    self.update_button_visual_targets_event_ctx(ctx);
+                    if hovered == Some(active) {
+                        self.activate_button(ctx, active);
+                    }
+                    ctx.set_handled();
+                }
+                if self.hovered_button != hovered {
+                    self.hovered_button = hovered;
+                    self.update_button_visual_targets_event_ctx(ctx);
+                }
+            }
+            PointerEvent::Cancel(_) => {
+                if self.clear_active_button_event_ctx(ctx) {
+                    ctx.set_handled();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_text_event(
+        &mut self,
+        _ctx: &mut EventCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        _event: &TextEvent,
+    ) {
+    }
+
+    fn accepts_pointer_interaction(&self) -> bool {
+        true
+    }
+
+    fn get_cursor(&self, ctx: &QueryCtx<'_>, pos: Point) -> CursorIcon {
+        if button_at_pos(self.size, ctx.to_local(pos)).is_some() {
+            CursorIcon::Pointer
+        } else {
+            CursorIcon::Default
+        }
+    }
+
+    fn register_children(&mut self, _ctx: &mut RegisterCtx<'_>) {}
+
+    fn on_anim_frame(
+        &mut self,
+        ctx: &mut UpdateCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        interval: u64,
+    ) {
+        let millis = (interval as f64 / 1_000_000.0) as f32;
+        let mut changed = false;
+        let mut ongoing = false;
+        for visual in &mut self.button_visuals {
+            changed |= visual.advance(millis);
+            ongoing |= !visual.is_stable();
+        }
+
+        if changed {
+            ctx.request_paint_only();
+        }
+        if ongoing {
+            ctx.request_anim_frame();
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
+        match event {
+            Update::HoveredChanged(false) => {
+                if self.hovered_button.take().is_some() {
+                    self.update_button_visual_targets_update_ctx(ctx);
+                }
+            }
+            Update::ActiveChanged(false) => {
+                if self.active_button.take().is_some() {
+                    self.update_button_visual_targets_update_ctx(ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn measure(
+        &mut self,
+        _ctx: &mut MeasureCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        axis: Axis,
+        len_req: LenReq,
+        _cross_length: Option<f64>,
+    ) -> f64 {
+        match axis {
+            Axis::Horizontal => match len_req {
+                LenReq::FitContent(space) => space,
+                LenReq::MinContent => 0.0,
+                LenReq::MaxContent => BUTTON_GROUP_WIDTH + TITLE_PADDING_X * 2.0,
+            },
+            Axis::Vertical => TITLE_BAR_HEIGHT,
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx<'_>, _props: &PropertiesRef<'_>, size: Size) {
+        if self.size != size {
+            self.size = size;
+            self.title_scene = None;
+        }
+        ctx.set_clip_path(size.to_rect());
+    }
+
+    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+        scene.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            TITLE_BAR_BG,
+            None,
+            &self.size.to_rect(),
+        );
+        if let Some(title_scene) = self.title_scene() {
+            scene.append(title_scene, Some(Affine::translate((TITLE_PADDING_X, 0.0))));
+        }
+        for button in TitleBarButton::paint_order() {
+            paint_title_bar_button(
+                scene,
+                self.size,
+                button,
+                self.button_visuals[button.visual_index()].alpha,
+                self.hovered_button == Some(button) || self.active_button == Some(button),
+            );
+        }
+    }
+
+    fn accessibility_role(&self) -> Role {
+        Role::TitleBar
+    }
+
+    fn accessibility(
+        &mut self,
+        _ctx: &mut AccessCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        node: &mut Node,
+    ) {
+        node.set_label(self.title.clone());
+    }
+
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
+    }
+
+    fn make_trace_span(&self, widget_id: WidgetId) -> Span {
+        trace_span!("TitleBar", id = widget_id.trace())
+    }
+}
+
+fn title_available_width(size: Size) -> f64 {
+    (size.width - BUTTON_GROUP_WIDTH - TITLE_PADDING_X * 2.0).max(0.0)
+}
+
+pub(crate) fn button_at_pos(size: Size, pos: Point) -> Option<TitleBarButton> {
+    TitleBarButton::paint_order()
+        .into_iter()
+        .find(|button| button_rect(size, *button).contains(pos))
+}
+
+fn button_rect(size: Size, button: TitleBarButton) -> Rect {
+    let x1 = size.width - button.right_index() * BUTTON_WIDTH;
+    Rect::new(x1 - BUTTON_WIDTH, 0.0, x1, size.height)
+}
+
+fn window_menu_position(pos: PhysicalPosition<f64>, scale_factor: f64) -> LogicalPosition<f64> {
+    let scale_factor = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    LogicalPosition::new(pos.x / scale_factor, pos.y / scale_factor)
+}
+
+fn is_title_bar_double_click(last: Option<TitleBarClick>, now: Instant, pos: Point) -> bool {
+    let Some(last) = last else {
+        return false;
+    };
+
+    now.duration_since(last.time) <= TITLE_BAR_DOUBLE_CLICK_MAX_DELAY
+        && (pos - last.pos).hypot2()
+            <= TITLE_BAR_DOUBLE_CLICK_MAX_DISTANCE * TITLE_BAR_DOUBLE_CLICK_MAX_DISTANCE
+}
+
+fn paint_title_bar_button(
+    scene: &mut Scene,
+    size: Size,
+    button: TitleBarButton,
+    background_alpha: f32,
+    hot: bool,
+) {
+    let rect = button_rect(size, button);
+    if background_alpha > BUTTON_ALPHA_EPSILON {
+        let color = button_background_color(button, background_alpha);
+        scene.fill(Fill::NonZero, Affine::IDENTITY, color, None, &rect);
+    }
+
+    let icon_color = if hot && button == TitleBarButton::Close {
+        Color::WHITE
+    } else {
+        BUTTON_ICON_COLOR
+    };
+    match button {
+        TitleBarButton::Help => paint_help_icon(scene, rect, icon_color),
+        TitleBarButton::Close => paint_close_icon(scene, rect, icon_color),
+        TitleBarButton::Maximize => paint_maximize_icon(scene, rect, icon_color),
+        TitleBarButton::Minimize => paint_minimize_icon(scene, rect, icon_color),
+    }
+}
+
+fn button_background_alpha(button: TitleBarButton, hovered: bool, active: bool) -> f32 {
+    if !hovered && !active {
+        return 0.0;
+    }
+
+    if button == TitleBarButton::Close {
+        CLOSE_HOVER_ALPHA
+    } else if active {
+        BUTTON_ACTIVE_ALPHA
+    } else {
+        BUTTON_HOVER_ALPHA
+    }
+}
+
+fn button_background_color(button: TitleBarButton, alpha: f32) -> Color {
+    let alpha = (alpha.clamp(0.0, 1.0) * 255.0).round() as u8;
+    if button == TitleBarButton::Close {
+        Color::from_rgba8(0xe8, 0x11, 0x23, alpha)
+    } else {
+        Color::from_rgba8(0xff, 0xff, 0xff, alpha)
+    }
+}
+
+fn paint_font_awesome_icon(scene: &mut Scene, rect: Rect, color: Color, icon: FontAwesomeIcon) {
+    let path = icon.path();
+    let bounds = path.bounding_box();
+    let scale = icon.target_size() / bounds.width().max(bounds.height()).max(1.0);
+    let x = (rect.x0 + rect.x1 - bounds.width() * scale) * 0.5 - bounds.x0 * scale;
+    let y = (rect.y0 + rect.y1 - bounds.height() * scale) * 0.5 - bounds.y0 * scale;
+    scene.fill(
+        Fill::NonZero,
+        Affine::translate((x, y)) * Affine::scale(scale),
+        color,
+        None,
+        path,
+    );
+}
+
+fn paint_minimize_icon(scene: &mut Scene, rect: Rect, color: Color) {
+    paint_font_awesome_icon(scene, rect, color, FontAwesomeIcon::Minus);
+}
+
+fn paint_maximize_icon(scene: &mut Scene, rect: Rect, color: Color) {
+    paint_font_awesome_icon(scene, rect, color, FontAwesomeIcon::WindowMaximize);
+}
+
+fn paint_close_icon(scene: &mut Scene, rect: Rect, color: Color) {
+    paint_font_awesome_icon(scene, rect, color, FontAwesomeIcon::Xmark);
+}
+
+fn paint_help_icon(scene: &mut Scene, rect: Rect, color: Color) {
+    paint_font_awesome_icon(scene, rect, color, FontAwesomeIcon::CircleQuestion);
+}
+
+fn truncate_title_for_width(title: &str, width: f64) -> String {
+    if width <= AVG_TITLE_CHAR_WIDTH * 4.0 {
+        return String::new();
+    }
+
+    let max_chars = (width / AVG_TITLE_CHAR_WIDTH).floor() as usize;
+    let mut chars = title.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() && max_chars > 3 {
+        let keep = max_chars.saturating_sub(3);
+        format!("{}...", truncated.chars().take(keep).collect::<String>())
+    } else {
+        title.to_owned()
+    }
+}
+
+fn render_title_scene(title: &str, width: f64, height: f64) -> Result<Arc<Scene>> {
+    let source = Source::new(
+        FileId::new(None, VirtualPath::new("/tinymist-viewer-title.typ")),
+        title_typst_source(title, width, height),
+    );
+    let world = TitleWorld { main: source };
+    let compiled = typst::compile::<PagedDocument>(&world);
+    for warning in compiled.warnings {
+        log::debug!("Typst title render warning: {warning:?}");
+    }
+    let doc = compiled
+        .output
+        .map_err(|errors| anyhow!("failed to compile title text: {errors:?}"))?;
+    let document = TypstDocument::Paged(Arc::new(doc));
+    let mut renderer = IncrSvgDocServer::default();
+    let frame = renderer.pack_delta(&document);
+    let update = preview_update_from_bytes(&frame).context("title preview frame is invalid")?;
+
+    let mut doc = IncrDocClient::default();
+    let mut vello = IncrVelloDocClient::default();
+    if update.reset_before_merge {
+        doc = IncrDocClient::default();
+        vello.reset();
+    }
+    let delta = BytesModuleStream::from_slice(update.payload).checkout_owned();
+    doc.merge_delta(delta);
+
+    let mut pages = vello.render_pages(&mut doc)?;
+    let (scene, _) = pages
+        .pop()
+        .context("Typst title render produced no pages")?;
+    Ok(scene)
+}
+
+fn title_typst_source(title: &str, width: f64, height: f64) -> String {
+    let title = typst_string_literal(title);
+    format!(
+        r##"#set page(width: {width}pt, height: {height}pt, margin: 0pt)
+#set text(font: "Libertinus Serif", size: {TITLE_TEXT_SIZE_PT}pt, fill: rgb("#f2f2f2"))
+#place(left + horizon, text({title}))
+"##
+    )
+}
+
+fn typst_string_literal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for c in text.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' | '\r' | '\t' => out.push(' '),
+            c if c.is_control() => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+struct TitleWorld {
+    main: Source,
+}
+
+impl World for TitleWorld {
+    fn library(&self) -> &LazyHash<Library> {
+        &title_typst_base().library
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        &title_typst_base().book
+    }
+
+    fn main(&self) -> FileId {
+        self.main.id()
+    }
+
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.main.id() {
+            Ok(self.main.clone())
+        } else {
+            Err(FileError::NotFound(id.vpath().as_rooted_path().to_owned()))
+        }
+    }
+
+    fn file(&self, id: FileId) -> FileResult<TypstBytes> {
+        Err(FileError::NotFound(id.vpath().as_rooted_path().to_owned()))
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        title_typst_base().fonts.get(index).cloned()
+    }
+
+    fn today(&self, _: Option<i64>) -> Option<Datetime> {
+        Some(Datetime::from_ymd(1970, 1, 1).expect("valid deterministic date"))
+    }
+}
+
+struct TitleTypstBase {
+    library: LazyHash<Library>,
+    book: LazyHash<FontBook>,
+    fonts: Vec<Font>,
+}
+
+fn title_typst_base() -> &'static TitleTypstBase {
+    static BASE: OnceLock<TitleTypstBase> = OnceLock::new();
+    BASE.get_or_init(|| {
+        let fonts = typst_assets::fonts()
+            .flat_map(|data| Font::iter(TypstBytes::new(data)))
+            .collect::<Vec<_>>();
+
+        TitleTypstBase {
+            library: LazyHash::new(Library::builder().build()),
+            book: LazyHash::new(FontBook::from_fonts(&fonts)),
+            fonts,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_controls_are_ordered_from_help_to_close() {
+        let size = Size::new(BUTTON_GROUP_WIDTH, TITLE_BAR_HEIGHT);
+        let y = TITLE_BAR_HEIGHT * 0.5;
+
+        assert_eq!(
+            button_at_pos(size, Point::new(22.0, y)),
+            Some(TitleBarButton::Help)
+        );
+        assert_eq!(
+            button_at_pos(size, Point::new(66.0, y)),
+            Some(TitleBarButton::Minimize)
+        );
+        assert_eq!(
+            button_at_pos(size, Point::new(110.0, y)),
+            Some(TitleBarButton::Maximize)
+        );
+        assert_eq!(
+            button_at_pos(size, Point::new(154.0, y)),
+            Some(TitleBarButton::Close)
+        );
+    }
+
+    #[test]
+    fn embedded_font_awesome_paths_parse_to_nonempty_bounds() {
+        for icon in [
+            FontAwesomeIcon::CircleQuestion,
+            FontAwesomeIcon::Xmark,
+            FontAwesomeIcon::WindowMaximize,
+            FontAwesomeIcon::Minus,
+        ] {
+            let bounds = icon.path().bounding_box();
+            assert!(bounds.width() > 0.0, "{icon:?} should have width");
+            assert!(bounds.height() > 0.0, "{icon:?} should have height");
+        }
+    }
+
+    #[test]
+    fn title_text_uses_libertinus_serif_at_ui_size() {
+        let source = title_typst_source("main.typ", 240.0, TITLE_BAR_HEIGHT);
+
+        assert!(source.contains(r#"font: "Libertinus Serif""#));
+        assert!(source.contains("size: 14pt"));
+    }
+
+    #[test]
+    fn button_background_targets_distinguish_hover_active_and_close() {
+        assert_eq!(
+            button_background_alpha(TitleBarButton::Minimize, false, false),
+            0.0
+        );
+        assert_eq!(
+            button_background_alpha(TitleBarButton::Minimize, true, false),
+            BUTTON_HOVER_ALPHA
+        );
+        assert_eq!(
+            button_background_alpha(TitleBarButton::Minimize, true, true),
+            BUTTON_ACTIVE_ALPHA
+        );
+        assert_eq!(
+            button_background_alpha(TitleBarButton::Close, true, false),
+            CLOSE_HOVER_ALPHA
+        );
+    }
+
+    #[test]
+    fn button_visual_reschedules_unfinished_same_target() {
+        let mut visual = ButtonVisual::default();
+        assert!(visual.move_to(BUTTON_HOVER_ALPHA));
+
+        visual.alpha = BUTTON_HOVER_ALPHA * 0.5;
+        visual.alpha_per_ms = 0.0;
+
+        assert!(visual.move_to(BUTTON_HOVER_ALPHA));
+        assert!(visual.alpha_per_ms > 0.0);
+    }
+
+    #[test]
+    fn title_bar_double_click_requires_nearby_recent_click() {
+        let now = Instant::now();
+        let first = TitleBarClick {
+            time: now,
+            pos: Point::new(20.0, 20.0),
+        };
+
+        assert!(is_title_bar_double_click(
+            Some(first),
+            now + Duration::from_millis(200),
+            Point::new(23.0, 22.0),
+        ));
+        assert!(!is_title_bar_double_click(
+            Some(first),
+            now + TITLE_BAR_DOUBLE_CLICK_MAX_DELAY + Duration::from_millis(1),
+            Point::new(20.0, 20.0),
+        ));
+        assert!(!is_title_bar_double_click(
+            Some(first),
+            now + Duration::from_millis(200),
+            Point::new(40.0, 20.0),
+        ));
+    }
+
+    #[test]
+    fn window_menu_position_converts_physical_to_logical() {
+        assert_eq!(
+            window_menu_position(PhysicalPosition::new(300.0, 150.0), 1.5),
+            LogicalPosition::new(200.0, 100.0),
+        );
+    }
+
+    #[test]
+    fn title_scene_renders_with_configured_font() {
+        render_title_scene("main.typ - Tinymist View", 320.0, TITLE_BAR_HEIGHT)
+            .expect("title text should render with the configured font");
+    }
+}

--- a/crates/tinymist-viewer/src/zoom_portal.rs
+++ b/crates/tinymist-viewer/src/zoom_portal.rs
@@ -18,7 +18,7 @@ use masonry::layout::{LayoutSize, LenDef, LenReq, SizeDef};
 use masonry::theme;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::peniko::Fill;
+use vello::peniko::{Color, Fill};
 use xilem::core::{
     Arg, MessageCtx, MessageResult, Mut, View, ViewArgument, ViewId, ViewMarker, ViewPathTracker,
 };
@@ -32,6 +32,9 @@ const NORMAL_SCROLL_LINE_PX: f64 = 120.0;
 const ZOOM_WHEEL_LINE_PX: f64 = 20.0;
 const ZOOM_WHEEL_THRESHOLD: f64 = 20.0;
 const VIEWPORT_EPSILON: f64 = 1e-12;
+const VIEWPORT_BACKGROUND_COLOR: Color = Color::from_rgb8(0x29, 0x29, 0x29);
+const SCROLLBAR_THUMB_COLOR: Color = Color::from_rgba8(0x80, 0x80, 0x80, 0x8f);
+const SCROLLBAR_THUMB_BORDER_COLOR: Color = Color::from_rgba8(0x80, 0x80, 0x80, 0x40);
 
 /// A view which puts `child` into a scrollable region and handles modified-wheel zoom.
 pub fn zoom_portal<Child, State, Action, F>(
@@ -524,7 +527,9 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for ZoomPortalWidget<W> {
         );
     }
 
-    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+        paint_viewport_background(scene, ctx.content_box_size());
+    }
 
     fn post_paint(
         &mut self,
@@ -767,19 +772,33 @@ fn scrollbar_track_rect(axis: Axis, portal_size: Size) -> Rect {
     )
 }
 
+fn viewport_background_rect(portal_size: Size) -> Rect {
+    portal_size.to_rect()
+}
+
+fn paint_viewport_background(scene: &mut Scene, portal_size: Size) {
+    scene.fill(
+        Fill::NonZero,
+        Affine::IDENTITY,
+        VIEWPORT_BACKGROUND_COLOR,
+        None,
+        &viewport_background_rect(portal_size),
+    );
+}
+
 fn paint_scrollbar_thumb(scene: &mut Scene, cursor_rect: Rect) {
     let cursor_rect = cursor_rect.to_rounded_rect(theme::SCROLLBAR_RADIUS);
     scene.fill(
         Fill::NonZero,
         Affine::IDENTITY,
-        theme::SCROLLBAR_COLOR,
+        SCROLLBAR_THUMB_COLOR,
         None,
         &cursor_rect,
     );
     scene.stroke(
         &Stroke::new(theme::SCROLLBAR_EDGE_WIDTH),
         Affine::IDENTITY,
-        theme::SCROLLBAR_BORDER_COLOR,
+        SCROLLBAR_THUMB_BORDER_COLOR,
         None,
         &cursor_rect,
     );
@@ -871,12 +890,12 @@ fn anchored_viewport_after_zoom(
 mod tests {
     use masonry::core::ScrollDelta;
     use masonry::dpi::PhysicalPosition;
-    use masonry::kurbo::{Axis, Point, Size};
+    use masonry::kurbo::{Axis, Point, Rect, Size};
 
     use super::{
         ScrollbarGeometry, ZOOM_WHEEL_LINE_PX, ZoomAnchor, anchored_viewport_after_zoom,
         centered_child_origin, content_pos_under_cursor, scroll_delta_logical_px, scroll_progress,
-        scrollbar_at_pos, zoom_action_from_wheel_delta,
+        scrollbar_at_pos, viewport_background_rect, zoom_action_from_wheel_delta,
     };
     use crate::doc::ZoomAction;
 
@@ -1022,6 +1041,14 @@ mod tests {
             scrollbar_at_pos(portal, Size::new(80.0, 80.0), Point::new(96.0, 50.0))
                 .map(|scrollbar| scrollbar.axis),
             None
+        );
+    }
+
+    #[test]
+    fn viewport_background_matches_allocated_body_size() {
+        assert_eq!(
+            viewport_background_rect(Size::new(800.0, 600.0)),
+            Rect::new(0.0, 0.0, 800.0, 600.0)
         );
     }
 

--- a/openspec/changes/add-native-viewer-title-bar/.openspec.yaml
+++ b/openspec/changes/add-native-viewer-title-bar/.openspec.yaml
@@ -1,0 +1,1 @@
+status: complete

--- a/openspec/changes/add-native-viewer-title-bar/README.md
+++ b/openspec/changes/add-native-viewer-title-bar/README.md
@@ -1,0 +1,3 @@
+# add-native-viewer-title-bar
+
+Add a viewer-owned title bar and native window chrome behavior for the GPU viewer.

--- a/openspec/changes/add-native-viewer-title-bar/design.md
+++ b/openspec/changes/add-native-viewer-title-bar/design.md
@@ -1,0 +1,34 @@
+## Overview
+
+The viewer owns its title bar inside the Xilem application tree and runs the native window without operating-system decorations. The title bar is a small custom Masonry widget that paints the document title and window controls, handles pointer interaction, and emits app-level actions such as toggling help.
+
+The Xilem app is driven through an explicit `masonry_winit` event-loop wrapper. This lets the viewer observe each winit window id and install platform native behavior before events are delegated back to Masonry.
+
+## Title Bar
+
+The title bar renders:
+
+- document title text, truncated to available width
+- help, minimize, maximize, and close buttons
+- hover and active button feedback
+- an accessible title-bar role and label
+
+The title-bar widget keeps all drawing local to `tinymist-viewer`; it does not add protocol messages or editor-side state. The help button toggles a Typst-rendered overlay with preview shortcuts. Close, minimize, maximize, drag, double-click maximize, and context-menu interactions use existing Masonry event APIs where available.
+
+## Native Windows Behavior
+
+Windows requires non-client hit testing for a decorationless window to feel native. The viewer installs a window subclass for live winit windows and promotes the title-bar drag area, resize edges, and maximize button to the matching Windows hit-test values.
+
+The maximize button remains visible as a custom title-bar button, but Windows receives the native maximize hit so Windows 11 snap-layout hover and maximize behavior keep working. Mouse messages are bridged back to the client area so the custom button hover and active visuals remain in sync with native non-client interaction.
+
+Non-Windows platforms keep the same Xilem title bar but use no-op native hit-test installation.
+
+## Provider Window Matching
+
+The GPU viewer provider passes `--document-title` based on the preview document path. The viewer window title becomes `<document> - Tinymist View`; connection status suffixes may be appended while reconnecting.
+
+Side-by-side layout helpers search using the computed viewer title instead of a fixed `Tinymist View` string so post-launch arrangement still finds the native viewer window.
+
+## Viewport Chrome
+
+The scrollable preview viewport paints the same dark background as the title bar and uses subtler overlay scrollbar colors. The body column gap is set to zero so the custom title bar and preview viewport meet without a visible seam.

--- a/openspec/changes/add-native-viewer-title-bar/proposal.md
+++ b/openspec/changes/add-native-viewer-title-bar/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The native GPU viewer runs outside editor chrome. With the operating-system title bar, the viewer has generic window controls and no place for preview-specific controls such as help. It also cannot align its viewport chrome with the preview content background.
+
+On Windows, removing native decorations without replacing non-client hit testing would lose expected resize, drag, maximize, and snap-layout behavior. The viewer needs a custom title bar that keeps native window interactions intact where the platform supports them.
+
+## What Changes
+
+- Make `tinymist-viewer` use a decorationless native window with a viewer-owned title bar.
+- Add title-bar controls for help, minimize, maximize, and close.
+- Add an in-app help overlay for preview keyboard and mouse interactions.
+- Preserve Windows native title-bar hit testing for drag, resize, maximize, and snap-layout hover behavior.
+- Let the GPU viewer provider pass a document title so native window search still works when the visible viewer title includes the document name.
+- Align the preview viewport background and scrollbar styling with the custom chrome.
+
+## Capabilities
+
+### New Capabilities
+
+- `native-viewer-title-bar`: GPU viewer-owned title bar, help overlay, and native window hit testing for decorationless windows.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `crates/tinymist-viewer` gains custom title-bar widgets, native Windows hit testing, and tests for the new window chrome behavior.
+- `contrib/tinymist-gpu-viewer/editors/vscode` passes a document title to `tinymist-viewer` and finds the viewer window by the updated title.
+- Validation should include targeted `tinymist-viewer` tests, Rust formatting, and GPU viewer provider type-checking when TypeScript dependencies are installed.

--- a/openspec/changes/add-native-viewer-title-bar/specs/native-viewer-title-bar/spec.md
+++ b/openspec/changes/add-native-viewer-title-bar/specs/native-viewer-title-bar/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Viewer-Owned Native Title Bar
+
+The native GPU viewer SHALL render a viewer-owned title bar when running in its native window.
+
+#### Scenario: Title bar shows document-aware window title
+
+- **GIVEN** the GPU viewer provider launches `tinymist-viewer` for a Typst document
+- **WHEN** the viewer window is created
+- **THEN** the visible window title SHALL include the document title and `Tinymist View`
+- **AND** reconnecting or stopped states MAY append a status suffix.
+
+#### Scenario: Title bar provides expected window controls
+
+- **GIVEN** the native viewer window is visible
+- **WHEN** the user interacts with title-bar controls
+- **THEN** the viewer SHALL support help, minimize, maximize, and close actions.
+
+### Requirement: Native Window Interaction For Decorationless Viewer
+
+The native GPU viewer SHALL preserve expected native window interactions for decorationless windows where the platform supports them.
+
+#### Scenario: Windows title-bar hit testing preserves drag and resize
+
+- **GIVEN** the viewer runs on Windows
+- **WHEN** the user points at the title-bar drag region or window resize edges
+- **THEN** the viewer SHALL expose the matching native non-client hit-test result.
+
+#### Scenario: Windows maximize button preserves snap behavior
+
+- **GIVEN** the viewer runs on Windows
+- **WHEN** the user hovers or clicks the custom maximize button
+- **THEN** the viewer SHALL expose native maximize-button hit testing so platform snap-layout behavior can remain available.
+
+### Requirement: Viewer Help Overlay
+
+The native GPU viewer SHALL expose preview interaction help from the viewer title bar.
+
+#### Scenario: User toggles preview help
+
+- **GIVEN** the native viewer window is visible
+- **WHEN** the user activates the help title-bar control
+- **THEN** the viewer SHALL toggle an in-app overlay describing preview interactions.

--- a/openspec/changes/add-native-viewer-title-bar/tasks.md
+++ b/openspec/changes/add-native-viewer-title-bar/tasks.md
@@ -1,0 +1,22 @@
+## 1. OpenSpec
+
+- [x] 1.1 Add proposal, design, tasks, and native-viewer-title-bar spec.
+
+## 2. Viewer Title Bar
+
+- [x] 2.1 Run `tinymist-viewer` in a decorationless native window.
+- [x] 2.2 Add a viewer-owned title bar with help, minimize, maximize, and close controls.
+- [x] 2.3 Add a Typst-rendered help overlay for preview interactions.
+- [x] 2.4 Pass document titles from the GPU viewer provider and keep side-by-side window matching working.
+
+## 3. Native Window Interaction
+
+- [x] 3.1 Add Windows native title-bar hit testing for drag, resize, and maximize.
+- [x] 3.2 Bridge maximize-button non-client mouse events back to the custom title-bar visuals.
+- [x] 3.3 Keep non-Windows native title-bar integration as a no-op.
+
+## 4. Validation
+
+- [x] 4.1 Add targeted tests for title-bar geometry, icon paths, help rendering, and native hit testing.
+- [x] 4.2 Run targeted `tinymist-viewer` tests.
+- [x] 4.3 Run formatting and diff checks.


### PR DESCRIPTION
- Add a viewer-owned title bar for the native GPU viewer window.
- Add help/minimize/maximize/close controls and a Typst-rendered help overlay.
- Preserve Windows native drag, resize, maximize, and snap-layout hit testing for the decorationless window.
- Add `add-native-viewer-title-bar` OpenSpec artifacts.
