### PR TITLE
fix: adapt export options for typst 0.15

### DIFF
--- a/crates/tinymist-cli/src/cmd/test.rs
+++ b/crates/tinymist-cli/src/cmd/test.rs
@@ -485,7 +485,7 @@ impl<'a> TestRunner<'a> {
             return false;
         };
 
-        let output = match typst_html::html(doc) {
+        let output = match typst_html::html(doc, &typst_html::HtmlOptions::default()) {
             Ok(output) => self.update_example(example, output.as_bytes(), "html"),
             Err(err) => {
                 self.diagnostics.lock().push(err);

--- a/crates/tinymist-cli/src/cmd/test.rs
+++ b/crates/tinymist-cli/src/cmd/test.rs
@@ -474,7 +474,11 @@ impl<'a> TestRunner<'a> {
         };
 
         let ppp = self.ctx.png.ppi / 72.0;
-        let pixmap = typst_render::render_merged(doc, ppp, Default::default(), None);
+        let render_options = typst_render::RenderOptions {
+            pixel_per_pt: f64::from(ppp).into(),
+            ..Default::default()
+        };
+        let pixmap = typst_render::render_merged(doc, &render_options, Default::default(), None);
         let output = pixmap.encode_png().context_ut("cannot encode pixmap");
         let output = output.and_then(|output| self.update_example(example, &output, "paged"));
         self.check_result(example, output, "paged")

--- a/crates/tinymist-task/src/compute/html.rs
+++ b/crates/tinymist-task/src/compute/html.rs
@@ -20,7 +20,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstHtmlDocument> for HtmlExport {
         doc: &Arc<TypstHtmlDocument>,
         _config: &ExportHtmlTask,
     ) -> Result<String> {
-        Ok(typst_html::html(doc)?)
+        Ok(typst_html::html(doc, &typst_html::HtmlOptions::default())?)
     }
 }
 

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -43,7 +43,7 @@ pub fn pdf_options(
     pdf_standards: &[PdfStandard],
     no_pdf_tags: bool,
     creation_timestamp: Option<i64>,
-) -> Result<PdfOptions<'static>> {
+) -> Result<PdfOptions> {
     let creation_timestamp = creation_timestamp
         .map(|ts| ts.to_utc_datetime().context("timestamp is out of range"))
         .transpose()?

--- a/crates/tinymist-task/src/compute/pdf.rs
+++ b/crates/tinymist-task/src/compute/pdf.rs
@@ -76,7 +76,8 @@ pub fn pdf_options(
             })
             .collect::<Vec<_>>(),
     )
-    .context_ut("prepare pdf standards")?;
+    .map_err(|err| err.message().clone())
+    .context("prepare pdf standards")?;
 
     let tagged = !no_pdf_tags && pages.is_none();
     // todo: emit warning diag

--- a/crates/tinymist-task/src/compute/png.rs
+++ b/crates/tinymist-task/src/compute/png.rs
@@ -36,6 +36,10 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PngExport {
         };
 
         let ppp = ppi / 72.;
