### PR TITLE
fix: adapt world and output APIs for typst 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7162,6 +7162,7 @@ dependencies = [
  "time",
  "typst",
  "typst-html",
+ "typst-layout",
  "typst-shim",
  "wasm-bindgen",
  "web-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,6 +7195,7 @@ dependencies = [
  "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=3284e80)",
  "typst-eval",
  "typst-html",
+ "typst-layout",
  "typst-pdf",
  "typst-render",
  "typst-shim",

--- a/crates/tinymist-analysis/src/track_values.rs
+++ b/crates/tinymist-analysis/src/track_values.rs
@@ -131,7 +131,7 @@ pub fn analyze_labels(document: &TypstDocument) -> (Vec<DynLabel>, usize) {
     let _guard = GLOBAL_STATS.stat(None, "analyze_labels");
 
     // Labels in the document.
-    for elem in document.introspector().all() {
+    for elem in document.introspector().query_labelled() {
         let Some(label) = elem.label() else { continue };
         let (is_derived, details) = {
             let derived = elem

--- a/crates/tinymist-cli/src/cmd/test.rs
+++ b/crates/tinymist-cli/src/cmd/test.rs
@@ -23,6 +23,7 @@ use tinymist_std::{bail, error::prelude::*, fs::paths::write_atomic, typst::Typs
 use typst::diag::{Severity, SourceDiagnostic};
 use typst::ecow::EcoVec;
 use typst::foundations::{Context, Label};
+use typst::introspection::Introspector;
 use typst::syntax::{FileId, LinkedNode, Source, Span, ast};
 use typst::{World, utils::PicoStr};
 use typst_shim::eval::TypstEngine;
@@ -448,7 +449,10 @@ impl<'a> TestRunner<'a> {
         }
     }
 
-    fn build_example<T: typst::Document>(&self, world: &dyn World) -> (bool, Option<T>) {
+    fn build_example<T: typst::model::Document + typst::foundations::Output>(
+        &self,
+        world: &dyn World,
+    ) -> (bool, Option<T>) {
         let result = typst_shim::compile_opt::<T>(world);
         if !result.warnings.is_empty() {
             self.diagnostics.lock().push(result.warnings);
@@ -557,7 +561,7 @@ impl<'a> TestRunner<'a> {
             return false;
         };
         // todo: error multiple times
-        doc.introspector.query_label(label).is_ok()
+        doc.introspector().query_label(label).is_ok()
     }
 }
 

--- a/crates/tinymist-debug/src/instrument.rs
+++ b/crates/tinymist-debug/src/instrument.rs
@@ -9,6 +9,7 @@ use tinymist_world::vfs::PathResolution;
 use tinymist_world::{CompilerFeat, CompilerWorld, vfs::FileId};
 use typst::Library;
 use typst::diag::FileResult;
+use typst::foundations::Duration;
 use typst::foundations::{Bytes, Datetime};
 use typst::syntax::Source;
 use typst::text::{Font, FontBook};
@@ -60,7 +61,7 @@ where
         self.base.font(index)
     }
 
-    fn today(&self, offset: Option<i64>) -> Option<Datetime> {
+    fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         self.base.today(offset)
     }
 }

--- a/crates/tinymist-debug/src/lib.rs
+++ b/crates/tinymist-debug/src/lib.rs
@@ -26,7 +26,7 @@ use cov::*;
 use instrument::InstrumentWorld;
 
 /// Collects the coverage of a single execution.
-pub fn collect_coverage<D: typst::Document, F: CompilerFeat>(
+pub fn collect_coverage<D: typst::model::Document + typst::foundations::Output, F: CompilerFeat>(
     base: &CompilerWorld<F>,
 ) -> Result<CoverageResult> {
     let (cov, result) = with_cov(base, |instr| {

--- a/crates/tinymist-query/src/analysis/definition.rs
+++ b/crates/tinymist-query/src/analysis/definition.rs
@@ -176,7 +176,7 @@ fn field_definition(ctx: &Arc<SharedContext>, node: ast::FieldAccess) -> Option<
 
 fn bib_definition(
     ctx: &Arc<SharedContext>,
-    introspector: &Introspector,
+    introspector: &dyn Introspector,
     key: &str,
 ) -> Option<Definition> {
     let bib_info = ctx.analyze_bib(introspector)?;
@@ -195,7 +195,7 @@ fn bib_definition(
 }
 
 fn ref_definition(
-    introspector: &Introspector,
+    introspector: &dyn Introspector,
     name: &str,
     ref_expr: ast::Expr,
 ) -> Option<Definition> {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1031,7 +1031,7 @@ impl SharedContext {
     }
 
     /// Get bib info of a source file.
-    pub fn analyze_bib(&self, introspector: &Introspector) -> Option<Arc<BibInfo>> {
+    pub fn analyze_bib(&self, introspector: &dyn Introspector) -> Option<Arc<BibInfo>> {
         let world = self.world();
         let world = (world as &dyn World).track();
 

--- a/crates/tinymist-query/src/document_metrics.rs
+++ b/crates/tinymist-query/src/document_metrics.rs
@@ -140,7 +140,7 @@ impl DocumentMetricsWorker<'_> {
     fn work(&mut self, doc: &TypstDocument) -> Option<()> {
         match doc {
             TypstDocument::Paged(paged_doc) => {
-                for page in &paged_doc.pages {
+                for page in paged_doc.pages() {
                     self.work_frame(&page.frame)?;
                 }
 

--- a/crates/tinymist-query/src/jump.rs
+++ b/crates/tinymist-query/src/jump.rs
@@ -7,7 +7,8 @@ use tinymist_std::typst::TypstDocument;
 use tinymist_world::debug_loc::SourceSpanOffset;
 use typst::{
     World,
-    layout::{Frame, FrameItem, Point, Position, Size},
+    introspection::PagedPosition as Position,
+    layout::{Frame, FrameItem, Point, Size},
     syntax::{LinkedNode, Source, Span, SyntaxKind},
     visualize::Geometry,
 };
@@ -135,7 +136,7 @@ fn jump_from_cursor_(
             let mut min_point = Point::default();
             let mut min_dis = u64::MAX;
 
-            for (idx, page) in paged_doc.pages.iter().enumerate() {
+            for (idx, page) in paged_doc.pages().iter().enumerate() {
                 // In a page, we try to find a closer span than the existing found one.
                 let mut p_dis = min_dis;
 

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -51,7 +51,7 @@ pub mod testing;
 pub use tinymist_analysis::{stats::GLOBAL_STATS, ty, upstream};
 
 /// The physical position in a document.
-pub type FramePosition = typst::layout::Position;
+pub type FramePosition = typst::introspection::PagedPosition;
 
 mod adt;
 mod lsp_typst_boundary;

--- a/crates/tinymist-std/Cargo.toml
+++ b/crates/tinymist-std/Cargo.toml
@@ -44,6 +44,7 @@ rkyv = { workspace = true, optional = true }
 
 # feature = "typst"
 typst = { workspace = true, optional = true }
+typst-layout = { workspace = true, optional = true }
 typst-html = { workspace = true, optional = true }
 typst-shim = { workspace = true, optional = true }
 
@@ -72,7 +73,7 @@ hex.workspace = true
 default = ["full"]
 full = ["web", "rkyv", "typst"]
 
-typst = ["dep:typst", "dep:typst-shim", "dep:typst-html"]
+typst = ["dep:typst", "dep:typst-shim", "dep:typst-html", "dep:typst-layout"]
 
 rkyv = ["rkyv/alloc", "rkyv/archive_le"]
 rkyv-validation = ["rkyv/validation"]

--- a/crates/tinymist-std/src/concepts/typst.rs
+++ b/crates/tinymist-std/src/concepts/typst.rs
@@ -12,9 +12,9 @@ pub(crate) mod well_known {
 
     pub use typst::layout::Abs as TypstAbs;
 
-    pub use typst::Document as TypstDocumentTrait;
+    pub use typst::model::Document as TypstDocumentTrait;
 
-    pub use typst::layout::PagedDocument as TypstPagedDocument;
+    pub use typst_layout::PagedDocument as TypstPagedDocument;
 
     pub use typst_html::HtmlDocument as TypstHtmlDocument;
 
@@ -40,7 +40,7 @@ impl TypstDocument {
     /// Gets the number of pages in the document.
     pub fn num_of_pages(&self) -> u32 {
         match self {
-            Self::Paged(doc) => doc.pages.len() as u32,
+            Self::Paged(doc) => doc.pages().len() as u32,
             Self::Html(_doc) => 1u32,
         }
     }
@@ -48,17 +48,17 @@ impl TypstDocument {
     /// Gets details about the document.
     pub fn info(&self) -> &typst::model::DocumentInfo {
         match self {
-            Self::Paged(doc) => &doc.info,
-            Self::Html(doc) => &doc.info,
+            Self::Paged(doc) => doc.info(),
+            Self::Html(doc) => doc.info(),
         }
     }
 
     /// Gets the introspector that can be queried for elements and their
     /// positions.
-    pub fn introspector(&self) -> &typst::introspection::Introspector {
+    pub fn introspector(&self) -> &dyn typst::introspection::Introspector {
         match self {
-            Self::Paged(doc) => &doc.introspector,
-            Self::Html(doc) => &doc.introspector,
+            Self::Paged(doc) => doc.introspector().as_ref(),
+            Self::Html(doc) => doc.introspector().as_ref(),
         }
     }
 }

--- a/crates/tinymist-task/Cargo.toml
+++ b/crates/tinymist-task/Cargo.toml
@@ -36,6 +36,7 @@ typst.workspace = true
 typst-assets.workspace = true
 typst-eval.workspace = true
 typst-html.workspace = true
+typst-layout.workspace = true
 typst-pdf.workspace = true
 typst-render.workspace = true
 typst-shim.workspace = true

--- a/crates/tinymist-task/src/compute.rs
+++ b/crates/tinymist-task/src/compute.rs
@@ -7,9 +7,11 @@ use tinymist_std::error::prelude::*;
 use tinymist_std::typst::TypstPagedDocument;
 use tinymist_world::{CompileSnapshot, CompilerFeat, ExportComputation, WorldComputeGraph};
 use typst::foundations::Bytes;
-use typst::layout::{Abs, Page};
+use typst::layout::Abs;
+use typst::model::Document;
 use typst::syntax::{SyntaxNode, ast};
 use typst::visualize::Color;
+use typst_layout::Page;
 
 use crate::{Pages, TaskWhen, exported_page_ranges};
 
@@ -42,7 +44,7 @@ pub struct ExportTimings;
 
 impl ExportTimings {
     /// Checks if the export is needed.
-    pub fn needs_run<F: CompilerFeat, D: typst::Document>(
+    pub fn needs_run<F: CompilerFeat, D: Document>(
         snap: &CompileSnapshot<F>,
         timing: Option<&TaskWhen>,
         docs: Option<&D>,
@@ -74,7 +76,7 @@ fn select_pages<'a>(
 ) -> Vec<(usize, &'a Page)> {
     let pages = pages.as_ref().map(|pages| exported_page_ranges(pages));
     document
-        .pages
+        .pages()
         .iter()
         .enumerate()
         .filter(|(i, _)| {

--- a/crates/tinymist-task/src/compute/png.rs
+++ b/crates/tinymist-task/src/compute/png.rs
@@ -6,6 +6,7 @@ use tinymist_std::error::prelude::*;
 use tinymist_std::typst::TypstPagedDocument;
 use tinymist_world::{CompilerFeat, ExportComputation, WorldComputeGraph};
 use typst::foundations::Bytes;
+use typst::model::DocumentInfo;
 
 use crate::compute::{parse_color, parse_length, select_pages};
 use crate::model::ExportPngTask;
@@ -38,13 +39,13 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PngExport {
 
         let exported_pages = select_pages(doc, &config.pages);
         if let Some(PageMerge { ref gap }) = config.merge {
-            let dummy_doc = TypstPagedDocument {
-                pages: exported_pages
+            let dummy_doc = TypstPagedDocument::new(
+                exported_pages
                     .into_iter()
                     .map(|(_, page)| page.clone())
                     .collect(),
-                ..Default::default()
-            };
+                DocumentInfo::default(),
+            );
             let gap = gap
                 .as_ref()
                 .and_then(|gap| parse_length(gap).ok())

--- a/crates/tinymist-task/src/compute/png.rs
+++ b/crates/tinymist-task/src/compute/png.rs
@@ -6,7 +6,7 @@ use tinymist_std::error::prelude::*;
 use tinymist_std::typst::TypstPagedDocument;
 use tinymist_world::{CompilerFeat, ExportComputation, WorldComputeGraph};
 use typst::foundations::Bytes;
-use typst::model::DocumentInfo;
+use typst::model::Document;
 
 use crate::compute::{parse_color, parse_length, select_pages};
 use crate::model::ExportPngTask;
@@ -44,7 +44,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PngExport {
                     .into_iter()
                     .map(|(_, page)| page.clone())
                     .collect(),
-                DocumentInfo::default(),
+                doc.info().clone(),
             );
             let gap = gap
                 .as_ref()

--- a/crates/tinymist-task/src/compute/query.rs
+++ b/crates/tinymist-task/src/compute/query.rs
@@ -10,7 +10,9 @@ use tinymist_world::{CompilerFeat, ExportComputation, WorldComputeGraph};
 use typst::World;
 use typst::diag::{SourceResult, StrResult};
 use typst::engine::Sink;
-use typst::foundations::{Content, IntoValue, LocatableSelector, Scope, Value};
+use typst::foundations::{Content, Context, IntoValue, LocatableSelector, Output, Scope, Value};
+use typst::model::Document;
+use typst::routines::SpanMode;
 use typst::syntax::Span;
 use typst::syntax::SyntaxMode;
 use typst_eval::eval_string;
@@ -23,17 +25,19 @@ pub struct DocumentQuery;
 impl DocumentQuery {
     // todo: query exporter
     /// Retrieve the matches for the selector.
-    pub fn retrieve<D: typst::Document>(
+    pub fn retrieve<D: Document + Output>(
         world: &dyn World,
         selector: &str,
         document: &D,
     ) -> StrResult<Vec<Content>> {
         let selector = eval_string(
-            &typst::ROUTINES,
             world.track(),
+            world.library(),
             Sink::new().track_mut(),
+            document.introspector().track(),
+            Context::none().track(),
             selector,
-            Span::detached(),
+            SpanMode::Uniform(Span::detached()),
             SyntaxMode::Code,
             Scope::default(),
         )
@@ -55,7 +59,7 @@ impl DocumentQuery {
             .collect::<Vec<_>>())
     }
 
-    fn run_inner<F: CompilerFeat, D: typst::Document>(
+    fn run_inner<F: CompilerFeat, D: Document + Output>(
         g: &Arc<WorldComputeGraph<F>>,
         doc: &Arc<D>,
         config: &QueryTask,
@@ -89,7 +93,7 @@ impl DocumentQuery {
     }
 
     /// Queries the document and returns the result as a value.
-    pub fn get_as_value<F: CompilerFeat, D: typst::Document>(
+    pub fn get_as_value<F: CompilerFeat, D: Document + Output>(
         g: &Arc<WorldComputeGraph<F>>,
         doc: &Arc<D>,
         config: &QueryTask,
@@ -109,7 +113,7 @@ impl DocumentQuery {
     }
 }
 
-impl<F: CompilerFeat, D: typst::Document> ExportComputation<F, D> for DocumentQuery {
+impl<F: CompilerFeat, D: Document + Output> ExportComputation<F, D> for DocumentQuery {
     type Output = SourceResult<String>;
     type Config = QueryTask;
 

--- a/crates/tinymist-task/src/compute/svg.rs
+++ b/crates/tinymist-task/src/compute/svg.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tinymist_std::error::prelude::*;
 use tinymist_std::typst::TypstPagedDocument;
 use tinymist_world::{CompilerFeat, ExportComputation, WorldComputeGraph};
-use typst::model::DocumentInfo;
+use typst::model::Document;
 
 use crate::compute::{parse_length, select_pages};
 use crate::model::ExportSvgTask;
@@ -32,7 +32,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for SvgExport {
                     .into_iter()
                     .map(|(_, page)| page.clone())
                     .collect(),
-                DocumentInfo::default(),
+                doc.info().clone(),
             );
             let gap = gap
                 .as_ref()

--- a/crates/tinymist-task/src/compute/svg.rs
+++ b/crates/tinymist-task/src/compute/svg.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tinymist_std::error::prelude::*;
 use tinymist_std::typst::TypstPagedDocument;
 use tinymist_world::{CompilerFeat, ExportComputation, WorldComputeGraph};
+use typst::model::DocumentInfo;
 
 use crate::compute::{parse_length, select_pages};
 use crate::model::ExportSvgTask;
@@ -26,13 +27,13 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for SvgExport {
         if let Some(PageMerge { ref gap }) = config.merge {
             // Typst does not expose svg-merging API.
             // Therefore, we have to create a dummy document here.
-            let dummy_doc = TypstPagedDocument {
-                pages: exported_pages
+            let dummy_doc = TypstPagedDocument::new(
+                exported_pages
                     .into_iter()
                     .map(|(_, page)| page.clone())
                     .collect(),
-                ..Default::default()
-            };
+                DocumentInfo::default(),
+            );
             let gap = gap
                 .as_ref()
                 .and_then(|gap| parse_length(gap).ok())

--- a/crates/tinymist-task/src/compute/text.rs
+++ b/crates/tinymist-task/src/compute/text.rs
@@ -89,13 +89,13 @@ impl fmt::Display for FullTextDigest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             TypstDocument::Paged(paged_doc) => {
-                for page in paged_doc.pages.iter() {
+                for page in paged_doc.pages() {
                     Self::export_frame(f, &page.frame)?;
                 }
                 Ok(())
             }
             TypstDocument::Html(html_doc) => {
-                Self::export_element(f, &html_doc.root)?;
+                Self::export_element(f, html_doc.root())?;
                 Ok(())
             }
         }

--- a/crates/tinymist-viewer/benches/page_incremental_rendering.rs
+++ b/crates/tinymist-viewer/benches/page_incremental_rendering.rs
@@ -15,7 +15,7 @@ use reflexo::vector::incr::IncrDocClient;
 use reflexo::vector::stream::BytesModuleStream;
 use reflexo_vec2svg::IncrSvgDocServer;
 use tinymist_preview::protocol::DIFF_V1_PREFIX;
-use tinymist_std::typst::TypstDocument;
+use tinymist_std::typst::{TypstDocument, TypstPagedDocument};
 use tinymist_viewer::doc::PageCanvas;
 use tinymist_viewer::incr::IncrVelloDocClient;
 use vello::Scene;
@@ -427,7 +427,7 @@ fn compile_document(page_count: usize, changed_page: Option<usize>) -> TypstDocu
 
     tinymist_tests::run_with_sources(&source, |verse, _| {
         let world = verse.snapshot();
-        let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+        let doc = typst::compile::<TypstPagedDocument>(&world)
             .output
             .expect("large-page benchmark fixture should compile");
         TypstDocument::Paged(Arc::new(doc))

--- a/crates/tinymist-viewer/src/doc.rs
+++ b/crates/tinymist-viewer/src/doc.rs
@@ -702,7 +702,7 @@ mod tests {
 
         tinymist_tests::run_with_sources(SOURCE, |verse, _| {
             let world = verse.snapshot();
-            let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+            let doc = typst::compile::<tinymist_std::typst::TypstPagedDocument>(&world)
                 .output
                 .expect("short viewer preview fixture should compile");
             let document = TypstDocument::Paged(Arc::new(doc));

--- a/crates/tinymist-viewer/src/incr.rs
+++ b/crates/tinymist-viewer/src/incr.rs
@@ -946,7 +946,7 @@ hello
     fn compile_incremental_doc(source: &str) -> IncrDocClient {
         tinymist_tests::run_with_sources(source, |verse, _| {
             let world = verse.snapshot();
-            let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+            let doc = typst::compile::<tinymist_std::typst::TypstPagedDocument>(&world)
                 .output
                 .expect("short vello renderer fixture should compile");
             let document = TypstDocument::Paged(Arc::new(doc));

--- a/crates/tinymist-viewer/src/main.rs
+++ b/crates/tinymist-viewer/src/main.rs
@@ -14,11 +14,10 @@ use reflexo::debug_loc::DocumentPosition;
 use reflexo::vector::incr::IncrDocClient;
 use reflexo::vector::stream::BytesModuleStream;
 use reflexo_vec2svg::IncrSvgDocServer;
-use tinymist_std::typst::TypstDocument;
+use tinymist_std::typst::{TypstDocument, TypstPagedDocument};
 use tokio::sync::mpsc;
 use typst::diag::{FileError, FileResult};
-use typst::foundations::{Bytes as TypstBytes, Datetime};
-use typst::layout::PagedDocument;
+use typst::foundations::{Bytes as TypstBytes, Datetime, Duration as TypstDuration};
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -473,7 +472,7 @@ fn render_status_scene(message: &str, width: f64, height: f64) -> Result<(Arc<Sc
         status_typst_source(message, width, height),
     );
     let world = StatusWorld { main: source };
-    let compiled = typst::compile::<PagedDocument>(&world);
+    let compiled = typst::compile::<TypstPagedDocument>(&world);
     for warning in compiled.warnings {
         log::debug!("Typst status render warning: {warning:?}");
     }
@@ -557,7 +556,7 @@ impl World for StatusWorld {
         status_typst_base().fonts.get(index).cloned()
     }
 
-    fn today(&self, _: Option<i64>) -> Option<Datetime> {
+    fn today(&self, _: Option<TypstDuration>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).expect("valid deterministic date"))
     }
 }

--- a/crates/tinymist-viewer/tests/vello_renderer_suite.rs
+++ b/crates/tinymist-viewer/tests/vello_renderer_suite.rs
@@ -20,7 +20,7 @@ use reflexo_vec2svg::IncrSvgDocServer;
 use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 use tinymist_preview::protocol::DIFF_V1_PREFIX;
-use tinymist_std::typst::TypstDocument;
+use tinymist_std::typst::{TypstDocument, TypstPagedDocument};
 use tinymist_viewer::incr::IncrVelloDocClient;
 use tinymist_viewer::{SvgResource, SvgResourceFormat, SvgResourceResolver};
 use typst::diag::{At, FileError, FileResult, SourceResult, StrResult, Warned, bail as typst_bail};
@@ -28,9 +28,7 @@ use typst::engine::Engine;
 use typst::foundations::{
     Array, Bytes, Context, Datetime, IntoValue, NoneValue, Repr, Smart, Value, func,
 };
-use typst::layout::{
-    Abs, Frame, FrameItem, Margin, PageElem, PagedDocument, Size as TypstSize, Transform,
-};
+use typst::layout::{Abs, Frame, FrameItem, Margin, PageElem, Size as TypstSize, Transform};
 use typst::model::{Numbering, NumberingPattern};
 use typst::syntax::{FileId, Source, Span, VirtualPath};
 use typst::text::{Font, FontBook, TextElem, TextSize};
@@ -387,7 +385,7 @@ fn render_suite_case(
         let width = size.width.ceil().max(1.0) as u32;
         let height = size.height.ceil().max(1.0) as u32;
         let mut page = rasterizer.render_page(&scene, size, width, height, background)?;
-        if let Some(source_page) = compiled.pages.get(page_idx) {
+        if let Some(source_page) = compiled.pages().get(page_idx) {
             render_link_overlays(&mut page, &source_page.frame);
         }
         rendered.push(page);
@@ -396,11 +394,11 @@ fn render_suite_case(
     Ok(merge_pages(&rendered))
 }
 
-fn compile_paged(world: &dyn World) -> Result<PagedDocument> {
+fn compile_paged(world: &dyn World) -> Result<TypstPagedDocument> {
     let Warned {
         output,
         warnings: _,
-    } = typst::compile::<PagedDocument>(world);
+    } = typst::compile::<TypstPagedDocument>(world);
     output.map_err(|errors| anyhow!("{}", format_diagnostics(&errors)))
 }
 
@@ -1312,7 +1310,7 @@ impl World for RenderWorld {
         self.base.fonts.get(index).cloned()
     }
 
-    fn today(&self, _: Option<i64>) -> Option<Datetime> {
+    fn today(&self, _: Option<typst::foundations::Duration>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
     }
 }

--- a/crates/tinymist-world/src/compute.rs
+++ b/crates/tinymist-world/src/compute.rs
@@ -6,8 +6,8 @@ use parking_lot::Mutex;
 use tinymist_std::error::prelude::*;
 use tinymist_std::typst::{TypstHtmlDocument, TypstPagedDocument};
 use typst::diag::{At, SourceResult, Warned};
-use typst::foundations::Output;
 use typst::ecow::EcoVec;
+use typst::foundations::Output;
 use typst::syntax::Span;
 
 use crate::snapshot::CompileSnapshot;

--- a/crates/tinymist-world/src/compute.rs
+++ b/crates/tinymist-world/src/compute.rs
@@ -6,6 +6,7 @@ use parking_lot::Mutex;
 use tinymist_std::error::prelude::*;
 use tinymist_std::typst::{TypstHtmlDocument, TypstPagedDocument};
 use typst::diag::{At, SourceResult, Warned};
+use typst::foundations::Output;
 use typst::ecow::EcoVec;
 use typst::syntax::Span;
 
@@ -272,7 +273,7 @@ pub type HtmlCompilationTask = CompilationTask<TypstHtmlDocument>;
 /// A task that compiles a document.
 pub struct CompilationTask<D>(std::marker::PhantomData<D>);
 
-impl<D: typst::Document + Send + Sync + 'static> CompilationTask<D> {
+impl<D: Output + Send + Sync + 'static> CompilationTask<D> {
     /// Ensures the main document.
     pub fn ensure_main<F: CompilerFeat>(world: &CompilerWorld<F>) -> SourceResult<()> {
         let main_id = world.main_id();
@@ -327,7 +328,7 @@ impl<D: typst::Document + Send + Sync + 'static> CompilationTask<D> {
 
 impl<F: CompilerFeat, D> WorldComputable<F> for CompilationTask<D>
 where
-    D: typst::Document + Send + Sync + 'static,
+    D: Output + Send + Sync + 'static,
 {
     type Output = Option<Warned<SourceResult<Arc<D>>>>;
 
@@ -343,7 +344,7 @@ pub struct OptionDocumentTask<D>(std::marker::PhantomData<D>);
 
 impl<F: CompilerFeat, D> WorldComputable<F> for OptionDocumentTask<D>
 where
-    D: typst::Document + Send + Sync + 'static,
+    D: Output + Send + Sync + 'static,
 {
     type Output = Option<Arc<D>>;
 
@@ -358,7 +359,7 @@ where
     }
 }
 
-impl<D> OptionDocumentTask<D> where D: typst::Document + Send + Sync + 'static {}
+impl<D> OptionDocumentTask<D> where D: Output + Send + Sync + 'static {}
 
 /// A task that computes the diagnostics of a document.
 struct CompilationDiagnostics {
@@ -444,7 +445,7 @@ impl<F: CompilerFeat> WorldComputeGraph<F> {
     }
 
     /// Compiles once from scratch.
-    pub fn pure_compile<D: ::typst::Document + Send + Sync + 'static>(
+    pub fn pure_compile<D: ::typst::foundations::Output + Send + Sync + 'static>(
         &self,
     ) -> Warned<SourceResult<Arc<D>>> {
         CompilationTask::<D>::execute(&self.snap.world)

--- a/crates/tinymist-world/src/debug_loc.rs
+++ b/crates/tinymist-world/src/debug_loc.rs
@@ -2,7 +2,7 @@
 //! file.
 
 pub use lsp_types::PositionEncodingKind;
-pub use typst::layout::Position as TypstPosition;
+pub use typst::introspection::PagedPosition as TypstPosition;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/tinymist-world/src/snapshot.rs
+++ b/crates/tinymist-world/src/snapshot.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use crate::{CompilerFeat, CompilerWorld, EntryReader, TaskInputs, args::TaskWhen};
 use ecow::EcoString;
 use serde::{Deserialize, Serialize};
-use tinymist_std::typst::TypstDocument;
+use tinymist_std::typst::{TypstDocument, TypstPagedDocument};
 
 /// Project instance id. This is slightly different from the project ids that
 /// persist in disk.
@@ -75,12 +75,12 @@ impl CompileSignal {
         match docs {
             Some(TypstDocument::Paged(doc)) => self.should_run_task(when, Some(doc.as_ref())),
             Some(TypstDocument::Html(doc)) => self.should_run_task(when, Some(doc.as_ref())),
-            None => self.should_run_task::<typst::layout::PagedDocument>(when, None),
+            None => self.should_run_task::<TypstPagedDocument>(when, None),
         }
     }
 
     /// Whether the task should run.
-    pub fn should_run_task<D: typst::Document>(
+    pub fn should_run_task<D: typst::model::Document>(
         &self,
         when: &TaskWhen,
         docs: Option<&D>,

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -501,6 +501,122 @@ type NowStorage = chrono::DateTime<chrono::Local>;
 #[cfg(not(any(feature = "web", feature = "system")))]
 type NowStorage = tinymist_std::time::UtcDateTime;
 
+fn duration_offset_seconds(offset: Duration) -> Option<i64> {
+    let seconds = offset.seconds();
+    if !seconds.is_finite() || seconds < i64::MIN as f64 || seconds > i64::MAX as f64 {
+        return None;
+    }
+
+    Some(seconds.trunc() as i64)
+}
+
+#[cfg(any(feature = "web", feature = "system"))]
+fn initial_now(creation_timestamp: Option<i64>) -> NowStorage {
+    creation_timestamp
+        .and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp, 0))
+        .map(Into::into)
+        .unwrap_or_else(|| tinymist_std::time::now().into())
+}
+
+#[cfg(not(any(feature = "web", feature = "system")))]
+fn initial_now(creation_timestamp: Option<i64>) -> NowStorage {
+    use tinymist_std::time::now;
+
+    creation_timestamp
+        .and_then(|timestamp| tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok())
+        .unwrap_or_else(|| now().into())
+}
+
+#[cfg(any(feature = "web", feature = "system"))]
+fn today_from_now(now: &NowStorage, offset: Option<Duration>) -> Option<Datetime> {
+    use chrono::{Datelike, FixedOffset};
+
+    let naive = match offset {
+        None => now.naive_local(),
+        Some(offset) => {
+            let seconds = duration_offset_seconds(offset)?;
+            let seconds = i32::try_from(seconds).ok()?;
+            now.with_timezone(&FixedOffset::east_opt(seconds)?)
+                .naive_local()
+        }
+    };
+
+    Datetime::from_ymd(
+        naive.year(),
+        naive.month().try_into().ok()?,
+        naive.day().try_into().ok()?,
+    )
+}
+
+#[cfg(not(any(feature = "web", feature = "system")))]
+fn today_from_now(now: &NowStorage, offset: Option<Duration>) -> Option<Datetime> {
+    use tinymist_std::time::to_typst_time;
+
+    let now = offset
+        .and_then(|offset| {
+            let timestamp = now
+                .unix_timestamp()
+                .checked_add(duration_offset_seconds(offset)?)?;
+            tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()
+        })
+        .unwrap_or(*now);
+
+    Some(to_typst_time(now))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn duration(seconds: i64) -> Duration {
+        Duration::construct(seconds, 0, 0, 0, 0)
+    }
+
+    #[test]
+    fn duration_offset_seconds_preserves_signed_whole_seconds() {
+        assert_eq!(duration_offset_seconds(duration(90)), Some(90));
+        assert_eq!(duration_offset_seconds(duration(-90)), Some(-90));
+    }
+
+    #[cfg(any(feature = "web", feature = "system"))]
+    #[test]
+    fn today_from_now_rejects_offsets_outside_fixed_offset_range() {
+        let now = initial_now(Some(0));
+        let too_large = duration(i64::from(i32::MAX) + 1);
+
+        assert_eq!(today_from_now(&now, Some(too_large)), None);
+    }
+
+    #[cfg(not(any(feature = "web", feature = "system")))]
+    #[test]
+    fn today_from_now_uses_creation_timestamp_and_duration_offset() {
+        let now = initial_now(Some(0));
+        let today = today_from_now(&now, None).unwrap();
+        let tomorrow = today_from_now(&now, Some(duration(86_400))).unwrap();
+
+        assert_eq!(
+            (today.year(), today.month(), today.day()),
+            (Some(1970), Some(1), Some(1))
+        );
+        assert_eq!(
+            (tomorrow.year(), tomorrow.month(), tomorrow.day()),
+            (Some(1970), Some(1), Some(2))
+        );
+    }
+
+    #[cfg(not(any(feature = "web", feature = "system")))]
+    #[test]
+    fn initial_now_falls_back_when_creation_timestamp_is_invalid() {
+        let now = initial_now(Some(i64::MAX));
+        let today = today_from_now(&now, None).unwrap();
+
+        assert_eq!(
+            (today.year(), today.month(), today.day()),
+            (Some(1970), Some(1), Some(1))
+        );
+    }
+}
+
 /// The world of the compiler.
 pub struct CompilerWorld<F: CompilerFeat> {
     /// State for the *root & entry* of compilation.
@@ -838,38 +954,10 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// return an error.
     #[cfg(any(feature = "web", feature = "system"))]
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
-        use chrono::{Datelike, FixedOffset};
-
-        let now = self.now.get_or_init(|| {
-            if let Some(timestamp) = self.creation_timestamp {
-                chrono::DateTime::from_timestamp(timestamp, 0)
-                    .unwrap_or_else(|| tinymist_std::time::now().into())
-                    .into()
-            } else {
-                tinymist_std::time::now().into()
-            }
-        });
-
-        let naive = match offset {
-            None => now.naive_local(),
-            Some(offset) => {
-                let seconds = offset.seconds().trunc();
-                if !seconds.is_finite()
-                    || seconds < f64::from(i32::MIN)
-                    || seconds > f64::from(i32::MAX)
-                {
-                    return None;
-                }
-                now.with_timezone(&FixedOffset::east_opt(seconds as i32)?)
-                    .naive_local()
-            }
-        };
-
-        Datetime::from_ymd(
-            naive.year(),
-            naive.month().try_into().ok()?,
-            naive.day().try_into().ok()?,
-        )
+        let now = self
+            .now
+            .get_or_init(|| initial_now(self.creation_timestamp));
+        today_from_now(now, offset)
     }
 
     /// Get the current date.
@@ -881,29 +969,10 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// return an error.
     #[cfg(not(any(feature = "web", feature = "system")))]
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
-        use tinymist_std::time::{now, to_typst_time};
-
-        let now = self.now.get_or_init(|| {
-            if let Some(timestamp) = self.creation_timestamp {
-                tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp)
-                    .unwrap_or_else(|_| now().into())
-            } else {
-                now().into()
-            }
-        });
-
-        let now = offset
-            .and_then(|offset| {
-                let seconds = offset.seconds();
-                if !seconds.is_finite() || seconds < i64::MIN as f64 || seconds > i64::MAX as f64 {
-                    return None;
-                }
-                let timestamp = now.unix_timestamp().checked_add(seconds.trunc() as i64)?;
-                tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()
-            })
-            .unwrap_or(*now);
-
-        Some(to_typst_time(now))
+        let now = self
+            .now
+            .get_or_init(|| initial_now(self.creation_timestamp));
+        today_from_now(now, offset)
     }
 }
 

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -895,10 +895,7 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
         let now = offset
             .and_then(|offset| {
                 let seconds = offset.seconds();
-                if !seconds.is_finite()
-                    || seconds < i64::MIN as f64
-                    || seconds > i64::MAX as f64
-                {
+                if !seconds.is_finite() || seconds < i64::MIN as f64 || seconds > i64::MAX as f64 {
                     return None;
                 }
                 let timestamp = now.unix_timestamp().checked_add(seconds.trunc() as i64)?;

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -501,120 +501,13 @@ type NowStorage = chrono::DateTime<chrono::Local>;
 #[cfg(not(any(feature = "web", feature = "system")))]
 type NowStorage = tinymist_std::time::UtcDateTime;
 
-fn duration_offset_seconds(offset: Duration) -> Option<i64> {
-    let seconds = offset.seconds();
-    if !seconds.is_finite() || seconds < i64::MIN as f64 || seconds > i64::MAX as f64 {
+fn duration_offset_seconds(offset: Duration) -> Option<i32> {
+    let seconds = offset.seconds().trunc();
+    if !seconds.is_finite() || seconds < f64::from(i32::MIN) || seconds > f64::from(i32::MAX) {
         return None;
     }
 
-    Some(seconds.trunc() as i64)
-}
-
-#[cfg(any(feature = "web", feature = "system"))]
-fn initial_now(creation_timestamp: Option<i64>) -> NowStorage {
-    creation_timestamp
-        .and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp, 0))
-        .map(Into::into)
-        .unwrap_or_else(|| tinymist_std::time::now().into())
-}
-
-#[cfg(not(any(feature = "web", feature = "system")))]
-fn initial_now(creation_timestamp: Option<i64>) -> NowStorage {
-    use tinymist_std::time::now;
-
-    creation_timestamp
-        .and_then(|timestamp| tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok())
-        .unwrap_or_else(|| now().into())
-}
-
-#[cfg(any(feature = "web", feature = "system"))]
-fn today_from_now(now: &NowStorage, offset: Option<Duration>) -> Option<Datetime> {
-    use chrono::{Datelike, FixedOffset};
-
-    let naive = match offset {
-        None => now.naive_local(),
-        Some(offset) => {
-            let seconds = duration_offset_seconds(offset)?;
-            let seconds = i32::try_from(seconds).ok()?;
-            now.with_timezone(&FixedOffset::east_opt(seconds)?)
-                .naive_local()
-        }
-    };
-
-    Datetime::from_ymd(
-        naive.year(),
-        naive.month().try_into().ok()?,
-        naive.day().try_into().ok()?,
-    )
-}
-
-#[cfg(not(any(feature = "web", feature = "system")))]
-fn today_from_now(now: &NowStorage, offset: Option<Duration>) -> Option<Datetime> {
-    use tinymist_std::time::to_typst_time;
-
-    let now = offset
-        .and_then(|offset| {
-            let timestamp = now
-                .unix_timestamp()
-                .checked_add(duration_offset_seconds(offset)?)?;
-            tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()
-        })
-        .unwrap_or(*now);
-
-    Some(to_typst_time(now))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn duration(seconds: i64) -> Duration {
-        Duration::construct(seconds, 0, 0, 0, 0)
-    }
-
-    #[test]
-    fn duration_offset_seconds_preserves_signed_whole_seconds() {
-        assert_eq!(duration_offset_seconds(duration(90)), Some(90));
-        assert_eq!(duration_offset_seconds(duration(-90)), Some(-90));
-    }
-
-    #[cfg(any(feature = "web", feature = "system"))]
-    #[test]
-    fn today_from_now_rejects_offsets_outside_fixed_offset_range() {
-        let now = initial_now(Some(0));
-        let too_large = duration(i64::from(i32::MAX) + 1);
-
-        assert_eq!(today_from_now(&now, Some(too_large)), None);
-    }
-
-    #[cfg(not(any(feature = "web", feature = "system")))]
-    #[test]
-    fn today_from_now_uses_creation_timestamp_and_duration_offset() {
-        let now = initial_now(Some(0));
-        let today = today_from_now(&now, None).unwrap();
-        let tomorrow = today_from_now(&now, Some(duration(86_400))).unwrap();
-
-        assert_eq!(
-            (today.year(), today.month(), today.day()),
-            (Some(1970), Some(1), Some(1))
-        );
-        assert_eq!(
-            (tomorrow.year(), tomorrow.month(), tomorrow.day()),
-            (Some(1970), Some(1), Some(2))
-        );
-    }
-
-    #[cfg(not(any(feature = "web", feature = "system")))]
-    #[test]
-    fn initial_now_falls_back_when_creation_timestamp_is_invalid() {
-        let now = initial_now(Some(i64::MAX));
-        let today = today_from_now(&now, None).unwrap();
-
-        assert_eq!(
-            (today.year(), today.month(), today.day()),
-            (Some(1970), Some(1), Some(1))
-        );
-    }
+    Some(seconds as i32)
 }
 
 /// The world of the compiler.
@@ -948,31 +841,68 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// Get the current date.
     ///
     /// If no offset is specified, the local date should be chosen. Otherwise,
-    /// the UTC date should be chosen with the corresponding offset in hours.
+    /// the UTC date should be chosen with the corresponding offset.
     ///
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     #[cfg(any(feature = "web", feature = "system"))]
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
-        let now = self
-            .now
-            .get_or_init(|| initial_now(self.creation_timestamp));
-        today_from_now(now, offset)
+        use chrono::{Datelike, FixedOffset};
+
+        let now = self.now.get_or_init(|| {
+            if let Some(timestamp) = self.creation_timestamp {
+                chrono::DateTime::from_timestamp(timestamp, 0)
+                    .unwrap_or_else(|| tinymist_std::time::now().into())
+                    .into()
+            } else {
+                tinymist_std::time::now().into()
+            }
+        });
+
+        let naive = match offset {
+            None => now.naive_local(),
+            Some(offset) => now
+                .with_timezone(&FixedOffset::east_opt(duration_offset_seconds(offset)?)?)
+                .naive_local(),
+        };
+
+        Datetime::from_ymd(
+            naive.year(),
+            naive.month().try_into().ok()?,
+            naive.day().try_into().ok()?,
+        )
     }
 
     /// Get the current date.
     ///
     /// If no offset is specified, the local date should be chosen. Otherwise,
-    /// the UTC date should be chosen with the corresponding offset in hours.
+    /// the UTC date should be chosen with the corresponding offset.
     ///
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     #[cfg(not(any(feature = "web", feature = "system")))]
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
-        let now = self
-            .now
-            .get_or_init(|| initial_now(self.creation_timestamp));
-        today_from_now(now, offset)
+        use tinymist_std::time::{now, to_typst_time};
+
+        let now = self.now.get_or_init(|| {
+            if let Some(timestamp) = self.creation_timestamp {
+                tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp)
+                    .unwrap_or_else(|_| now().into())
+            } else {
+                now().into()
+            }
+        });
+
+        let now = offset
+            .and_then(|offset| {
+                let timestamp = now
+                    .unix_timestamp()
+                    .checked_add(i64::from(duration_offset_seconds(offset)?))?;
+                tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()
+            })
+            .unwrap_or(*now);
+
+        Some(to_typst_time(now))
     }
 }
 

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -29,7 +29,7 @@ use tinymist_vfs::{
 use typst::{
     Features, Library, LibraryExt, World, WorldExt,
     diag::{At, FileError, FileResult, SourceResult, eco_format},
-    foundations::{Bytes, Datetime, Dict},
+    foundations::{Bytes, Datetime, Dict, Duration},
     syntax::{Source, Span, VirtualPath},
     text::{Font, FontBook},
     utils::LazyHash,
@@ -837,8 +837,8 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     #[cfg(any(feature = "web", feature = "system"))]
-    fn today(&self, offset: Option<i64>) -> Option<Datetime> {
-        use chrono::{Datelike, Duration};
+    fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
+        use chrono::{Datelike, FixedOffset};
 
         let now = self.now.get_or_init(|| {
             if let Some(timestamp) = self.creation_timestamp {
@@ -852,7 +852,17 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
 
         let naive = match offset {
             None => now.naive_local(),
-            Some(o) => now.naive_utc() + Duration::try_hours(o)?,
+            Some(offset) => {
+                let seconds = offset.seconds().trunc();
+                if !seconds.is_finite()
+                    || seconds < f64::from(i32::MIN)
+                    || seconds > f64::from(i32::MAX)
+                {
+                    return None;
+                }
+                now.with_timezone(&FixedOffset::east_opt(seconds as i32)?)
+                    .naive_local()
+            }
         };
 
         Datetime::from_ymd(
@@ -870,8 +880,8 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     #[cfg(not(any(feature = "web", feature = "system")))]
-    fn today(&self, offset: Option<i64>) -> Option<Datetime> {
-        use tinymist_std::time::{Duration, now, to_typst_time};
+    fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
+        use tinymist_std::time::{now, to_typst_time};
 
         let now = self.now.get_or_init(|| {
             if let Some(timestamp) = self.creation_timestamp {
@@ -884,10 +894,15 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
 
         let now = offset
             .and_then(|offset| {
-                let dur = Duration::from_secs(offset.checked_mul(3600)? as u64)
-                    .try_into()
-                    .ok()?;
-                now.checked_add(dur)
+                let seconds = offset.seconds();
+                if !seconds.is_finite()
+                    || seconds < i64::MIN as f64
+                    || seconds > i64::MAX as f64
+                {
+                    return None;
+                }
+                let timestamp = now.unix_timestamp().checked_add(seconds.trunc() as i64)?;
+                Some(tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()?)
             })
             .unwrap_or(*now);
 
@@ -944,7 +959,7 @@ impl typst::World for WorldWithMain<'_> {
         self.world.font(index)
     }
 
-    fn today(&self, offset: Option<i64>) -> Option<Datetime> {
+    fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         self.world.today(offset)
     }
 }

--- a/crates/tinymist-world/src/world.rs
+++ b/crates/tinymist-world/src/world.rs
@@ -899,7 +899,7 @@ impl<F: CompilerFeat> World for CompilerWorld<F> {
                     return None;
                 }
                 let timestamp = now.unix_timestamp().checked_add(seconds.trunc() as i64)?;
-                Some(tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()?)
+                tinymist_std::time::UtcDateTime::from_unix_timestamp(timestamp).ok()
             })
             .unwrap_or(*now);
 

--- a/crates/tinymist/src/project.rs
+++ b/crates/tinymist/src/project.rs
@@ -35,7 +35,7 @@ use tinymist_query::{
 use tinymist_render::PeriscopeRenderer;
 use tinymist_std::{error::prelude::*, ImmutPath};
 use tokio::sync::mpsc;
-use typst::{diag::FileResult, foundations::Bytes, layout::Position as TypstPosition};
+use typst::{diag::FileResult, foundations::Bytes, introspection::PagedPosition as TypstPosition};
 
 use super::ServerState;
 use crate::actor::editor::{EditorRequest, ProjVersion};

--- a/crates/tinymist/src/resource/symbols.rs
+++ b/crates/tinymist/src/resource/symbols.rs
@@ -267,7 +267,7 @@ fn extract_rendered_symbols<'a>(
             paged_doc: &TypstPagedDocument,
             symbols: impl Iterator<Item = &'a String>,
         ) {
-            for (pg, s) in paged_doc.pages.iter().zip(symbols) {
+            for (pg, s) in paged_doc.pages().iter().zip(symbols) {
                 self.work_frame(&pg.frame, s);
             }
         }

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -610,7 +610,7 @@ impl ExportTask {
                     .as_ref()
                     .map_err(|e| e.clone())
             };
-            let total_pages = || paged_doc().map(|d| d.pages.len()).unwrap_or_default();
+            let total_pages = || paged_doc().map(|d| d.pages().len()).unwrap_or_default();
 
             Ok(match task {
                 Preview(..) => Bytes::new([]).into(),
@@ -766,15 +766,21 @@ fn log_err<T>(artifact: Result<T>) -> Option<T> {
     }
 }
 
-fn extra_compile_for_export<D: typst::Document + Send + Sync + 'static>(
+fn extra_compile_for_export<
+    D: typst::model::Document + typst::foundations::Output + Send + Sync + 'static,
+>(
     world: &LspWorld,
 ) -> Result<Arc<D>> {
     let res = tokio::task::block_in_place(|| CompilationTask::<D>::execute(world));
 
     match res.output {
         Ok(v) => Ok(v),
-        Err(e) if e.is_empty() => bail!("failed to compile: internal error"),
-        Err(e) => bail!("failed to compile: {}", e[0].message),
+        Err(e) => {
+            if e.is_empty() {
+                bail!("failed to compile: internal error");
+            }
+            bail!("failed to compile: {}", e[0].message);
+        }
     }
 }
 

--- a/crates/tinymist/src/task/export2.rs
+++ b/crates/tinymist/src/task/export2.rs
@@ -89,7 +89,7 @@ pub struct ProjectExport;
 impl ProjectExport {
     /// Exports the document to bytes artifact.
     fn export_bytes<
-        D: typst::Document + Send + Sync + 'static,
+        D: typst::model::Document + typst::foundations::Output + Send + Sync + 'static,
         T: ExportComputation<LspCompilerFeat, D, Output = Bytes>,
     >(
         graph: &Arc<WorldComputeGraph<LspCompilerFeat>>,
@@ -109,7 +109,7 @@ impl ProjectExport {
 
     /// Exports the document to string artifact.
     fn export_string<
-        D: typst::Document + Send + Sync + 'static,
+        D: typst::model::Document + typst::foundations::Output + Send + Sync + 'static,
         T: ExportComputation<LspCompilerFeat, D, Output = String>,
     >(
         graph: &Arc<WorldComputeGraph<LspCompilerFeat>>,

--- a/crates/tinymist/src/tool/preview/compile.rs
+++ b/crates/tinymist/src/tool/preview/compile.rs
@@ -9,7 +9,8 @@ use tinymist_preview::{
 };
 use tinymist_project::LspCompiledArtifact;
 use tinymist_query::{jump_from_click, jump_from_cursor};
-use typst::layout::{Abs, Point, Position};
+use typst::introspection::PagedPosition as Position;
+use typst::layout::{Abs, Point};
 use typst::syntax::{LinkedNode, Source, Span, SyntaxKind};
 use typst::World;
 use typst_shim::syntax::LinkedNodeExt;
@@ -144,7 +145,7 @@ impl tinymist_preview::CompileView for PreviewCompileView {
         let world = self.art.world();
 
         let page = pos.page_no.checked_sub(1)?;
-        let page = doc.pages.get(page)?;
+        let page = doc.pages().get(page)?;
 
         let click = Point::new(Abs::pt(pos.x as f64), Abs::pt(pos.y as f64));
         jump_from_click(world, &page.frame, click)

--- a/crates/tinymist/src/tool/word_count.rs
+++ b/crates/tinymist/src/tool/word_count.rs
@@ -150,7 +150,7 @@ impl SpanMapper {
     fn doc(&mut self, doc: &TypstDocument) {
         match doc {
             TypstDocument::Paged(paged_doc) => {
-                for page in paged_doc.pages.iter() {
+                for page in paged_doc.pages().iter() {
                     self.frame(&page.frame);
                 }
             }

--- a/crates/typlite/src/parser/media.rs
+++ b/crates/typlite/src/parser/media.rs
@@ -6,13 +6,16 @@ use std::sync::{Arc, LazyLock};
 
 use base64::Engine;
 use cmark_writer::ast::{HtmlAttribute, HtmlElement as CmarkHtmlElement, Node};
+use comemo::Track;
 use ecow::{EcoString, eco_format};
 use tinymist_project::diag::print_diagnostics_to_string;
 use tinymist_project::{EntryReader, MEMORY_MAIN_ENTRY, TaskInputs, base::ShadowApi};
 use typst::{
     World,
     foundations::{Bytes, Dict, IntoValue},
+    introspection::EmptyIntrospector,
     layout::{Abs, Frame},
+    model::LateLinkResolver,
     utils::LazyHash,
 };
 use typst_html::{HtmlElement, HtmlNode};
@@ -78,7 +81,16 @@ impl HtmlToAstParser {
             });
         };
 
-        let svg = typst_svg::svg_frame(&frame.inner);
+        let introspector = EmptyIntrospector;
+        let link_resolver = LateLinkResolver::new(None, &introspector);
+        let svg = typst_svg::svg_in_html(
+            &frame.inner,
+            frame.text_size,
+            frame.id.as_deref(),
+            &eco_format!("{}", frame.css.to_inline()),
+            &frame.anchors,
+            link_resolver.track(),
+        );
         let frame_url = match self.create_asset_url(&svg) {
             Ok(url) => url,
             Err(e) => {
@@ -127,7 +139,10 @@ impl HtmlToAstParser {
             return Node::Text(EcoString::new());
         }
 
-        let svg = typst_svg::svg_frame(frame);
+        let introspector = EmptyIntrospector;
+        let link_resolver = LateLinkResolver::new(None, &introspector);
+        let svg =
+            typst_svg::svg_in_html(frame, Abs::pt(12.0), None, "", &[], link_resolver.track());
         self.convert_svg(svg)
     }
 

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -120,7 +120,7 @@ fn conv(world: LspWorld, kind: ConvKind) -> String {
 
 fn redact(doc: HtmlDocument) -> HtmlDocument {
     let mut doc = doc;
-    for node in doc.root.children.make_mut().iter_mut() {
+    for node in doc.root_mut().children.make_mut().iter_mut() {
         redact_node(node);
     }
     doc

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -364,7 +364,7 @@ mod tests {
     use std::sync::Arc;
 
     use reflexo_vec2svg::IncrSvgDocServer;
-    use tinymist_std::typst::TypstDocument;
+    use tinymist_std::typst::{TypstDocument, TypstPagedDocument};
 
     use super::{escape_html_text, protocol};
 
@@ -380,7 +380,7 @@ mod tests {
             "#set page(width: 1pt, height: 1pt, margin: 0pt)",
             |verse, _| {
                 let world = verse.snapshot();
-                let doc = typst::compile::<typst::layout::PagedDocument>(&world)
+                let doc = typst::compile::<TypstPagedDocument>(&world)
                     .output
                     .expect("short preview fixture should compile");
                 let document = TypstDocument::Paged(Arc::new(doc));

--- a/crates/typst-preview/src/lib.rs
+++ b/crates/typst-preview/src/lib.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use tinymist_std::error::IgnoreLogging;
 use tinymist_std::typst::TypstDocument;
 use tokio::sync::{broadcast, mpsc};
-use typst::{layout::Position, syntax::Span};
+use typst::{introspection::PagedPosition, syntax::Span};
 
 use crate::actor::editor::{EditorActor, EditorActorRequest};
 use crate::actor::render::RenderActorRequest;
@@ -496,7 +496,7 @@ pub trait CompileView: Send + Sync {
     }
 
     /// Resolve the document position.
-    fn resolve_document_position(&self, _by: Location) -> Vec<Position> {
+    fn resolve_document_position(&self, _by: Location) -> Vec<PagedPosition> {
         vec![]
     }
 

--- a/crates/typst-preview/src/outline.rs
+++ b/crates/typst-preview/src/outline.rs
@@ -4,7 +4,7 @@ use reflexo_typst::debug_loc::DocumentPosition;
 use serde::{Deserialize, Serialize};
 use tinymist_std::typst::TypstDocument;
 use typst::foundations::{Content, NativeElement, Packed, StyleChain};
-use typst::introspection::Introspector;
+use typst::introspection::{Introspector, PagedPosition};
 use typst::model::HeadingElem;
 use typst::syntax::Span;
 
@@ -22,7 +22,7 @@ pub(crate) struct HeadingNode {
 }
 
 /// Construct the outline for the document.
-pub(crate) fn get_outline(introspector: &Introspector) -> Option<Vec<HeadingNode>> {
+pub(crate) fn get_outline(introspector: &dyn Introspector) -> Option<Vec<HeadingNode>> {
     let mut tree: Vec<HeadingNode> = vec![];
     // Stores the level of the topmost skipped ancestor of the next bookmarked
     // heading. A skipped heading is a heading with 'bookmarked: false', that
@@ -97,10 +97,13 @@ pub(crate) fn get_outline(introspector: &Introspector) -> Option<Vec<HeadingNode
 }
 
 impl HeadingNode {
-    fn leaf(introspector: &Introspector, element: &Packed<HeadingElem>) -> Self {
+    fn leaf(introspector: &dyn Introspector, element: &Packed<HeadingElem>) -> Self {
         let position = {
             let loc = element.location().unwrap();
-            let pos = introspector.position(loc);
+            let pos = introspector
+                .position(loc)
+                .map(|pos| pos.as_paged_or_default())
+                .unwrap_or(PagedPosition::ORIGIN);
             DocumentPosition {
                 page_no: pos.page.into(),
                 x: pos.point.x.to_pt() as f32,

--- a/crates/typst-shim/src/stable/eval.rs
+++ b/crates/typst-shim/src/stable/eval.rs
@@ -5,8 +5,9 @@ use typst::World;
 use typst::diag::SourceResult;
 use typst::engine::{Engine, Route, Sink, Traced};
 use typst::foundations::{Context, Func, Module, Value};
-use typst::introspection::Introspector;
+use typst::introspection::EmptyIntrospector;
 use typst::syntax::Source;
+use typst::utils::Protected;
 
 pub use typst_eval::*;
 
@@ -17,8 +18,8 @@ pub fn eval_compat(world: &dyn World, source: &Source) -> SourceResult<Module> {
     let mut sink = Sink::default();
 
     typst_eval::eval(
-        &typst::ROUTINES,
         world.track(),
+        world.library(),
         traced.track(),
         sink.track_mut(),
         route.track(),
@@ -29,7 +30,7 @@ pub fn eval_compat(world: &dyn World, source: &Source) -> SourceResult<Module> {
 /// The Typst Engine.
 pub struct TypstEngine<'a> {
     /// The introspector to be queried for elements and their positions.
-    pub introspector: Introspector,
+    pub introspector: EmptyIntrospector,
     /// May hold a span that is currently under inspection.
     pub traced: Traced,
     /// The route the engine took during compilation. This is used to detect
@@ -49,7 +50,7 @@ impl<'a> TypstEngine<'a> {
     /// Creates a new Typst Engine.
     pub fn new(world: &'a dyn World) -> Self {
         Self {
-            introspector: Introspector::default(),
+            introspector: EmptyIntrospector,
             traced: Traced::default(),
             route: Route::default(),
             sink: Sink::default(),
@@ -60,9 +61,9 @@ impl<'a> TypstEngine<'a> {
     /// Creates the engine.
     pub fn as_engine(&'a mut self) -> Engine<'a> {
         Engine {
-            routines: &typst::ROUTINES,
+            library: self.world.library(),
             world: self.world.track(),
-            introspector: self.introspector.track(),
+            introspector: Protected::new(self.introspector.track()),
             traced: self.traced.track(),
             sink: self.sink.track_mut(),
             route: self.route.clone(),

--- a/crates/typst-shim/src/syntax_only.rs
+++ b/crates/typst-shim/src/syntax_only.rs
@@ -1,8 +1,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use typst::{
-    Document, World,
+    World,
     diag::{SourceDiagnostic, SourceResult, Warned},
     ecow::eco_vec,
+    foundations::Output,
 };
 use typst_syntax::Span;
 
@@ -18,7 +19,7 @@ pub fn is_syntax_only() -> bool {
 /// error.
 pub fn compile_opt<D>(world: &dyn World) -> Warned<SourceResult<D>>
 where
-    D: Document,
+    D: Output,
 {
     if is_syntax_only() {
         Warned {


### PR DESCRIPTION
This PR is part of the Typst 0.15 cleanup stack. It sits on top of the dependency/toolchain group and covers the first world/document output API adaptation slice.

## Upstream Typst Changes

- [`typst/typst#7964` Bundle export](https://github.com/typst/typst/pull/7964) splits document output into target-specific APIs.
  - Tinymist now works with `typst_layout::PagedDocument`, `typst_html::HtmlDocument`, `typst::model::Document`, and `typst::foundations::Output` instead of relying on the old broad document surface.
  - Document fields are private; callers need accessors such as `pages()`, `info()`, `introspector()`, and `root_mut()`.
  - Document introspection changes around `typst/typst@7d2edbdb3` move consumers toward the target document's output introspector.
  - `DocumentInfo` is the compiled-document metadata payload (`title`, `author`, `description`, `keywords`, `date`, `locale`). Typst populates it while creating the target document from document/text styles, not from finished `Page` or `Frame` values.
  - HTML/SVG conversion now goes through the bundle-aware `svg_in_html` path with a `LateLinkResolver`.
- [`typst/typst#7691`](https://github.com/typst/typst/pull/7691) changes `World::today` from an hour offset to `Option<typst::foundations::Duration>`.
- `typst/typst@acc3fed51` moves paged positions to `typst::introspection::PagedPosition`.
- Typst 0.15 also requires protected engine introspection through `typst::utils::Protected`.

## Tinymist Changes

- Adapts `tinymist-std`, `tinymist-world`, and `tinymist-task` to the new `Document` / `Output` split and concrete paged/HTML document types.
- Updates query export for the new `eval_string` signature and uses `SpanMode::Uniform(Span::detached())` for selector strings that do not come from a `.typ` source range.
- Updates paged document access, output introspector access, debug location typing, preview/outline consumers, and HTML root mutation to the new accessor-based APIs.
- Preserves original compiled document metadata for merged PNG/SVG exports with `doc.info().clone()` while still constructing a temporary document from selected pages.
- Updates typlite SVG embedding to forward real `HtmlFrame` metadata when available and use neutral standalone-frame defaults when only a bare `Frame` is available.
- Updates `World::today` for Typst duration offsets while keeping existing cached `now` initialization in place; only the duration-to-second offset conversion is factored out.
- Refreshes the minimal `Cargo.lock` metadata needed by the new `typst-layout` dependency path.
