### PR TITLE
fix: adapt diagnostics and spans for typst 0.15

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -734,13 +734,13 @@ impl<'a> SyntaxClass<'a> {
         use SyntaxClass::*;
         match self {
             Label { .. } => false,
-            VarAccess(cls) => cls.node().erroneous(),
+            VarAccess(cls) => cls.node().diagnosis().errors,
             Normal(_, node)
             | Callee(node)
             | At { node }
             | Ref { node, .. }
             | ImportPath(node)
-            | IncludePath(node) => node.erroneous(),
+            | IncludePath(node) => node.diagnosis().errors,
         }
     }
 }

--- a/crates/tinymist-dap/src/lib.rs
+++ b/crates/tinymist-dap/src/lib.rs
@@ -165,7 +165,7 @@ impl BreakpointContext<'_, '_, '_> {
         root.synthesize(self.span);
 
         // Check for well-formedness.
-        let errors = root.errors();
+        let errors = root.errors_and_warnings().0;
         if !errors.is_empty() {
             return Err(errors.into_iter().map(Into::into).collect());
         }

--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -14,7 +14,7 @@ use typst::{
     diag::{EcoString, SourceDiagnostic, Tracepoint, eco_format},
     ecow::EcoVec,
     syntax::{
-        FileId, Span, Spanned, SyntaxNode,
+        DiagSpan, FileId, Span, Spanned, SyntaxNode,
         ast::{self, AstNode},
     },
 };
