### PR TITLE
feat(viewer): persist native window state

### DIFF
--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -13,6 +13,8 @@ const VIEWER_WINDOW_TITLE = "Tinymist View";
 const WINDOW_LAYOUT_DELAY_MS = 700;
 const WINDOW_LAYOUT_TIMEOUT_MS = 10_000;
 const WINDOW_LAYOUT_POLL_MS = 250;
+const MIN_VIEWER_INNER_WIDTH = 800;
+const MIN_VIEWER_INNER_HEIGHT = 844;
 
 type WindowLayoutMode = "disabled" | "sideBySide";
 type PreviewTarget = "paged" | "html";
@@ -29,10 +31,18 @@ interface TinymistPreviewTask {
   documentPath: string;
   target: PreviewTarget;
   dataPlaneHost: string;
+  initialWindowState?: ViewerWindowState;
 }
 
 interface TinymistPreviewerProvider {
   providePreviewer(): Promise<TinymistPreviewer> | TinymistPreviewer;
+}
+
+interface ViewerWindowState {
+  inner_width: number;
+  inner_height: number;
+  outer_x?: number;
+  outer_y?: number;
 }
 
 interface WindowRect {
@@ -40,6 +50,11 @@ interface WindowRect {
   y: number;
   width: number;
   height: number;
+}
+
+interface WindowLaunchPlan {
+  initialWindowState?: ViewerWindowState;
+  repairSideBySideLayout: boolean;
 }
 
 let outputChannel: vscode.OutputChannel | undefined;
@@ -86,6 +101,8 @@ async function launchViewer(
   const viewerTitle = viewerWindowTitle(documentTitle);
   const layoutMode = getWindowLayoutMode();
   const args = ["--data-plane-host", task.dataPlaneHost, "--document-title", documentTitle];
+  const windowPlan = await windowLaunchPlanForTask(task, layoutMode);
+  appendInitialWindowArgs(args, windowPlan.initialWindowState);
   const cwd = path.dirname(task.documentPath);
   appendLog(`Starting ${executable} ${args.join(" ")}`);
 
@@ -99,7 +116,7 @@ async function launchViewer(
   });
 
   activeViewers.set(task.taskId, viewer);
-  scheduleWindowLayout(viewer, viewerTitle, layoutMode === "sideBySide");
+  scheduleWindowLayout(viewer, viewerTitle, windowPlan.repairSideBySideLayout);
   viewer.stdout.on("data", (data: Buffer) => appendLog(data.toString()));
   viewer.stderr.on("data", (data: Buffer) => appendLog(data.toString()));
   viewer.on("error", (error) => {
@@ -130,6 +147,116 @@ function deleteActiveViewer(taskId: string, viewer: ChildProcessWithoutNullStrea
   if (activeViewers.get(taskId) === viewer) {
     activeViewers.delete(taskId);
   }
+}
+
+async function windowLaunchPlanForTask(
+  task: TinymistPreviewTask,
+  layoutMode: WindowLayoutMode,
+): Promise<WindowLaunchPlan> {
+  const storedWindowState = normalizeStoredWindowState(task.initialWindowState);
+  if (layoutMode === "sideBySide") {
+    const sideBySideState = await prepareSideBySideInitialWindowState();
+    if (storedWindowState) {
+      appendLog(
+        "Using stored viewer window state after side-by-side pre-layout; skipping viewer layout repair.",
+      );
+      return {
+        initialWindowState: storedWindowState,
+        repairSideBySideLayout: false,
+      };
+    }
+
+    return {
+      initialWindowState: sideBySideState,
+      repairSideBySideLayout: true,
+    };
+  }
+
+  return {
+    initialWindowState: storedWindowState,
+    repairSideBySideLayout: false,
+  };
+}
+
+async function prepareSideBySideInitialWindowState(): Promise<ViewerWindowState | undefined> {
+  try {
+    const rect = await prepareSideBySideLayoutBeforeSpawn();
+    if (!rect) {
+      return undefined;
+    }
+
+    appendLog(
+      `Prepared side-by-side viewer initial window rect ${rect.width}x${rect.height}+${rect.x}+${rect.y}.`,
+    );
+    return windowStateFromRect(rect);
+  } catch (error) {
+    appendLog(`Could not prepare side-by-side window layout before launch: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+function appendInitialWindowArgs(args: string[], state: ViewerWindowState | undefined) {
+  if (!state) {
+    return;
+  }
+
+  args.push("--initial-window-inner-size", `${state.inner_width}x${state.inner_height}`);
+  if (state.outer_x !== undefined && state.outer_y !== undefined) {
+    args.push(`--initial-window-position=${state.outer_x},${state.outer_y}`);
+  }
+}
+
+function windowStateFromRect(rect: WindowRect): ViewerWindowState | undefined {
+  if (!isFiniteInteger(rect.width) || !isFiniteInteger(rect.height)) {
+    return undefined;
+  }
+  if (rect.width <= 0 || rect.height <= 0) {
+    return undefined;
+  }
+
+  const state: ViewerWindowState = {
+    inner_width: rect.width,
+    inner_height: rect.height,
+  };
+  if (isFiniteInteger(rect.x) && isFiniteInteger(rect.y)) {
+    state.outer_x = rect.x;
+    state.outer_y = rect.y;
+  }
+  return state;
+}
+
+function normalizeStoredWindowState(value: unknown): ViewerWindowState | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const { inner_width, inner_height, outer_x, outer_y } = value;
+  if (
+    !isFiniteInteger(inner_width) ||
+    !isFiniteInteger(inner_height) ||
+    inner_width < MIN_VIEWER_INNER_WIDTH ||
+    inner_height < MIN_VIEWER_INNER_HEIGHT
+  ) {
+    return undefined;
+  }
+
+  const state: ViewerWindowState = { inner_width, inner_height };
+  if (outer_x !== undefined || outer_y !== undefined) {
+    if (!isFiniteInteger(outer_x) || !isFiniteInteger(outer_y)) {
+      return undefined;
+    }
+    state.outer_x = outer_x;
+    state.outer_y = outer_y;
+  }
+  return state;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
 }
 
 function resolveViewerExecutable(context: vscode.ExtensionContext): string {
@@ -201,6 +328,194 @@ function getWindowLayoutMode(): WindowLayoutMode {
     .get<string>("windowLayout", "sideBySide");
 
   return configured === "sideBySide" ? "sideBySide" : "disabled";
+}
+
+async function prepareSideBySideLayoutBeforeSpawn(): Promise<WindowRect | undefined> {
+  switch (process.platform) {
+    case "win32":
+      return prepareSideBySideLayoutBeforeSpawnWin32();
+    case "darwin":
+      return prepareSideBySideLayoutBeforeSpawnMacOS();
+    case "linux":
+      return prepareSideBySideLayoutBeforeSpawnLinux();
+    default:
+      appendLog(`Skipping side-by-side pre-layout: unsupported platform ${process.platform}.`);
+      return undefined;
+  }
+}
+
+async function prepareSideBySideLayoutBeforeSpawnWin32(): Promise<WindowRect> {
+  const script = `
+$codeProcessNames = @('Code', 'Code - Insiders', 'VSCodium', 'Code - OSS')
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class TinymistWindowApi {
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll")]
+    public static extern bool MoveWindow(IntPtr hWnd, int x, int y, int width, int height, bool repaint);
+
+    [DllImport("user32.dll")]
+    public static extern bool ShowWindowAsync(IntPtr hWnd, int command);
+}
+'@
+
+function Get-VisibleTopLevelWindows {
+    $script:tinymistWindows = New-Object 'System.Collections.Generic.List[object]'
+    $callback = [TinymistWindowApi+EnumWindowsProc]{
+        param([IntPtr] $handle, [IntPtr] $param)
+
+        if (-not [TinymistWindowApi]::IsWindowVisible($handle)) {
+            return $true
+        }
+
+        $titleBuilder = New-Object System.Text.StringBuilder 512
+        [void][TinymistWindowApi]::GetWindowText($handle, $titleBuilder, $titleBuilder.Capacity)
+        $title = $titleBuilder.ToString()
+        if ([string]::IsNullOrWhiteSpace($title)) {
+            return $true
+        }
+
+        [uint32] $windowPid = 0
+        [void][TinymistWindowApi]::GetWindowThreadProcessId($handle, [ref] $windowPid)
+        $script:tinymistWindows.Add([pscustomobject]@{
+            Handle = $handle
+            ProcessId = [int] $windowPid
+            Title = $title
+        })
+
+        return $true
+    }
+
+    [void][TinymistWindowApi]::EnumWindows($callback, [IntPtr]::Zero)
+    return $script:tinymistWindows
+}
+
+function Test-CodeWindow($window) {
+    try {
+        $processName = (Get-Process -Id $window.ProcessId -ErrorAction Stop).ProcessName
+    } catch {
+        $processName = ''
+    }
+
+    return (($codeProcessNames -contains $processName) -or ($window.Title -like '*Visual Studio Code*') -or ($window.Title -like '*VSCodium*') -or ($window.Title -like '*Code - OSS*'))
+}
+
+$codeWindow = Get-VisibleTopLevelWindows | Where-Object { Test-CodeWindow $_ } | Select-Object -First 1
+if (-not $codeWindow) {
+    throw 'Could not find a visible VS Code window.'
+}
+
+$workArea = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+$halfWidth = [Math]::Floor($workArea.Width / 2)
+$rightWidth = $workArea.Width - $halfWidth
+
+[void][TinymistWindowApi]::ShowWindowAsync($codeWindow.Handle, 9)
+[void][TinymistWindowApi]::MoveWindow($codeWindow.Handle, $workArea.Left, $workArea.Top, $halfWidth, $workArea.Height, $true)
+
+[pscustomobject]@{
+    x = [int] ($workArea.Left + $halfWidth)
+    y = [int] $workArea.Top
+    width = [int] $rightWidth
+    height = [int] $workArea.Height
+} | ConvertTo-Json -Compress
+`;
+
+  const { stdout } = await runFile("powershell.exe", [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script,
+  ]);
+  const rect = parseWindowRectJson(stdout);
+  if (!rect) {
+    throw new Error("Could not parse viewer window rect from PowerShell output.");
+  }
+  return rect;
+}
+
+async function prepareSideBySideLayoutBeforeSpawnMacOS(): Promise<WindowRect> {
+  const script = `
+set codeProcessNames to {"Code", "Visual Studio Code", "Code - Insiders", "VSCodium", "Code - OSS"}
+tell application "Finder"
+  set desktopBounds to bounds of window of desktop
+end tell
+
+set screenLeft to item 1 of desktopBounds
+set screenTop to item 2 of desktopBounds
+set screenRight to item 3 of desktopBounds
+set screenBottom to item 4 of desktopBounds
+set screenWidth to screenRight - screenLeft
+set screenHeight to screenBottom - screenTop
+set halfWidth to screenWidth div 2
+set rightWidth to screenWidth - halfWidth
+set viewerLeft to screenLeft + halfWidth
+
+tell application "System Events"
+  set codeProcess to missing value
+  repeat with processName in codeProcessNames
+    if exists process (contents of processName) then
+      set codeProcess to process (contents of processName)
+      exit repeat
+    end if
+  end repeat
+
+  if codeProcess is missing value then
+    error "Could not find a VS Code process."
+  end if
+  if not (exists window 1 of codeProcess) then
+    error "Could not find a VS Code window."
+  end if
+
+  set position of window 1 of codeProcess to {screenLeft, screenTop}
+  set size of window 1 of codeProcess to {halfWidth, screenHeight}
+end tell
+
+return (viewerLeft as string) & "," & (screenTop as string) & "," & (rightWidth as string) & "," & (screenHeight as string)
+`;
+
+  const { stdout } = await runFile("osascript", ["-e", script]);
+  const rect = parseWindowRectCsv(stdout);
+  if (!rect) {
+    throw new Error("Could not parse viewer window rect from AppleScript output.");
+  }
+  return rect;
+}
+
+async function prepareSideBySideLayoutBeforeSpawnLinux(): Promise<WindowRect> {
+  const windows = await getLinuxWindows();
+  const code = windows.find(isLinuxCodeWindow);
+  if (!code) {
+    throw new Error("Could not find a VS Code window.");
+  }
+
+  const rects = splitSideBySideWorkArea(await getLinuxWorkArea());
+  await moveLinuxWindow(
+    code.id,
+    rects.code.x,
+    rects.code.y,
+    rects.code.width,
+    rects.code.height,
+  );
+  return rects.viewer;
 }
 
 async function arrangeWindowsSideBySide(viewerPid: number, viewerTitle: string) {
@@ -443,6 +758,60 @@ function splitSideBySideWorkArea(workArea: WindowRect): { code: WindowRect; view
       height: workArea.height,
     },
   };
+}
+
+function parseWindowRectJson(stdout: string): WindowRect | undefined {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const line = lines[lines.length - 1];
+  if (!line) {
+    return undefined;
+  }
+
+  try {
+    return normalizeWindowRect(JSON.parse(line));
+  } catch {
+    return undefined;
+  }
+}
+
+function parseWindowRectCsv(stdout: string): WindowRect | undefined {
+  const values = stdout
+    .trim()
+    .split(",")
+    .map((value) => Number(value.trim()));
+  if (values.length !== 4) {
+    return undefined;
+  }
+
+  return normalizeWindowRect({
+    x: values[0],
+    y: values[1],
+    width: values[2],
+    height: values[3],
+  });
+}
+
+function normalizeWindowRect(value: unknown): WindowRect | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const { x, y, width, height } = value;
+  if (
+    !isFiniteInteger(x) ||
+    !isFiniteInteger(y) ||
+    !isFiniteInteger(width) ||
+    !isFiniteInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return undefined;
+  }
+
+  return { x, y, width, height };
 }
 
 interface CommandResult {

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -17,6 +17,7 @@ use reflexo::debug_loc::DocumentPosition;
 use reflexo::vector::incr::IncrDocClient;
 use reflexo::vector::stream::BytesModuleStream;
 use reflexo_vec2svg::IncrSvgDocServer;
+use serde::{Deserialize, Serialize};
 use tinymist_std::typst::TypstDocument;
 use tokio::sync::mpsc;
 use typst::diag::{FileError, FileResult};
@@ -27,7 +28,7 @@ use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt, World};
 use winit::application::ApplicationHandler;
-use winit::dpi::LogicalSize;
+use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::{DeviceEvent, StartCause, WindowEvent as WinitWindowEvent};
 use winit::event_loop::ActiveEventLoop;
 use winit::window::WindowId as WinitWindowId;
@@ -44,6 +45,9 @@ use xilem::{AppState, EventLoop, WidgetView, WindowId, Xilem, window};
 mod native_title_bar;
 mod title_bar;
 
+use tinymist_preview::{
+    ViewerWindowState as ControlPlaneViewerWindowState, ViewerWindowStateMessage,
+};
 use tinymist_viewer::doc::{ZoomAction, doc};
 use tinymist_viewer::incr::{IncrVelloDocClient, RenderedPage};
 use tinymist_viewer::protocol::preview_update_from_bytes;
@@ -66,6 +70,7 @@ const DEFAULT_VIEWER_INNER_WIDTH: u32 = 800;
 const DEFAULT_VIEWER_CONTENT_HEIGHT: u32 = 800;
 const MIN_VIEWER_INNER_WIDTH: u32 = 800;
 const MIN_VIEWER_INNER_HEIGHT: u32 = DEFAULT_VIEWER_CONTENT_HEIGHT + TITLE_BAR_HEIGHT as u32;
+const VIEWER_WINDOW_STATE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Parser)]
 struct Args {
@@ -81,6 +86,23 @@ struct Args {
     /// The document title shown in the viewer window.
     #[clap(long = "document-title", value_name = "TITLE")]
     pub document_title: Option<String>,
+
+    /// Initial native window inner size, for example 960x1080.
+    #[clap(
+        long = "initial-window-inner-size",
+        value_name = "WIDTHxHEIGHT",
+        value_parser = parse_initial_window_inner_size
+    )]
+    pub initial_window_inner_size: Option<PhysicalSize<u32>>,
+
+    /// Initial native window outer position, for example 960,0.
+    #[clap(
+        long = "initial-window-position",
+        value_name = "X,Y",
+        allow_hyphen_values = true,
+        value_parser = parse_initial_window_position
+    )]
+    pub initial_window_position: Option<PhysicalPosition<i32>>,
 }
 
 fn main() -> Result<()> {
@@ -91,7 +113,12 @@ fn main() -> Result<()> {
         .try_init()?;
 
     let (tx, rx) = mpsc::unbounded_channel();
+    let (window_state_tx, window_state_rx) = mpsc::unbounded_channel();
 
+    let initial_window_state = ViewerWindowState::from_initial_geometry(
+        args.initial_window_inner_size,
+        args.initial_window_position,
+    );
     let default_size = Size::new(
         f64::from(DEFAULT_VIEWER_INNER_WIDTH),
         f64::from(DEFAULT_VIEWER_CONTENT_HEIGHT),
@@ -103,6 +130,7 @@ fn main() -> Result<()> {
             data_plane_host,
             document_title,
             window_id: WindowId::next(),
+            initial_window_state,
             running: true,
             pages: vec![],
             background_color: None,
@@ -114,6 +142,7 @@ fn main() -> Result<()> {
             zoom_scale: DEFAULT_ZOOM_SCALE,
             tx,
             rx: Some(rx),
+            window_state_rx: Some(window_state_rx),
         },
         PreviewState::windows,
     );
@@ -129,6 +158,8 @@ fn main() -> Result<()> {
     let mut app = ViewerEventLoopApp {
         masonry_state,
         app_driver: Box::new(driver),
+        window_state: initial_window_state,
+        window_state_tx: Some(window_state_tx),
     };
     event_loop
         .run_app(&mut app)
@@ -139,6 +170,30 @@ fn main() -> Result<()> {
 struct ViewerEventLoopApp {
     masonry_state: MasonryState<'static>,
     app_driver: Box<dyn AppDriver>,
+    window_state: ViewerWindowState,
+    window_state_tx: Option<mpsc::UnboundedSender<ViewerWindowState>>,
+}
+
+impl ViewerEventLoopApp {
+    fn record_window_event(&mut self, event: &WinitWindowEvent) {
+        let changed = match event {
+            WinitWindowEvent::Moved(position) => self.window_state.set_outer_position(*position),
+            WinitWindowEvent::Resized(size) => self.window_state.set_inner_size(*size),
+            _ => false,
+        };
+
+        if changed {
+            self.send_window_state();
+        }
+    }
+
+    fn send_window_state(&mut self) {
+        if let Some(tx) = &self.window_state_tx
+            && tx.send(self.window_state).is_err()
+        {
+            self.window_state_tx = None;
+        }
+    }
 }
 
 impl ApplicationHandler<MasonryUserEvent> for ViewerEventLoopApp {
@@ -162,6 +217,7 @@ impl ApplicationHandler<MasonryUserEvent> for ViewerEventLoopApp {
         event: WinitWindowEvent,
     ) {
         native_title_bar::install_for_window_id(window_id);
+        self.record_window_event(&event);
         self.masonry_state.handle_window_event(
             event_loop,
             window_id,
@@ -202,10 +258,144 @@ impl ApplicationHandler<MasonryUserEvent> for ViewerEventLoopApp {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct ViewerWindowState {
+    #[serde(default = "default_viewer_inner_width")]
+    inner_width: u32,
+    #[serde(default = "default_viewer_inner_height")]
+    inner_height: u32,
+    #[serde(default)]
+    outer_x: Option<i32>,
+    #[serde(default)]
+    outer_y: Option<i32>,
+}
+
+impl Default for ViewerWindowState {
+    fn default() -> Self {
+        Self {
+            inner_width: default_viewer_inner_width(),
+            inner_height: default_viewer_inner_height(),
+            outer_x: None,
+            outer_y: None,
+        }
+    }
+}
+
+impl ViewerWindowState {
+    fn from_initial_geometry(
+        size: Option<PhysicalSize<u32>>,
+        position: Option<PhysicalPosition<i32>>,
+    ) -> Self {
+        let mut state = Self::default();
+        if let Some(size) = size {
+            state.inner_width = size.width.max(1);
+            state.inner_height = size.height.max(1);
+        }
+        if let Some(position) = position {
+            state.outer_x = Some(position.x);
+            state.outer_y = Some(position.y);
+        }
+        state
+    }
+
+    fn inner_size(self) -> PhysicalSize<u32> {
+        PhysicalSize::new(self.inner_width, self.inner_height)
+    }
+
+    fn outer_position(self) -> Option<PhysicalPosition<i32>> {
+        Some(PhysicalPosition::new(self.outer_x?, self.outer_y?))
+    }
+
+    fn set_inner_size(&mut self, size: PhysicalSize<u32>) -> bool {
+        if !is_valid_window_inner_size(size) {
+            return false;
+        }
+
+        if self.inner_width == size.width && self.inner_height == size.height {
+            return false;
+        }
+
+        self.inner_width = size.width;
+        self.inner_height = size.height;
+        true
+    }
+
+    fn set_outer_position(&mut self, position: PhysicalPosition<i32>) -> bool {
+        if self.outer_x == Some(position.x) && self.outer_y == Some(position.y) {
+            return false;
+        }
+
+        self.outer_x = Some(position.x);
+        self.outer_y = Some(position.y);
+        true
+    }
+}
+
+fn default_viewer_inner_width() -> u32 {
+    DEFAULT_VIEWER_INNER_WIDTH
+}
+
+fn default_viewer_inner_height() -> u32 {
+    MIN_VIEWER_INNER_HEIGHT
+}
+
+fn is_valid_window_inner_size(size: PhysicalSize<u32>) -> bool {
+    size.width >= MIN_VIEWER_INNER_WIDTH && size.height >= MIN_VIEWER_INNER_HEIGHT
+}
+
+fn viewer_window_state_payload(state: ViewerWindowState) -> serde_json::Result<String> {
+    serde_json::to_string(&ViewerWindowStateMessage {
+        schema_version: VIEWER_WINDOW_STATE_SCHEMA_VERSION,
+        window: ControlPlaneViewerWindowState {
+            inner_width: state.inner_width,
+            inner_height: state.inner_height,
+            outer_x: state.outer_x,
+            outer_y: state.outer_y,
+        },
+    })
+}
+
+fn parse_initial_window_inner_size(value: &str) -> Result<PhysicalSize<u32>, String> {
+    let (width, height) = value
+        .split_once('x')
+        .or_else(|| value.split_once('X'))
+        .ok_or_else(|| "expected WIDTHxHEIGHT".to_owned())?;
+    let width = parse_positive_u32(width, "width")?;
+    let height = parse_positive_u32(height, "height")?;
+    Ok(PhysicalSize::new(width, height))
+}
+
+fn parse_initial_window_position(value: &str) -> Result<PhysicalPosition<i32>, String> {
+    let (x, y) = value
+        .split_once(',')
+        .ok_or_else(|| "expected X,Y".to_owned())?;
+    let x = x
+        .trim()
+        .parse::<i32>()
+        .map_err(|err| format!("invalid x position: {err}"))?;
+    let y = y
+        .trim()
+        .parse::<i32>()
+        .map_err(|err| format!("invalid y position: {err}"))?;
+    Ok(PhysicalPosition::new(x, y))
+}
+
+fn parse_positive_u32(value: &str, name: &str) -> Result<u32, String> {
+    let value = value
+        .trim()
+        .parse::<u32>()
+        .map_err(|err| format!("invalid {name}: {err}"))?;
+    if value == 0 {
+        return Err(format!("{name} must be greater than zero"));
+    }
+    Ok(value)
+}
+
 struct PreviewState {
     data_plane_host: String,
     document_title: Option<String>,
     window_id: WindowId,
+    initial_window_state: ViewerWindowState,
     running: bool,
     pages: Vec<RenderedPage>,
     background_color: Option<Color>,
@@ -217,6 +407,7 @@ struct PreviewState {
     zoom_scale: f64,
     tx: mpsc::UnboundedSender<PreviewEvent>,
     rx: Option<mpsc::UnboundedReceiver<PreviewEvent>>,
+    window_state_rx: Option<mpsc::UnboundedReceiver<ViewerWindowState>>,
 }
 
 impl AppState for PreviewState {
@@ -230,16 +421,23 @@ impl PreviewState {
         let window_id = self.window_id;
         let title = self.window_title();
         let root = self.view();
+        let initial_window_state = self.initial_window_state;
         std::iter::once(window(window_id, title, root).with_options(|options| {
-            options
+            let options = options
                 .with_decorations(false)
                 .with_min_inner_size(LogicalSize::new(
                     f64::from(MIN_VIEWER_INNER_WIDTH),
                     f64::from(MIN_VIEWER_INNER_HEIGHT),
                 ))
-                .on_close(|state: &mut PreviewState| {
-                    state.running = false;
-                })
+                .with_initial_inner_size(initial_window_state.inner_size());
+            let options = if let Some(position) = initial_window_state.outer_position() {
+                options.with_initial_position(position)
+            } else {
+                options
+            };
+            options.on_close(|state: &mut PreviewState| {
+                state.running = false;
+            })
         }))
     }
 
@@ -323,6 +521,7 @@ impl PreviewState {
             |proxy, args: &mut PreviewState| {
                 let address = websocket_address(&args.data_plane_host);
                 let rx = args.rx.take();
+                let mut window_state_rx = args.window_state_rx.take();
                 async move {
                     let Some(mut rx) = rx else {
                         log::warn!("spawn client multiple times for preview");
@@ -374,6 +573,27 @@ impl PreviewState {
                                             log::warn!("Error sending click position to websocket: {err}");
                                         }
                                     }
+                                }
+                            }
+                            state = async {
+                                match &mut window_state_rx {
+                                    Some(rx) => rx.recv().await,
+                                    None => None,
+                                }
+                            }, if window_state_rx.is_some() => {
+                                let Some(state) = state else {
+                                    window_state_rx = None;
+                                    continue;
+                                };
+                                let payload = match viewer_window_state_payload(state) {
+                                    Ok(payload) => payload,
+                                    Err(err) => {
+                                        log::debug!("failed to serialize viewer window state: {err}");
+                                        continue;
+                                    }
+                                };
+                                if let Err(err) = handle.text(format!("viewer-window-state {payload}")) {
+                                    log::debug!("failed to send viewer window state to preview server: {err}");
                                 }
                             }
                             res = &mut future => {
@@ -1186,6 +1406,98 @@ mod tests {
         assert!(!is_supported_external_link("ftp://example.com"));
         assert!(!is_supported_external_link("http:example.com"));
         assert!(!is_supported_external_link("mailto:"));
+    }
+
+    #[test]
+    fn viewer_window_state_ignores_transient_small_sizes() {
+        let mut state = ViewerWindowState::default();
+
+        assert!(!state.set_inner_size(PhysicalSize::new(320, 200)));
+        assert_eq!(
+            state.inner_size(),
+            PhysicalSize::new(MIN_VIEWER_INNER_WIDTH, MIN_VIEWER_INNER_HEIGHT)
+        );
+
+        assert!(state.set_inner_size(PhysicalSize::new(1024, 900)));
+        assert_eq!(state.inner_size(), PhysicalSize::new(1024, 900));
+    }
+
+    #[test]
+    fn initial_window_state_uses_cli_geometry() {
+        let state = ViewerWindowState::from_initial_geometry(
+            Some(PhysicalSize::new(1280, 720)),
+            Some(PhysicalPosition::new(-12, 34)),
+        );
+
+        assert_eq!(state.inner_size(), PhysicalSize::new(1280, 720));
+        assert_eq!(state.outer_position(), Some(PhysicalPosition::new(-12, 34)));
+    }
+
+    #[test]
+    fn parses_initial_window_inner_size() {
+        assert_eq!(
+            parse_initial_window_inner_size("1280x900").expect("size should parse"),
+            PhysicalSize::new(1280, 900)
+        );
+        assert_eq!(
+            parse_initial_window_inner_size("1280X900").expect("size should parse"),
+            PhysicalSize::new(1280, 900)
+        );
+
+        assert!(parse_initial_window_inner_size("1280,900").is_err());
+        assert!(parse_initial_window_inner_size("0x900").is_err());
+        assert!(parse_initial_window_inner_size("1280x0").is_err());
+        assert!(parse_initial_window_inner_size("wide").is_err());
+    }
+
+    #[test]
+    fn parses_initial_window_position() {
+        assert_eq!(
+            parse_initial_window_position("-10,20").expect("position should parse"),
+            PhysicalPosition::new(-10, 20)
+        );
+        assert_eq!(
+            parse_initial_window_position(" 10 , -20 ").expect("position should parse"),
+            PhysicalPosition::new(10, -20)
+        );
+
+        assert!(parse_initial_window_position("10x20").is_err());
+        assert!(parse_initial_window_position("left,20").is_err());
+    }
+
+    #[test]
+    fn cli_accepts_negative_initial_window_position() {
+        let args =
+            Args::try_parse_from(["tinymist-viewer", "--initial-window-position", "-541,349"])
+                .expect("negative window position should parse as an option value");
+
+        assert_eq!(
+            args.initial_window_position,
+            Some(PhysicalPosition::new(-541, 349))
+        );
+    }
+
+    #[test]
+    fn viewer_window_state_payload_uses_schema_payload() {
+        let message = viewer_window_state_payload(ViewerWindowState {
+            inner_width: 1280,
+            inner_height: 900,
+            outer_x: Some(24),
+            outer_y: Some(48),
+        })
+        .expect("state should serialize");
+
+        let payload = serde_json::from_str::<serde_json::Value>(&message)
+            .expect("event payload should be valid json");
+
+        assert_eq!(
+            payload["schema_version"],
+            VIEWER_WINDOW_STATE_SCHEMA_VERSION
+        );
+        assert_eq!(payload["window"]["inner_width"], 1280);
+        assert_eq!(payload["window"]["inner_height"], 900);
+        assert_eq!(payload["window"]["outer_x"], 24);
+        assert_eq!(payload["window"]["outer_y"], 48);
     }
 
     #[test]

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -14,13 +14,13 @@ use hyper_tungstenite::{tungstenite::Message, HyperWebsocket, HyperWebsocketStre
 use lsp_types::notification::Notification;
 use lsp_types::Url;
 use reflexo_typst::error::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sync_ls::just_ok;
 use tinymist_assets::TYPST_PREVIEW_HTML;
 use tinymist_preview::{
     frontend_html, ControlPlaneMessage, ControlPlaneRx, ControlPlaneTx, DocToSrcJumpInfo,
-    PreviewBuilder, PreviewConfig, PreviewMode, Previewer, WsMessage,
+    PreviewBuilder, PreviewConfig, PreviewMode, Previewer, ViewerWindowState, WsMessage,
 };
 use tinymist_query::{LspPosition, LspRange};
 use tinymist_std::error::IgnoreLogging;
@@ -480,6 +480,13 @@ impl PreviewState {
                         }
                     }
                     Outline(s) => client.send_notification::<NotifDocumentOutline>(&s),
+                    ViewerWindowState(s) => client.send_notification::<NotifViewerWindowState>(
+                        &ViewerWindowStateParams {
+                            task_id: tid.clone(),
+                            schema_version: s.schema_version,
+                            window: s.window,
+                        },
+                    ),
                 }
             }
 
@@ -604,6 +611,20 @@ struct NotifDocumentOutline;
 impl Notification for NotifDocumentOutline {
     type Params = tinymist_preview::Outline;
     const METHOD: &'static str = "tinymist/documentOutline";
+}
+
+#[derive(Serialize, Deserialize)]
+struct ViewerWindowStateParams {
+    task_id: String,
+    schema_version: u32,
+    window: ViewerWindowState,
+}
+
+struct NotifViewerWindowState;
+
+impl Notification for NotifViewerWindowState {
+    type Params = ViewerWindowStateParams;
+    const METHOD: &'static str = "tinymist/preview/windowState";
 }
 
 fn send_show_document(client: &TypedLspClient<PreviewState>, s: &DocToSrcJumpInfo, tid: &str) {

--- a/crates/typst-preview/src/actor/editor.rs
+++ b/crates/typst-preview/src/actor/editor.rs
@@ -11,7 +11,7 @@ use crate::debug_loc::{InternQuery, SpanInterner};
 use crate::outline::Outline;
 use crate::{
     ChangeCursorPositionRequest, DocToSrcJumpInfo, EditorServer, MemoryFiles, MemoryFilesShort,
-    ResolveSourceLocRequest,
+    ResolveSourceLocRequest, ViewerWindowStateMessage,
 };
 
 use super::webview::WebviewActorRequest;
@@ -39,6 +39,7 @@ pub enum EditorActorRequest {
     Shutdown,
     DocToSrcJumpResolve(DocToSrcJumpResolveRequest),
     DocToSrcJump(DocToSrcJumpInfo),
+    ViewerWindowState(ViewerWindowStateMessage),
     Outline(Outline),
     CompileStatus(CompileStatus),
 }
@@ -146,6 +147,8 @@ pub enum ControlPlaneResponse {
     CompileStatus(CompileStatus),
     #[serde(rename = "outline")]
     Outline(Outline),
+    #[serde(rename = "viewerWindowState")]
+    ViewerWindowState(ViewerWindowStateMessage),
 }
 
 impl<T: EditorServer> EditorActor<T> {
@@ -184,6 +187,9 @@ impl<T: EditorServer> EditorActor<T> {
                         },
                         EditorActorRequest::DocToSrcJump(jump_info) => {
                             self.editor_conn.resp_ctl_plane("DocToSrcJump", ControlPlaneResponse::EditorScrollTo(jump_info)).await
+                        },
+                        EditorActorRequest::ViewerWindowState(state) => {
+                            self.editor_conn.resp_ctl_plane("ViewerWindowState", ControlPlaneResponse::ViewerWindowState(state)).await
                         },
                         EditorActorRequest::DocToSrcJumpResolve(req) => {
                             self.source_scroll_by_span(req.span)

--- a/crates/typst-preview/src/actor/webview.rs
+++ b/crates/typst-preview/src/actor/webview.rs
@@ -5,7 +5,7 @@ use tokio::sync::{broadcast, mpsc};
 
 use super::{editor::EditorActorRequest, render::RenderActorRequest};
 use crate::{
-    WsMessage,
+    ViewerWindowStateMessage, WsMessage,
     actor::{editor::DocToSrcJumpResolveRequest, render::ResolveSpanRequest},
 };
 
@@ -168,6 +168,10 @@ where
                         let path = serde_json::from_str(path);
                         if let Ok(path) = path {
                             self.render_sender.send(RenderActorRequest::WebviewResolveFrameLoc(path)).log_error("WebViewActor");
+                        };
+                    } else if let Some(state) = msg.strip_prefix("viewer-window-state ") {
+                        if let Ok(state) = serde_json::from_str::<ViewerWindowStateMessage>(state) {
+                            self.editor_sender.send(EditorActorRequest::ViewerWindowState(state)).log_error("WebViewActor");
                         };
                     } else {
                         let err = self.webview_websocket_conn.send(WsMessage::Text(format!("error, received unknown message: {msg}"))).await;

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -471,6 +471,22 @@ pub struct MemoryFilesShort {
     // mtime: Option<u64>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewerWindowState {
+    pub inner_width: u32,
+    pub inner_height: u32,
+    #[serde(default)]
+    pub outer_x: Option<i32>,
+    #[serde(default)]
+    pub outer_y: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewerWindowStateMessage {
+    pub schema_version: u32,
+    pub window: ViewerWindowState,
+}
+
 pub trait CompileView: Send + Sync {
     /// Get the compiled document.
     fn doc(&self) -> Option<TypstDocument>;

--- a/editors/vscode/src/features/preview-window-state.ts
+++ b/editors/vscode/src/features/preview-window-state.ts
@@ -1,0 +1,130 @@
+import * as vscode from "vscode";
+
+export const VIEWER_WINDOW_STATE_SCHEMA_VERSION = 1;
+const VIEWER_WINDOW_STATE_STORAGE_KEY = "tinymist.gpuViewer.windowState.v1";
+const MIN_VIEWER_INNER_WIDTH = 800;
+const MIN_VIEWER_INNER_HEIGHT = 844;
+
+export interface ViewerWindowState {
+  inner_width: number;
+  inner_height: number;
+  outer_x?: number;
+  outer_y?: number;
+}
+
+interface ViewerWindowStateRecord {
+  schema_version: number;
+  window: ViewerWindowState;
+}
+
+interface ViewerWindowStateNotification {
+  task_id?: string;
+  schema_version: number;
+  window: ViewerWindowState;
+}
+
+let viewerWindowStateWriteQueue: Promise<void> = Promise.resolve();
+
+export function loadStoredViewerWindowState(
+  context: vscode.ExtensionContext,
+): ViewerWindowState | undefined {
+  const record = context.globalState.get<ViewerWindowStateRecord>(VIEWER_WINDOW_STATE_STORAGE_KEY);
+  if (!isObject(record) || record.schema_version !== VIEWER_WINDOW_STATE_SCHEMA_VERSION) {
+    return undefined;
+  }
+
+  return normalizeViewerWindowState(record.window);
+}
+
+export async function saveStoredViewerWindowState(
+  context: vscode.ExtensionContext,
+  notification: unknown,
+) {
+  const payload = normalizeViewerWindowStateNotification(notification);
+  if (!payload) {
+    return;
+  }
+
+  viewerWindowStateWriteQueue = viewerWindowStateWriteQueue
+    .catch(() => undefined)
+    .then(async () => {
+      const window = mergeViewerWindowState(loadStoredViewerWindowState(context), payload.window);
+      await context.globalState.update(VIEWER_WINDOW_STATE_STORAGE_KEY, {
+        schema_version: VIEWER_WINDOW_STATE_SCHEMA_VERSION,
+        window,
+      } satisfies ViewerWindowStateRecord);
+    });
+  await viewerWindowStateWriteQueue;
+}
+
+function normalizeViewerWindowStateNotification(
+  value: unknown,
+): ViewerWindowStateNotification | undefined {
+  if (!isObject(value) || value.schema_version !== VIEWER_WINDOW_STATE_SCHEMA_VERSION) {
+    return undefined;
+  }
+
+  const window = normalizeViewerWindowState(value.window);
+  if (!window) {
+    return undefined;
+  }
+
+  return {
+    task_id: typeof value.task_id === "string" ? value.task_id : undefined,
+    schema_version: VIEWER_WINDOW_STATE_SCHEMA_VERSION,
+    window,
+  };
+}
+
+function mergeViewerWindowState(
+  previous: ViewerWindowState | undefined,
+  next: ViewerWindowState,
+): ViewerWindowState {
+  if (next.outer_x !== undefined && next.outer_y !== undefined) {
+    return next;
+  }
+
+  if (previous?.outer_x === undefined || previous.outer_y === undefined) {
+    return next;
+  }
+
+  return {
+    ...next,
+    outer_x: previous.outer_x,
+    outer_y: previous.outer_y,
+  };
+}
+
+function normalizeViewerWindowState(value: unknown): ViewerWindowState | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const { inner_width, inner_height, outer_x, outer_y } = value;
+  if (
+    !isFiniteInteger(inner_width) ||
+    !isFiniteInteger(inner_height) ||
+    inner_width < MIN_VIEWER_INNER_WIDTH ||
+    inner_height < MIN_VIEWER_INNER_HEIGHT
+  ) {
+    return undefined;
+  }
+
+  const state: ViewerWindowState = { inner_width, inner_height };
+  if (outer_x !== undefined || outer_y !== undefined) {
+    if (!isFiniteInteger(outer_x) || !isFiniteInteger(outer_y)) {
+      return undefined;
+    }
+    state.outer_x = outer_x;
+    state.outer_y = outer_y;
+  }
+  return state;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -35,6 +35,7 @@ import {
   type PreviewerSourceMetadata,
   type ResolvedPreviewer,
 } from "./previewer";
+import { loadStoredViewerWindowState } from "./preview-window-state";
 
 /**
  * The launch preview implementation which depends on `isCompat` of previewActivate.
@@ -537,6 +538,7 @@ async function launchPreviewLsp(task: LaunchInBrowserTask | LaunchInWebViewTask)
             dataPlaneHost: `ws://127.0.0.1:${dataPlanePort}`,
             dataPlanePort,
             staticServerPort,
+            initialWindowState: loadStoredViewerWindowState(context),
             isBrowsing: !!isBrowsing,
             isPrimary: !!isPrimary,
           });

--- a/editors/vscode/src/features/previewer.ts
+++ b/editors/vscode/src/features/previewer.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { resolvePreviewerValue } from "../config";
 import { tinymist } from "../lsp";
 import { loadHTMLFile } from "../util";
+import type { ViewerWindowState } from "./preview-window-state";
 
 export type PreviewerSourceKind = "builtin" | "html" | "extension";
 export type PreviewTarget = "paged" | "html";
@@ -33,6 +34,7 @@ export interface TinymistPreviewTask {
   dataPlaneHost: string;
   dataPlanePort: string | number;
   staticServerPort: string | number;
+  initialWindowState?: ViewerWindowState;
   isBrowsing: boolean;
   isPrimary: boolean;
 }

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -24,6 +24,7 @@ import {
 } from "./config";
 import { TinymistStatus, wordCountItemProcess } from "./ui-extends";
 import { previewProcessOutline } from "./features/preview";
+import { saveStoredViewerWindowState } from "./features/preview-window-state";
 import { l10nMsg } from "./l10n";
 import { wordPattern } from "./language";
 import type { createSystemLanguageClient } from "./lsp.system";
@@ -675,6 +676,11 @@ export class LanguageState {
     // (Optional) The server requests to update the document outline
     client.onNotification("tinymist/documentOutline", async (data: any) => {
       previewProcessOutline(data);
+    });
+
+    // (Optional) The server reports native previewer window state updates from the control plane.
+    client.onNotification("tinymist/preview/windowState", async (data: unknown) => {
+      await saveStoredViewerWindowState(this.context, data);
     });
   }
 


### PR DESCRIPTION
- Persist native GPU viewer window size and position through client-owned storage.
- Add viewer startup geometry arguments and schema-versioned window-state messages.
- Forward window-state updates through `typst-preview`, `tinymist`, and the VS Code extension.
- Keep side-by-side pre-layout active while preserving stored viewer geometry.
- Add `improve-viewer-window-state` OpenSpec artifacts.
