### PR TITLE
build: bump world crates to v0.15.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1634,7 +1634,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1875,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2963,7 +2963,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3323,7 +3323,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4094,7 +4094,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5122,7 +5122,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5341,7 +5341,7 @@ dependencies = [
 [[package]]
 name = "reflexo"
 version = "0.7.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=62c49c70d1382f1ac89baeda591760a29152282d#62c49c70d1382f1ac89baeda591760a29152282d"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e#69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "reflexo-typst"
 version = "0.7.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=62c49c70d1382f1ac89baeda591760a29152282d#62c49c70d1382f1ac89baeda591760a29152282d"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e#69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e"
 dependencies = [
  "codespan-reporting 0.11.1",
  "comemo",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "reflexo-typst2vec"
 version = "0.7.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=62c49c70d1382f1ac89baeda591760a29152282d#62c49c70d1382f1ac89baeda591760a29152282d"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e#69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e"
 dependencies = [
  "bitvec",
  "comemo",
@@ -5427,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "reflexo-vec2svg"
 version = "0.7.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=62c49c70d1382f1ac89baeda591760a29152282d#62c49c70d1382f1ac89baeda591760a29152282d"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e#69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -5735,7 +5735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6239,7 +6239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6273,7 +6273,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6503,7 +6503,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6533,7 +6533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6941,7 +6941,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-derive"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -6962,7 +6962,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-l10n"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6991,7 +6991,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-package"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-project"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-std"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-task"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7233,7 +7233,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-vfs"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "comemo",
  "ecow",
@@ -7307,7 +7307,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-world"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8103,7 +8103,7 @@ dependencies = [
 
 [[package]]
 name = "typst-shim"
-version = "0.14.6"
+version = "0.15.0-rc1"
 dependencies = [
  "cfg-if",
  "comemo",
@@ -8264,7 +8264,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9220,7 +9220,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,9 +360,9 @@ typstyle-core = { git = "https://github.com/Myriad-Dreamin/typstyle.git", rev = 
 # These patches use a different version of `reflexo`.
 #
 # A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
-reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "62c49c70d1382f1ac89baeda591760a29152282d" }
-reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "62c49c70d1382f1ac89baeda591760a29152282d" }
-reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "62c49c70d1382f1ac89baeda591760a29152282d" }
+reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e" }
+reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e" }
+reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "69580cd8c6c8dbe4ba9a5622d194cbcf3e4cb04e" }
 
 # These patches use local `reflexo` for development.
 # reflexo = { path = "../typst.ts/crates/reflexo/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,15 +225,15 @@ insta-cmd = "0.6.0"
 # Our Own Crates
 tinymist-assets = { version = "=0.14.20" }
 
-tinymist-derive = { path = "./crates/tinymist-derive/", version = "0.14.6" }
-tinymist-l10n = { path = "./crates/tinymist-l10n/", version = "0.14.6" }
-tinymist-package = { path = "./crates/tinymist-package/", version = "0.14.6" }
-tinymist-std = { path = "./crates/tinymist-std/", version = "0.14.6", default-features = false }
-tinymist-vfs = { path = "./crates/tinymist-vfs/", version = "0.14.6", default-features = false }
-tinymist-world = { path = "./crates/tinymist-world/", version = "0.14.6", default-features = false }
-tinymist-project = { path = "./crates/tinymist-project/", version = "0.14.6" }
-tinymist-task = { path = "./crates/tinymist-task/", version = "0.14.6" }
-typst-shim = { path = "./crates/typst-shim", version = "0.14.6", features = [
+tinymist-derive = { path = "./crates/tinymist-derive/", version = "0.15.0-rc1" }
+tinymist-l10n = { path = "./crates/tinymist-l10n/", version = "0.15.0-rc1" }
+tinymist-package = { path = "./crates/tinymist-package/", version = "0.15.0-rc1" }
+tinymist-std = { path = "./crates/tinymist-std/", version = "0.15.0-rc1", default-features = false }
+tinymist-vfs = { path = "./crates/tinymist-vfs/", version = "0.15.0-rc1", default-features = false }
+tinymist-world = { path = "./crates/tinymist-world/", version = "0.15.0-rc1", default-features = false }
+tinymist-project = { path = "./crates/tinymist-project/", version = "0.15.0-rc1" }
+tinymist-task = { path = "./crates/tinymist-task/", version = "0.15.0-rc1" }
+typst-shim = { path = "./crates/typst-shim", version = "0.15.0-rc1", features = [
     "nightly",
 ] }
 

--- a/crates/tinymist-derive/Cargo.toml
+++ b/crates/tinymist-derive/Cargo.toml
@@ -4,7 +4,7 @@ description = "Provides derive for tinymist."
 categories = ["compilers"]
 keywords = ["typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-l10n/Cargo.toml
+++ b/crates/tinymist-l10n/Cargo.toml
@@ -4,7 +4,7 @@ description = "Localization support for tinymist and typst."
 categories = ["compilers", "command-line-utilities"]
 keywords = ["language", "typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-package/Cargo.toml
+++ b/crates/tinymist-package/Cargo.toml
@@ -4,7 +4,7 @@ description = "Tinymist package support for Typst."
 categories = ["compilers"]
 keywords = ["api", "language", "typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-project/Cargo.toml
+++ b/crates/tinymist-project/Cargo.toml
@@ -4,7 +4,7 @@ description = "Project model of typst for tinymist."
 categories = ["compilers"]
 keywords = ["language", "typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-std/Cargo.toml
+++ b/crates/tinymist-std/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tinymist-std"
 description = "Additional functions wrapping Rust's standard library."
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-task/Cargo.toml
+++ b/crates/tinymist-task/Cargo.toml
@@ -4,7 +4,7 @@ description = "Task model of typst for tinymist."
 categories = ["compilers"]
 keywords = ["language", "typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-vfs/Cargo.toml
+++ b/crates/tinymist-vfs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tinymist-vfs"
 description = "Vfs for tinymist."
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/tinymist-world/Cargo.toml
+++ b/crates/tinymist-world/Cargo.toml
@@ -4,7 +4,7 @@ description = "Typst's World implementation for tinymist."
 categories = ["compilers"]
 keywords = ["language", "typst"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/typst-shim/Cargo.toml
+++ b/crates/typst-shim/Cargo.toml
@@ -3,7 +3,7 @@ name = "typst-shim"
 description = "A compatibility layer for Typst release and mainline versions."
 authors = ["The Typst Project Developers"]
 # group: world
-version = "0.14.6"
+version = "0.15.0-rc1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
- Bump workspace tinymist crate versions to `0.15.0-rc1`
- Update `Cargo.lock` to match the new crate versions
- Refresh `reflexo` git dependencies to the newer pinned revision
- Align the root workspace manifest and crate manifests with the release candidate version
