### PR TITLE
fix(typlite): adapt paragraph and line breaks for typst 0.15

### DIFF
--- a/crates/typlite/src/markdown.typ
+++ b/crates/typlite/src/markdown.typ
@@ -228,7 +228,7 @@
     },
   )
 
-  show linebreak: it => if-not-paged(it, md-linebreak)
+  // show linebreak: it => if-not-paged(it, md-linebreak)
   show figure: it => if-not-paged(it, md-figure(it.body, caption: it.caption))
 
   html.elem("m1document", body)

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -58,7 +58,13 @@ impl HtmlToAstParser {
                 Ok(())
             }
 
-            tag::p | tag::span | tag::div => {
+            tag::p => {
+                self.flush_inline_buffer();
+                self.convert_children(element)?;
+                Ok(())
+            }
+
+            tag::span | tag::div => {
                 self.convert_children(element)?;
                 Ok(())
             }
@@ -90,11 +96,10 @@ impl HtmlToAstParser {
                 Ok(())
             }
 
-            md_tag::parbreak => {
-                self.flush_inline_buffer();
-                Ok(())
-            }
-
+            // md_tag::parbreak => {
+            //     self.flush_inline_buffer();
+            //     Ok(())
+            // }
             md_tag::heading => {
                 self.flush_inline_buffer();
                 let attrs = HeadingAttr::parse(&element.attrs)?;


### PR DESCRIPTION
## Summary
- Adjust Typlite paragraph conversion to flush the inline buffer on `<p>` elements so paragraph boundaries survive Typst 0.15 HTML output.
- Disable the old linebreak/parbreak conversion path that conflicts with the current Typst-generated HTML shape.
- Keep the corresponding snapshot updates in the snapshot PR for unified review.