### PR TITLE
fix: adapt text, font, and color APIs for typst 0.15

### DIFF
--- a/crates/tinymist-analysis/src/sig.rs
+++ b/crates/tinymist-analysis/src/sig.rs
@@ -295,7 +295,7 @@ fn analyze_closure_signature(
             }
             // todo: pattern
             ast::Param::Named(named) => {
-                let default = unwrap_parens(named.expr()).to_untyped().clone().into_text();
+                let default = unwrap_parens(named.expr()).to_untyped().clone().full_text();
                 add_param(Interned::new(ParamTy {
                     name: named.name().get().into(),
                     docs: Some(eco_format!("Default value: {default}")),
@@ -346,7 +346,7 @@ impl fmt::Display for PatternDisplay<'_> {
                             f,
                             "{}: {}",
                             named.name().as_str(),
-                            unwrap_parens(named.expr()).to_untyped().text()
+                            unwrap_parens(named.expr()).to_untyped().full_text()
                         )?,
                         ast::DestructuringItem::Spread(spread) => write!(
                             f,

--- a/crates/tinymist-analysis/src/syntax/comment.rs
+++ b/crates/tinymist-analysis/src/syntax/comment.rs
@@ -40,7 +40,11 @@ fn extract_mod_docs_between(
             break 'scan_comments;
         }
 
-        crate::log_debug_ct!("found comment for docs: {:?}: {:?}", n.kind(), n.text());
+        crate::log_debug_ct!(
+            "found comment for docs: {:?}: {:?}",
+            n.kind(),
+            n.leaf_text()
+        );
         if matcher.process(n.get()) {
             if first_group {
                 break 'scan_comments;
@@ -92,7 +96,7 @@ impl CommentGroupMatcher {
                 CommentGroupSignal::Hash
             }
             SyntaxKind::Space => {
-                if n.text().contains('\n') {
+                if n.leaf_text().contains('\n') {
                     self.newline_count += 1;
                 }
                 if self.newline_count > 1 {
@@ -152,13 +156,13 @@ impl DocCommentMatcher {
     pub fn process(&mut self, n: &SyntaxNode) -> bool {
         match self.group_matcher.process(n) {
             CommentGroupSignal::LineComment => {
-                let text = n.text();
+                let text = n.leaf_text();
                 if !self.strict || text.starts_with("///") {
                     self.comments.push(RawComment::Line(text.clone()));
                 }
             }
             CommentGroupSignal::BlockComment => {
-                let text = n.text();
+                let text = n.leaf_text();
                 if !self.strict {
                     self.comments.push(RawComment::Block(text.clone()));
                 }

--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -307,7 +307,7 @@ pub fn is_mark(sk: SyntaxKind) -> bool {
 /// Checks if the node can be recognized as an identifier.
 pub fn is_ident_like(node: &SyntaxNode) -> bool {
     fn can_be_ident(node: &SyntaxNode) -> bool {
-        typst::syntax::is_ident(node.text())
+        typst::syntax::is_ident(node.leaf_text())
     }
 
     use SyntaxKind::*;
@@ -625,7 +625,7 @@ impl<'a> VarClass<'a> {
                 });
 
                 let ident_case = ident.map(|ident| {
-                    if ident.text().is_empty() {
+                    if ident.leaf_text().is_empty() {
                         FieldClass::DotSuffix(SourceSpanOffset {
                             span: ident.span(),
                             offset: 0,
@@ -748,7 +748,7 @@ impl<'a> SyntaxClass<'a> {
 /// Classifies node's syntax (inner syntax) that can be operated on by IDE
 /// functionality.
 pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClass<'_>> {
-    if matches!(node.kind(), SyntaxKind::Error) && node.text().starts_with('<') {
+    if matches!(node.kind(), SyntaxKind::Error) && node.leaf_text().starts_with('<') {
         return Some(SyntaxClass::error_as_label(node));
     }
 
@@ -760,7 +760,7 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
         }
 
         // Gets the trivia text before the cursor.
-        let previous_text = node.text().as_bytes();
+        let previous_text = node.leaf_text().as_bytes();
         let previous_text = if node.range().contains(&cursor) {
             &previous_text[..cursor - node.offset()]
         } else {
@@ -839,7 +839,7 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
                 || (matches!(
                     node.kind(),
                     SyntaxKind::Text | SyntaxKind::MathText | SyntaxKind::Error
-                ) && node.text().starts_with("."))
+                ) && node.leaf_text().starts_with("."))
         }
         && let Some(dot_access) = classify_dot_access(&node)
     {
@@ -880,7 +880,7 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
                 || (matches!(
                     node.kind(),
                     SyntaxKind::Text | SyntaxKind::MathText | SyntaxKind::Error
-                ) && node.text().starts_with(":"))
+                ) && node.leaf_text().starts_with(":"))
         }
         && let Some(ref_syntax) = classify_ref(&node)
     {
@@ -889,7 +889,7 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
 
     if node.kind() == SyntaxKind::Text
         && node.offset() + 1 == cursor
-        && node.text().starts_with('@')
+        && node.leaf_text().starts_with('@')
     {
         return Some(SyntaxClass::At { node });
     }
@@ -1760,7 +1760,7 @@ Text
 
     fn access_node_(s: &str, cursor: i32) -> Option<String> {
         access_var(s, cursor, |_source, var| {
-            Some(var.accessed_node()?.get().clone().into_text().into())
+            Some(var.accessed_node()?.get().clone().full_text().into())
         })
     }
 
@@ -1772,7 +1772,7 @@ Text
         access_var(s, cursor, |source, var| {
             let field = var.accessing_field()?;
             Some(match field {
-                FieldClass::Field(ident) => format!("Field: {}", ident.text()),
+                FieldClass::Field(ident) => format!("Field: {}", ident.leaf_text()),
                 FieldClass::DotSuffix(span_offset) => {
                     let offset = source.find(span_offset.span)?.offset() + span_offset.offset;
                     format!("DotSuffix: {offset:?}")

--- a/crates/tinymist-analysis/src/ty/def.rs
+++ b/crates/tinymist-analysis/src/ty/def.rs
@@ -344,11 +344,11 @@ impl TypeSource {
     pub fn name(&self) -> StrRef {
         self.name_repr
             .get_or_init(|| {
-                let name = self.name_node.text();
+                let name = self.name_node.leaf_text();
                 if !name.is_empty() {
                     return name.into();
                 }
-                let name = self.name_node.clone().into_text();
+                let name = self.name_node.clone().full_text();
                 name.into()
             })
             .clone()

--- a/crates/tinymist-debug/src/cov.rs
+++ b/crates/tinymist-debug/src/cov.rs
@@ -387,7 +387,7 @@ impl InstrumentWorker {
     }
 
     fn visit_node_fallback(&mut self, node: &SyntaxNode) {
-        let txt = node.text();
+        let txt = node.leaf_text();
         if !txt.is_empty() {
             self.instrumented.push_str(txt);
         }

--- a/crates/tinymist-debug/src/debugger/instr.rs
+++ b/crates/tinymist-debug/src/debugger/instr.rs
@@ -153,7 +153,7 @@ impl InstrumentWorker {
     }
 
     fn visit_node_fallback(&mut self, node: &SyntaxNode) {
-        let txt = node.text();
+        let txt = node.leaf_text();
         if !txt.is_empty() {
             self.instrumented.push_str(txt);
         }

--- a/crates/tinymist-lint/src/lib.rs
+++ b/crates/tinymist-lint/src/lib.rs
@@ -296,7 +296,7 @@ impl DataFlowVisitor for Linter<'_> {
         }
         self.exprs(expr.args().to_untyped().exprs());
 
-        if expr.target().to_untyped().text() == "text" {
+        if expr.target().to_untyped().leaf_text() == "text" {
             self.check_bad_font(expr.args().items());
         }
 
@@ -405,7 +405,7 @@ impl DataFlowVisitor for Linter<'_> {
     fn func_call(&mut self, expr: ast::FuncCall<'_>) -> Option<()> {
         // warn if text(font: ("Font Name", "Font Name")) in which Font Name ends with
         // "VF"
-        if expr.callee().to_untyped().text() == "text" {
+        if expr.callee().to_untyped().leaf_text() == "text" {
             self.check_bad_font(expr.args().items());
         }
         self.exprs(expr.args().to_untyped().exprs().chain(expr.callee().once()));
@@ -637,7 +637,7 @@ impl DataFlowVisitor for LateFuncLinter<'_, '_> {
                 ast::Expr::ShowRule(..) | ast::Expr::SetRule(..) => diag,
                 expr if expr.hash() => diag.with_hint(eco_format!(
                     "consider ignoring the value explicitly using underscore: `let _ = {}`",
-                    expr.to_untyped().clone().into_text()
+                    expr.to_untyped().clone().full_text()
                 )),
                 _ => diag,
             };
@@ -1010,19 +1010,19 @@ impl BuggyBlockLoc<'_> {
                     eco_format!(
                         "consider changing parent to `show {}: it => {{ {}; it }}`",
                         match show_parent.selector() {
-                            Some(selector) => selector.to_untyped().clone().into_text(),
+                            Some(selector) => selector.to_untyped().clone().full_text(),
                             None => "".into(),
                         },
-                        show.to_untyped().clone().into_text()
+                        show.to_untyped().clone().full_text()
                     )
                 } else {
                     eco_format!(
                         "consider changing parent to `show {}: {}`",
                         match show_parent.selector() {
-                            Some(selector) => selector.to_untyped().clone().into_text(),
+                            Some(selector) => selector.to_untyped().clone().full_text(),
                             None => "".into(),
                         },
-                        show_set.to_untyped().clone().into_text()
+                        show_set.to_untyped().clone().full_text()
                     )
                 }
             }
@@ -1036,32 +1036,32 @@ impl BuggyBlockLoc<'_> {
                     eco_format!(
                         "consider changing parent to `show {}: if {neg}({}) {{ .. }}`",
                         match show.selector() {
-                            Some(selector) => selector.to_untyped().clone().into_text(),
+                            Some(selector) => selector.to_untyped().clone().full_text(),
                             None => "".into(),
                         },
-                        conditional.condition().to_untyped().clone().into_text()
+                        conditional.condition().to_untyped().clone().full_text()
                     )
                 } else {
                     eco_format!(
                         "consider changing parent to `{} if {neg}({})`",
-                        show_set.to_untyped().clone().into_text(),
-                        conditional.condition().to_untyped().clone().into_text()
+                        show_set.to_untyped().clone().full_text(),
+                        conditional.condition().to_untyped().clone().full_text()
                     )
                 }
             }
             BuggyBlockLoc::While(w) => {
                 eco_format!(
                     "consider changing parent to `show: it => if {} {{ {}; it }}`",
-                    w.condition().to_untyped().clone().into_text(),
-                    show_set.to_untyped().clone().into_text()
+                    w.condition().to_untyped().clone().full_text(),
+                    show_set.to_untyped().clone().full_text()
                 )
             }
             BuggyBlockLoc::For(f) => {
                 eco_format!(
                     "consider changing parent to `show: {}.fold(it => it, (style-it, {}) => it => {{ {}; style-it(it) }})`",
-                    f.iterable().to_untyped().clone().into_text(),
-                    f.pattern().to_untyped().clone().into_text(),
-                    show_set.to_untyped().clone().into_text()
+                    f.iterable().to_untyped().clone().full_text(),
+                    f.pattern().to_untyped().clone().full_text(),
+                    show_set.to_untyped().clone().full_text()
                 )
             }
         }

--- a/crates/tinymist-query/src/analysis.rs
+++ b/crates/tinymist-query/src/analysis.rs
@@ -438,7 +438,7 @@ mod post_type_check_tests {
                 .unwrap();
             let root = LinkedNode::new(source.root());
             let node = root.leaf_at_compat(pos + 1).unwrap();
-            let text = node.get().clone().into_text();
+            let text = node.get().clone().full_text();
 
             let result = ctx.type_check(&source);
             let post_ty = post_type_check(ctx.shared_(), &result, node);
@@ -473,7 +473,7 @@ mod type_describe_tests {
                 .unwrap();
             let root = LinkedNode::new(source.root());
             let node = root.leaf_at_compat(pos + 1).unwrap();
-            let text = node.get().clone().into_text();
+            let text = node.get().clone().full_text();
 
             let ti = ctx.type_check(&source);
             let post_ty = post_type_check(ctx.shared_(), &ti, node);
@@ -623,7 +623,7 @@ mod call_info_tests {
             w.sort_by(|x, y| x.0.span().into_raw().cmp(&y.0.span().into_raw()));
 
             for (arg, arg_call_info) in w {
-                writeln!(f, "{} -> {:?}", arg.clone().into_text(), arg_call_info)?;
+                writeln!(f, "{} -> {:?}", arg.clone().full_text(), arg_call_info)?;
             }
 
             Ok(())

--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -342,10 +342,10 @@ impl<'a> CompletionCursor<'a> {
             }
             Some(SelectedNode::Label(from_label)) => {
                 let mut rng = from_label.range();
-                if from_label.text().starts_with('<') && !snippet.starts_with('<') {
+                if from_label.leaf_text().starts_with('<') && !snippet.starts_with('<') {
                     rng.start += 1;
                 }
-                if from_label.text().ends_with('>') && !snippet.ends_with('>') {
+                if from_label.leaf_text().ends_with('>') && !snippet.ends_with('>') {
                     rng.end -= 1;
                 }
 
@@ -358,7 +358,7 @@ impl<'a> CompletionCursor<'a> {
                 } else {
                     from_ref.range()
                 };
-                if from_ref.text().starts_with('@') && !snippet.starts_with('@') {
+                if from_ref.leaf_text().starts_with('@') && !snippet.starts_with('@') {
                     rng.start += 1;
                 }
 
@@ -508,7 +508,7 @@ impl<'a> CompletionWorker<'a> {
             Some(SyntaxClass::Callee(..) | SyntaxClass::VarAccess(..) | SyntaxClass::Normal(..))
         ) && cursor.leaf.diagnosis().errors
         {
-            let mut chars = cursor.leaf.text().chars();
+            let mut chars = cursor.leaf.leaf_text().chars();
             match chars.next() {
                 Some(ch) if ch.is_numeric() => return None,
                 Some('.') => {
@@ -838,8 +838,8 @@ impl CompletionPair<'_, '_, '_> {
                 && node.children().fold(0i32, |acc, node| match node.kind() {
                     SyntaxKind::LeftParen => acc + 1,
                     SyntaxKind::RightParen => acc - 1,
-                    SyntaxKind::Error if node.text() == "(" => acc + 1,
-                    SyntaxKind::Error if node.text() == ")" => acc - 1,
+                    SyntaxKind::Error if node.leaf_text() == "(" => acc + 1,
+                    SyntaxKind::Error if node.leaf_text() == ")" => acc - 1,
                     _ => acc,
                 }) > 0;
             if is_unclosed {

--- a/crates/tinymist-query/src/analysis/completion/mode.rs
+++ b/crates/tinymist-query/src/analysis/completion/mode.rs
@@ -4,7 +4,7 @@ use super::*;
 impl CompletionPair<'_, '_, '_> {
     /// Complete in comments. Or rather, don't!
     pub fn complete_comments(&mut self) -> bool {
-        let text = self.cursor.leaf.get().text();
+        let text = self.cursor.leaf.get().leaf_text();
         // check if next line defines a function
         if (text == "///" || text == "/// ")
             // hash node

--- a/crates/tinymist-query/src/analysis/completion/snippet.rs
+++ b/crates/tinymist-query/src/analysis/completion/snippet.rs
@@ -153,7 +153,7 @@ impl CompletionPair<'_, '_, '_> {
                 ..Default::default()
             };
             if let Some(node_before_before_cursor) = &node_before_before_cursor {
-                let node_content = SnippetEscape(node.get().clone().into_text());
+                let node_content = SnippetEscape(node.get().clone().full_text());
                 let before = EcoTextEdit {
                     range: self.cursor.lsp_range_of(rng.start..self.cursor.from),
                     new_text: EcoString::new(),
@@ -270,7 +270,7 @@ impl CompletionPair<'_, '_, '_> {
             }
             let more_args = fn_feat.min_pos() > 1 || fn_feat.min_named() > 0;
             if self.worker.ctx.analysis.completion_feat.ufcs_left() && more_args {
-                let node_content = SnippetEscape(node.get().clone().into_text());
+                let node_content = SnippetEscape(node.get().clone().full_text());
                 let before = EcoTextEdit {
                     range: self.cursor.lsp_range_of(rng.start..self.cursor.from),
                     new_text: eco_format!("{name}{lb}"),

--- a/crates/tinymist-query/src/analysis/completion/typst_specific.rs
+++ b/crates/tinymist-query/src/analysis/completion/typst_specific.rs
@@ -131,11 +131,11 @@ impl CompletionPair<'_, '_, '_> {
             Some(SelectedNode::Label(node)) => {
                 let range = node.range();
                 let remove_open = node
-                    .text()
+                    .leaf_text()
                     .starts_with('<')
                     .then_some(range.start..range.start + 1);
                 let remove_close = node
-                    .text()
+                    .leaf_text()
                     .ends_with('>')
                     .then_some(range.end - 1..range.end);
                 (remove_open, remove_close)

--- a/crates/tinymist-query/src/color_presentation.rs
+++ b/crates/tinymist-query/src/color_presentation.rs
@@ -1,5 +1,5 @@
 use typst::foundations::Repr;
-use typst::visualize::Color;
+use typst::visualize::{Color, Rgb};
 
 use crate::prelude::*;
 
@@ -35,7 +35,7 @@ pub struct ColorPresentationRequest {
 impl ColorPresentationRequest {
     /// Serve the request.
     pub fn request(self) -> Option<Vec<ColorPresentation>> {
-        let color = typst::visualize::Color::Rgb(typst::visualize::Rgb::new(
+        let color = Color::from(Rgb::new(
             self.color.red,
             self.color.green,
             self.color.blue,
@@ -43,15 +43,15 @@ impl ColorPresentationRequest {
         ));
         Some(vec![
             simple(format!("{:?}", color.to_hex())),
-            simple(Color::Rgb(color.to_rgb()).repr().to_string()),
-            simple(Color::Luma(color.to_luma()).repr().to_string()),
-            simple(Color::Oklab(color.to_oklab()).repr().to_string()),
-            simple(Color::Oklch(color.to_oklch()).repr().to_string()),
-            simple(Color::Rgb(color.to_rgb()).repr().to_string()),
-            simple(Color::LinearRgb(color.to_linear_rgb()).repr().to_string()),
-            simple(Color::Cmyk(color.to_cmyk()).repr().to_string()),
-            simple(Color::Hsl(color.to_hsl()).repr().to_string()),
-            simple(Color::Hsv(color.to_hsv()).repr().to_string()),
+            simple(Color::from(color.to_rgb()).repr().to_string()),
+            simple(Color::from(color.to_luma()).repr().to_string()),
+            simple(Color::from(color.to_oklab()).repr().to_string()),
+            simple(Color::from(color.to_oklch()).repr().to_string()),
+            simple(Color::from(color.to_rgb()).repr().to_string()),
+            simple(Color::from(color.to_linear_rgb()).repr().to_string()),
+            simple(Color::from(color.to_cmyk()).repr().to_string()),
+            simple(Color::from(color.to_hsl()).repr().to_string()),
+            simple(Color::from(color.to_hsv()).repr().to_string()),
         ])
     }
 }

--- a/crates/tinymist-query/src/document_metrics.rs
+++ b/crates/tinymist-query/src/document_metrics.rs
@@ -170,7 +170,7 @@ impl DocumentMetricsWorker<'_> {
     }
 
     fn work_text(&mut self, text: &TextItem) -> Option<()> {
-        let font_key = text.font.clone();
+        let font_key = text.font.font().clone();
         let glyph_len = text.glyphs.len();
 
         let has_source_info = if let Some(font_info) = self.font_info.get(&font_key) {

--- a/crates/tinymist-query/src/on_enter.rs
+++ b/crates/tinymist-query/src/on_enter.rs
@@ -119,7 +119,7 @@ impl OnEnterWorker<'_> {
             .count();
 
         let comment_prefix = {
-            let mut scanner = unscanny::Scanner::new(leaf.text());
+            let mut scanner = unscanny::Scanner::new(leaf.leaf_text());
             scanner.eat_while('/');
             scanner.eat_if('!');
             scanner.before()

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -66,7 +66,7 @@ impl SemanticRequest for SignatureHelpRequest {
                 }
                 ArgClass::Named(name) => {
                     let focus_name = focus_name
-                        .get_or_init(|| Interned::new_str(&name.get().clone().into_text()));
+                        .get_or_init(|| Interned::new_str(&name.get().clone().full_text()));
                     if focus_name == &param.name {
                         active_parameter = Some(real_offset);
                     }

--- a/crates/tinymist-query/src/syntax/index.rs
+++ b/crates/tinymist-query/src/syntax/index.rs
@@ -38,7 +38,7 @@ impl IndexWorker {
     fn visit(&mut self, node: &SyntaxNode) {
         match node.cast::<ast::Expr>() {
             Some(ast::Expr::Str(path_str)) => {
-                if path_str.to_untyped().text().len() > 65536 {
+                if path_str.to_untyped().leaf_text().len() > 65536 {
                     // skip long strings
                     return;
                 }

--- a/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
+++ b/crates/tinymist-query/src/syntax/lexical_hierarchy.rs
@@ -539,7 +539,7 @@ impl LexicalHierarchyWorker {
                 (EcoString::new(), LexicalKind::Block)
             }
             SyntaxKind::Markup => {
-                let name = node.get().to_owned().into_text();
+                let name = node.get().to_owned().full_text();
                 if name.is_empty() {
                     return None;
                 }

--- a/crates/tinymist-viewer/src/render.rs
+++ b/crates/tinymist-viewer/src/render.rs
@@ -24,7 +24,13 @@ use reflexo::{
     },
 };
 use smallvec::SmallVec;
-use typst::visualize::{Color as TypstColor, ColorSpace as TypstColorSpace, WeightedColor};
+use typst::{
+    foundations::Smart,
+    visualize::{
+        Color as TypstColor, ColorSpace as TypstColorSpace,
+        ProcessColorSpace as TypstProcessColorSpace, WeightedColor,
+    },
+};
 use vello::peniko;
 use vello::{
     Scene,
@@ -1141,7 +1147,7 @@ fn raw_gradient_stops(gradient: &GradientItem) -> peniko::ColorStops {
 
 fn sample_gradient_color(
     gradient: &GradientItem,
-    mixing_space: TypstColorSpace,
+    mixing_space: TypstProcessColorSpace,
     t: f64,
 ) -> Option<TypstColor> {
     let t = t.clamp(0.0, 1.0);
@@ -1177,21 +1183,21 @@ fn sample_gradient_color(
             WeightedColor::new(typst_color_from_rgba8(col_0), 1.0 - t),
             WeightedColor::new(typst_color_from_rgba8(col_1), t),
         ],
-        mixing_space,
+        Smart::Custom(TypstColorSpace::Process(mixing_space)),
     )
     .ok()
 }
 
-fn typst_color_space(space: ColorSpace) -> Option<TypstColorSpace> {
+fn typst_color_space(space: ColorSpace) -> Option<TypstProcessColorSpace> {
     Some(match space {
         ColorSpace::Luma | ColorSpace::Srgb => return None,
-        ColorSpace::Oklab => TypstColorSpace::Oklab,
-        ColorSpace::Oklch => TypstColorSpace::Oklch,
-        ColorSpace::D65Gray => TypstColorSpace::D65Gray,
-        ColorSpace::LinearRgb => TypstColorSpace::LinearRgb,
-        ColorSpace::Hsl => TypstColorSpace::Hsl,
-        ColorSpace::Hsv => TypstColorSpace::Hsv,
-        ColorSpace::Cmyk => TypstColorSpace::Cmyk,
+        ColorSpace::Oklab => TypstProcessColorSpace::Oklab,
+        ColorSpace::Oklch => TypstProcessColorSpace::Oklch,
+        ColorSpace::D65Gray => TypstProcessColorSpace::D65Gray,
+        ColorSpace::LinearRgb => TypstProcessColorSpace::LinearRgb,
+        ColorSpace::Hsl => TypstProcessColorSpace::Hsl,
+        ColorSpace::Hsv => TypstProcessColorSpace::Hsv,
+        ColorSpace::Cmyk => TypstProcessColorSpace::Cmyk,
     })
 }
 

--- a/crates/tinymist-world/src/font/web/mod.rs
+++ b/crates/tinymist-world/src/font/web/mod.rs
@@ -228,6 +228,7 @@ fn infer_info_from_web_font(
         family,
         variant,
         flags,
+        axes: Vec::new(),
         coverage,
     })
 }

--- a/crates/tinymist-world/src/parser/semantic_tokens.rs
+++ b/crates/tinymist-world/src/parser/semantic_tokens.rs
@@ -111,7 +111,7 @@ pub struct SemanticToken {
 impl SemanticToken {
     /// Creates a new semantic token.
     fn new(token_type: TokenType, modifiers: ModifierSet, node: &LinkedNode) -> Self {
-        let source = node.get().clone().into_text();
+        let source = node.get().clone().full_text();
 
         let raw_position = node.offset() as u64;
         let raw_position = ((raw_position >> 32) as u32, raw_position as u32);

--- a/crates/tinymist/src/resource/symbols.rs
+++ b/crates/tinymist/src/resource/symbols.rs
@@ -2,11 +2,12 @@ use std::sync::LazyLock;
 use std::{path::Path, sync::Arc};
 
 use reflexo_typst::TypstPagedDocument;
-use reflexo_typst::{vector::font::GlyphId, TypstFont};
+use reflexo_typst::vector::font::GlyphId;
 use reflexo_vec2svg::SvgGlyphBuilder;
 use sync_ls::LspResult;
 use tinymist_query::GLOBAL_STATS;
 use typst::foundations::Bytes;
+use typst::text::FontInstance;
 use typst::{syntax::VirtualPath, World};
 
 use super::prelude::*;
@@ -205,7 +206,7 @@ fn populate(
 fn render_symbols(
     snap: &LspComputeGraph,
     symbols: &[SymbolItem],
-) -> LspResult<HashMap<String, (TypstFont, GlyphId)>> {
+) -> LspResult<HashMap<String, (FontInstance, GlyphId)>> {
     const PRELUDE: &str = r#"#show math.equation: set text(font: (
   "New Computer Modern Math",
   "Latin Modern Math",
@@ -254,12 +255,12 @@ fn render_symbols(
 fn extract_rendered_symbols<'a>(
     doc: &TypstPagedDocument,
     symbols: impl Iterator<Item = &'a String>,
-) -> HashMap<String, (TypstFont, GlyphId)> {
+) -> HashMap<String, (FontInstance, GlyphId)> {
     use typst::layout::Frame;
     use typst::layout::FrameItem;
 
     struct Worker {
-        res: HashMap<String, (TypstFont, GlyphId)>,
+        res: HashMap<String, (FontInstance, GlyphId)>,
     }
 
     impl Worker {
@@ -315,7 +316,7 @@ fn extract_rendered_symbols<'a>(
 
 fn render_glyphs(
     symbols: &[SymbolItem],
-    glyph_mapping: &HashMap<String, (TypstFont, GlyphId)>,
+    glyph_mapping: &HashMap<String, (FontInstance, GlyphId)>,
 ) -> LspResult<Vec<ResourceSymbolItem>> {
     let glyph_provider = reflexo_vec2svg::GlyphProvider::default();
     let glyph_pass = reflexo_typst::vector::pass::ConvertInnerImpl::new(glyph_provider, false);
@@ -345,7 +346,7 @@ fn render_glyphs(
     Ok(rendered_symbols)
 }
 
-fn create_display_svg(font: &TypstFont, gid: GlyphId, svg_path: &str) -> String {
+fn create_display_svg(font: &FontInstance, gid: GlyphId, svg_path: &str) -> String {
     let face = font.ttf();
 
     let (x_min, x_max) = face

--- a/crates/tinymist/src/resource/symbols.rs
+++ b/crates/tinymist/src/resource/symbols.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 use std::{path::Path, sync::Arc};
 
-use reflexo_typst::TypstPagedDocument;
 use reflexo_typst::vector::font::GlyphId;
+use reflexo_typst::TypstPagedDocument;
 use reflexo_vec2svg::SvgGlyphBuilder;
 use sync_ls::LspResult;
 use tinymist_query::GLOBAL_STATS;

--- a/crates/tinymist/src/tool/ast.rs
+++ b/crates/tinymist/src/tool/ast.rs
@@ -27,8 +27,8 @@ impl AstRepr<'_> {
 
         write!(f, "{: >indent$}{:?}(", "", node.kind())?;
 
-        if !node.text().is_empty() {
-            write!(f, "{:?}", node.text())?;
+        if !node.full_text().is_empty() {
+            write!(f, "{:?}", node.full_text())?;
         } else if node.get().children().len() > 0 {
             write!(f, "{:?}, ", node.children().len())?;
             f.write_str("{\n")?;


### PR DESCRIPTION
Part of the Typst 0.15 cleanup stack. This slice covers text accessor, font metadata, color presentation, and viewer color-space API changes.

## Upstream Typst Changes

- [`typst/typst#8393`](https://github.com/typst/typst/pull/8393) changes syntax/source text access. Tinymist updates semantic tokens, analysis matchers, lint/debug instrumentation, query helpers, and AST utilities to use the new accessor style.
- [`typst/typst#8425`](https://github.com/typst/typst/pull/8425) adds font axis metadata. Tinymist initializes font axes and forwards them through document metrics and symbol glyph handling.
- [`typst/typst#7629`](https://github.com/typst/typst/pull/7629) changes color presentation behavior. Tinymist updates color presentation conversion and renderer color-space handling for the Typst 0.15 color APIs.

## Tinymist Changes

- Updates text access in `tinymist-query`, `tinymist-analysis`, `tinymist-debug`, `tinymist-lint`, and AST-facing helpers.
- Updates `tinymist-world` font metadata construction for the new axes field.
- Updates document metrics and symbol glyph collection to preserve font axis information.
- Updates `tinymist-query` color presentations for the revised Typst color API.
- Updates viewer rendering color-space conversion so Typst 0.15 colors are mapped correctly before rendering.
