### PR TITLE
feat: restore bundle export for typst 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7329,6 +7329,7 @@ dependencies = [
  "ttf-parser",
  "typst",
  "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=3284e80)",
+ "typst-bundle",
  "typst-shim",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6750,6 +6750,7 @@ dependencies = [
  "typlite",
  "typst",
  "typst-ansi-hl",
+ "typst-bundle",
  "typst-html",
  "typst-pdf",
  "typst-render",
@@ -7838,6 +7839,29 @@ version = "0.14.2"
 source = "git+https://github.com/typst/typst-assets?rev=955ae8d#955ae8db08d6e36694eb9cc61e61f586032ea572"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "typst-bundle"
+version = "0.15.0"
+source = "git+https://github.com/ParaN3xus/typst.git?branch=nightly#6743cf2415fb3c11c292d371d16746cbee44c114"
+dependencies = [
+ "comemo",
+ "ecow",
+ "either",
+ "indexmap 2.14.0",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "typst-html",
+ "typst-layout",
+ "typst-library",
+ "typst-macros",
+ "typst-pdf",
+ "typst-render",
+ "typst-svg",
+ "typst-syntax 0.15.0",
+ "typst-timing 0.15.0",
+ "typst-utils 0.15.0",
 ]
 
 [[package]]
@@ -10237,8 +10261,3 @@ dependencies = [
  "syn 2.0.117",
  "winnow 1.0.3",
 ]
-
-[[patch.unused]]
-name = "typst-bundle"
-version = "0.15.0"
-source = "git+https://github.com/ParaN3xus/typst.git?branch=nightly#6743cf2415fb3c11c292d371d16746cbee44c114"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ reflexo-typst = { version = "0.7.0", default-features = false }
 reflexo-vec2svg = { version = "0.7.0" }
 
 typst = "0.15.0"
+typst-bundle = "0.15.0"
 typst-layout = "0.15.0"
 typst-html = "0.15.0"
 typst-library = "0.15.0"

--- a/crates/tinymist-cli/src/cmd/compile.rs
+++ b/crates/tinymist-cli/src/cmd/compile.rs
@@ -2,11 +2,11 @@
 
 use std::path::PathBuf;
 
-use tinymist::project::*;
-use tinymist::world::system::print_diagnostics;
-use tinymist::world::WorldComputeGraph;
 use tinymist::ExportTask;
-use tinymist_std::{error::prelude::*, ImmutPath};
+use tinymist::project::*;
+use tinymist::world::WorldComputeGraph;
+use tinymist::world::system::print_diagnostics;
+use tinymist_std::{ImmutPath, error::prelude::*};
 
 /// Specify the project compilation.
 #[derive(Debug, Clone, clap::Parser)]

--- a/crates/tinymist-cli/src/cmd/compile.rs
+++ b/crates/tinymist-cli/src/cmd/compile.rs
@@ -2,11 +2,11 @@
 
 use std::path::PathBuf;
 
-use tinymist::ExportTask;
 use tinymist::project::*;
-use tinymist::world::WorldComputeGraph;
 use tinymist::world::system::print_diagnostics;
-use tinymist_std::{ImmutPath, error::prelude::*};
+use tinymist::world::WorldComputeGraph;
+use tinymist::ExportTask;
+use tinymist_std::{error::prelude::*, ImmutPath};
 
 /// Specify the project compilation.
 #[derive(Debug, Clone, clap::Parser)]
@@ -67,8 +67,12 @@ pub async fn compile_main(args: CompileArgs) -> Result<()> {
     let graph = WorldComputeGraph::from_world(world);
 
     // Compiles the project
-    let is_html = matches!(output.task, ProjectTask::ExportHtml(..));
-    let compiled = CompiledArtifact::from_graph(graph, is_html);
+    let compiled = if matches!(output.task, ProjectTask::ExportBundle(..)) {
+        CompiledArtifact::from_graph_without_doc(graph)
+    } else {
+        let is_html = matches!(output.task, ProjectTask::ExportHtml(..));
+        CompiledArtifact::from_graph(graph, is_html)
+    };
 
     let diag = compiled.diagnostics();
     print_diagnostics(compiled.world(), diag, DiagnosticFormat::Human)

--- a/crates/tinymist-cli/src/cmd/generate_script.rs
+++ b/crates/tinymist-cli/src/cmd/generate_script.rs
@@ -198,6 +198,10 @@ fn shell_build_script(shell: Shell) -> Result<String> {
             ProjectTask::ExportSvgHtml(..) => {
                 cmd.push("--format=svg_html");
             }
+            ProjectTask::ExportBundle(..) => {
+                cmd.push("--format=bundle");
+                cmd.push("--features=bundle");
+            }
             ProjectTask::ExportMd(..) => {
                 cmd.push("--format=md");
             }

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -1,13 +1,13 @@
 use std::{path::Path, sync::OnceLock};
 
-use clap::{ArgAction, ValueHint, builder::ValueParser};
+use clap::{builder::ValueParser, ArgAction, ValueHint};
 use tinymist_std::{bail, error::prelude::Result};
 
+use tinymist_world::args::{parse_input_pair, PdfExportArgs, PngExportArgs};
 pub use tinymist_world::args::{CompileFontArgs, CompilePackageArgs};
-use tinymist_world::args::{PdfExportArgs, PngExportArgs, parse_input_pair};
 
-use crate::PROJECT_ROUTE_USER_ACTION_PRIORITY;
 use crate::model::*;
+use crate::PROJECT_ROUTE_USER_ACTION_PRIORITY;
 
 /// Project document commands.
 #[derive(Debug, Clone, clap::Subcommand)]
@@ -254,6 +254,14 @@ impl TaskCompileArgs {
                 merge: None,
             }),
             OutputFormat::Html => ProjectTask::ExportHtml(ExportHtmlTask { export }),
+            OutputFormat::Bundle => ProjectTask::ExportBundle(ExportBundleTask {
+                export,
+                pages: self.pages.clone(),
+                pdf_standards: self.pdf.standard.clone(),
+                no_pdf_tags: self.pdf.no_tags,
+                creation_timestamp: None,
+                ppi: self.png.ppi.try_into().unwrap(),
+            }),
         };
 
         Ok(ApplyProjectTask {

--- a/crates/tinymist-project/src/args.rs
+++ b/crates/tinymist-project/src/args.rs
@@ -1,13 +1,13 @@
 use std::{path::Path, sync::OnceLock};
 
-use clap::{builder::ValueParser, ArgAction, ValueHint};
+use clap::{ArgAction, ValueHint, builder::ValueParser};
 use tinymist_std::{bail, error::prelude::Result};
 
-use tinymist_world::args::{parse_input_pair, PdfExportArgs, PngExportArgs};
 pub use tinymist_world::args::{CompileFontArgs, CompilePackageArgs};
+use tinymist_world::args::{PdfExportArgs, PngExportArgs, parse_input_pair};
 
-use crate::model::*;
 use crate::PROJECT_ROUTE_USER_ACTION_PRIORITY;
+use crate::model::*;
 
 /// Project document commands.
 #[derive(Debug, Clone, clap::Subcommand)]

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -105,6 +105,16 @@ impl<F: CompilerFeat> CompiledArtifact<F> {
         }
     }
 
+    /// Runs diagnostics without precompiling a paged or HTML document.
+    pub fn from_graph_without_doc(graph: Arc<WorldComputeGraph<F>>) -> CompiledArtifact<F> {
+        CompiledArtifact {
+            diag: graph.shared_diagnostics().expect("diag"),
+            graph,
+            doc: None,
+            deps: OnceLock::default(),
+        }
+    }
+
     /// Returns the error count.
     pub fn error_cnt(&self) -> usize {
         self.diag.error_cnt()

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -14,9 +14,9 @@ use tinymist_world::vfs::notify::{
 };
 use tinymist_world::vfs::{FileId, FsProvider, RevisingVfs, WorkspaceResolver};
 use tinymist_world::{
-    CompileSignal, CompileSnapshot, CompilerFeat, CompilerUniverse, DiagnosticsTask, EntryReader,
-    EntryState, FlagTask, HtmlCompilationTask, PagedCompilationTask, ProjectInsId, TaskInputs,
-    WorldComputeGraph, WorldDeps,
+    BundleCompilationTask, CompileSignal, CompileSnapshot, CompilerFeat, CompilerUniverse,
+    DiagnosticsTask, EntryReader, EntryState, FlagTask, HtmlCompilationTask, PagedCompilationTask,
+    ProjectInsId, TaskInputs, WorldComputeGraph, WorldDeps,
 };
 use tokio::sync::mpsc;
 use typst::World;
@@ -91,6 +91,7 @@ impl<F: CompilerFeat> CompiledArtifact<F> {
     pub fn from_graph(graph: Arc<WorldComputeGraph<F>>, is_html: bool) -> CompiledArtifact<F> {
         let _ = graph.provide::<FlagTask<HtmlCompilationTask>>(Ok(FlagTask::flag(is_html)));
         let _ = graph.provide::<FlagTask<PagedCompilationTask>>(Ok(FlagTask::flag(!is_html)));
+        let _ = graph.provide::<FlagTask<BundleCompilationTask>>(Ok(FlagTask::flag(false)));
         let doc = if is_html {
             graph.shared_compile_html().expect("html").map(From::from)
         } else {
@@ -107,6 +108,9 @@ impl<F: CompilerFeat> CompiledArtifact<F> {
 
     /// Runs diagnostics without precompiling a paged or HTML document.
     pub fn from_graph_without_doc(graph: Arc<WorldComputeGraph<F>>) -> CompiledArtifact<F> {
+        let _ = graph.provide::<FlagTask<HtmlCompilationTask>>(Ok(FlagTask::flag(false)));
+        let _ = graph.provide::<FlagTask<PagedCompilationTask>>(Ok(FlagTask::flag(false)));
+        let _ = graph.provide::<FlagTask<BundleCompilationTask>>(Ok(FlagTask::flag(true)));
         CompiledArtifact {
             diag: graph.shared_diagnostics().expect("diag"),
             graph,
@@ -910,7 +914,11 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
                     deps: OnceLock::default(),
                 }
             } else {
-                CompiledArtifact::from_graph(graph, matches!(export_target, ExportTarget::Html))
+                match export_target {
+                    ExportTarget::Bundle => CompiledArtifact::from_graph_without_doc(graph),
+                    ExportTarget::Html => CompiledArtifact::from_graph(graph, true),
+                    ExportTarget::Paged => CompiledArtifact::from_graph(graph, false),
+                }
             };
 
             let res = CompileStatusResult {

--- a/crates/tinymist-project/src/lsp.rs
+++ b/crates/tinymist-project/src/lsp.rs
@@ -239,12 +239,19 @@ impl LspUniverseBuilder {
         let package_registry = Arc::new(package_registry);
         let resolver = Arc::new(RegistryPathMapper::new(package_registry.clone()));
 
-        // todo: typst doesn't allow to merge features
-        let features = match export_target {
-            ExportTarget::Html => Features::from_iter([typst::Feature::Html]),
-            ExportTarget::Bundle => Features::from_iter([typst::Feature::Bundle]),
-            ExportTarget::Paged => features,
+        let target_feature = match export_target {
+            ExportTarget::Html => Some(typst::Feature::Html),
+            ExportTarget::Bundle => Some(typst::Feature::Bundle),
+            ExportTarget::Paged => None,
         };
+        let features = [
+            typst::Feature::Html,
+            typst::Feature::A11yExtras,
+            typst::Feature::Bundle,
+        ]
+        .into_iter()
+        .filter(|feature| features.is_enabled(*feature) || Some(*feature) == target_feature)
+        .collect();
 
         LspUniverse::new_raw(
             entry,

--- a/crates/tinymist-project/src/lsp.rs
+++ b/crates/tinymist-project/src/lsp.rs
@@ -240,10 +240,10 @@ impl LspUniverseBuilder {
         let resolver = Arc::new(RegistryPathMapper::new(package_registry.clone()));
 
         // todo: typst doesn't allow to merge features
-        let features = if matches!(export_target, ExportTarget::Html) {
-            Features::from_iter([typst::Feature::Html])
-        } else {
-            features
+        let features = match export_target {
+            ExportTarget::Html => Features::from_iter([typst::Feature::Html]),
+            ExportTarget::Bundle => Features::from_iter([typst::Feature::Bundle]),
+            ExportTarget::Paged => features,
         };
 
         LspUniverse::new_raw(

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -2,8 +2,8 @@
 
 use tinymist_std::time::ToUtcDateTime;
 use tinymist_world::args::PdfStandard;
-pub use typst_pdf::pdf;
 pub use typst_pdf::PdfStandard as TypstPdfStandard;
+pub use typst_pdf::pdf;
 
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
 

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -2,8 +2,8 @@
 
 use tinymist_std::time::ToUtcDateTime;
 use tinymist_world::args::PdfStandard;
-pub use typst_pdf::PdfStandard as TypstPdfStandard;
 pub use typst_pdf::pdf;
+pub use typst_pdf::PdfStandard as TypstPdfStandard;
 
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
 
@@ -22,84 +22,95 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PdfExport {
         doc: &Arc<TypstPagedDocument>,
         config: &ExportPdfTask,
     ) -> Result<Bytes> {
-        let creation_timestamp = config
-            .creation_timestamp
-            .map(|ts| ts.to_utc_datetime().context("timestamp is out of range"))
-            .transpose()?
-            .unwrap_or_else(tinymist_std::time::utc_now);
-        // todo: this seems different from `Timestamp::new_local` which also embeds the
-        // timezone information.
-        let timestamp = Timestamp::new_utc(tinymist_std::time::to_typst_time(creation_timestamp));
+        let options = pdf_options(
+            config.pages.as_deref(),
+            &config.pdf_standards,
+            config.no_pdf_tags,
+            config.creation_timestamp,
+        )?;
 
-        let standards = PdfStandards::new(
-            &config
-                .pdf_standards
-                .iter()
-                .map(|standard| match standard {
-                    tinymist_world::args::PdfStandard::V_1_4 => typst_pdf::PdfStandard::V_1_4,
-                    tinymist_world::args::PdfStandard::V_1_5 => typst_pdf::PdfStandard::V_1_5,
-                    tinymist_world::args::PdfStandard::V_1_6 => typst_pdf::PdfStandard::V_1_6,
-                    tinymist_world::args::PdfStandard::V_1_7 => typst_pdf::PdfStandard::V_1_7,
-                    tinymist_world::args::PdfStandard::V_2_0 => typst_pdf::PdfStandard::V_2_0,
-                    tinymist_world::args::PdfStandard::A_1b => typst_pdf::PdfStandard::A_1b,
-                    tinymist_world::args::PdfStandard::A_1a => typst_pdf::PdfStandard::A_1a,
-                    tinymist_world::args::PdfStandard::A_2b => typst_pdf::PdfStandard::A_2b,
-                    tinymist_world::args::PdfStandard::A_2u => typst_pdf::PdfStandard::A_2u,
-                    tinymist_world::args::PdfStandard::A_2a => typst_pdf::PdfStandard::A_2a,
-                    tinymist_world::args::PdfStandard::A_3b => typst_pdf::PdfStandard::A_3b,
-                    tinymist_world::args::PdfStandard::A_3u => typst_pdf::PdfStandard::A_3u,
-                    tinymist_world::args::PdfStandard::A_3a => typst_pdf::PdfStandard::A_3a,
-                    tinymist_world::args::PdfStandard::A_4 => typst_pdf::PdfStandard::A_4,
-                    tinymist_world::args::PdfStandard::A_4f => typst_pdf::PdfStandard::A_4f,
-                    tinymist_world::args::PdfStandard::A_4e => typst_pdf::PdfStandard::A_4e,
-                    tinymist_world::args::PdfStandard::Ua_1 => typst_pdf::PdfStandard::Ua_1,
-                })
-                .collect::<Vec<_>>(),
-        )
-        .context_ut("prepare pdf standards")?;
-
-        let tagged = !config.no_pdf_tags && config.pages.is_none();
-        // todo: emit warning diag
-        if config.pages.is_some() && !config.no_pdf_tags {
-            log::warn!(
-                "the resulting PDF will be inaccessible because using --pages implies --no-pdf-tags"
-            );
-        }
-        if !tagged {
-            const ACCESSIBLE: &[(PdfStandard, &str)] = &[
-                (PdfStandard::A_1a, "PDF/A-1a"),
-                (PdfStandard::A_2a, "PDF/A-2a"),
-                (PdfStandard::A_3a, "PDF/A-3a"),
-                (PdfStandard::Ua_1, "PDF/UA-1"),
-            ];
-
-            for (standard, name) in ACCESSIBLE {
-                if config.pdf_standards.contains(standard) {
-                    if config.no_pdf_tags {
-                        log::warn!("cannot disable PDF tags when exporting a {name} document");
-                    } else {
-                        log::warn!(
-                            "cannot disable PDF tags when exporting a {name} document. Hint: using --pages implies --no-pdf-tags"
-                        );
-                    }
-                }
-            }
-        }
-
-        let options = PdfOptions {
-            page_ranges: config
-                .pages
-                .as_ref()
-                .map(|pages| exported_page_ranges(pages)),
-            timestamp: Some(timestamp),
-            standards,
-            tagged,
-            ..Default::default()
-        };
         // log::info!("used options for pdf export: {options:?}");
 
         // todo: Some(pdf_uri.as_str())
         // todo: ident option
         Ok(Bytes::new(typst_pdf::pdf(doc, &options)?))
     }
+}
+
+/// Creates PDF options from shared project export arguments.
+pub fn pdf_options(
+    pages: Option<&[Pages]>,
+    pdf_standards: &[PdfStandard],
+    no_pdf_tags: bool,
+    creation_timestamp: Option<i64>,
+) -> Result<PdfOptions<'static>> {
+    let creation_timestamp = creation_timestamp
+        .map(|ts| ts.to_utc_datetime().context("timestamp is out of range"))
+        .transpose()?
+        .unwrap_or_else(tinymist_std::time::utc_now);
+    // todo: this seems different from `Timestamp::new_local` which also embeds the
+    // timezone information.
+    let timestamp = Timestamp::new_utc(tinymist_std::time::to_typst_time(creation_timestamp));
+
+    let standards = PdfStandards::new(
+        &pdf_standards
+            .iter()
+            .map(|standard| match standard {
+                PdfStandard::V_1_4 => typst_pdf::PdfStandard::V_1_4,
+                PdfStandard::V_1_5 => typst_pdf::PdfStandard::V_1_5,
+                PdfStandard::V_1_6 => typst_pdf::PdfStandard::V_1_6,
+                PdfStandard::V_1_7 => typst_pdf::PdfStandard::V_1_7,
+                PdfStandard::V_2_0 => typst_pdf::PdfStandard::V_2_0,
+                PdfStandard::A_1b => typst_pdf::PdfStandard::A_1b,
+                PdfStandard::A_1a => typst_pdf::PdfStandard::A_1a,
+                PdfStandard::A_2b => typst_pdf::PdfStandard::A_2b,
+                PdfStandard::A_2u => typst_pdf::PdfStandard::A_2u,
+                PdfStandard::A_2a => typst_pdf::PdfStandard::A_2a,
+                PdfStandard::A_3b => typst_pdf::PdfStandard::A_3b,
+                PdfStandard::A_3u => typst_pdf::PdfStandard::A_3u,
+                PdfStandard::A_3a => typst_pdf::PdfStandard::A_3a,
+                PdfStandard::A_4 => typst_pdf::PdfStandard::A_4,
+                PdfStandard::A_4f => typst_pdf::PdfStandard::A_4f,
+                PdfStandard::A_4e => typst_pdf::PdfStandard::A_4e,
+                PdfStandard::Ua_1 => typst_pdf::PdfStandard::Ua_1,
+            })
+            .collect::<Vec<_>>(),
+    )
+    .context_ut("prepare pdf standards")?;
+
+    let tagged = !no_pdf_tags && pages.is_none();
+    // todo: emit warning diag
+    if pages.is_some() && !no_pdf_tags {
+        log::warn!(
+            "the resulting PDF will be inaccessible because using --pages implies --no-pdf-tags"
+        );
+    }
+    if !tagged {
+        const ACCESSIBLE: &[(PdfStandard, &str)] = &[
+            (PdfStandard::A_1a, "PDF/A-1a"),
+            (PdfStandard::A_2a, "PDF/A-2a"),
+            (PdfStandard::A_3a, "PDF/A-3a"),
+            (PdfStandard::Ua_1, "PDF/UA-1"),
+        ];
+
+        for (standard, name) in ACCESSIBLE {
+            if pdf_standards.contains(standard) {
+                if no_pdf_tags {
+                    log::warn!("cannot disable PDF tags when exporting a {name} document");
+                } else {
+                    log::warn!(
+                        "cannot disable PDF tags when exporting a {name} document. Hint: using --pages implies --no-pdf-tags"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(PdfOptions {
+        page_ranges: pages.map(exported_page_ranges),
+        timestamp: Some(timestamp),
+        standards,
+        tagged,
+        ..Default::default()
+    })
 }

--- a/crates/tinymist-task/src/model.rs
+++ b/crates/tinymist-task/src/model.rs
@@ -68,6 +68,8 @@ pub enum ProjectTask {
     ExportSvg(ExportSvgTask),
     /// An export HTML task.
     ExportHtml(ExportHtmlTask),
+    /// An export bundle task.
+    ExportBundle(ExportBundleTask),
     /// An export HTML task.
     ExportSvgHtml(ExportHtmlTask),
     /// An export Markdown task.
@@ -92,6 +94,7 @@ impl ProjectTask {
             | Self::ExportPng(..)
             | Self::ExportSvg(..)
             | Self::ExportHtml(..)
+            | Self::ExportBundle(..)
             | Self::ExportSvgHtml(..)
             | Self::ExportMd(..)
             | Self::ExportTeX(..)
@@ -108,6 +111,7 @@ impl ProjectTask {
             Self::ExportPng(task) => &task.export,
             Self::ExportSvg(task) => &task.export,
             Self::ExportHtml(task) => &task.export,
+            Self::ExportBundle(task) => &task.export,
             Self::ExportSvgHtml(task) => &task.export,
             Self::ExportTeX(task) => &task.export,
             Self::ExportMd(task) => &task.export,
@@ -124,6 +128,7 @@ impl ProjectTask {
             Self::ExportPng(task) => &mut task.export,
             Self::ExportSvg(task) => &mut task.export,
             Self::ExportHtml(task) => &mut task.export,
+            Self::ExportBundle(task) => &mut task.export,
             Self::ExportSvgHtml(task) => &mut task.export,
             Self::ExportTeX(task) => &mut task.export,
             Self::ExportMd(task) => &mut task.export,
@@ -137,6 +142,7 @@ impl ProjectTask {
         match self {
             Self::ExportPdf { .. } => "pdf",
             Self::Preview(..) | Self::ExportSvgHtml { .. } | Self::ExportHtml { .. } => "html",
+            Self::ExportBundle { .. } => "",
             Self::ExportMd { .. } => "md",
             Self::ExportTeX { .. } => "tex",
             Self::ExportText { .. } => "txt",
@@ -308,6 +314,31 @@ pub struct ExportHtmlTask {
     /// The shared export arguments.
     #[serde(flatten)]
     pub export: ExportTask,
+}
+
+/// An export bundle task specifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ExportBundleTask {
+    /// The shared export arguments.
+    #[serde(flatten)]
+    pub export: ExportTask,
+    /// Which pages to export in PDF documents. When unspecified, all pages are
+    /// exported.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pages: Option<Vec<Pages>>,
+    /// One (or multiple comma-separated) PDF standards that Typst will enforce
+    /// conformance with for PDF documents.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub pdf_standards: Vec<PdfStandard>,
+    /// Disable tagged PDF output for PDF documents.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub no_pdf_tags: bool,
+    /// The document's creation date formatted as a UNIX timestamp (in seconds).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub creation_timestamp: Option<i64>,
+    /// The PPI (pixels per inch) to use for PNG documents.
+    pub ppi: Scalar,
 }
 
 /// An export markdown task specifier.

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -48,6 +48,7 @@ ttf-parser.workspace = true
 typst-shim.workspace = true
 typst-assets.workspace = true
 typst.workspace = true
+typst-bundle.workspace = true
 wasm-bindgen = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = ["console"] }
 

--- a/crates/tinymist-world/src/args.rs
+++ b/crates/tinymist-world/src/args.rs
@@ -325,6 +325,8 @@ pub enum OutputFormat {
     Svg,
     /// Export to HTML.
     Html,
+    /// Export to Bundle.
+    Bundle,
 }
 
 display_possible_values!(OutputFormat);
@@ -342,6 +344,8 @@ pub enum ExportTarget {
     Paged,
     /// The current export target is for HTML export.
     Html,
+    /// The current export target is for bundle export.
+    Bundle,
 }
 
 /// A PDF standard that Typst can enforce conformance with.
@@ -427,6 +431,8 @@ pub enum Feature {
     Html,
     /// The A11yExtras feature.
     A11yExtras,
+    /// The bundle export feature
+    Bundle,
 }
 
 display_possible_values!(Feature);
@@ -435,6 +441,7 @@ impl From<Feature> for typst::Feature {
     fn from(f: Feature) -> typst::Feature {
         match f {
             Feature::Html => typst::Feature::Html,
+            Feature::Bundle => typst::Feature::Bundle,
             Feature::A11yExtras => typst::Feature::A11yExtras,
         }
     }

--- a/crates/tinymist-world/src/compute.rs
+++ b/crates/tinymist-world/src/compute.rs
@@ -9,6 +9,7 @@ use typst::diag::{At, SourceResult, Warned};
 use typst::ecow::EcoVec;
 use typst::foundations::Output;
 use typst::syntax::Span;
+use typst_bundle::Bundle;
 
 use crate::snapshot::CompileSnapshot;
 use crate::{CompilerFeat, CompilerWorld, EntryReader, TaskInputs};
@@ -270,6 +271,9 @@ pub type PagedCompilationTask = CompilationTask<TypstPagedDocument>;
 /// A task that compiles an HTML document.
 pub type HtmlCompilationTask = CompilationTask<TypstHtmlDocument>;
 
+/// A task that compiles a bundle.
+pub type BundleCompilationTask = CompilationTask<Bundle>;
+
 /// A task that compiles a document.
 pub struct CompilationTask<D>(std::marker::PhantomData<D>);
 
@@ -383,6 +387,7 @@ impl CompilationDiagnostics {
 pub struct DiagnosticsTask {
     paged: CompilationDiagnostics,
     html: CompilationDiagnostics,
+    bundle: CompilationDiagnostics,
 }
 
 impl<F: CompilerFeat> WorldComputable<F> for DiagnosticsTask {
@@ -391,10 +396,12 @@ impl<F: CompilerFeat> WorldComputable<F> for DiagnosticsTask {
     fn compute(graph: &Arc<WorldComputeGraph<F>>) -> Result<Self> {
         let paged = graph.compute::<PagedCompilationTask>()?.clone();
         let html = graph.compute::<HtmlCompilationTask>()?.clone();
+        let bundle = graph.compute::<BundleCompilationTask>()?.clone();
 
         Ok(Self {
             paged: CompilationDiagnostics::from_result(&paged),
             html: CompilationDiagnostics::from_result(&html),
+            bundle: CompilationDiagnostics::from_result(&bundle),
         })
     }
 }
@@ -411,6 +418,10 @@ impl DiagnosticsTask {
                 errors: None,
                 warnings: None,
             },
+            bundle: CompilationDiagnostics {
+                errors: None,
+                warnings: None,
+            },
         }
     }
 
@@ -418,12 +429,14 @@ impl DiagnosticsTask {
     pub fn error_cnt(&self) -> usize {
         self.paged.errors.as_ref().map_or(0, |e| e.len())
             + self.html.errors.as_ref().map_or(0, |e| e.len())
+            + self.bundle.errors.as_ref().map_or(0, |e| e.len())
     }
 
     /// Gets the number of warnings.
     pub fn warning_cnt(&self) -> usize {
         self.paged.warnings.as_ref().map_or(0, |e| e.len())
             + self.html.warnings.as_ref().map_or(0, |e| e.len())
+            + self.bundle.warnings.as_ref().map_or(0, |e| e.len())
     }
 
     /// Gets the diagnostics.
@@ -434,6 +447,8 @@ impl DiagnosticsTask {
             .chain(self.paged.warnings.iter())
             .chain(self.html.errors.iter())
             .chain(self.html.warnings.iter())
+            .chain(self.bundle.errors.iter())
+            .chain(self.bundle.warnings.iter())
             .flatten()
     }
 }

--- a/crates/tinymist/Cargo.toml
+++ b/crates/tinymist/Cargo.toml
@@ -64,6 +64,7 @@ toml.workspace = true
 ttf-parser.workspace = true
 typlite = { workspace = true, default-features = false }
 typst.workspace = true
+typst-bundle.workspace = true
 typst-svg.workspace = true
 typst-pdf.workspace = true
 typst-render.workspace = true

--- a/crates/tinymist/src/cmd.rs
+++ b/crates/tinymist/src/cmd.rs
@@ -340,7 +340,7 @@ impl ServerState {
                 .map_err(internal_error)?;
             let main = entry
                 .main()
-                .and_then(|e| Some(e.vpath().realize(&root)))
+                .map(|e| e.vpath().realize(&root))
                 .ok_or_else(
                     || error_once!("main file must be resolved, got", entry: display_entry()),
                 )

--- a/crates/tinymist/src/cmd/export.rs
+++ b/crates/tinymist/src/cmd/export.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use tinymist_project::{
-    ExportHtmlTask, ExportPdfTask, ExportPngTask, ExportSvgTask, ExportTeXTask, ExportTextTask,
-    Pages, ProjectTask, QueryTask,
+    ExportBundleTask, ExportHtmlTask, ExportPdfTask, ExportPngTask, ExportSvgTask, ExportTeXTask,
+    ExportTextTask, Pages, ProjectTask, QueryTask,
 };
 use tinymist_std::error::prelude::*;
 use tinymist_task::{ExportMarkdownTask, PageMerge};
@@ -56,6 +56,23 @@ struct ExportPngOpts {
     page_number_template: Option<String>,
     merge: Option<PageMerge>,
     fill: Option<String>,
+    ppi: Option<f32>,
+}
+
+/// See [`ProjectTask`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ExportBundleOpts {
+    /// Which pages to export in PDF documents. When unspecified, all pages are
+    /// exported.
+    pages: Option<Vec<Pages>>,
+    /// The creation timestamp for PDF documents (in seconds).
+    creation_timestamp: Option<String>,
+    /// A PDF standard that Typst can enforce conformance with.
+    pdf_standard: Option<Vec<PdfStandard>>,
+    /// Disable PDF tags.
+    no_pdf_tags: Option<bool>,
+    /// PPI for PNG documents.
     ppi: Option<f32>,
 }
 
@@ -135,6 +152,45 @@ impl ServerState {
         self.export(
             path,
             ProjectTask::ExportHtml(ExportHtmlTask { export }),
+            args,
+        )
+    }
+
+    /// Export the current document as bundle file(s).
+    pub fn export_bundle(&mut self, mut args: Vec<JsonValue>) -> ScheduleResult {
+        let path = get_arg!(args[0] as PathBuf);
+        let opts = get_arg_or_default!(args[1] as ExportBundleOpts);
+
+        let creation_timestamp = if let Some(value) = opts.creation_timestamp {
+            Some(
+                parse_source_date_epoch(&value)
+                    .map_err(|e| invalid_params(format!("Cannot parse creation timestamp: {e}")))?,
+            )
+        } else {
+            self.config.creation_timestamp()
+        };
+        let no_pdf_tags = opts.no_pdf_tags.unwrap_or(self.config.no_pdf_tags());
+        let pdf_standards = opts
+            .pdf_standard
+            .or_else(|| self.config.pdf_standards())
+            .unwrap_or_default();
+        let ppi = opts.ppi.or_else(|| self.config.ppi()).unwrap_or(144.);
+        let ppi = ppi
+            .try_into()
+            .context("cannot convert ppi")
+            .map_err(invalid_params)?;
+
+        let export = self.config.export_task();
+        self.export(
+            path,
+            ProjectTask::ExportBundle(ExportBundleTask {
+                export,
+                pages: opts.pages,
+                pdf_standards,
+                no_pdf_tags,
+                creation_timestamp,
+                ppi,
+            }),
             args,
         )
     }

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -330,6 +330,7 @@ impl ServerState {
             .with_command_("tinymist.exportPng", State::export_png)
             .with_command_("tinymist.exportText", State::export_text)
             .with_command_("tinymist.exportHtml", State::export_html)
+            .with_command_("tinymist.exportBundle", State::export_bundle)
             .with_command_("tinymist.exportMarkdown", State::export_markdown)
             .with_command_("tinymist.exportTeX", State::export_tex)
             .with_command_("tinymist.exportQuery", State::export_query)

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -21,13 +21,16 @@ use tinymist_std::fs::paths::write_atomic;
 use tinymist_std::path::PathClean;
 use tinymist_std::typst::TypstDocument;
 use tinymist_task::{
-    output_template, DocumentQuery, ExportMarkdownTask, ExportPngTask, ExportSvgTask, ExportTarget,
-    ImageOutput, PathPattern, PdfExport, PngExport, SvgExport, TextExport,
+    output_template, pdf_options, DocumentQuery, ExportBundleTask, ExportMarkdownTask,
+    ExportPngTask, ExportSvgTask, ExportTarget, ImageOutput, PathPattern, PdfExport, PngExport,
+    SvgExport, TextExport,
 };
 use tokio::sync::mpsc;
 use typlite::{Format, Typlite};
+use typst::diag::Warned;
 use typst::ecow::EcoString;
 use typst::foundations::Repr;
+use typst_bundle::{Bundle, BundleOptions, VirtualFs};
 
 use futures::Future;
 use parking_lot::Mutex;
@@ -159,7 +162,11 @@ impl ServerState {
     ) -> LspResult<CompilerQueryResponse> {
         let is_html = matches!(task, ProjectTask::ExportHtml { .. });
         // todo: we may get some file missing errors here
-        let artifact = CompiledArtifact::from_graph(snap.clone(), is_html);
+        let artifact = if matches!(task, ProjectTask::ExportBundle { .. }) {
+            CompiledArtifact::from_graph_without_doc(snap.clone())
+        } else {
+            CompiledArtifact::from_graph(snap.clone(), is_html)
+        };
         let id = artifact.world().main_id();
 
         let res = if write {
@@ -366,7 +373,7 @@ impl ExportTask {
         if write_to.is_relative() {
             bail!("ExportTask({task:?}): output path is relative: {write_to:?}");
         }
-        if write_to.is_dir() {
+        if write_to.is_dir() && !matches!(task, ProjectTask::ExportBundle { .. }) {
             bail!("ExportTask({task:?}): output path is a directory: {write_to:?}");
         }
 
@@ -382,6 +389,9 @@ impl ExportTask {
             }) => write_to.with_file_name(page_number_template),
             _ => write_to,
         };
+        if matches!(task, ProjectTask::ExportBundle { .. }) {
+            return Ok(Some(write_to));
+        }
         if !write_to.add_extension(task.extension()) {
             write_to = write_to.with_file_name(format!("main.{}", task.extension()));
         }
@@ -438,6 +448,9 @@ impl ExportTask {
                         })
                         .collect(),
                 }
+            }
+            ExportArtifact::Bundle { .. } => {
+                bail!("cannot export bundle to memory")
             }
         };
 
@@ -546,6 +559,16 @@ impl ExportTask {
                     items: res_items,
                 }
             }
+            ExportArtifact::Bundle { items } => {
+                let root = write_to.clone();
+                let fut = tokio::task::spawn_blocking(move || write_bundle_files(&root, &items));
+                fut.await.context_ut("failed to export")??;
+
+                OnExportResponse::Single {
+                    path: Some(write_to),
+                    data: None,
+                }
+            }
         };
 
         log::debug!("ExportTask({export_id}): export complete");
@@ -564,6 +587,10 @@ impl ExportTask {
         let CompiledArtifact {
             graph, doc, diag, ..
         } = artifact;
+
+        if let ExportBundle(config) = task {
+            return FutureFolder::compute(move |_| export_bundle_artifact(&graph, &config)).await?;
+        }
 
         // Prepare the document.
         let doc = match doc {
@@ -623,6 +650,7 @@ impl ExportTask {
                     typst_html::html(html_doc()?)
                         .map_err(|e| format!("export error: {e:?}"))
                         .context_ut("failed to export to html")?.into(),
+                ExportBundle(..) => unreachable!(),
                 ExportSvgHtml(ExportHtmlTask { export: _ }) =>
                     reflexo_vec2svg::render_svg_html::<DefaultExportFeature>(paged_doc()?).into(),
                 ExportText(ExportTextTask { export: _ }) => TextExport::run_on_doc(doc)?.into(),
@@ -673,6 +701,9 @@ enum ExportArtifact {
         total_pages: usize,
         items: Vec<(usize, Bytes)>,
     },
+    Bundle {
+        items: Vec<(PathBuf, Bytes)>,
+    },
 }
 
 impl From<Bytes> for ExportArtifact {
@@ -722,6 +753,67 @@ impl WithPages for ImageOutput<String> {
             },
         }
     }
+}
+
+fn export_bundle_artifact(
+    graph: &LspComputeGraph,
+    config: &ExportBundleTask,
+) -> Result<ExportArtifact> {
+    let Warned { output, warnings } = typst::compile::<Bundle>(graph.world());
+    for warning in warnings {
+        log::warn!("bundle export warning: {}", warning.message);
+    }
+
+    let bundle = output.map_err(|errors| {
+        print_diagnostics_to_string(
+            graph.world(),
+            errors.iter(),
+            reflexo_typst::DiagnosticFormat::Human,
+        )
+        .map(|msg| anyhow::anyhow!("failed to compile bundle: {msg}"))
+        .unwrap_or_else(|err| anyhow::anyhow!("failed to compile bundle: {err}"))
+    })?;
+
+    let options = BundleOptions {
+        pixel_per_pt: config.ppi.to_f32() / 72.0,
+        pdf: pdf_options(
+            config.pages.as_deref(),
+            &config.pdf_standards,
+            config.no_pdf_tags,
+            config.creation_timestamp,
+        )?,
+    };
+    let fs = typst_bundle::export(&bundle, &options).map_err(|errors| {
+        print_diagnostics_to_string(
+            graph.world(),
+            errors.iter(),
+            reflexo_typst::DiagnosticFormat::Human,
+        )
+        .map(|msg| anyhow::anyhow!("failed to export bundle: {msg}"))
+        .unwrap_or_else(|err| anyhow::anyhow!("failed to export bundle: {err}"))
+    })?;
+
+    Ok(ExportArtifact::Bundle {
+        items: collect_bundle_files(&fs),
+    })
+}
+
+fn collect_bundle_files(fs: &VirtualFs) -> Vec<(PathBuf, Bytes)> {
+    fs.iter()
+        .map(|(path, data)| (path.realize(Path::new("")), data.clone()))
+        .collect()
+}
+
+fn write_bundle_files(root: &Path, items: &[(PathBuf, Bytes)]) -> Result<()> {
+    std::fs::create_dir_all(root).context("failed to create output directory")?;
+    for (path, data) in items {
+        let realized = root.join(path);
+        if let Some(parent) = realized.parent() {
+            std::fs::create_dir_all(parent).context("failed to create directory")?;
+        }
+        write_atomic(realized, data.clone()).context("failed to write file")?;
+    }
+    Ok(())
 }
 
 /// User configuration for export.

--- a/crates/tinymist/src/task/export2.rs
+++ b/crates/tinymist/src/task/export2.rs
@@ -15,8 +15,9 @@ use crate::project::{
     TaskWhen,
 };
 use crate::world::base::{
-    ConfigTask, DiagnosticsTask, ExportComputation, FlagTask, HtmlCompilationTask,
-    OptionDocumentTask, PagedCompilationTask, WorldComputable, WorldComputeGraph,
+    BundleCompilationTask, ConfigTask, DiagnosticsTask, ExportComputation, FlagTask,
+    HtmlCompilationTask, OptionDocumentTask, PagedCompilationTask, WorldComputable,
+    WorldComputeGraph,
 };
 
 /// A task that checks if the project needs to be compiled.
@@ -68,6 +69,7 @@ impl ProjectCompilation {
 
         let _ = graph.provide::<FlagTask<PagedCompilationTask>>(Ok(FlagTask::flag(compile_paged)));
         let _ = graph.provide::<FlagTask<HtmlCompilationTask>>(Ok(FlagTask::flag(compile_html)));
+        let _ = graph.provide::<FlagTask<BundleCompilationTask>>(Ok(FlagTask::flag(false)));
 
         Ok(compile_paged || compile_html)
     }

--- a/crates/tinymist/src/task/export2.rs
+++ b/crates/tinymist/src/task/export2.rs
@@ -149,6 +149,7 @@ impl WorldComputable<LspCompilerFeat> for ProjectExport {
                 ExportPng(_config) => todo!(),
                 ExportSvg(_config) => todo!(),
                 ExportHtml(config) => Self::export_string::<_, HtmlExport>(graph, when, config),
+                ExportBundle(..) => unreachable!(),
                 // todo: configuration
                 ExportSvgHtml(_config) => Self::export_string::<
                     _,

--- a/editors/vscode/Configuration.md
+++ b/editors/vscode/Configuration.md
@@ -117,6 +117,7 @@ The target to export the document to. Defaults to `paged`. Note: you can still e
 - **Valid Values**:
   - `"paged"` : The current export target is for PDF, PNG, and SVG export.
   - `"html"` : The current export target is for HTML export.
+  - `"bundle"` : The current export target is for bundle export.
 - **Default**: `"paged"`
 
 ## `tinymist.fontPaths`
@@ -413,7 +414,7 @@ Whether to prefix newlines after comments with the corresponding comment prefix.
 
 ## `tinymist.typstExtraArgs`
 
-CLI-shaped arguments for the supported Typst subset that Tinymist parses today. Supported examples include `--input`, `--features=html`, `--root`, `--font-path`, `--ignore-system-fonts`, `--package-path`, `--package-cache-path`, `--creation-timestamp`, and `--cert`, plus a final entry file. Dedicated settings such as `tinymist.rootPath`, `tinymist.fontPaths`, and `tinymist.systemFonts` override overlapping arguments. See [Compiler Settings](https://myriad-dreamin.github.io/tinymist/feature/compiler-settings.html) for examples.
+CLI-shaped arguments for the supported Typst subset that Tinymist parses today. Supported examples include `--input`, `--features=html`, `--features=bundle`, `--root`, `--font-path`, `--ignore-system-fonts`, `--package-path`, `--package-cache-path`, `--creation-timestamp`, and `--cert`, plus a final entry file. Dedicated settings such as `tinymist.rootPath`, `tinymist.fontPaths`, and `tinymist.systemFonts` override overlapping arguments. See [Compiler Settings](https://myriad-dreamin.github.io/tinymist/feature/compiler-settings.html) for examples.
 
 - **Type**: `array`
 - **Default**: `[]`

--- a/editors/vscode/e2e-workspaces/ieee-paper/ieee-template.typ
+++ b/editors/vscode/e2e-workspaces/ieee-paper/ieee-template.typ
@@ -1,6 +1,6 @@
 /// We test that whether current target is HTML (which is used by the converter).
 /// `ieee` will not style the document if `is-html-target` is true.
-#let is-html-target = ("target" in dictionary(std))
+#let is-html-target = ("html" in dictionary(std))
 
 #let title-state = state("tex:title", "")
 #let authors-state = state("tex:authors", ())

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -115,6 +115,7 @@
                       "png",
                       "svg",
                       "html",
+                      "bundle",
                       "markdown",
                       "tex",
                       "text",
@@ -126,6 +127,7 @@
                       "PNG",
                       "SVG",
                       "HTML",
+                      "Bundle",
                       "Markdown",
                       "TeX",
                       "Plain Text",
@@ -145,6 +147,7 @@
                         "png",
                         "svg",
                         "html",
+                        "bundle",
                         "markdown",
                         "tex",
                         "text",
@@ -156,6 +159,7 @@
                         "PNG",
                         "SVG",
                         "HTML",
+                        "Bundle",
                         "Markdown",
                         "TeX",
                         "Plain Text",
@@ -182,6 +186,40 @@
                   "string"
                 ],
                 "description": "The unix timestamp of the PDF creation. If not specified, the current time is used."
+              },
+              "bundle.pages": {
+                "type": [
+                  "string",
+                  "array"
+                ],
+                "description": "The page range(s) to export into the bundle. Uses the same syntax as `pages`.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "bundle.creationTimestamp": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The unix timestamp of the PDF creation inside the bundle. If not specified, the current time is used."
+              },
+              "bundle.pdfStandard": {
+                "type": "array",
+                "description": "Optional PDF standards for PDF documents inside the bundle.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "bundle.pdfTags": {
+                "type": "boolean",
+                "description": "Whether to include tagged structure in PDF documents inside the bundle for better accessibility.",
+                "default": true
+              },
+              "bundle.ppi": {
+                "type": "number",
+                "description": "The PPI (pixels per inch) to use for raster exports inside the bundle.",
+                "default": 144
               },
               "png.ppi": {
                 "type": "number",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -372,11 +372,13 @@
           "default": "paged",
           "enum": [
             "paged",
-            "html"
+            "html",
+            "bundle"
           ],
           "enumDescriptions": [
             "%extension.tinymist.config.tinymist.exportTarget.string.enum.paged%",
-            "%extension.tinymist.config.tinymist.exportTarget.string.enum.html%"
+            "%extension.tinymist.config.tinymist.exportTarget.string.enum.html%",
+            "%extension.tinymist.config.tinymist.exportTarget.string.enum.bundle%"
           ]
         },
         "tinymist.exportPdf": {

--- a/editors/vscode/src/cmd.export.ts
+++ b/editors/vscode/src/cmd.export.ts
@@ -18,6 +18,14 @@ export interface ExportPngOpts {
   ppi?: number;
 }
 
+export interface ExportBundleOpts {
+  pages?: string[];
+  creationTimestamp?: string | null;
+  pdfStandard?: string[];
+  noPdfTags?: boolean;
+  ppi?: number;
+}
+
 export interface ExportSvgOpts {
   pages?: string[];
   pageNumberTemplate?: string;
@@ -48,6 +56,7 @@ export interface ExportTextOpts {}
 export type ExportOpts =
   | ExportPdfOpts
   | ExportPngOpts
+  | ExportBundleOpts
   | ExportSvgOpts
   | ExportTypliteOpts
   | ExportQueryOpts

--- a/editors/vscode/src/features/export.ts
+++ b/editors/vscode/src/features/export.ts
@@ -13,7 +13,16 @@ import { l10nMsg } from "../l10n";
 import { type ExportResponse, tinymist } from "../lsp";
 
 /// These are names of the export functions in the LSP client, e.g. `exportPdf`, `exportHtml`.
-export type ExportKind = "Pdf" | "Html" | "Svg" | "Png" | "Markdown" | "TeX" | "Text" | "Query";
+export type ExportKind =
+  | "Pdf"
+  | "Html"
+  | "Bundle"
+  | "Svg"
+  | "Png"
+  | "Markdown"
+  | "TeX"
+  | "Text"
+  | "Query";
 
 export function exportActivate(context: IContext) {
   context.subscriptions.push(
@@ -73,6 +82,11 @@ export const quickExports: QuickExportFormatMeta[] = [
     label: "HTML",
     description: l10nMsg("Export as HTML"),
     exportKind: "Html",
+  },
+  {
+    label: "Bundle",
+    description: l10nMsg("Export as Bundle"),
+    exportKind: "Bundle",
   },
   {
     label: "Markdown",
@@ -255,7 +269,7 @@ export async function commandShow(kind: ExportKind, extraOpts?: ExportOpts): Pro
   // See https://github.com/Myriad-Dreamin/tinymist/issues/837
   // Also see https://github.com/microsoft/vscode/issues/85930
   const openBySystemDefault = openIn === "systemDefault";
-  if (openBySystemDefault) {
+  if (openBySystemDefault && kind !== "Bundle") {
     actionOpts.open = true;
   }
 
@@ -278,6 +292,17 @@ export async function commandShow(kind: ExportKind, extraOpts?: ExportOpts): Pro
   if (!exportResponse || "message" in exportResponse) {
     // show error message
     await vscode.window.showErrorMessage(`Failed to export ${kind}: ${exportResponse?.message}`);
+    return;
+  }
+
+  if (kind === "Bundle") {
+    const exportPath =
+      "items" in exportResponse ? exportResponse.items[0]?.path : exportResponse.path;
+    if (!exportPath) {
+      await vscode.window.showErrorMessage(`Failed to export ${kind}: no path in response`);
+      return;
+    }
+    await commands.executeCommand("revealFileInOS", vscode.Uri.file(exportPath));
     return;
   }
 

--- a/editors/vscode/src/features/tasks.export.ts
+++ b/editors/vscode/src/features/tasks.export.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/complexity/useLiteralKeys: special keys */
 import * as vscode from "vscode";
 import type {
+  ExportBundleOpts,
   ExportHtmlOpts,
   ExportPdfOpts,
   ExportPngOpts,
@@ -13,7 +14,17 @@ import { tinymist } from "../lsp";
 import { extensionState } from "../state";
 import { VirtualConsole } from "../util";
 
-export type ExportFormat = "pdf" | "png" | "svg" | "html" | "markdown" | "text" | "query" | "pdfpc";
+export type ExportFormat =
+  | "pdf"
+  | "png"
+  | "svg"
+  | "html"
+  | "bundle"
+  | "markdown"
+  | "tex"
+  | "text"
+  | "query"
+  | "pdfpc";
 
 export interface ExportArgs {
   format: ExportFormat | ExportFormat[];
@@ -42,6 +53,14 @@ export interface ExportArgs {
   "pdf.pdfValidator"?: string;
   "pdf.pdfStandard"?: string[];
   "pdf.pdfTags"?: boolean;
+
+  "bundle.pages"?: string | string[];
+  "bundle.creationTimestamp"?: string | null;
+  "bundle.pdfVersion"?: string;
+  "bundle.pdfValidator"?: string;
+  "bundle.pdfStandard"?: string[];
+  "bundle.pdfTags"?: boolean;
+  "bundle.ppi"?: number;
 
   "png.ppi"?: number;
 
@@ -75,7 +94,7 @@ export const runExport = (def: vscode.TaskDefinition) => {
     onDidWrite: vc.writeEmitter.event,
     onDidClose: closeEmitter.event,
     open,
-    close() {},
+    close() { },
   });
 
   async function open() {
@@ -120,7 +139,7 @@ export const exportOps = (exportArgs: ExportArgs) => ({
     const key = `${from}.${prop}` as keyof ExportArgs;
     return exportArgs[key] === undefined ? exportArgs[prop] : (exportArgs[key] as ExportArgs[P]);
   },
-  resolvePagesOpts(fmt: "pdf" | "png" | "svg") {
+  resolvePagesOpts(fmt: "pdf" | "png" | "svg" | "bundle") {
     const pages = this.inheritedProp("pages", fmt);
     return typeof pages === "string" ? pages.split(",") : pages;
   },
@@ -192,6 +211,34 @@ export const provideFormats = (exportArgs: ExportArgs, ops = exportOps(exportArg
       return {};
     },
     export: tinymist.exportHtml,
+  },
+  bundle: {
+    opts(): ExportBundleOpts {
+      const rawCreationTimestamp =
+        exportArgs["bundle.creationTimestamp"] ?? exportArgs["pdf.creationTimestamp"];
+      const creationTimestamp = rawCreationTimestamp?.includes("T")
+        ? Math.floor(new Date(rawCreationTimestamp).getTime() / 1000).toString()
+        : rawCreationTimestamp;
+
+      const pdfVersion = exportArgs["bundle.pdfVersion"] ?? exportArgs["pdf.pdfVersion"];
+      const pdfValidator = exportArgs["bundle.pdfValidator"] ?? exportArgs["pdf.pdfValidator"];
+      const pdfStandard = exportArgs["bundle.pdfStandard"] ??
+        exportArgs["pdf.pdfStandard"] ?? [
+          ...(pdfVersion ? [pdfVersion] : []),
+          ...(pdfValidator ? [pdfValidator] : []),
+        ];
+
+      const pdfTags = exportArgs["bundle.pdfTags"] ?? exportArgs["pdf.pdfTags"];
+
+      return {
+        pages: ops.resolvePagesOpts("bundle"),
+        creationTimestamp,
+        pdfStandard,
+        noPdfTags: pdfTags === undefined ? undefined : !pdfTags,
+        ppi: exportArgs["bundle.ppi"] ?? exportArgs["png.ppi"],
+      };
+    },
+    export: tinymist.exportBundle,
   },
   markdown: {
     opts(): ExportTypliteOpts {

--- a/editors/vscode/src/lsp.ts
+++ b/editors/vscode/src/lsp.ts
@@ -359,6 +359,7 @@ export class LanguageState {
   exportSvg = exportCommand("tinymist.exportSvg");
   exportPng = exportCommand("tinymist.exportPng");
   exportHtml = exportCommand("tinymist.exportHtml");
+  exportBundle = exportCommand("tinymist.exportBundle");
   exportMarkdown = exportCommand("tinymist.exportMarkdown");
   exportTeX = exportCommand("tinymist.exportTeX");
   exportText = exportCommand("tinymist.exportText");

--- a/locales/tinymist-vscode-rt.toml
+++ b/locales/tinymist-vscode-rt.toml
@@ -12,6 +12,10 @@ en = "A page number template must be present if the source document renders to m
 en = "A typst file help export to TeX, e.g. `/ieee-tex.typ` or `@local/ieee-tex:0.1.0`"
 zh = "提供一个帮助导出为 TeX 的 typst 文件，例如 `/ieee-tex.typ` 或 `@local/ieee-tex:0.1.0`"
 
+["Export as Bundle"]
+en = "Export as Bundle"
+zh = "导出为 Bundle"
+
 ["Export as HTML"]
 en = "Export as HTML"
 zh = "导出为 HTML"

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -1064,8 +1064,8 @@ en = "Export target"
 zh = "导出目标"
 
 [extension.tinymist.config.tinymist.exportTarget.desc]
-en = "The target to export the document to. Defaults to `paged`. Note: you can still export PDF when it is set to `html`. This configuration only affects how the language server completes your code."
-zh = "导出文档的目标。默认为 `paged`。注意：即使设置为 `html`，您仍然可以导出 PDF。此配置仅影响语言服务器如何补全您的代码。"
+en = "The target to export the document to. Defaults to `paged`. Note: you can still export PDF when it is set to `html` or `bundle`. This configuration only affects how the language server completes your code."
+zh = "导出文档的目标。默认为 `paged`。注意：即使设置为 `html` 或 `bundle`，您仍然可以导出 PDF。此配置仅影响语言服务器如何补全您的代码。"
 
 [extension.tinymist.config.tinymist.exportTarget.string.enum.paged]
 en = "The current export target is for PDF, PNG, and SVG export."
@@ -1074,6 +1074,10 @@ zh = "当前的导出目标是 PDF、PNG 和 SVG 导出。"
 [extension.tinymist.config.tinymist.exportTarget.string.enum.html]
 en = "The current export target is for HTML export."
 zh = "当前的导出目标是 HTML 导出。"
+
+[extension.tinymist.config.tinymist.exportTarget.string.enum.bundle]
+en = "The current export target is for bundle export."
+zh = "当前的导出目标是 bundle 导出。"
 
 [extension.tinymist.config.tinymist.exportPdf.title]
 en = "Export PDF"

--- a/tools/editor-tools/src/features/exporter/formats.ts
+++ b/tools/editor-tools/src/features/exporter/formats.ts
@@ -39,73 +39,89 @@ const MERGE_OPTS: OptionSchema[] = [
   },
 ];
 
+const PDF_OPTS: OptionSchema[] = [
+  {
+    key: "pdf.creationTimestamp",
+    type: "datetime",
+    label: "Creation Timestamp",
+    description: "The document's creation date (leave empty for current time)",
+    default: "",
+    validate: (value: string) => {
+      if (value.trim() === "") {
+        return; // Allow empty input
+      }
+      if (!/^\d+$/.test(value)) {
+        return "Creation timestamp must be a valid non-negative integer UNIX timestamp";
+      }
+      const num = Number(value);
+      if (Number.isNaN(num) || !Number.isInteger(num) || num < 0) {
+        return "Creation timestamp must be a valid non-negative integer UNIX timestamp";
+      }
+    },
+  },
+  {
+    key: "pdf.pdfVersion",
+    type: "select",
+    label: "PDF Version",
+    description: "Optional version of the PDF document",
+    options: [
+      { value: "1.4", label: "PDF 1.4" },
+      { value: "1.5", label: "PDF 1.5" },
+      { value: "1.6", label: "PDF 1.6" },
+      { value: "1.7", label: "PDF 1.7" },
+      { value: "2.0", label: "PDF 2.0" },
+    ],
+  },
+  {
+    key: "pdf.pdfValidator",
+    type: "select",
+    label: "PDF Validator",
+    description: "Optional validator for exporting PDF documents to a specific subset of PDF",
+    options: [
+      { value: "a-1b", label: "PDF/A-1b" },
+      { value: "a-1a", label: "PDF/A-1a" },
+      { value: "a-2b", label: "PDF/A-2b" },
+      { value: "a-2u", label: "PDF/A-2u" },
+      { value: "a-2a", label: "PDF/A-2a" },
+      { value: "a-3b", label: "PDF/A-3b" },
+      { value: "a-3u", label: "PDF/A-3u" },
+      { value: "a-3a", label: "PDF/A-3a" },
+      { value: "a-4", label: "PDF/A-4" },
+      { value: "a-4f", label: "PDF/A-4f" },
+      { value: "a-4e", label: "PDF/A-4e" },
+      { value: "ua-1", label: "PDF/UA-1" },
+    ],
+  },
+  {
+    key: "pdf.pdfTags",
+    type: "boolean",
+    label: "PDF Tags",
+    description: "Include tagged structure in the PDF for better accessibility.",
+    default: true,
+  },
+];
+
+const PPI_OPT: OptionSchema = {
+  key: "png.ppi",
+  type: "number",
+  label: "PPI (Pixels per inch)",
+  description: "Resolution for the exported image",
+  default: 144,
+  min: 0,
+  validate: (value: string) => {
+    const num = Number(value);
+    if (Number.isNaN(num) || !Number.isFinite(num) || num <= 0) {
+      return "PPI must be a valid positive number";
+    }
+  },
+};
+
 export const EXPORT_FORMATS: ExportFormat[] = [
   {
     id: "pdf",
     label: "PDF",
     fileExtension: "pdf",
-    options: [
-      PAGES_OPT,
-      {
-        key: "pdf.creationTimestamp",
-        type: "datetime",
-        label: "Creation Timestamp",
-        description: "The document's creation date (leave empty for current time)",
-        default: "",
-        validate: (value: string) => {
-          if (value.trim() === "") {
-            return; // Allow empty input
-          }
-          if (!/^\d+$/.test(value)) {
-            return "Creation timestamp must be a valid non-negative integer UNIX timestamp";
-          }
-          const num = Number(value);
-          if (Number.isNaN(num) || !Number.isInteger(num) || num < 0) {
-            return "Creation timestamp must be a valid non-negative integer UNIX timestamp";
-          }
-        },
-      },
-      {
-        key: "pdf.pdfVersion",
-        type: "select",
-        label: "PDF Version",
-        description: "Optional version of the PDF document",
-        options: [
-          { value: "1.4", label: "PDF 1.4" },
-          { value: "1.5", label: "PDF 1.5" },
-          { value: "1.6", label: "PDF 1.6" },
-          { value: "1.7", label: "PDF 1.7" },
-          { value: "2.0", label: "PDF 2.0" },
-        ],
-      },
-      {
-        key: "pdf.pdfValidator",
-        type: "select",
-        label: "PDF Validator",
-        description: "Optional validator for exporting PDF documents to a specific subset of PDF",
-        options: [
-          { value: "a-1b", label: "PDF/A-1b" },
-          { value: "a-1a", label: "PDF/A-1a" },
-          { value: "a-2b", label: "PDF/A-2b" },
-          { value: "a-2u", label: "PDF/A-2u" },
-          { value: "a-2a", label: "PDF/A-2a" },
-          { value: "a-3b", label: "PDF/A-3b" },
-          { value: "a-3u", label: "PDF/A-3u" },
-          { value: "a-3a", label: "PDF/A-3a" },
-          { value: "a-4", label: "PDF/A-4" },
-          { value: "a-4f", label: "PDF/A-4f" },
-          { value: "a-4e", label: "PDF/A-4e" },
-          { value: "ua-1", label: "PDF/UA-1" },
-        ],
-      },
-      {
-        key: "pdf.pdfTags",
-        type: "boolean",
-        label: "PDF Tags",
-        description: "Include tagged structure in the PDF for better accessibility.",
-        default: true,
-      },
-    ],
+    options: [PAGES_OPT, ...PDF_OPTS],
   },
   {
     id: "png",
@@ -114,20 +130,7 @@ export const EXPORT_FORMATS: ExportFormat[] = [
     options: [
       ...IMAGE_PAGES_OPTS,
       ...MERGE_OPTS,
-      {
-        key: "png.ppi",
-        type: "number",
-        label: "PPI (Pixels per inch)",
-        description: "Resolution for the exported image",
-        default: 144,
-        min: 0,
-        validate: (value: string) => {
-          const num = Number(value);
-          if (Number.isNaN(num) || !Number.isFinite(num) || num <= 0) {
-            return "PPI must be a valid positive number";
-          }
-        },
-      },
+      PPI_OPT,
       {
         key: "png.fill",
         type: "color",
@@ -148,6 +151,12 @@ export const EXPORT_FORMATS: ExportFormat[] = [
     label: "HTML",
     fileExtension: "html",
     options: [],
+  },
+  {
+    id: "bundle",
+    label: "Bundle",
+    fileExtension: "",
+    options: [PAGES_OPT, ...PDF_OPTS, PPI_OPT],
   },
   {
     id: "markdown",

--- a/tools/editor-tools/src/features/exporter/types.ts
+++ b/tools/editor-tools/src/features/exporter/types.ts
@@ -1,6 +1,15 @@
 export type Scalar = string | number | boolean;
 
-export type ExportFormatId = "pdf" | "png" | "svg" | "html" | "markdown" | "tex" | "text" | "query";
+export type ExportFormatId =
+  | "pdf"
+  | "png"
+  | "svg"
+  | "html"
+  | "bundle"
+  | "markdown"
+  | "tex"
+  | "text"
+  | "query";
 
 export interface OptionSchema {
   key: string;

--- a/typ/packages/package-docs/template.typ
+++ b/typ/packages/package-docs/template.typ
@@ -14,7 +14,7 @@
 #let is-pdf-target = is-pdf-target()
 #let is-web-target = is-web-target()
 #let is-md-target = x-target == "md"
-#let sys-is-html-target = ("target" in dictionary(std))
+#let sys-is-html-target = ("html" in dictionary(std))
 
 #let part-counter = counter("shiroa-part-counter")
 /// Creates an embedded block typst frame.

--- a/typ/packages/package-docs/theme.typ
+++ b/typ/packages/package-docs/theme.typ
@@ -2,7 +2,7 @@
 #import templates: *
 
 #let is-md-target = book-sys.target == "md"
-#let sys-is-html-target = book-sys.sys-is-html-target
+#let sys-is-html-target = ("html" in dictionary(std))
 
 // Theme (Colors)
 #let dark-theme = book-theme-from(toml("theme-style.toml"), xml: it => xml(it), target: "web-ayu")

--- a/typ/templates/page.typ
+++ b/typ/templates/page.typ
@@ -16,7 +16,7 @@
 #let is-pdf-target = is-pdf-target()
 #let is-web-target = is-web-target()
 #let is-md-target = x-target == "md"
-#let sys-is-html-target = ("target" in dictionary(std))
+#let sys-is-html-target = ("html" in dictionary(std))
 
 // Theme (Colors)
 #let themes = theme-box-styles-from(toml("theme-style.toml"), read: it => read(it))

--- a/typ/templates/target.typ
+++ b/typ/templates/target.typ
@@ -1,4 +1,4 @@
 #import "@preview/shiroa:0.3.1": book-sys
 
 #let is-md-target = book-sys.target == "md"
-#let sys-is-html-target = book-sys.sys-is-html-target
+#let sys-is-html-target = ("html" in dictionary(std))

--- a/typ/templates/theme.typ
+++ b/typ/templates/theme.typ
@@ -76,7 +76,7 @@
   light-theme: none,
   dark-theme: none,
 ) = {
-  let sys-is-html-target = ("target" in dictionary(std))
+  let sys-is-html-target = ("html" in dictionary(std))
 
   if light-theme == none {
     for (name, it) in preset.pairs() {
@@ -122,7 +122,7 @@
     default-theme: default-theme,
   ) = themes
   let is-md-target = x-target == "md"
-  let sys-is-html-target = ("target" in dictionary(std))
+  let sys-is-html-target = ("html" in dictionary(std))
 
   if is-md-target {
     show: html.elem.with(tag)


### PR DESCRIPTION
This PR is part of the Typst 0.15 nightly cleanup stack. It sits on top of the analysis/eval API group and keeps this slice focused on bundle export plumbing.

## Upstream Typst Changes

- [`typst/typst#7964` Bundle export](https://github.com/typst/typst/pull/7964) introduces bundle output as a first-class target and changes how HTML/PDF/SVG/PNG export paths are selected from compiled documents.
- Typst 0.15 exposes target information differently in `dictionary(std)`: the `target` key is always present, so target checks that relied only on key presence need to check for the actual HTML target value.
- The broader export option changes from later Typst PRs remain outside this slice; this PR is only the bundle export plumbing needed before those option-level adaptations.

## Tinymist Changes

- Adds bundle export support through the compile/project/LSP pipeline so bundle output can flow through tinymist's existing compilation tasks.
- Extends export task models and PDF/export compute paths for the bundle target.
- Adds CLI export wiring and server command registration for bundle-aware export tasks.
- Adds VS Code command/task integration and localized command text for bundle export.
- Updates editor-tools exporter format metadata so the frontend can surface the bundle target.
- Updates Typst templates that check whether the system target is HTML to use the 0.15-compatible target value check.
