### PR TITLE
fix: preserve entry path selection contract

### DIFF
--- a/crates/tinymist-world/src/entry.rs
+++ b/crates/tinymist-world/src/entry.rs
@@ -145,21 +145,25 @@ impl EntryState {
     }
 
     /// Tries to select an entry in the workspace.
+    ///
+    /// If a workspace root is set, the path must be inside that root and the
+    /// selected entry keeps the same root. Selecting a path outside the root is
+    /// rejected because that has undefined workspace semantics.
+    ///
+    /// If no workspace root is set, selection falls back to rooting the entry by
+    /// its parent directory. This matches typst-cli behavior with and without
+    /// an explicit `--root`.
     pub fn try_select_path_in_workspace(&self, path: &Path) -> Result<Option<EntryState>> {
-        Ok(match self.workspace_root() {
-            Some(root) => match path.strip_prefix(&root) {
-                Ok(path) => match VirtualPath::virtualize(&root, path) {
-                    Ok(path) => Some(EntryState::new_rooted(root.clone(), Some(path))),
-                    Err(_) => None,
-                },
-                Err(err) => {
-                    return Err(
-                        error_once!("entry file is not in workspace", err: err, entry: path.display(), root: root.display()),
-                    );
-                }
-            },
-            None => EntryState::new_rooted_by_parent(path.into()),
-        })
+        match self.workspace_root() {
+            Some(root) => {
+                let path = VirtualPath::virtualize(&root, path).map_err(|err| {
+                    error_once!("entry file is not in workspace", err: err, entry: path.display(), root: root.display())
+                })?;
+
+                Ok(Some(EntryState::new_rooted(root.clone(), Some(path))))
+            }
+            None => Ok(EntryState::new_rooted_by_parent(path.into())),
+        }
     }
 
     /// Checks if the world is detached.
@@ -250,5 +254,104 @@ impl TryFrom<EntryOpts> for EntryState {
             }
             EntryOpts::Detached => Ok(EntryState::new_detached()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tinymist_vfs::WorkspaceResolution;
+
+    #[cfg(windows)]
+    const ROOT: &str = r"C:\workspace";
+    #[cfg(not(windows))]
+    const ROOT: &str = "/workspace";
+
+    fn assert_workspace_entry(entry: &EntryState, root: &ImmutPath, vpath: &str) {
+        assert_eq!(entry.root(), Some(root.clone()));
+        assert_eq!(entry.main().unwrap().vpath().get_with_slash(), vpath);
+
+        let resolution = WorkspaceResolver::resolve(entry.main().unwrap()).unwrap();
+        assert!(matches!(resolution, WorkspaceResolution::Workspace(id) if id.path() == *root));
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_selects_absolute_workspace_path() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_workspace(root.clone());
+        let selected = entry
+            .try_select_path_in_workspace(&root.join("main.typ"))
+            .unwrap()
+            .unwrap();
+
+        assert_workspace_entry(&selected, &root, "/main.typ");
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_selects_nested_absolute_workspace_path() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_workspace(root.clone());
+        let selected = entry
+            .try_select_path_in_workspace(&root.join("chapters").join("main.typ"))
+            .unwrap()
+            .unwrap();
+
+        assert_workspace_entry(&selected, &root, "/chapters/main.typ");
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_rejects_relative_path_with_workspace_root() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_workspace(root);
+
+        assert!(
+            entry
+                .try_select_path_in_workspace(Path::new("main.typ"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_rejects_path_outside_workspace() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_workspace(root);
+
+        assert!(
+            entry
+                .try_select_path_in_workspace(Path::new("/outside/main.typ"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn select_in_workspace_accepts_virtual_path_without_leading_slash() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_workspace(root.clone());
+        let selected = entry.select_in_workspace(Path::new("main.typ"));
+
+        assert_workspace_entry(&selected, &root, "/main.typ");
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_uses_parent_root_without_workspace_root() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let entry = EntryState::new_rootless(VirtualPath::new("/old.typ").unwrap());
+        let selected = entry
+            .try_select_path_in_workspace(&root.join("main.typ"))
+            .unwrap()
+            .unwrap();
+
+        assert_workspace_entry(&selected, &root, "/main.typ");
+    }
+
+    #[test]
+    fn try_select_path_in_workspace_keeps_detached_parent_root_fallback() {
+        let root = ImmutPath::from(Path::new(ROOT));
+        let selected = EntryState::new_detached()
+            .try_select_path_in_workspace(&root.join("main.typ"))
+            .unwrap()
+            .unwrap();
+
+        assert_workspace_entry(&selected, &root, "/main.typ");
     }
 }


### PR DESCRIPTION
- preserve the two-branch entry selection contract for rooted vs root-by-parent worlds
- use `VirtualPath::virtualize(root, path)` directly for rooted workspace paths
- document the `--root` / no-`--root` behavior match with typst-cli
- add tinymist-world entry regression tests for rooted selection, outside-root rejection, and parent-root fallback