+        let render_options = typst_render::RenderOptions {
+            pixel_per_pt: f64::from(ppp).into(),
+            ..Default::default()
+        };
 
         let exported_pages = select_pages(doc, &config.pages);
         if let Some(PageMerge { ref gap }) = config.merge {
@@ -50,7 +54,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PngExport {
                 .as_ref()
                 .and_then(|gap| parse_length(gap).ok())
                 .unwrap_or_default();
-            let pixmap = typst_render::render_merged(&dummy_doc, ppp, gap, fill);
+            let pixmap = typst_render::render_merged(&dummy_doc, &render_options, gap, fill);
             let png = pixmap
                 .encode_png()
                 .map(Bytes::new)
@@ -60,7 +64,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for PngExport {
             let exported = exported_pages
                 .into_iter()
                 .map(|(i, page)| {
-                    let pixmap = typst_render::render(page, ppp);
+                    let pixmap = typst_render::render(page, &render_options);
                     let png = pixmap
                         .encode_png()
                         .map(Bytes::new)

--- a/crates/tinymist-task/src/compute/svg.rs
+++ b/crates/tinymist-task/src/compute/svg.rs
@@ -39,7 +39,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for SvgExport {
                 .as_ref()
                 .and_then(|gap| parse_length(gap).ok())
                 .unwrap_or_default();
-            let svg = typst_svg::svg_merged(&dummy_doc, gap);
+            let svg = typst_svg::svg_merged(&dummy_doc, &svg_options, gap);
             Ok(ImageOutput::Merged(svg))
         } else {
             let exported = exported_pages

--- a/crates/tinymist-task/src/compute/svg.rs
+++ b/crates/tinymist-task/src/compute/svg.rs
@@ -23,6 +23,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for SvgExport {
         doc: &Arc<TypstPagedDocument>,
         config: &ExportSvgTask,
     ) -> Result<Self::Output> {
+        let svg_options = typst_svg::SvgOptions::default();
         let exported_pages = select_pages(doc, &config.pages);
         if let Some(PageMerge { ref gap }) = config.merge {
             // Typst does not expose svg-merging API.
@@ -44,7 +45,7 @@ impl<F: CompilerFeat> ExportComputation<F, TypstPagedDocument> for SvgExport {
             let exported = exported_pages
                 .into_iter()
                 .map(|(i, page)| {
-                    let svg = typst_svg::svg(page);
+                    let svg = typst_svg::svg(page, &svg_options);
                     Ok(PagedOutput {
                         page: i,
                         value: svg,

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -647,7 +647,7 @@ impl ExportTask {
                 ExportPng(config) => PngExport::run(&graph, paged_doc()?,& config)?.with_pages(total_pages()),
                 Query(config) => DocumentQuery::run(&graph, paged_doc()?, &config)??.into(),
                 ExportHtml(ExportHtmlTask { export: _ }) =>
-                    typst_html::html(html_doc()?)
+                    typst_html::html(html_doc()?, &typst_html::HtmlOptions::default())
                         .map_err(|e| format!("export error: {e:?}"))
                         .context_ut("failed to export to html")?.into(),
                 ExportBundle(..) => unreachable!(),

--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -775,13 +775,18 @@ fn export_bundle_artifact(
     })?;
 
     let options = BundleOptions {
-        pixel_per_pt: config.ppi.to_f32() / 72.0,
+        html: typst_html::HtmlOptions::default(),
         pdf: pdf_options(
             config.pages.as_deref(),
             &config.pdf_standards,
             config.no_pdf_tags,
             config.creation_timestamp,
         )?,
+        png: typst_render::RenderOptions {
+            pixel_per_pt: f64::from(config.ppi.to_f32() / 72.0).into(),
+            ..Default::default()
+        },
+        svg: typst_svg::SvgOptions::default(),
     };
     let fs = typst_bundle::export(&bundle, &options).map_err(|errors| {
         print_diagnostics_to_string(

--- a/crates/typlite/src/parser/media.rs
+++ b/crates/typlite/src/parser/media.rs
@@ -87,6 +87,7 @@ impl HtmlToAstParser {
         let svg = typst_svg::svg_in_html(
             &frame.inner,
             frame.text_size,
+            false,
             frame.id.as_deref(),
             &eco_format!("{}", frame.css.to_inline()),
             &frame.anchors,
@@ -142,8 +143,15 @@ impl HtmlToAstParser {
 
         let introspector = EmptyIntrospector;
         let link_resolver = LateLinkResolver::new(None, &introspector);
-        let svg =
-            typst_svg::svg_in_html(frame, Abs::pt(12.0), None, "", &[], link_resolver.track());
+        let svg = typst_svg::svg_in_html(
+            frame,
+            Abs::pt(12.0),
+            false,
+            None,
+            "",
+            &[],
+            link_resolver.track(),
+        );
         self.convert_svg(svg)
     }
 

--- a/crates/typlite/src/parser/media.rs
+++ b/crates/typlite/src/parser/media.rs
@@ -326,7 +326,7 @@ impl HtmlToAstParser {
             }
         };
 
-        let svg = typst_svg::svg_merged(&doc, Abs::zero());
+        let svg = typst_svg::svg_merged(&doc, &typst_svg::SvgOptions::default(), Abs::zero());
         self.convert_svg(svg)
     }
 }

--- a/crates/typlite/src/tests.rs
+++ b/crates/typlite/src/tests.rs
@@ -102,7 +102,11 @@ fn conv(world: LspWorld, kind: ConvKind) -> String {
         Err(err) => return format!("failed to convert to markdown: {err}"),
     };
 
-    let repr = typst_html::html(&redact(doc.base.clone())).unwrap();
+    let repr = typst_html::html(
+        &redact(doc.base.clone()),
+        &typst_html::HtmlOptions { pretty: true },
+    )
+    .unwrap();
     let res = match kind {
         ConvKind::Md { .. } => doc.to_md_string().unwrap(),
         ConvKind::LaTeX => doc.to_tex_string().unwrap(),


### PR DESCRIPTION
Part of the Typst 0.15 cleanup stack. This slice covers export option changes across PNG, SVG, PDF, HTML, CLI rendering, and typlite fixtures.

## Upstream Typst Changes

- [`typst/typst#6357`](https://github.com/typst/typst/pull/6357) changes page export and render option handling. Tinymist updates PNG/SVG page export and CLI render option plumbing.
- [`typst/typst#8370`](https://github.com/typst/typst/pull/8370) changes merged SVG options. Tinymist updates merged SVG export construction.
- [`typst/typst#8371`](https://github.com/typst/typst/pull/8371) changes generic export options and remaining HTML export paths. Tinymist updates export computations and HTML export callers to the new option shape.
- [`typst/typst#8294`](https://github.com/typst/typst/pull/8294) changes PDF standards error handling. Tinymist updates PDF export error conversion for the new result type.

## Tinymist Changes

- Updates `tinymist-task` PNG, SVG, PDF, and HTML export computations to the Typst 0.15 option APIs.
- Updates CLI render option forwarding for the new page/export option surface.
- Updates typlite export tests affected by the Typst 0.15 export option behavior.
