### PR TITLE
ci: run checks on stable branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - nightly
+      - stable/**
     tags:
       - "*"
   pull_request:
@@ -11,6 +12,7 @@ on:
     branches:
       - main
       - nightly
+      - stable/**
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This updates the CI workflow branch filters so pushes and PRs targeting stable/* branches trigger the full tinymist::ci workflow.\n\nThis is needed for dependency bump PRs against stable/v0.15.0; without it, only the PR title lint runs.