@@ -53,8 +53,8 @@ pub fn lint_file(
 /// duplicating warnings.
 #[derive(Default, Clone, Hash)]
 pub struct KnownIssues {
-    unknown_vars: EcoVec<Span>,
-    unknown_fonts: EcoVec<(Span, EcoString)>,
+    unknown_vars: EcoVec<DiagSpan>,
+    unknown_fonts: EcoVec<(DiagSpan, EcoString)>,
 }
 
 impl KnownIssues {
@@ -71,8 +71,6 @@ impl KnownIssues {
                 unknown_fonts.push((diag.span, font_name));
             }
         }
-        unknown_vars.sort_by_key(|span| span.into_raw());
-        unknown_fonts.sort_by_key(|(span, _)| span.into_raw());
         let unknown_vars = EcoVec::from(unknown_vars);
         let unknown_fonts = EcoVec::from(unknown_fonts);
         Self {
@@ -82,14 +80,14 @@ impl KnownIssues {
     }
 
     pub(crate) fn has_unknown_math_ident(&self, ident: ast::MathIdent<'_>) -> bool {
-        self.unknown_vars.contains(&ident.span())
+        self.unknown_vars.contains(&ident.span().into())
     }
 
     pub(crate) fn get_unknown_font(&self, span: Span) -> Option<&EcoString> {
+        let span = DiagSpan::from(span);
         self.unknown_fonts
-            .binary_search_by_key(&span.into_raw(), |(s, _)| s.into_raw())
-            .ok()
-            .map(|i| &self.unknown_fonts[i].1)
+            .iter()
+            .find_map(|(candidate, name)| (*candidate == span).then_some(name))
     }
 }
 

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -896,7 +896,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
         move || {
             let compiled = if syntax_only {
                 let main = graph.snap.world.main();
-                let source_res = graph.world().source(main).at(Span::from_range(main, 0..0));
+                let source_res = graph.world().source(main).at(Span::detached());
                 let syntax_res = source_res.and_then(|source| {
                     let errors = source.root().errors_and_warnings().0;
                     if errors.is_empty() {

--- a/crates/tinymist-project/src/compiler.rs
+++ b/crates/tinymist-project/src/compiler.rs
@@ -898,7 +898,7 @@ impl<F: CompilerFeat, Ext: 'static> ProjectInsState<F, Ext> {
                 let main = graph.snap.world.main();
                 let source_res = graph.world().source(main).at(Span::from_range(main, 0..0));
                 let syntax_res = source_res.and_then(|source| {
-                    let errors = source.root().errors();
+                    let errors = source.root().errors_and_warnings().0;
                     if errors.is_empty() {
                         Ok(())
                     } else {

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -188,10 +188,8 @@ mod expr_tests {
     use tinymist_std::path::unix_slash;
     use tinymist_world::vfs::WorkspaceResolver;
     use typst::syntax::Source;
-    use typst_shim::syntax::RootedPathExt;
-    use typst_shim::syntax::VirtualPathExt;
+    use typst_shim::syntax::{RootedPathExt, VirtualPathExt, source_range};
 
-    use crate::prelude::source_range;
     use crate::syntax::{Expr, RefExpr};
     use crate::tests::*;
 
@@ -363,8 +361,8 @@ mod type_check_tests {
 
     use typst::syntax::Source;
 
-    use crate::prelude::source_range;
     use crate::tests::*;
+    use typst_shim::syntax::source_range;
 
     use super::{Ty, TypeInfo};
 

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -191,6 +191,7 @@ mod expr_tests {
     use typst_shim::syntax::RootedPathExt;
     use typst_shim::syntax::VirtualPathExt;
 
+    use crate::prelude::source_range;
     use crate::syntax::{Expr, RefExpr};
     use crate::tests::*;
 
@@ -202,7 +203,7 @@ mod expr_tests {
         fn show_expr(&self, node: &Expr) -> String {
             match node {
                 Expr::Decl(decl) => {
-                    let range = self.range(decl.span()).unwrap_or_default();
+                    let range = source_range(self, decl.span()).unwrap_or_default();
                     let fid = if let Some(fid) = decl.file_id() {
                         if WorkspaceResolver::is_package_file(fid) {
                             let package = fid.package_compat().expect("package file");
@@ -362,6 +363,7 @@ mod type_check_tests {
 
     use typst::syntax::Source;
 
+    use crate::prelude::source_range;
     use crate::tests::*;
 
     use super::{Ty, TypeInfo};
@@ -400,7 +402,7 @@ mod type_check_tests {
             let mut mapping = info
                 .mapping
                 .iter()
-                .map(|pair| (source.range(*pair.0).unwrap_or_default(), pair.1))
+                .map(|pair| (source_range(source, *pair.0).unwrap_or_default(), pair.1))
                 .collect::<Vec<_>>();
 
             mapping.sort_by(|x, y| {

--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -506,7 +506,7 @@ impl<'a> CompletionWorker<'a> {
         if matches!(
             cursor.syntax,
             Some(SyntaxClass::Callee(..) | SyntaxClass::VarAccess(..) | SyntaxClass::Normal(..))
-        ) && cursor.leaf.erroneous()
+        ) && cursor.leaf.diagnosis().errors
         {
             let mut chars = cursor.leaf.text().chars();
             match chars.next() {

--- a/crates/tinymist-query/src/analysis/definition.rs
+++ b/crates/tinymist-query/src/analysis/definition.rs
@@ -2,6 +2,7 @@
 
 use typst::foundations::{Label, Selector, Type};
 use typst::introspection::Introspector;
+use typst_shim::syntax::source_range;
 
 use super::{InsTy, SharedContext, prelude::*};
 use crate::syntax::{Decl, DeclExpr, Expr, ExprInfo, SyntaxClass, VarClass};
@@ -72,13 +73,8 @@ impl HasNameRange for Decl {
             return None;
         }
 
-        let span = self.span();
-        if let Some(range) = span.range() {
-            return Some(range.clone());
-        }
-
         let src = ctx.source_by_id(self.file_id()?).ok()?;
-        src.range(span)
+        source_range(&src, self.span())
     }
 }
 

--- a/crates/tinymist-query/src/code_context.rs
+++ b/crates/tinymist-query/src/code_context.rs
@@ -9,7 +9,7 @@ use tinymist_world::vfs::WorkspaceResolver;
 use tinymist_world::{EntryReader, EntryState, ShadowApi, diag::print_diagnostics_to_string};
 use typst::diag::{At, SourceResult};
 use typst::foundations::{Args, Dict, NativeFunc, eco_format};
-use typst::syntax::Span;
+use typst::syntax::RangeMapper;
 use typst::utils::LazyHash;
 use typst::{
     foundations::{Bytes, IntoValue, StyleChain},
@@ -256,8 +256,9 @@ fn eval_path_expr(
             }
 
             let mut expr = typst::syntax::parse_code(code);
-            let span = Span::from_range(id, 0..code.len());
-            expr.synthesize(span);
+            let mapper = RangeMapper::new([0..code.len()]).context("invalid code range mapper")?;
+            expr.synthesize_mapped(id, &mapper)
+                .context("failed to map code span")?;
 
             let expr = match expr.cast::<ast::Code>() {
                 Some(v) => v,

--- a/crates/tinymist-query/src/code_context.rs
+++ b/crates/tinymist-query/src/code_context.rs
@@ -256,7 +256,8 @@ fn eval_path_expr(
             }
 
             let mut expr = typst::syntax::parse_code(code);
-            let mapper = RangeMapper::new([0..code.len()]).context("invalid code range mapper")?;
+            let mapper = RangeMapper::new(std::iter::once(0..code.len()))
+                .context("invalid code range mapper")?;
             expr.synthesize_mapped(id, &mapper)
                 .context("failed to map code span")?;
 

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -218,7 +218,7 @@ fn diagnostic_message(typst_diagnostic: &TypstDiagnostic) -> String {
     let mut message = typst_diagnostic.message.to_string();
     for hint in &typst_diagnostic.hints {
         message.push_str("\nHint: ");
-        message.push_str(hint);
+        message.push_str(&hint.v);
     }
     message
 }
@@ -263,7 +263,7 @@ impl DiagnosticRefiner for OutOfRootHintRefiner {
             && raw
                 .hints
                 .iter()
-                .any(|hint| hint.contains("cannot read file outside of project root"))
+                .any(|hint| hint.v.contains("cannot read file outside of project root"))
     }
 
     fn refine(&self, mut raw: TypstDiagnostic) -> TypstDiagnostic {

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -174,7 +174,7 @@ impl<'w> DiagWorker<'w> {
         let uri = self.ctx.uri_for_id(id).ok()?;
         let source = self.ctx.source_by_id(id).ok()?;
 
-        let typst_range = source.range(tracepoint.span)?;
+        let typst_range = source_range(&source, tracepoint.span)?;
         let lsp_range = self.ctx.to_lsp_range(typst_range, &source);
 
         Some(DiagnosticRelatedInformation {
@@ -186,22 +186,22 @@ impl<'w> DiagWorker<'w> {
         })
     }
 
-    fn diagnostic_span_id(&self, typst_diagnostic: &TypstDiagnostic) -> (TypstFileId, Span) {
+    fn diagnostic_span_id(&self, typst_diagnostic: &TypstDiagnostic) -> (TypstFileId, DiagSpan) {
         iter::once(typst_diagnostic.span)
-            .chain(typst_diagnostic.trace.iter().map(|trace| trace.span))
+            .chain(typst_diagnostic.trace.iter().map(|trace| trace.span.into()))
             .find_map(|span| Some((span.id()?, span)))
-            .unwrap_or_else(|| (self.ctx.world().main(), Span::detached()))
+            .unwrap_or_else(|| (self.ctx.world().main(), Span::detached().into()))
     }
 
-    fn diagnostic_range(&self, source: &Source, typst_span: Span) -> LspRange {
+    fn diagnostic_range(&self, source: &Source, typst_span: DiagSpan) -> LspRange {
         // Due to nvaner/typst-lsp#241 and maybe typst/typst#2035, we sometimes fail to
         // find the span. In that case, we use a default span as a better
         // alternative to panicking.
         //
         // This may have been fixed after Typst 0.7.0, but it's still nice to avoid
         // panics in case something similar reappears.
-        match source.find(typst_span) {
-            Some(node) => self.ctx.to_lsp_range(node.range(), source),
+        match source_range(source, typst_span) {
+            Some(range) => self.ctx.to_lsp_range(range, source),
             None => LspRange::new(LspPosition::new(0, 0), LspPosition::new(0, 0)),
         }
     }

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -10,7 +10,7 @@ use tinymist_world::package::PackageSpec;
 use typst::diag::{StrResult, eco_format};
 use typst::syntax::package::PackageManifest;
 use typst::syntax::{FileId, Span, VirtualRoot};
-use typst_shim::syntax::RootedPathExt;
+use typst_shim::syntax::{RootedPathExt, source_range};
 
 use crate::LocalContext;
 use crate::docs::{DefDocs, PackageDefInfo, file_id_repr, module_docs};
@@ -111,7 +111,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
                     v.id().and_then(|fid| {
                         let allocated = file_ids.insert_full(fid).0;
                         let src = ctx.source_by_id(fid).ok()?;
-                        let rng = src.range(v)?;
+                        let rng = source_range(&src, v)?;
                         Some((allocated, rng.start, rng.end))
                     })
                 });

--- a/crates/tinymist-query/src/document_metrics.rs
+++ b/crates/tinymist-query/src/document_metrics.rs
@@ -206,7 +206,7 @@ impl DocumentMetricsWorker<'_> {
         let world = self.ctx.world();
         let file_id = span.id()?;
         let source = world.source(file_id).ok()?;
-        let range = source.range(span)?;
+        let range = source_range(&source, span)?;
         let byte_index = range.start + usize::from(span_offset);
         let byte_index = byte_index.min(range.end - 1);
         let line = source.lines().byte_to_line(byte_index)?;

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -19,6 +19,7 @@ use tinymist_std::error::WithContextUntyped;
 use tinymist_std::hash::FxHashMap;
 use tinymist_world::EntryReader;
 use typst::syntax::{FileId, LinkedNode, Source, Span};
+use typst_shim::syntax::source_range;
 
 pub mod protocol;
 use protocol as p;
@@ -219,7 +220,7 @@ impl<'a, W: fmt::Write> LsifEncoder<'a, W> {
     }
 
     fn emit_span(&mut self, span: Span, source: &Source) -> Option<i32> {
-        let range = source.range(span)?;
+        let range = source_range(source, span)?;
         self.emit_element(p::Element::Vertex(p::Vertex::Range {
             range: self.ctx.to_lsp_range(range, source),
             tag: None,

--- a/crates/tinymist-query/src/prelude.rs
+++ b/crates/tinymist-query/src/prelude.rs
@@ -24,9 +24,11 @@ pub use typst::diag::{EcoString, Tracepoint};
 pub use typst::foundations::Value;
 pub use typst::syntax::ast::{self, AstNode};
 pub use typst::syntax::{
-    FileId as TypstFileId, LinkedNode, Source, Spanned, SyntaxKind, SyntaxNode,
+    DiagSpan, FileId as TypstFileId, LinkedNode, Source, Spanned, SyntaxKind, SyntaxNode,
 };
-pub use typst_shim::syntax::{LinkedNodeExt, RootedPathExt, VirtualPathExt, resolve_path_from_id};
+pub use typst_shim::syntax::{
+    LinkedNodeExt, RootedPathExt, VirtualPathExt, resolve_path_from_id, source_range,
+};
 
 pub use crate::SemanticRequest;
 pub use crate::analysis::{Definition, LocalContext};

--- a/crates/tinymist-query/src/references.rs
+++ b/crates/tinymist-query/src/references.rs
@@ -175,7 +175,7 @@ impl ReferencesWorker<'_> {
     ) {
         self.references.extend(spans.filter_map(|(span, adjust)| {
             // todo: this is not necessary a name span
-            let mut range = src.range(span)?;
+            let mut range = source_range(src, span)?;
             if let Some((start, end)) = adjust {
                 range.start = (range.start as isize + start) as usize;
                 range.end = (range.end as isize + end) as usize;

--- a/crates/tinymist-query/src/syntax/expr.rs
+++ b/crates/tinymist-query/src/syntax/expr.rs
@@ -893,10 +893,10 @@ impl ExprWorker<'_> {
         if self.init_stage || span.is_detached() || span.id() != Some(self.fid) {
             return;
         }
-        let Some(item_range) = self.source.range(span) else {
+        let Some(item_range) = source_range(&self.source, span) else {
             return;
         };
-        let Some(binding_range) = self.source.range(child.span()) else {
+        let Some(binding_range) = source_range(&self.source, child.span()) else {
             return;
         };
         self.module_items.insert(

--- a/crates/tinymist-task/src/compute.rs
+++ b/crates/tinymist-task/src/compute.rs
@@ -89,8 +89,11 @@ fn select_pages<'a>(
 
 fn parse_length(gap: &str) -> Result<Abs> {
     let length = typst::syntax::parse_code(gap);
-    if length.erroneous() {
-        bail!("invalid length: {gap}, errors: {:?}", length.errors());
+    if length.diagnosis().errors {
+        bail!(
+            "invalid length: {gap}, errors: {:?}",
+            length.errors_and_warnings().0
+        );
     }
 
     let length: Option<ast::Numeric> = descendants(&length).into_iter().find_map(SyntaxNode::cast);

--- a/crates/tinymist-viewer/tests/vello_renderer_suite.rs
+++ b/crates/tinymist-viewer/tests/vello_renderer_suite.rs
@@ -405,7 +405,7 @@ fn compile_paged(world: &dyn World) -> Result<TypstPagedDocument> {
         output,
         warnings: _,
     } = typst::compile::<TypstPagedDocument>(world);
-    output.map_err(|errors| anyhow!("{}", format_diagnostics(&errors)))
+    output.map_err(|errors| anyhow!("{}", format_diagnostics(errors.as_ref())))
 }
 
 fn format_diagnostics(errors: &[typst::diag::SourceDiagnostic]) -> String {
@@ -413,7 +413,7 @@ fn format_diagnostics(errors: &[typst::diag::SourceDiagnostic]) -> String {
     for error in errors {
         let _ = writeln!(out, "{}", error.message);
         for hint in &error.hints {
-            let _ = writeln!(out, "  hint: {hint}");
+            let _ = writeln!(out, "  hint: {}", hint.v);
         }
     }
     out

--- a/crates/tinymist-world/src/diag.rs
+++ b/crates/tinymist-world/src/diag.rs
@@ -57,7 +57,7 @@ pub fn print_diagnostics_to<'d, 'files>(
         }
         .with_message(diagnostic.message.clone())
         .with_notes(
-                diagnostic
+            diagnostic
                 .hints
                 .iter()
                 .map(|e| (eco_format!("hint: {}", e.v)).into())

--- a/crates/tinymist-world/src/diag.rs
+++ b/crates/tinymist-world/src/diag.rs
@@ -9,8 +9,9 @@ use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 use tinymist_std::Result;
 use tinymist_vfs::FileId;
+use typst::WorldExt;
 use typst::diag::{Severity, SourceDiagnostic, StrResult, eco_format};
-use typst::syntax::Span;
+use typst::syntax::DiagSpan;
 
 use crate::{CodeSpanReportWorld, DiagnosticFormat, SourceWorld};
 
@@ -81,6 +82,7 @@ pub fn print_diagnostics_to<'d, 'files>(
 }
 
 /// Creates a label for a span.
-fn label(world: &dyn SourceWorld, span: Span) -> Option<Label<FileId>> {
-    Some(Label::primary(span.id()?, world.source_range(span)?))
+fn label(world: &dyn SourceWorld, span: impl Into<DiagSpan>) -> Option<Label<FileId>> {
+    let span = span.into();
+    Some(Label::primary(span.id()?, world.range(span)?))
 }

--- a/crates/tinymist-world/src/diag.rs
+++ b/crates/tinymist-world/src/diag.rs
@@ -57,10 +57,10 @@ pub fn print_diagnostics_to<'d, 'files>(
         }
         .with_message(diagnostic.message.clone())
         .with_notes(
-            diagnostic
+                diagnostic
                 .hints
                 .iter()
-                .map(|e| (eco_format!("hint: {e}")).into())
+                .map(|e| (eco_format!("hint: {}", e.v)).into())
                 .collect(),
         )
         .with_labels(label(world.world, diagnostic.span).into_iter().collect());

--- a/crates/tinymist/src/task/user_action.rs
+++ b/crates/tinymist/src/task/user_action.rs
@@ -20,7 +20,7 @@ use tinymist_project::LspComputeGraph;
 use tinymist_std::error::IgnoreLogging;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use typst::{syntax::Span, World};
+use typst::{syntax::Span, World, WorldExt};
 
 use crate::project::LspWorld;
 use crate::{internal_error, AliveLock, ConnWithCancel, ServerState};
@@ -477,7 +477,7 @@ async fn make_http_server(
 fn resolve_span(world: &LspWorld, span: Span) -> Option<(String, u32)> {
     let id = span.id()?;
     let source = world.source(id).ok()?;
-    let range = source.range(span)?;
+    let range = world.range(span)?;
     let line = source.lines().byte_to_line(range.start)?;
     Some((format!("{id:?}"), line as u32 + 1))
 }

--- a/crates/typlite/src/lib.rs
+++ b/crates/typlite/src/lib.rs
@@ -11,6 +11,7 @@ pub mod parser;
 pub mod tags;
 pub mod writer;
 
+use std::ops::Range;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -28,7 +29,7 @@ use typst::WorldExt;
 use typst::diag::SourceDiagnostic;
 use typst::foundations::Bytes;
 use typst_html::HtmlDocument;
-use typst_syntax::{RootedPath, Span, VirtualPath, VirtualRoot};
+use typst_syntax::{DiagSpan, LinkedNode, RootedPath, Source, Span, VirtualPath, VirtualRoot};
 
 pub use crate::common::Format;
 use crate::diagnostics::WarningCollector;
@@ -113,7 +114,7 @@ impl MarkdownDocument {
         mut diagnostic: SourceDiagnostic,
         info: &WrapInfo,
     ) -> Option<SourceDiagnostic> {
-        if let Some(span) = info.remap_span(self.world.as_ref(), diagnostic.span) {
+        if let Some(span) = info.remap_diag_span(self.world.as_ref(), diagnostic.span) {
             diagnostic.span = span;
         } else {
             return None;
@@ -131,6 +132,20 @@ impl MarkdownDocument {
                     None => None,
                 },
             )
+            .collect();
+
+        diagnostic.hints = diagnostic
+            .hints
+            .into_iter()
+            .filter_map(|mut spanned| {
+                match info.remap_diag_span(self.world.as_ref(), spanned.span) {
+                    Some(span) => {
+                        spanned.span = span;
+                        Some(spanned)
+                    }
+                    None => None,
+                }
+            })
             .collect();
 
         Some(diagnostic)
@@ -213,13 +228,29 @@ pub struct WrapInfo {
 }
 
 impl WrapInfo {
+    /// Translate a diagnostic span from the wrapper file back into the original
+    /// file.
+    pub fn remap_diag_span(&self, world: &dyn typst::World, span: DiagSpan) -> Option<DiagSpan> {
+        if span.id() != Some(self.wrap_file_id) {
+            return Some(span);
+        }
+
+        let range = self.remap_range(world, world.range(span)?)?;
+        Some(DiagSpan::from_range(self.original_file_id, range))
+    }
+
     /// Translate a span from the wrapper file back into the original file.
     pub fn remap_span(&self, world: &dyn typst::World, span: Span) -> Option<Span> {
         if span.id() != Some(self.wrap_file_id) {
             return Some(span);
         }
 
-        let range = world.range(span)?;
+        let range = self.remap_range(world, world.range(span)?)?;
+        let original_source = world.source(self.original_file_id).ok()?;
+        WrapInfo::span_covering_range(&original_source, range)
+    }
+
+    fn remap_range(&self, world: &dyn typst::World, range: Range<usize>) -> Option<Range<usize>> {
         let start = range.start.checked_sub(self.prefix_len_bytes)?;
         let end = range.end.checked_sub(self.prefix_len_bytes)?;
 
@@ -230,7 +261,22 @@ impl WrapInfo {
             return None;
         }
 
-        Some(Span::from_range(self.original_file_id, start..end))
+        Some(start..end)
+    }
+
+    fn span_covering_range(source: &Source, range: Range<usize>) -> Option<Span> {
+        fn inner(node: LinkedNode<'_>, range: &Range<usize>) -> Option<Span> {
+            let node_range = node.range();
+            if range.start < node_range.start || range.end > node_range.end {
+                return None;
+            }
+
+            node.children()
+                .find_map(|child| inner(child, range))
+                .or_else(|| Some(node.span()))
+        }
+
+        inner(LinkedNode::new(source.root()), &range)
     }
 }
 

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -331,8 +331,8 @@ impl HtmlToAstParser {
         self.warnings.extend(std::iter::once(diag));
     }
 
-    fn remap_span_from_wrapper(&self, span: Span, info: &crate::WrapInfo) -> Option<Span> {
-        info.remap_span(self.world.as_ref(), span)
+    fn remap_span_from_wrapper(&self, span: Span, info: &crate::WrapInfo) -> Option<DiagSpan> {
+        info.remap_diag_span(self.world.as_ref(), span.into())
     }
 }
 

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use typst::diag::SourceDiagnostic;
-use typst_syntax::Span;
+use typst_syntax::{DiagSpan, Span};
 
 use cmark_writer::WriteResult;
 use cmark_writer::ast::{CustomNode, HtmlAttribute, HtmlElement as CmarkHtmlElement, Node};
@@ -325,7 +325,7 @@ impl HtmlToAstParser {
             .wrap_info
             .as_ref()
             .and_then(|info| self.remap_span_from_wrapper(span, info))
-            .unwrap_or(span);
+            .unwrap_or(span.into());
 
         let diag = SourceDiagnostic::warning(span, message);
         self.warnings.extend(std::iter::once(diag));

--- a/crates/typst-shim/src/nightly/syntax.rs
+++ b/crates/typst-shim/src/nightly/syntax.rs
@@ -1,14 +1,30 @@
 //! Typst Syntax
+use std::ops::Range;
 use std::path::Path;
 
+use typst::syntax::DiagSpan;
+use typst::syntax::DiagSpanKind;
 use typst::syntax::LinkedNode;
 use typst::syntax::RootedPath;
 use typst::syntax::Side;
+use typst::syntax::Source;
 use typst::syntax::VirtualPath;
 use typst::syntax::VirtualRoot;
 use typst::syntax::package::PackageSpec;
 
 pub use crate::path::resolve_path_from_id;
+
+/// Get the byte range for a diagnostic span within a source file.
+pub fn source_range(source: &Source, span: impl Into<DiagSpan>) -> Option<Range<usize>> {
+    match span.into().get() {
+        DiagSpanKind::Detached => None,
+        DiagSpanKind::Number { id, num, sub_range } if id == source.id() => {
+            source.range(num, sub_range)
+        }
+        DiagSpanKind::Range { id, range } if id == source.id() => Some(range),
+        _ => None,
+    }
+}
 
 /// The `LinkedNodeExt` trait is designed for compatibility between new and old
 /// versions of `typst`.

--- a/crates/typst-shim/src/stable/syntax.rs
+++ b/crates/typst-shim/src/stable/syntax.rs
@@ -1,14 +1,22 @@
 //! Typst Syntax
+use std::ops::Range;
 use std::path::Path;
 
 use typst::syntax::LinkedNode;
 use typst::syntax::RootedPath;
 use typst::syntax::Side;
+use typst::syntax::Source;
+use typst::syntax::Span;
 use typst::syntax::VirtualPath;
 use typst::syntax::VirtualRoot;
 use typst::syntax::package::PackageSpec;
 
 pub use crate::path::resolve_path_from_id;
+
+/// Get the byte range for a span within a source file.
+pub fn source_range(source: &Source, span: impl Into<Span>) -> Option<Range<usize>> {
+    source.range(span.into())
+}
 
 /// The `LinkedNodeExt` trait is designed for compatibility between new and old
 /// versions of `typst`.


### PR DESCRIPTION
Part of the Typst 0.15 cleanup stack. This slice covers diagnostics/span migration and the minimal query prerequisites needed before the later export and text accessor slices.

## Upstream Typst Changes

- [`typst/typst#8052`](https://github.com/typst/typst/pull/8052) makes diagnostic hints carry span metadata. Tinymist renders the hint message payload instead of formatting the whole spanned wrapper.
- [`typst/typst#8254`](https://github.com/typst/typst/pull/8254) changes diagnostic, user-action, and test-range span handling. Tinymist updates LSP diagnostics, user-action conversion, and range-sensitive tests for the new span shape.
- [`typst/typst#8188`](https://github.com/typst/typst/pull/8188) changes syntax diagnostics. Tinymist updates syntax matchers and diagnostics conversion paths that inspect syntax-side errors.
- [`typst/typst#8307`](https://github.com/typst/typst/pull/8307) changes bibliography lookup. Tinymist now finds bibliography elements through the document introspector and packs them back to `BibliographyElem`.
- Typst 0.15 deprecates rooted virtual-path access through `as_rooted_path`; diagnostics now use the slash-form virtual path accessor for extension checks.

## Tinymist Changes

- Updates `tinymist-world` diagnostic rendering for spanned hint values.
- Updates `tinymist-query`, `tinymist-analysis`, `tinymist-lint`, and debug-facing syntax diagnostics for the new span and syntax diagnostic APIs.
- Updates user-action span conversion and affected test ranges.
- Updates code-context path evaluation to construct `RangeMapper` from an iterator, matching the lint expectations of the current toolchain.
- Carries the small bibliography lookup prerequisite in this slice so later query-oriented slices build on the updated Typst API.
