### PR TITLE
feat: convert builtin Typst docs to Markdown

### DIFF
--- a/crates/tinymist-analysis/src/docs/def.rs
+++ b/crates/tinymist-analysis/src/docs/def.rs
@@ -400,6 +400,12 @@ pub type TypelessParamDocs = ParamDocsT<()>;
 /// Documentation about a parameter.
 pub type ParamDocs = ParamDocsT<TypeRepr>;
 
+/// Resolves lazy documentation text.
+pub trait DocTextResolver {
+    /// Gets display-ready documentation text.
+    fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString;
+}
+
 /// Describes a function parameter.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ParamDocsT<T> {
@@ -418,17 +424,12 @@ pub struct ParamDocsT<T> {
 
 impl ParamDocs {
     /// Create a new parameter documentation.
-    pub fn new(param: &ParamTy, ty: Option<&Ty>) -> Self {
+    pub fn new(ctx: &mut impl DocTextResolver, param: &ParamTy, ty: Option<&Ty>) -> Self {
         let docs = param
             .docs
             .as_ref()
-            .map(|docs| docs.raw().clone())
+            .map(|docs| ctx.resolve_doc_text(docs))
             .unwrap_or_default();
-        Self::new_with_docs(param, ty, docs)
-    }
-
-    /// Create a new parameter documentation with display-ready docs.
-    pub fn new_with_docs(param: &ParamTy, ty: Option<&Ty>, docs: EcoString) -> Self {
         Self {
             name: param.name.as_ref().into(),
             docs,

--- a/crates/tinymist-analysis/src/docs/def.rs
+++ b/crates/tinymist-analysis/src/docs/def.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 
 use ecow::{EcoString, eco_format};
@@ -9,6 +10,93 @@ use super::tidy::*;
 use crate::syntax::DeclExpr;
 use crate::ty::{Interned, ParamAttrs, ParamTy, StrRef, Ty, TypeVarBounds};
 use crate::upstream::plain_docs_sentence;
+
+/// The source format of documentation text.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DocTextKind {
+    /// Documentation that is already ready to display as Markdown.
+    Plain,
+    /// Official Typst documentation that must be converted before display.
+    Official,
+}
+
+/// Lazily resolved documentation text.
+#[derive(Debug, Clone)]
+pub struct DocText {
+    raw: EcoString,
+    kind: DocTextKind,
+    resolved: OnceLock<EcoString>,
+}
+
+impl DocText {
+    /// Creates documentation that is already ready to display as Markdown.
+    pub fn plain(raw: EcoString) -> Self {
+        Self {
+            raw,
+            kind: DocTextKind::Plain,
+            resolved: OnceLock::new(),
+        }
+    }
+
+    /// Creates official Typst documentation that must be converted before display.
+    pub fn official(raw: EcoString) -> Self {
+        Self {
+            raw,
+            kind: DocTextKind::Official,
+            resolved: OnceLock::new(),
+        }
+    }
+
+    /// Gets the raw documentation text.
+    pub fn raw(&self) -> &EcoString {
+        &self.raw
+    }
+
+    /// Gets the source format of this documentation text.
+    pub fn kind(&self) -> DocTextKind {
+        self.kind
+    }
+
+    /// Gets display-ready documentation text.
+    pub fn get_or_init(
+        &self,
+        convert_official: impl FnOnce(&EcoString) -> EcoString,
+    ) -> &EcoString {
+        match self.kind {
+            DocTextKind::Plain => &self.raw,
+            DocTextKind::Official => self.resolved.get_or_init(|| convert_official(&self.raw)),
+        }
+    }
+}
+
+impl PartialEq for DocText {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.raw == other.raw
+    }
+}
+
+impl Eq for DocText {}
+
+impl PartialOrd for DocText {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DocText {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.kind
+            .cmp(&other.kind)
+            .then_with(|| self.raw.cmp(&other.raw))
+    }
+}
+
+impl Hash for DocText {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.kind.hash(state);
+        self.raw.hash(state);
+    }
+}
 
 /// The documentation string of an item
 #[derive(Debug, Clone, Default)]
@@ -331,9 +419,19 @@ pub struct ParamDocsT<T> {
 impl ParamDocs {
     /// Create a new parameter documentation.
     pub fn new(param: &ParamTy, ty: Option<&Ty>) -> Self {
+        let docs = param
+            .docs
+            .as_ref()
+            .map(|docs| docs.raw().clone())
+            .unwrap_or_default();
+        Self::new_with_docs(param, ty, docs)
+    }
+
+    /// Create a new parameter documentation with display-ready docs.
+    pub fn new_with_docs(param: &ParamTy, ty: Option<&Ty>, docs: EcoString) -> Self {
         Self {
             name: param.name.as_ref().into(),
-            docs: param.docs.clone().unwrap_or_default(),
+            docs,
             cano_type: format_ty(ty.or(Some(&param.ty))),
             default: param.default.clone(),
             attrs: param.attrs,

--- a/crates/tinymist-analysis/src/sig.rs
+++ b/crates/tinymist-analysis/src/sig.rs
@@ -4,12 +4,13 @@ use core::fmt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use ecow::{EcoString, EcoVec, eco_format, eco_vec};
+use ecow::{EcoVec, eco_format, eco_vec};
 use typst::foundations::{Closure, ClosureNode, Func};
 use typst::syntax::ast;
 use typst::syntax::ast::AstNode;
 use typst::utils::LazyHash;
 
+use crate::docs::DocText;
 // use super::{BoundChecker, Definition};
 use crate::ty::{InsTy, ParamTy, SigTy, StrRef, Ty};
 use crate::ty::{Interned, ParamAttrs};
@@ -71,7 +72,7 @@ impl Signature {
 #[derive(Debug, Clone)]
 pub struct PrimarySignature {
     /// The documentation of the function
-    pub docs: Option<EcoString>,
+    pub docs: Option<DocText>,
     /// The documentation of the parameter.
     pub param_specs: Vec<Interned<ParamTy>>,
     /// Whether the function has fill, stroke, or size parameters.
@@ -164,23 +165,9 @@ pub struct PartialSignature {
 /// Gets the signature of a function.
 #[comemo::memoize]
 pub fn func_signature(func: Func) -> Signature {
-    func_signature_impl(func, |docs| docs)
-}
-
-/// Gets the signature of a function, converting official docs while building it.
-pub fn func_signature_with_docs(
-    func: Func,
-    convert_docs: impl FnMut(EcoString) -> EcoString,
-) -> Signature {
-    func_signature_impl(func, convert_docs)
-}
-
-fn func_signature_impl(
-    mut func: Func,
-    mut convert_docs: impl FnMut(EcoString) -> EcoString,
-) -> Signature {
     use typst::foundations::FuncInner;
     let mut with_stack = eco_vec![];
+    let mut func = func;
     while let FuncInner::With(with) = func.inner() {
         let (inner, args) = with.as_ref();
         with_stack.push(ArgsInfo {
@@ -235,7 +222,7 @@ fn func_signature_impl(
         FuncInner::With(..) => unreachable!(),
         FuncInner::Closure(closure) => {
             analyze_closure_signature(closure.clone(), &mut add_param);
-            (func.docs().map(From::from), None)
+            (func.docs().map(|docs| DocText::plain(docs.into())), None)
         }
         FuncInner::Element(..) | FuncInner::Native(..) | FuncInner::Plugin(..) => {
             for param in func.params() {
@@ -244,7 +231,7 @@ fn func_signature_impl(
                     name: name.into(),
                     docs: param
                         .to_native()
-                        .map(|native| convert_docs(native.docs.into())),
+                        .map(|native| DocText::official(native.docs.into())),
                     default: param.default().map(|default| truncated_repr(&default)),
                     ty: Ty::from_param_site(&func, &param),
                     attrs: (&param).into(),
@@ -252,7 +239,7 @@ fn func_signature_impl(
             }
 
             (
-                func.docs().map(|docs| convert_docs(docs.into())),
+                func.docs().map(|docs| DocText::official(docs.into())),
                 func.returns().map(|r| Ty::from_return_site(&func, r)),
             )
         }
@@ -317,7 +304,7 @@ fn analyze_closure_signature(
                 let default = unwrap_parens(named.expr()).to_untyped().clone().full_text();
                 add_param(Interned::new(ParamTy {
                     name: named.name().get().into(),
-                    docs: Some(eco_format!("Default value: {default}")),
+                    docs: Some(DocText::plain(eco_format!("Default value: {default}"))),
                     default: Some(default),
                     ty: Ty::Any,
                     attrs: ParamAttrs::named(),

--- a/crates/tinymist-analysis/src/sig.rs
+++ b/crates/tinymist-analysis/src/sig.rs
@@ -164,9 +164,23 @@ pub struct PartialSignature {
 /// Gets the signature of a function.
 #[comemo::memoize]
 pub fn func_signature(func: Func) -> Signature {
+    func_signature_impl(func, |docs| docs)
+}
+
+/// Gets the signature of a function, converting official docs while building it.
+pub fn func_signature_with_docs(
+    func: Func,
+    convert_docs: impl FnMut(EcoString) -> EcoString,
+) -> Signature {
+    func_signature_impl(func, convert_docs)
+}
+
+fn func_signature_impl(
+    mut func: Func,
+    mut convert_docs: impl FnMut(EcoString) -> EcoString,
+) -> Signature {
     use typst::foundations::FuncInner;
     let mut with_stack = eco_vec![];
-    let mut func = func;
     while let FuncInner::With(with) = func.inner() {
         let (inner, args) = with.as_ref();
         with_stack.push(ArgsInfo {
@@ -217,25 +231,30 @@ pub fn func_signature(func: Func) -> Signature {
         }
     };
 
-    let ret_ty = match func.inner() {
+    let (docs, ret_ty) = match func.inner() {
         FuncInner::With(..) => unreachable!(),
         FuncInner::Closure(closure) => {
             analyze_closure_signature(closure.clone(), &mut add_param);
-            None
+            (func.docs().map(From::from), None)
         }
         FuncInner::Element(..) | FuncInner::Native(..) | FuncInner::Plugin(..) => {
             for param in func.params() {
                 let name = param.name().unwrap_or_default();
                 add_param(Interned::new(ParamTy {
                     name: name.into(),
-                    docs: param.to_native().map(|native| native.docs.into()),
+                    docs: param
+                        .to_native()
+                        .map(|native| convert_docs(native.docs.into())),
                     default: param.default().map(|default| truncated_repr(&default)),
                     ty: Ty::from_param_site(&func, &param),
                     attrs: (&param).into(),
                 }));
             }
 
-            func.returns().map(|r| Ty::from_return_site(&func, r))
+            (
+                func.docs().map(|docs| convert_docs(docs.into())),
+                func.returns().map(|r| Ty::from_return_site(&func, r)),
+            )
         }
     };
 
@@ -252,7 +271,7 @@ pub fn func_signature(func: Func) -> Signature {
     }
 
     let signature = Arc::new(PrimarySignature {
-        docs: func.docs().map(From::from),
+        docs,
         param_specs,
         has_fill_or_size_or_stroke,
         sig_ty: sig_ty.into(),

--- a/crates/tinymist-analysis/src/ty/def.rs
+++ b/crates/tinymist-analysis/src/ty/def.rs
@@ -20,7 +20,7 @@ use typst::{
 use super::{BoundPred, BuiltinTy, PackageId};
 use crate::{
     adt::{interner::impl_internable, snapshot_map},
-    docs::UntypedDefDocs,
+    docs::{DocText, UntypedDefDocs},
     syntax::{DeclExpr, UnaryOp},
 };
 
@@ -833,7 +833,7 @@ pub struct ParamTy {
     /// The name of the parameter.
     pub name: StrRef,
     /// The docstring of the parameter.
-    pub docs: Option<EcoString>,
+    pub docs: Option<DocText>,
     /// The default value of the variable.
     pub default: Option<EcoString>,
     /// The type of the parameter.

--- a/crates/tinymist-query/src/analysis/completion/type.rs
+++ b/crates/tinymist-query/src/analysis/completion/type.rs
@@ -92,7 +92,16 @@ impl TypeCompletionWorker<'_, '_, '_, '_> {
             Ty::Param(param) => {
                 // todo: variadic
 
-                let docs = docs.or_else(|| param.docs.as_ref().map(|docs| docs.raw().as_str()));
+                let resolved_docs;
+                let docs = if docs.is_some() {
+                    docs
+                } else {
+                    resolved_docs = param
+                        .docs
+                        .as_ref()
+                        .map(|docs| crate::docs::resolve_doc_text(self.base.worker.ctx, docs));
+                    resolved_docs.as_deref()
+                };
                 if param.attrs.positional {
                     self.type_completion(&param.ty, docs);
                 }

--- a/crates/tinymist-query/src/analysis/completion/type.rs
+++ b/crates/tinymist-query/src/analysis/completion/type.rs
@@ -92,7 +92,7 @@ impl TypeCompletionWorker<'_, '_, '_, '_> {
             Ty::Param(param) => {
                 // todo: variadic
 
-                let docs = docs.or_else(|| param.docs.as_deref());
+                let docs = docs.or_else(|| param.docs.as_ref().map(|docs| docs.raw().as_str()));
                 if param.attrs.positional {
                     self.type_completion(&param.ty, docs);
                 }

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1123,21 +1123,16 @@ impl SharedContext {
         self: &Arc<Self>,
         docs: &str,
         source_fid: Option<TypstFileId>,
-        docs_content: crate::docs::DocsContent,
     ) -> StrResult<EcoString> {
         let dark = matches!(self.analysis.color_theme, ColorTheme::Dark);
         let res = self.analysis.caches.converted_docs.entry(
-            hash128(&(
-                source_fid,
-                docs,
-                docs_content,
-                self.analysis.remove_html,
-                dark,
-            )),
+            hash128(&(source_fid, docs, self.analysis.remove_html, dark)),
             self.lifetime,
         );
-        res.get_or_init(|| crate::docs::convert_docs(self, docs, source_fid, docs_content))
-            .clone()
+        res.get_or_init(|| {
+            crate::docs::convert_docs(self, docs, source_fid, crate::docs::DocsContent::Plain)
+        })
+        .clone()
     }
 
     /// Remove html tags from markup content if necessary.

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -523,7 +523,7 @@ impl LocalContext {
         match def.decl.kind() {
             DefKind::Function => {
                 let sig = self.sig_of_def(def.clone())?;
-                let docs = crate::docs::sig_docs(&sig)?;
+                let docs = crate::docs::sig_docs(self, &sig)?;
                 Some(DefDocs::Function(Box::new(docs)))
             }
             DefKind::Struct | DefKind::Constant | DefKind::Variable => {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -171,7 +171,6 @@ impl Analysis {
     pub fn clear_cache(&self) {
         self.caches.signatures.clear();
         self.caches.docstrings.clear();
-        self.caches.converted_docs.clear();
         self.caches.def_signatures.clear();
         self.caches.static_signatures.clear();
         self.caches.terms.clear();
@@ -300,7 +299,6 @@ impl LocalContextGuard {
         caches.terms.retain(|(l, _)| retainer(*l));
         caches.signatures.retain(|(l, _)| retainer(*l));
         caches.docstrings.retain(|(l, _)| retainer(*l));
-        caches.converted_docs.retain(|(l, _)| retainer(*l));
     }
 }
 
@@ -1119,22 +1117,6 @@ impl SharedContext {
         .clone()
     }
 
-    pub(crate) fn convert_docs_cached(
-        self: &Arc<Self>,
-        docs: &str,
-        source_fid: Option<TypstFileId>,
-    ) -> StrResult<EcoString> {
-        let dark = matches!(self.analysis.color_theme, ColorTheme::Dark);
-        let res = self.analysis.caches.converted_docs.entry(
-            hash128(&(source_fid, docs, self.analysis.remove_html, dark)),
-            self.lifetime,
-        );
-        res.get_or_init(|| {
-            crate::docs::convert_docs(self, docs, source_fid, crate::docs::DocsContent::Plain)
-        })
-        .clone()
-    }
-
     /// Remove html tags from markup content if necessary.
     pub fn remove_html(&self, markup: EcoString) -> EcoString {
         if !self.analysis.remove_html {
@@ -1324,7 +1306,6 @@ pub struct AnalysisGlobalCaches {
     static_signatures: CacheMap<DeferredCompute<Option<Signature>>>,
     signatures: CacheMap<DeferredCompute<Option<Signature>>>,
     docstrings: CacheMap<DeferredCompute<Option<Arc<DocString>>>>,
-    converted_docs: CacheMap<DeferredCompute<StrResult<EcoString>>>,
     terms: CacheMap<(Value, Ty)>,
 }
 

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::{collections::HashSet, ops::Deref};
 
 use comemo::{Track, Tracked};
+use ecow::EcoString;
 use lsp_types::Url;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
@@ -170,6 +171,7 @@ impl Analysis {
     pub fn clear_cache(&self) {
         self.caches.signatures.clear();
         self.caches.docstrings.clear();
+        self.caches.converted_docs.clear();
         self.caches.def_signatures.clear();
         self.caches.static_signatures.clear();
         self.caches.terms.clear();
@@ -298,6 +300,7 @@ impl LocalContextGuard {
         caches.terms.retain(|(l, _)| retainer(*l));
         caches.signatures.retain(|(l, _)| retainer(*l));
         caches.docstrings.retain(|(l, _)| retainer(*l));
+        caches.converted_docs.retain(|(l, _)| retainer(*l));
     }
 }
 
@@ -1116,6 +1119,27 @@ impl SharedContext {
         .clone()
     }
 
+    pub(crate) fn convert_docs_cached(
+        self: &Arc<Self>,
+        docs: &str,
+        source_fid: Option<TypstFileId>,
+        docs_content: crate::docs::DocsContent,
+    ) -> StrResult<EcoString> {
+        let dark = matches!(self.analysis.color_theme, ColorTheme::Dark);
+        let res = self.analysis.caches.converted_docs.entry(
+            hash128(&(
+                source_fid,
+                docs,
+                docs_content,
+                self.analysis.remove_html,
+                dark,
+            )),
+            self.lifetime,
+        );
+        res.get_or_init(|| crate::docs::convert_docs(self, docs, source_fid, docs_content))
+            .clone()
+    }
+
     /// Remove html tags from markup content if necessary.
     pub fn remove_html(&self, markup: EcoString) -> EcoString {
         if !self.analysis.remove_html {
@@ -1305,6 +1329,7 @@ pub struct AnalysisGlobalCaches {
     static_signatures: CacheMap<DeferredCompute<Option<Signature>>>,
     signatures: CacheMap<DeferredCompute<Option<Signature>>>,
     docstrings: CacheMap<DeferredCompute<Option<Arc<DocString>>>>,
+    converted_docs: CacheMap<DeferredCompute<StrResult<EcoString>>>,
     terms: CacheMap<(Value, Ty)>,
 }
 

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -1,14 +1,12 @@
 //! Analysis of function signatures.
 
-use ecow::EcoString;
 use itertools::Either;
-use tinymist_analysis::docs::tidy::remove_list_annotations;
-use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature_with_docs};
+use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature};
 use tinymist_derive::BindTyCtx;
 
 use super::{Definition, SharedContext, prelude::*};
 use crate::analysis::PostTypeChecker;
-use crate::docs::{DocsContent, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
+use crate::docs::{DocText, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
 use crate::syntax::classify_def_loosely;
 use crate::ty::{
     BoundChecker, DocSource, DynTypeBounds, ParamAttrs, ParamTy, SigWithTy, TyCtx, TypeInfo,
@@ -146,7 +144,7 @@ pub(crate) fn sig_of_type(
 
                 param_specs.push(Interned::new(ParamTy {
                     name,
-                    docs: Some(doc.docs.clone()),
+                    docs: Some(DocText::plain(doc.docs.clone())),
                     default,
                     ty,
                     attrs: ParamAttrs::positional(),
@@ -168,7 +166,7 @@ pub(crate) fn sig_of_type(
 
                 param_specs.push(Interned::new(ParamTy {
                     name: name.clone(),
-                    docs: docstring.map(|doc| doc.docs.clone()),
+                    docs: docstring.map(|doc| DocText::plain(doc.docs.clone())),
                     default,
                     ty,
                     attrs: ParamAttrs::named(),
@@ -180,7 +178,7 @@ pub(crate) fn sig_of_type(
 
                 param_specs.push(Interned::new(ParamTy {
                     name: doc.name.clone(),
-                    docs: Some(doc.docs.clone()),
+                    docs: Some(DocText::plain(doc.docs.clone())),
                     default,
                     ty: sig_ty.rest_param().cloned().unwrap_or(Ty::Any),
                     attrs: ParamAttrs::variadic(),
@@ -188,7 +186,7 @@ pub(crate) fn sig_of_type(
             }
 
             let sig = Signature::Primary(Arc::new(PrimarySignature {
-                docs: Some(docstring.docs.clone()),
+                docs: Some(DocText::plain(docstring.docs.clone())),
                 param_specs,
                 has_fill_or_size_or_stroke,
                 sig_ty,
@@ -345,24 +343,5 @@ fn analyze_dyn_signature(
         SignatureTarget::Convert(func) | SignatureTarget::Runtime(func) => func.clone(),
     };
 
-    Some(func_signature_with_docs(func, |docs| {
-        convert_official_doc(ctx, docs)
-    }))
-}
-
-fn convert_official_doc(ctx: &Arc<SharedContext>, docs: EcoString) -> EcoString {
-    if docs.trim().is_empty() {
-        return docs;
-    }
-
-    match ctx.convert_docs_cached(&docs, None, DocsContent::Official) {
-        Ok(converted) => {
-            let converted = remove_list_annotations(&converted);
-            ctx.remove_html(converted.trim().into())
-        }
-        Err(err) => {
-            log::warn!("failed to convert official Typst docs to Markdown: {err}");
-            ctx.remove_html(docs)
-        }
-    }
+    Some(func_signature(func))
 }

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -3,9 +3,8 @@
 use ecow::EcoString;
 use itertools::Either;
 use tinymist_analysis::docs::tidy::remove_list_annotations;
-use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature};
+use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature_with_docs};
 use tinymist_derive::BindTyCtx;
-use typst::foundations::FuncInner;
 
 use super::{Definition, SharedContext, prelude::*};
 use crate::analysis::PostTypeChecker;
@@ -346,68 +345,9 @@ fn analyze_dyn_signature(
         SignatureTarget::Convert(func) | SignatureTarget::Runtime(func) => func.clone(),
     };
 
-    let sig = func_signature(func.clone());
-    if func_has_official_docs(&func) {
-        Some(convert_official_signature_docs(ctx, sig))
-    } else {
-        Some(sig)
-    }
-}
-
-fn func_has_official_docs(func: &Func) -> bool {
-    let mut func = func;
-    loop {
-        match func.inner() {
-            FuncInner::With(with) => func = &with.as_ref().0,
-            FuncInner::Element(..) | FuncInner::Native(..) | FuncInner::Plugin(..) => return true,
-            FuncInner::Closure(..) => return false,
-        }
-    }
-}
-
-fn convert_official_signature_docs(ctx: &Arc<SharedContext>, sig: Signature) -> Signature {
-    match sig {
-        Signature::Primary(primary) => {
-            Signature::Primary(convert_official_primary_signature_docs(ctx, &primary))
-        }
-        Signature::Partial(partial) => Signature::Partial(Arc::new(PartialSignature {
-            signature: convert_official_primary_signature_docs(ctx, &partial.signature),
-            with_stack: partial.with_stack.clone(),
-        })),
-    }
-}
-
-fn convert_official_primary_signature_docs(
-    ctx: &Arc<SharedContext>,
-    primary: &PrimarySignature,
-) -> Arc<PrimarySignature> {
-    let param_specs = primary
-        .param_specs
-        .iter()
-        .map(|param| {
-            Interned::new(ParamTy {
-                name: param.name.clone(),
-                docs: param
-                    .docs
-                    .clone()
-                    .map(|docs| convert_official_doc(ctx, docs)),
-                default: param.default.clone(),
-                ty: param.ty.clone(),
-                attrs: param.attrs,
-            })
-        })
-        .collect();
-
-    Arc::new(PrimarySignature {
-        docs: primary
-            .docs
-            .clone()
-            .map(|docs| convert_official_doc(ctx, docs)),
-        param_specs,
-        has_fill_or_size_or_stroke: primary.has_fill_or_size_or_stroke,
-        sig_ty: primary.sig_ty.clone(),
-        _broken: primary._broken,
-    })
+    Some(func_signature_with_docs(func, |docs| {
+        convert_official_doc(ctx, docs)
+    }))
 }
 
 fn convert_official_doc(ctx: &Arc<SharedContext>, docs: EcoString) -> EcoString {

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -1,12 +1,15 @@
 //! Analysis of function signatures.
 
+use ecow::EcoString;
 use itertools::Either;
+use tinymist_analysis::docs::tidy::remove_list_annotations;
 use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature};
 use tinymist_derive::BindTyCtx;
+use typst::foundations::FuncInner;
 
 use super::{Definition, SharedContext, prelude::*};
 use crate::analysis::PostTypeChecker;
-use crate::docs::{UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
+use crate::docs::{DocsContent, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
 use crate::syntax::classify_def_loosely;
 use crate::ty::{
     BoundChecker, DocSource, DynTypeBounds, ParamAttrs, ParamTy, SigWithTy, TyCtx, TypeInfo,
@@ -343,5 +346,83 @@ fn analyze_dyn_signature(
         SignatureTarget::Convert(func) | SignatureTarget::Runtime(func) => func.clone(),
     };
 
-    Some(func_signature(func))
+    let sig = func_signature(func.clone());
+    if func_has_official_docs(&func) {
+        Some(convert_official_signature_docs(ctx, sig))
+    } else {
+        Some(sig)
+    }
+}
+
+fn func_has_official_docs(func: &Func) -> bool {
+    let mut func = func;
+    loop {
+        match func.inner() {
+            FuncInner::With(with) => func = &with.as_ref().0,
+            FuncInner::Element(..) | FuncInner::Native(..) | FuncInner::Plugin(..) => return true,
+            FuncInner::Closure(..) => return false,
+        }
+    }
+}
+
+fn convert_official_signature_docs(ctx: &Arc<SharedContext>, sig: Signature) -> Signature {
+    match sig {
+        Signature::Primary(primary) => {
+            Signature::Primary(convert_official_primary_signature_docs(ctx, &primary))
+        }
+        Signature::Partial(partial) => Signature::Partial(Arc::new(PartialSignature {
+            signature: convert_official_primary_signature_docs(ctx, &partial.signature),
+            with_stack: partial.with_stack.clone(),
+        })),
+    }
+}
+
+fn convert_official_primary_signature_docs(
+    ctx: &Arc<SharedContext>,
+    primary: &PrimarySignature,
+) -> Arc<PrimarySignature> {
+    let param_specs = primary
+        .param_specs
+        .iter()
+        .map(|param| {
+            Interned::new(ParamTy {
+                name: param.name.clone(),
+                docs: param
+                    .docs
+                    .clone()
+                    .map(|docs| convert_official_doc(ctx, docs)),
+                default: param.default.clone(),
+                ty: param.ty.clone(),
+                attrs: param.attrs,
+            })
+        })
+        .collect();
+
+    Arc::new(PrimarySignature {
+        docs: primary
+            .docs
+            .clone()
+            .map(|docs| convert_official_doc(ctx, docs)),
+        param_specs,
+        has_fill_or_size_or_stroke: primary.has_fill_or_size_or_stroke,
+        sig_ty: primary.sig_ty.clone(),
+        _broken: primary._broken,
+    })
+}
+
+fn convert_official_doc(ctx: &Arc<SharedContext>, docs: EcoString) -> EcoString {
+    if docs.trim().is_empty() {
+        return docs;
+    }
+
+    match ctx.convert_docs_cached(&docs, None, DocsContent::Official) {
+        Ok(converted) => {
+            let converted = remove_list_annotations(&converted);
+            ctx.remove_html(converted.trim().into())
+        }
+        Err(err) => {
+            log::warn!("failed to convert official Typst docs to Markdown: {err}");
+            ctx.remove_html(docs)
+        }
+    }
 }

--- a/crates/tinymist-query/src/docs/convert.rs
+++ b/crates/tinymist-query/src/docs/convert.rs
@@ -17,18 +17,12 @@ use typst::syntax::FileId;
 use typst_shim::syntax::VirtualPathExt;
 
 use crate::analysis::SharedContext;
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub(crate) enum DocsContent {
-    Plain,
-    Official,
-}
+use crate::docs::{DocText, DocTextKind};
 
 pub(crate) fn convert_docs(
     ctx: &SharedContext,
-    content: &str,
+    content: &DocText,
     source_fid: Option<FileId>,
-    docs_content: DocsContent,
 ) -> StrResult<EcoString> {
     let mut entry = ctx.world().entry_state();
     let import_context = source_fid.map(|fid| {
@@ -67,7 +61,7 @@ pub(crate) fn convert_docs(
         inputs: None,
     });
 
-    let content = prepare_docs_content(content, docs_content);
+    let content = prepare_docs_content(content);
 
     // todo: bad performance: content.to_owned()
     w.map_shadow_by_id(w.main(), Bytes::from_string(content))?;
@@ -88,9 +82,9 @@ pub(crate) fn convert_docs(
     Ok(conv.replace("```example", "```typ"))
 }
 
-fn prepare_docs_content(content: &str, docs_content: DocsContent) -> String {
-    if docs_content != DocsContent::Official {
-        return content.to_owned();
+fn prepare_docs_content(content: &DocText) -> String {
+    if content.kind() != DocTextKind::Official {
+        return content.raw().to_string();
     }
 
     let mut prepared = String::new();
@@ -107,7 +101,7 @@ fn prepare_docs_content(content: &str, docs_content: DocsContent) -> String {
     prepared.push_str("}\n");
     prepared.push_str("#let footnote(body) = [(#body)]\n");
     prepared.push('\n');
-    prepared.push_str(&rewrite_builtin_doc_refs(content));
+    prepared.push_str(&rewrite_builtin_doc_refs(content.raw()));
     prepared
 }
 
@@ -260,10 +254,12 @@ mod tests {
                 let docs = "#docs-table(table.header[A][B], [C], [D])";
                 let shared = ctx.shared();
 
-                let plain_err = convert_docs(shared, docs, None, DocsContent::Plain).unwrap_err();
+                let plain = DocText::plain(docs.into());
+                let plain_err = convert_docs(shared, &plain, None).unwrap_err();
                 assert!(plain_err.contains("unknown variable: docs-table"));
 
-                let official = convert_docs(shared, docs, None, DocsContent::Official).unwrap();
+                let official_docs = DocText::official(docs.into());
+                let official = convert_docs(shared, &official_docs, None).unwrap();
                 assert!(official.contains("| A | B |"));
                 assert!(official.contains("| C | D |"));
             });

--- a/crates/tinymist-query/src/docs/convert.rs
+++ b/crates/tinymist-query/src/docs/convert.rs
@@ -260,14 +260,10 @@ mod tests {
                 let docs = "#docs-table(table.header[A][B], [C], [D])";
                 let shared = ctx.shared();
 
-                let plain_err = shared
-                    .convert_docs_cached(docs, None, DocsContent::Plain)
-                    .unwrap_err();
+                let plain_err = convert_docs(shared, docs, None, DocsContent::Plain).unwrap_err();
                 assert!(plain_err.contains("unknown variable: docs-table"));
 
-                let official = shared
-                    .convert_docs_cached(docs, None, DocsContent::Official)
-                    .unwrap();
+                let official = convert_docs(shared, docs, None, DocsContent::Official).unwrap();
                 assert!(official.contains("| A | B |"));
                 assert!(official.contains("| C | D |"));
             });

--- a/crates/tinymist-query/src/docs/convert.rs
+++ b/crates/tinymist-query/src/docs/convert.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ecow::{EcoString, eco_format};
+use tinymist_analysis::upstream::resolve;
 use tinymist_std::path::unix_slash;
 use tinymist_world::diag::print_diagnostics_to_string;
 use tinymist_world::vfs::WorkspaceResolver;
@@ -17,10 +18,17 @@ use typst_shim::syntax::VirtualPathExt;
 
 use crate::analysis::SharedContext;
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(crate) enum DocsContent {
+    Plain,
+    Official,
+}
+
 pub(crate) fn convert_docs(
     ctx: &SharedContext,
     content: &str,
     source_fid: Option<FileId>,
+    docs_content: DocsContent,
 ) -> StrResult<EcoString> {
     let mut entry = ctx.world().entry_state();
     let import_context = source_fid.map(|fid| {
@@ -59,8 +67,10 @@ pub(crate) fn convert_docs(
         inputs: None,
     });
 
+    let content = prepare_docs_content(content, docs_content);
+
     // todo: bad performance: content.to_owned()
-    w.map_shadow_by_id(w.main(), Bytes::from_string(content.to_owned()))?;
+    w.map_shadow_by_id(w.main(), Bytes::from_string(content))?;
     // todo: bad performance
     w.take_db();
     let (w, wrap_info) = feat
@@ -76,6 +86,145 @@ pub(crate) fn convert_docs(
     let conv = print_diag_or_error(w.as_ref(), res)?;
 
     Ok(conv.replace("```example", "```typ"))
+}
+
+fn prepare_docs_content(content: &str, docs_content: DocsContent) -> String {
+    if docs_content != DocsContent::Official {
+        return content.to_owned();
+    }
+
+    let mut prepared = String::new();
+    prepared.push_str("#let short-or-long(short, long) = long\n");
+    prepared.push_str("#let docs-table(..args) = {\n");
+    prepared.push_str("  let cells = args.pos()\n");
+    prepared.push_str("  if cells.len() == 0 { return none }\n");
+    prepared.push_str("  table(columns: cells.first().children.len(), ..cells)\n");
+    prepared.push_str("}\n");
+    prepared.push_str("#let __tinymist-docs-example = example\n");
+    prepared.push_str("#let example(..args) = {\n");
+    prepared.push_str("  let positional = args.pos()\n");
+    prepared.push_str("  if positional.len() > 0 { __tinymist-docs-example(positional.at(0)) }\n");
+    prepared.push_str("}\n");
+    prepared.push_str("#let footnote(body) = [(#body)]\n");
+    prepared.push('\n');
+    prepared.push_str(&rewrite_builtin_doc_refs(content));
+    prepared
+}
+
+fn rewrite_builtin_doc_refs(content: &str) -> String {
+    let mut rewritten = String::with_capacity(content.len());
+    let mut cursor = 0;
+
+    while cursor < content.len() {
+        if content[cursor..].starts_with("```") {
+            let end = content[cursor + 3..]
+                .find("```")
+                .map(|offset| cursor + 3 + offset + 3)
+                .unwrap_or(content.len());
+            rewritten.push_str(&content[cursor..end]);
+            cursor = end;
+            continue;
+        }
+
+        let Some(offset) = content[cursor..].find('@') else {
+            rewritten.push_str(&content[cursor..]);
+            break;
+        };
+
+        let at = cursor + offset;
+        rewritten.push_str(&content[cursor..at]);
+
+        let start = at + 1;
+        let Some(first) = content[start..].chars().next() else {
+            rewritten.push('@');
+            break;
+        };
+
+        if !is_ref_label_start(first) {
+            rewritten.push('@');
+            cursor = start;
+            continue;
+        }
+
+        let mut end = start + first.len_utf8();
+        for ch in content[end..].chars() {
+            if !is_ref_label_continue(ch) {
+                break;
+            }
+
+            end += ch.len_utf8();
+        }
+
+        let mut label_end = end;
+        while label_end > start && content[..label_end].ends_with('.') {
+            label_end -= 1;
+        }
+
+        let label = &content[start..label_end];
+        if label.is_empty() {
+            rewritten.push('@');
+            cursor = start;
+            continue;
+        }
+
+        let url = resolve(label, "https://typst.app/docs/").ok();
+        if let Some((body, body_end)) = bracket_body(content, end) {
+            push_link_or_text(&mut rewritten, url.as_deref(), body);
+            cursor = body_end;
+        } else {
+            push_link_or_text(&mut rewritten, url.as_deref(), label);
+            rewritten.push_str(&content[label_end..end]);
+            cursor = end;
+        }
+    }
+
+    rewritten
+}
+
+fn push_link_or_text(output: &mut String, url: Option<&str>, body: &str) {
+    if let Some(url) = url {
+        output.push_str("#link(");
+        output.push_str(&format!("{url:?}"));
+        output.push_str(")[");
+        output.push_str(body);
+        output.push(']');
+    } else {
+        output.push_str(body);
+    }
+}
+
+fn bracket_body(content: &str, cursor: usize) -> Option<(&str, usize)> {
+    if !content[cursor..].starts_with('[') {
+        return None;
+    }
+
+    let body_start = cursor + 1;
+    let mut depth = 1usize;
+    let mut pos = body_start;
+    for ch in content[body_start..].chars() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((&content[body_start..pos], pos + 1));
+                }
+            }
+            _ => {}
+        }
+
+        pos += ch.len_utf8();
+    }
+
+    None
+}
+
+fn is_ref_label_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || matches!(ch, '_' | '-')
+}
+
+fn is_ref_label_continue(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':' | '/')
 }
 
 fn print_diag_or_error<T>(
@@ -95,5 +244,33 @@ fn print_diag_or_error<T>(
 
             Err(eco_format!("failed to convert docs: {err}"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    use super::*;
+
+    #[test]
+    fn official_helpers_are_scoped() {
+        run_with_sources("", |verse, path| {
+            run_with_ctx(verse, path, &|ctx, _| {
+                let docs = "#docs-table(table.header[A][B], [C], [D])";
+                let shared = ctx.shared();
+
+                let plain_err = shared
+                    .convert_docs_cached(docs, None, DocsContent::Plain)
+                    .unwrap_err();
+                assert!(plain_err.contains("unknown variable: docs-table"));
+
+                let official = shared
+                    .convert_docs_cached(docs, None, DocsContent::Official)
+                    .unwrap();
+                assert!(official.contains("| A | B |"));
+                assert!(official.contains("| C | D |"));
+            });
+        });
     }
 }

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -11,7 +11,6 @@ use typst::syntax::Span;
 
 use crate::LocalContext;
 use crate::analysis::SharedContext;
-use crate::docs::DocsContent;
 
 pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     let source = ctx.source_by_id(pos.id()?).ok()?;
@@ -117,7 +116,8 @@ fn convert_official_doc(ctx: &SharedContext, docs: EcoString) -> EcoString {
         return docs;
     }
 
-    match crate::docs::convert_docs(ctx, &docs, None, DocsContent::Official) {
+    let docs_text = DocText::official(docs.clone());
+    match crate::docs::convert_docs(ctx, &docs_text, None) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())
@@ -135,7 +135,8 @@ pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> Eco
     }
 
     let shared = ctx.shared_();
-    match crate::docs::convert_docs(&shared, &docs, None, DocsContent::Plain) {
+    let docs_text = DocText::plain(docs.clone());
+    match crate::docs::convert_docs(&shared, &docs_text, None) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -135,7 +135,7 @@ pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> Eco
     }
 
     let shared = ctx.shared_();
-    match shared.convert_docs_cached(&docs, None) {
+    match crate::docs::convert_docs(&shared, &docs, None, DocsContent::Plain) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -3,7 +3,9 @@ use std::sync::OnceLock;
 use ecow::EcoString;
 use tinymist_analysis::Signature;
 use tinymist_analysis::docs::tidy::remove_list_annotations;
-use tinymist_analysis::docs::{DocText, ParamDocs, SignatureDocs, VarDocs, format_ty};
+use tinymist_analysis::docs::{
+    DocText, DocTextResolver, ParamDocs, SignatureDocs, VarDocs, format_ty,
+};
 use tinymist_analysis::ty::DocSource;
 use typst::syntax::Span;
 
@@ -72,36 +74,12 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
     let ret_in = type_sig.body.as_ref();
 
     let pos = pos_in
-        .map(|(param, ty)| {
-            let docs = param
-                .docs
-                .as_ref()
-                .map(|docs| resolve_doc_text(ctx, docs))
-                .unwrap_or_default();
-            ParamDocs::new_with_docs(param, ty, docs)
-        })
+        .map(|(param, ty)| ParamDocs::new(ctx, param, ty))
         .collect::<Vec<_>>();
     let named = named_in
-        .map(|(param, ty)| {
-            let docs = param
-                .docs
-                .as_ref()
-                .map(|docs| resolve_doc_text(ctx, docs))
-                .unwrap_or_default();
-            (
-                param.name.clone(),
-                ParamDocs::new_with_docs(param, ty, docs),
-            )
-        })
+        .map(|(param, ty)| (param.name.clone(), ParamDocs::new(ctx, param, ty)))
         .collect::<std::collections::BTreeMap<_, _>>();
-    let rest = rest_in.map(|(param, ty)| {
-        let docs = param
-            .docs
-            .as_ref()
-            .map(|docs| resolve_doc_text(ctx, docs))
-            .unwrap_or_default();
-        ParamDocs::new_with_docs(param, ty, docs)
-    });
+    let rest = rest_in.map(|(param, ty)| ParamDocs::new(ctx, param, ty));
 
     let ret_ty = format_ty(ret_in);
 
@@ -126,6 +104,12 @@ pub(crate) fn resolve_doc_text(ctx: &mut LocalContext, docs: &DocText) -> EcoStr
     let shared = ctx.shared();
     docs.get_or_init(|raw| convert_official_doc(shared, raw.clone()))
         .clone()
+}
+
+impl DocTextResolver for LocalContext {
+    fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString {
+        resolve_doc_text(self, docs)
+    }
 }
 
 fn convert_official_doc(ctx: &SharedContext, docs: EcoString) -> EcoString {

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -1,13 +1,15 @@
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use ecow::EcoString;
 use tinymist_analysis::Signature;
 use tinymist_analysis::docs::tidy::remove_list_annotations;
-use tinymist_analysis::docs::{ParamDocs, SignatureDocs, VarDocs, format_ty};
+use tinymist_analysis::docs::{DocText, ParamDocs, SignatureDocs, VarDocs, format_ty};
 use tinymist_analysis::ty::DocSource;
 use typst::syntax::Span;
 
 use crate::LocalContext;
+use crate::analysis::SharedContext;
 use crate::docs::DocsContent;
 
 pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
@@ -52,7 +54,7 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     }
 }
 
-pub(crate) fn sig_docs(sig: &Signature) -> Option<SignatureDocs> {
+pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<SignatureDocs> {
     let type_sig = sig.type_sig().clone();
 
     let pos_in = sig
@@ -71,16 +73,45 @@ pub(crate) fn sig_docs(sig: &Signature) -> Option<SignatureDocs> {
     let ret_in = type_sig.body.as_ref();
 
     let pos = pos_in
-        .map(|(param, ty)| ParamDocs::new(param, ty))
+        .map(|(param, ty)| {
+            let docs = param
+                .docs
+                .as_ref()
+                .map(|docs| resolve_doc_text(ctx, docs))
+                .unwrap_or_default();
+            ParamDocs::new_with_docs(param, ty, docs)
+        })
         .collect::<Vec<_>>();
     let named = named_in
-        .map(|(param, ty)| (param.name.clone(), ParamDocs::new(param, ty)))
+        .map(|(param, ty)| {
+            let docs = param
+                .docs
+                .as_ref()
+                .map(|docs| resolve_doc_text(ctx, docs))
+                .unwrap_or_default();
+            (
+                param.name.clone(),
+                ParamDocs::new_with_docs(param, ty, docs),
+            )
+        })
         .collect::<std::collections::BTreeMap<_, _>>();
-    let rest = rest_in.map(|(param, ty)| ParamDocs::new(param, ty));
+    let rest = rest_in.map(|(param, ty)| {
+        let docs = param
+            .docs
+            .as_ref()
+            .map(|docs| resolve_doc_text(ctx, docs))
+            .unwrap_or_default();
+        ParamDocs::new_with_docs(param, ty, docs)
+    });
 
     let ret_ty = format_ty(ret_in);
 
-    let docs = sig.primary().docs.clone().unwrap_or_default();
+    let docs = sig
+        .primary()
+        .docs
+        .as_ref()
+        .map(|docs| resolve_doc_text(ctx, docs))
+        .unwrap_or_default();
 
     Some(SignatureDocs {
         docs,
@@ -90,6 +121,29 @@ pub(crate) fn sig_docs(sig: &Signature) -> Option<SignatureDocs> {
         ret_ty,
         hover_docs: OnceLock::new(),
     })
+}
+
+pub(crate) fn resolve_doc_text(ctx: &mut LocalContext, docs: &DocText) -> EcoString {
+    let shared = ctx.shared_();
+    docs.get_or_init(|raw| convert_official_doc(&shared, raw.clone()))
+        .clone()
+}
+
+fn convert_official_doc(ctx: &Arc<SharedContext>, docs: EcoString) -> EcoString {
+    if docs.trim().is_empty() {
+        return docs;
+    }
+
+    match ctx.convert_docs_cached(&docs, None, DocsContent::Official) {
+        Ok(converted) => {
+            let converted = remove_list_annotations(&converted);
+            ctx.remove_html(converted.trim().into())
+        }
+        Err(err) => {
+            log::warn!("failed to convert official Typst docs to Markdown: {err}");
+            ctx.remove_html(docs)
+        }
+    }
 }
 
 pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> EcoString {

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -151,7 +151,7 @@ pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> Eco
     }
 
     let shared = ctx.shared_();
-    match shared.convert_docs_cached(&docs, None, DocsContent::Plain) {
+    match shared.convert_docs_cached(&docs, None) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -1,11 +1,14 @@
 use std::sync::OnceLock;
 
+use ecow::EcoString;
 use tinymist_analysis::Signature;
+use tinymist_analysis::docs::tidy::remove_list_annotations;
 use tinymist_analysis::docs::{ParamDocs, SignatureDocs, VarDocs, format_ty};
 use tinymist_analysis::ty::DocSource;
 use typst::syntax::Span;
 
 use crate::LocalContext;
+use crate::docs::DocsContent;
 
 pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     let source = ctx.source_by_id(pos.id()?).ok()?;
@@ -38,7 +41,7 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
             })
         }
         DocSource::Ins(ins) => ins.syntax.as_ref().map(|src| {
-            let docs = src.doc.as_ref().into();
+            let docs = convert_typst_docs(ctx, src.doc.as_ref().into());
             VarDocs {
                 docs,
                 return_ty,
@@ -69,20 +72,40 @@ pub(crate) fn sig_docs(sig: &Signature) -> Option<SignatureDocs> {
 
     let pos = pos_in
         .map(|(param, ty)| ParamDocs::new(param, ty))
-        .collect();
+        .collect::<Vec<_>>();
     let named = named_in
         .map(|(param, ty)| (param.name.clone(), ParamDocs::new(param, ty)))
-        .collect();
+        .collect::<std::collections::BTreeMap<_, _>>();
     let rest = rest_in.map(|(param, ty)| ParamDocs::new(param, ty));
 
     let ret_ty = format_ty(ret_in);
 
+    let docs = sig.primary().docs.clone().unwrap_or_default();
+
     Some(SignatureDocs {
-        docs: sig.primary().docs.clone().unwrap_or_default(),
+        docs,
         pos,
         named,
         rest,
         ret_ty,
         hover_docs: OnceLock::new(),
     })
+}
+
+pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> EcoString {
+    if docs.trim().is_empty() {
+        return docs;
+    }
+
+    let shared = ctx.shared_();
+    match shared.convert_docs_cached(&docs, None, DocsContent::Plain) {
+        Ok(converted) => {
+            let converted = remove_list_annotations(&converted);
+            ctx.remove_html(converted.trim().into())
+        }
+        Err(err) => {
+            log::warn!("failed to convert Typst docs to Markdown: {err}");
+            ctx.remove_html(docs)
+        }
+    }
 }

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::sync::OnceLock;
 
 use ecow::EcoString;
@@ -124,17 +123,17 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
 }
 
 pub(crate) fn resolve_doc_text(ctx: &mut LocalContext, docs: &DocText) -> EcoString {
-    let shared = ctx.shared_();
-    docs.get_or_init(|raw| convert_official_doc(&shared, raw.clone()))
+    let shared = ctx.shared();
+    docs.get_or_init(|raw| convert_official_doc(shared, raw.clone()))
         .clone()
 }
 
-fn convert_official_doc(ctx: &Arc<SharedContext>, docs: EcoString) -> EcoString {
+fn convert_official_doc(ctx: &SharedContext, docs: EcoString) -> EcoString {
     if docs.trim().is_empty() {
         return docs;
     }
 
-    match ctx.convert_docs_cached(&docs, None, DocsContent::Official) {
+    match crate::docs::convert_docs(ctx, &docs, None, DocsContent::Official) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())

--- a/crates/tinymist-query/src/docs/mod.rs
+++ b/crates/tinymist-query/src/docs/mod.rs
@@ -9,7 +9,7 @@ use tinymist_std::path::unix_slash;
 use typst::syntax::FileId;
 use typst_shim::syntax::VirtualPathExt;
 
-pub(crate) use convert::convert_docs;
+pub(crate) use convert::{DocsContent, convert_docs};
 pub(crate) use def::*;
 pub use module::*;
 pub use package::*;

--- a/crates/tinymist-query/src/docs/mod.rs
+++ b/crates/tinymist-query/src/docs/mod.rs
@@ -9,7 +9,7 @@ use tinymist_std::path::unix_slash;
 use typst::syntax::FileId;
 use typst_shim::syntax::VirtualPathExt;
 
-pub(crate) use convert::{DocsContent, convert_docs};
+pub(crate) use convert::convert_docs;
 pub(crate) use def::*;
 pub use module::*;
 pub use package::*;

--- a/crates/tinymist-query/src/fixtures/hover/docs_table.typ
+++ b/crates/tinymist-query/src/fixtures/hover/docs_table.typ
@@ -1,0 +1,2 @@
+
+#(/* ident after */ json);

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@builtin.typ.snap
@@ -26,40 +26,20 @@ let table(
 
 A table of items.
 
-Tables are used to arrange content in cells. Cells can contain arbitrary
-content, including multiple paragraphs and are specified in row-major order.
-For a hands-on explanation of all the ways you can use and customize tables
-in Typst, check out the @guides:tables[Table Guide].
+Tables are used to arrange content in cells. Cells can contain arbitrary content, including multiple paragraphs and are specified in row-major order. For a hands-on explanation of all the ways you can use and customize tables in Typst, check out the Table Guide.
 
-Because tables are just grids with different defaults for some cell
-properties (notably `stroke` and `inset`), refer to the
-@grid:track-size[grid documentation] for more information on how to size the
-table tracks and specify the cell appearance properties.
+Because tables are just grids with different defaults for some cell properties (notably `stroke` and `inset`), refer to the grid documentation for more information on how to size the table tracks and specify the cell appearance properties.
 
-If you are unsure whether you should be using a table or a grid, consider
-whether the content you are arranging semantically belongs together as a set
-of related data points or similar or whether you are just want to enhance
-your presentation by arranging unrelated content in a grid. In the former
-case, a table is the right choice, while in the latter case, a grid is more
-appropriate. Furthermore, Assistive Technology (AT) like screen readers will
-announce content in a `table` as tabular while a grid's content will be
-announced no different than multiple content blocks in the document flow. AT
-users will be able to navigate tables two-dimensionally by cell.
+If you are unsure whether you should be using a table or a grid, consider whether the content you are arranging semantically belongs together as a set of related data points or similar or whether you are just want to enhance your presentation by arranging unrelated content in a grid. In the former case, a table is the right choice, while in the latter case, a grid is more appropriate. Furthermore, Assistive Technology (AT) like screen readers will announce content in a `table` as tabular while a grid’s content will be announced no different than multiple content blocks in the document flow. AT users will be able to navigate tables two-dimensionally by cell.
 
-Note that, to override a particular cell's properties or apply show rules on
-table cells, you can use the @table.cell element. See its documentation for
-more information.
+Note that, to override a particular cell’s properties or apply show rules on table cells, you can use the [table.cell](https://typst.app/docs/reference/model/table/#definitions-cell) element. See its documentation for more information.
 
-Although the `table` and the `grid` share most properties, set and show
-rules on one of them do not affect the other. Locating most of your styling
-in set and show rules is recommended, as it keeps the table's actual usages
-clean and easy to read. It also allows you to easily change the appearance
-of all tables in one place.
+Although the `table` and the `grid` share most properties, set and show rules on one of them do not affect the other. Locating most of your styling in set and show rules is recommended, as it keeps the table’s actual usages clean and easy to read. It also allows you to easily change the appearance of all tables in one place.
 
-To give a table a caption and make it @ref[referenceable], put it into a
-@figure[figure].
+To give a table a caption and make it [referenceable](https://typst.app/docs/reference/model/ref/), put it into a [figure](https://typst.app/docs/reference/model/figure/).
 
-= Example <example>
+## Example
+
 The example below demonstrates some of the most common table options.
 
 ```typ
@@ -83,8 +63,7 @@ The example below demonstrates some of the most common table options.
 )
 ```
 
-Much like with grids, you can use @table.cell to customize the appearance
-and the position of each cell.
+Much like with grids, you can use [table.cell](https://typst.app/docs/reference/model/table/#definitions-cell) to customize the appearance and the position of each cell.
 
 ```typ
 >>> #set page(width: auto)
@@ -128,16 +107,11 @@ and the position of each cell.
 )
 ```
 
-= Accessibility <accessibility>
-Tables are challenging to consume for users of Assistive Technology (AT). To
-make the life of AT users easier, we strongly recommend that you use
-@table.header and @table.footer to mark the header and footer sections of
-your table. This will allow AT to announce the column labels for each cell.
+## Accessibility
 
-Because navigating a table by cell is more cumbersome than reading it
-visually, you should consider making the core information in your table
-available as text as well. You can do this by wrapping your table in a
-@figure[figure] and using its caption to summarize the table's content.
+Tables are challenging to consume for users of Assistive Technology (AT). To make the life of AT users easier, we strongly recommend that you use [table.header](https://typst.app/docs/reference/model/table/#definitions-header) and [table.footer](https://typst.app/docs/reference/model/table/#definitions-footer) to mark the header and footer sections of your table. This will allow AT to announce the column labels for each cell.
+
+Because navigating a table by cell is more cumbersome than reading it visually, you should consider making the core information in your table available as text as well. You can do this by wrapping your table in a [figure](https://typst.app/docs/reference/model/figure/) and using its caption to summarize the table’s content.
 
 # Rest Parameters
 
@@ -147,8 +121,7 @@ available as text as well. You can do this by wrapping your table in a
 type: content
 ```
 
-The contents of the table cells, plus any extra table lines specified
-with the @table.hline and @table.vline elements.
+The contents of the table cells, plus any extra table lines specified with the [table.hline](https://typst.app/docs/reference/model/table/#definitions-hline) and [table.vline](https://typst.app/docs/reference/model/table/#definitions-vline) elements.
 
 # Named Parameters
 
@@ -158,17 +131,17 @@ with the @table.hline and @table.vline elements.
 type: alignment | array | auto | function
 ```
 
-How to align the cells' content.
+How to align the cells’ content.
 
 If set to `auto`, the outer alignment is used.
 
 You can specify the alignment in any of the following fashions:
+
 - use a single alignment for all cells
 - use an array of alignments corresponding to each column
-- use a function that maps a cell's X/Y position (both starting from
-  zero) to its alignment
+- use a function that maps a cell’s X/Y position (both starting from zero) to its alignment
 
-See the @guides:tables:alignment[Table Guide] for details.
+See the Table Guide for details.
 
 ```typ
 #table(
@@ -185,8 +158,7 @@ See the @guides:tables:alignment[Table Guide] for details.
 type: array | auto | length | type
 ```
 
-The gaps between columns. Takes precedence over `gutter`. See the
-@grid.gutter[grid documentation] for more information on gutters.
+The gaps between columns. Takes precedence over `gutter`. See the [grid documentation](https://typst.app/docs/reference/layout/grid/#parameters-gutter) for more information on gutters.
 
 ## columns (named)
 
@@ -194,8 +166,7 @@ The gaps between columns. Takes precedence over `gutter`. See the
 type: array | auto | length | type
 ```
 
-The column sizes. See the @grid:track-size[grid documentation] for more
-information on track sizing.
+The column sizes. See the grid documentation for more information on track sizing.
 
 ## fill (named)
 
@@ -206,12 +177,12 @@ type: color
 How to fill the cells.
 
 This can be:
+
 - a single fill for all cells
 - an array of fill corresponding to each column
-- a function that maps a cell's position to its fill
+- a function that maps a cell’s position to its fill
 
-Most notably, arrays and functions are useful for creating striped
-tables. See the @guides:tables:fills[Table Guide] for more details.
+Most notably, arrays and functions are useful for creating striped tables. See the Table Guide for more details.
 
 ```typ
 #table(
@@ -236,9 +207,7 @@ tables. See the @guides:tables:fills[Table Guide] for more details.
 type: array | auto | length | type
 ```
 
-The gaps between rows and columns. This is a shorthand for setting
-`column-gutter` and `row-gutter` to the same value. See the
-@grid.gutter[grid documentation] for more information on gutters.
+The gaps between rows and columns. This is a shorthand for setting `column-gutter` and `row-gutter` to the same value. See the [grid documentation](https://typst.app/docs/reference/layout/grid/#parameters-gutter) for more information on gutters.
 
 ## inset (named)
 
@@ -246,19 +215,17 @@ The gaps between rows and columns. This is a shorthand for setting
 type: inset
 ```
 
-How much to pad the cells' content.
+How much to pad the cells’ content.
 
-To specify the same inset for all cells, use a single length for all
-sides, or a dictionary of lengths for individual sides. See the
-@box.inset[box's documentation] for more details.
+To specify the same inset for all cells, use a single length for all sides, or a dictionary of lengths for individual sides. See the [box’s documentation](https://typst.app/docs/reference/layout/box/#parameters-inset) for more details.
 
 To specify a varying inset for different cells, you can:
+
 - use a single, uniform inset for all cells
 - use an array of insets for each column
-- use a function that maps a cell's X/Y position (both starting from
-  zero) to its inset
+- use a function that maps a cell’s X/Y position (both starting from zero) to its inset
 
-See the @grid:styling[grid documentation] for more details.
+See the grid documentation for more details.
 
 ```typ
 #table(
@@ -282,8 +249,7 @@ See the @grid:styling[grid documentation] for more details.
 type: array | auto | length | type
 ```
 
-The gaps between rows. Takes precedence over `gutter`. See the
-@grid.gutter[grid documentation] for more information on gutters.
+The gaps between rows. Takes precedence over `gutter`. See the [grid documentation](https://typst.app/docs/reference/layout/grid/#parameters-gutter) for more information on gutters.
 
 ## rows (named)
 
@@ -291,8 +257,7 @@ The gaps between rows. Takes precedence over `gutter`. See the
 type: array | auto | length | type
 ```
 
-The row sizes. See the @grid:track-size[grid documentation] for more
-information on track sizing.
+The row sizes. See the grid documentation for more information on track sizing.
 
 ## stroke (named)
 
@@ -300,25 +265,21 @@ information on track sizing.
 type: stroke
 ```
 
-How to @stroke[stroke] the cells.
+How to [stroke](https://typst.app/docs/reference/visualize/stroke/) the cells.
 
 Strokes can be disabled by setting this to `none`.
 
-If it is necessary to place lines which can cross spacing between cells
-produced by the @table.gutter[`gutter`] option, or to override the
-stroke between multiple specific cells, consider specifying one or more
-of @table.hline and @table.vline alongside your table cells.
+If it is necessary to place lines which can cross spacing between cells produced by the [`gutter`](https://typst.app/docs/reference/model/table/#parameters-gutter) option, or to override the stroke between multiple specific cells, consider specifying one or more of [table.hline](https://typst.app/docs/reference/model/table/#definitions-hline) and [table.vline](https://typst.app/docs/reference/model/table/#definitions-vline) alongside your table cells.
 
-To specify the same stroke for all cells, use a single @stroke[stroke]
-for all sides, or a dictionary of @stroke[strokes] for individual sides.
-See the @rect.stroke[rectangle's documentation] for more details.
+To specify the same stroke for all cells, use a single [stroke](https://typst.app/docs/reference/visualize/stroke/) for all sides, or a dictionary of [strokes](https://typst.app/docs/reference/visualize/stroke/) for individual sides. See the [rectangle’s documentation](https://typst.app/docs/reference/visualize/rect/#parameters-stroke) for more details.
 
 To specify varying strokes for different cells, you can:
+
 - use a single stroke for all cells
 - use an array of strokes corresponding to each column
-- use a function that maps a cell's position to its stroke
+- use a function that maps a cell’s position to its stroke
 
-See the @guides:tables:strokes[Table Guide] for more details.
+See the Table Guide for more details.
 
 
 ======

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@cases_doc.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@cases_doc.typ.snap
@@ -22,7 +22,8 @@ A case distinction.
 
 Content across different branches can be aligned with the `&` symbol.
 
-= Example <example>
+## Example
+
 ```typ
 $ f(x, y) := cases(
   1 "if" (x dot y)/2 <= 0,
@@ -52,9 +53,7 @@ type: array | none | str | symbol
 
 The delimiter to use.
 
-Can be a single character specifying the left delimiter, in which case
-the right delimiter is inferred. Otherwise, can be an array containing a
-left and a right delimiter.
+Can be a single character specifying the left delimiter, in which case the right delimiter is inferred. Otherwise, can be an array containing a left and a right delimiter.
 
 ```typ
 #set math.cases(delim: "[")

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@docs_table.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@docs_table.typ.snap
@@ -1,0 +1,93 @@
+---
+source: crates/tinymist-query/src/hover.rs
+expression: content
+input_file: crates/tinymist-query/src/fixtures/hover/docs_table.typ
+---
+Range: 0:20:0:24
+
+```typc
+let json(
+  source: [json],
+) = any;
+```
+
+
+======
+
+
+Reads structured data from a JSON file.
+
+The file must contain a valid JSON value, such as object or array. The JSON values will be converted into corresponding Typst values as listed in the table below.
+
+The function returns a dictionary, an array or, depending on the JSON file, another JSON data type.
+
+The JSON files in the example contain objects with the keys `temperature`, `unit`, and `weather`.
+
+## Example
+
+```typ
+#let forecast(day) = block[
+  #box(square(
+    width: 2cm,
+    inset: 8pt,
+    fill: if day.weather == "sunny" {
+      yellow
+    } else {
+      aqua
+    },
+    align(
+      bottom + right,
+      strong(day.weather),
+    ),
+  ))
+  #h(6pt)
+  #set text(22pt, baseline: -8pt)
+  #day.temperature °#day.unit
+]
+
+#forecast(json("monday.json"))
+#forecast(json("tuesday.json"))
+```
+
+## Conversion details
+
+| JSON value | Converted into Typst |
+| --- | --- |
+| `null` | `none` |
+| bool | [bool](https://typst.app/docs/reference/foundations/bool/) |
+| number | [float](https://typst.app/docs/reference/foundations/float/) or [int](https://typst.app/docs/reference/foundations/int/) |
+| string | [str](https://typst.app/docs/reference/foundations/str/) |
+| array | [array](https://typst.app/docs/reference/foundations/array/) |
+| object | [dictionary](https://typst.app/docs/reference/foundations/dictionary/) |
+
+| Typst value | Converted into JSON |
+| --- | --- |
+| types that can be converted from JSON | corresponding JSON value |
+| [bytes](https://typst.app/docs/reference/foundations/bytes/) | string via [repr](https://typst.app/docs/reference/foundations/repr/) |
+| [symbol](https://typst.app/docs/reference/foundations/symbol/) | string |
+| [content](https://typst.app/docs/reference/foundations/content/) | an object describing the content |
+| other types ([length](https://typst.app/docs/reference/layout/length/), etc.) | string via [repr](https://typst.app/docs/reference/foundations/repr/) |
+
+### Notes
+
+- In most cases, JSON numbers will be converted to floats or integers depending on whether they are whole numbers. However, be aware that integers larger than 2<sup>63</sup>−1 or smaller than −2<sup>63</sup> will be converted to floating-point numbers, which may result in an approximative value.
+
+- Bytes are not encoded as JSON arrays for performance and readability reasons. Consider using [cbor.encode](https://typst.app/docs/reference/data-loading/cbor/#definitions-encode) for binary data.
+
+- The `repr` function is for debugging purposes only, and its output is not guaranteed to be stable across Typst versions.
+
+# Positional Parameters
+
+## source
+
+```typc
+type: [json]
+```
+
+A path to a JSON file or raw JSON bytes.
+
+
+======
+
+
+[Open docs](https://typst.app/docs/reference/data-loading/json/)

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@pagebreak.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@pagebreak.typ.snap
@@ -20,7 +20,8 @@ A manual page break.
 
 Must not be used inside any containers.
 
-= Example <example>
+## Example
+
 ```typ
 The next page contains
 more details on compound theory.
@@ -30,14 +31,9 @@ more details on compound theory.
 In 1984, the first ...
 ```
 
-Even without manual page breaks, content will be automatically paginated
-based on the configured page size. You can set @page.height[the page height]
-to `auto` to let the page grow dynamically until a manual page break
-occurs.
+Even without manual page breaks, content will be automatically paginated based on the configured page size. You can set [the page height](https://typst.app/docs/reference/layout/page/#parameters-height) to `auto` to let the page grow dynamically until a manual page break occurs.
 
-Pagination tries to avoid single lines of text at the top or bottom of a
-page (these are called _widows_ and _orphans_). You can adjust the
-@text.costs parameter to disable this behavior.
+Pagination tries to avoid single lines of text at the top or bottom of a page (these are called _widows_ and _orphans_). You can adjust the [text.costs](https://typst.app/docs/reference/text/text/#parameters-costs) parameter to disable this behavior.
 
 # Named Parameters
 
@@ -47,8 +43,7 @@ page (these are called _widows_ and _orphans_). You can adjust the
 type: "even" | "odd" | none
 ```
 
-If given, ensures that the next page will be an even/odd page, with an
-empty page in between if necessary.
+If given, ensures that the next page will be an even/odd page, with an empty page in between if necessary.
 
 ```typ
 #set page(height: 30pt)
@@ -64,8 +59,7 @@ Third.
 type: bool
 ```
 
-If `true`, the page break is skipped if the current page is already
-empty.
+If `true`, the page break is skipped if the current page is already empty.
 
 
 ======

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@render_equation_no_html.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@render_equation_no_html.typ.snap
@@ -18,7 +18,9 @@ let lam(
 
 Lambda constructor.
 
-Typing Rule:Γ,x:A⊢M:BΓ⊢a:BΓ⊢λ(x:A)→M:π(x:A)→B
+Typing Rule:
+
+Γ,x:A⊢M:BΓ⊢a:BΓ⊢λ(x:A)→M:π(x:A)→B
 
 # Positional Parameters
 

--- a/crates/tinymist-query/src/fixtures/signature_help/snaps/test@builtin.typ.snap
+++ b/crates/tinymist-query/src/fixtures/signature_help/snaps/test@builtin.typ.snap
@@ -11,7 +11,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/builtin.typ
    "activeParameter": 0,
    "documentation": {
     "kind": "markdown",
-    "value": "A horizontal line under content.\n\n```example\n$ underline(1 + 2 + ... + 5) $\n```"
+    "value": "A horizontal line under content.\n\n```typ\n$ underline(1 + 2 + ... + 5) $\n```"
    },
    "label": "underline(body: content) -> underline",
    "parameters": [

--- a/crates/tinymist-query/src/fixtures/signature_help/snaps/test@builtin2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/signature_help/snaps/test@builtin2.typ.snap
@@ -11,7 +11,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/builtin2.typ
    "activeParameter": 0,
    "documentation": {
     "kind": "markdown",
-    "value": "A horizontal line under content.\n\n```example\n$ underline(1 + 2 + ... + 5) $\n```"
+    "value": "A horizontal line under content.\n\n```typ\n$ underline(1 + 2 + ... + 5) $\n```"
    },
    "label": "underline(body: content) -> underline",
    "parameters": [

--- a/crates/tinymist-query/src/fixtures/signature_help/snaps/test@list_item.typ.snap
+++ b/crates/tinymist-query/src/fixtures/signature_help/snaps/test@list_item.typ.snap
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/list_item.typ
     {
      "documentation": {
       "kind": "markdown",
-      "value": "The item's body."
+      "value": "The item’s body."
      },
      "label": "body:"
     }

--- a/crates/tinymist-query/src/fixtures/signature_help/snaps/test@pos_callee2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/signature_help/snaps/test@pos_callee2.typ.snap
@@ -11,7 +11,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/pos_callee2.typ
    "activeParameter": 0,
    "documentation": {
     "kind": "markdown",
-    "value": "Strongly emphasizes content by increasing the font weight.\n\nIncreases the current font weight by a given `delta`.\n\n= Example <example>\n```example\nThis is *strong.* \\\nThis is #strong[too.] \\\n\n#show strong: set text(red)\nAnd this is *evermore.*\n```\n\n= Syntax <syntax>\nThis function also has dedicated syntax: To strongly emphasize content,\nsimply enclose it in stars/asterisks (`*`). Note that this only works at\nword boundaries. To strongly emphasize part of a word, you have to use the\nfunction."
+    "value": "Strongly emphasizes content by increasing the font weight.\n\nIncreases the current font weight by a given `delta`.\n\n## Example\n\n```typ\nThis is *strong.* \\\nThis is #strong[too.] \\\n\n#show strong: set text(red)\nAnd this is *evermore.*\n```\n\n## Syntax\n\nThis function also has dedicated syntax: To strongly emphasize content, simply enclose it in stars/asterisks (`*`). Note that this only works at word boundaries. To strongly emphasize part of a word, you have to use the function."
    },
    "label": "strong(body: content, delta: int) -> strong",
    "parameters": [
@@ -25,7 +25,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/pos_callee2.typ
     {
      "documentation": {
       "kind": "markdown",
-      "value": "The delta to apply on the font weight.\n\n```example\n#set strong(delta: 0)\nNo *effect!*\n```"
+      "value": "The delta to apply on the font weight.\n\n```typ\n#set strong(delta: 0)\nNo *effect!*\n```"
      },
      "label": "delta:"
     }

--- a/crates/tinymist-query/src/fixtures/signature_help/snaps/test@where.typ.snap
+++ b/crates/tinymist-query/src/fixtures/signature_help/snaps/test@where.typ.snap
@@ -11,7 +11,7 @@ input_file: crates/tinymist-query/src/fixtures/signature_help/where.typ
    "activeParameter": 0,
    "documentation": {
     "kind": "markdown",
-    "value": "A horizontal line under content.\n\n```example\n$ underline(1 + 2 + ... + 5) $\n```"
+    "value": "A horizontal line under content.\n\n```typ\n$ underline(1 + 2 + ... + 5) $\n```"
    },
    "label": "underline(body: content) -> underline",
    "parameters": [

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -88,14 +88,11 @@ impl SemanticRequest for SignatureHelpRequest {
                     .unwrap_or("any")
             ));
 
+            let documentation = param.docs.as_ref().map(|docs| markdown_docs(docs.clone()));
+
             params.push(ParameterInformation {
                 label: lsp_types::ParameterLabel::Simple(format!("{}:", param.name)),
-                documentation: param.docs.as_ref().map(|docs| {
-                    Documentation::MarkupContent(MarkupContent {
-                        value: docs.as_ref().into(),
-                        kind: MarkupKind::Markdown,
-                    })
-                }),
+                documentation,
             });
         }
         label.push(')');
@@ -115,7 +112,11 @@ impl SemanticRequest for SignatureHelpRequest {
         Some(SignatureHelp {
             signatures: vec![SignatureInformation {
                 label: label.to_string(),
-                documentation: sig.primary().docs.as_deref().map(markdown_docs),
+                documentation: sig
+                    .primary()
+                    .docs
+                    .as_ref()
+                    .map(|docs| markdown_docs(docs.clone())),
                 parameters: Some(params),
                 active_parameter: active_parameter.map(|x| x as u32),
             }],
@@ -125,10 +126,10 @@ impl SemanticRequest for SignatureHelpRequest {
     }
 }
 
-fn markdown_docs(docs: &str) -> Documentation {
+fn markdown_docs(docs: EcoString) -> Documentation {
     Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
-        value: docs.to_owned(),
+        value: docs.into(),
     })
 }
 

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -88,10 +88,7 @@ impl SemanticRequest for SignatureHelpRequest {
                     .unwrap_or("any")
             ));
 
-            let documentation = param
-                .docs
-                .as_ref()
-                .map(|docs| markdown_docs(crate::docs::resolve_doc_text(ctx, docs)));
+            let documentation = param.docs.as_ref().map(|docs| markdown_docs(ctx, docs));
 
             params.push(ParameterInformation {
                 label: lsp_types::ParameterLabel::Simple(format!("{}:", param.name)),
@@ -119,7 +116,7 @@ impl SemanticRequest for SignatureHelpRequest {
                     .primary()
                     .docs
                     .as_ref()
-                    .map(|docs| markdown_docs(crate::docs::resolve_doc_text(ctx, docs))),
+                    .map(|docs| markdown_docs(ctx, docs)),
                 parameters: Some(params),
                 active_parameter: active_parameter.map(|x| x as u32),
             }],
@@ -129,7 +126,8 @@ impl SemanticRequest for SignatureHelpRequest {
     }
 }
 
-fn markdown_docs(docs: EcoString) -> Documentation {
+fn markdown_docs(ctx: &mut LocalContext, docs: &crate::docs::DocText) -> Documentation {
+    let docs = crate::docs::resolve_doc_text(ctx, docs);
     Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value: docs.into(),

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -88,7 +88,10 @@ impl SemanticRequest for SignatureHelpRequest {
                     .unwrap_or("any")
             ));
 
-            let documentation = param.docs.as_ref().map(|docs| markdown_docs(docs.clone()));
+            let documentation = param
+                .docs
+                .as_ref()
+                .map(|docs| markdown_docs(crate::docs::resolve_doc_text(ctx, docs)));
 
             params.push(ParameterInformation {
                 label: lsp_types::ParameterLabel::Simple(format!("{}:", param.name)),
@@ -116,7 +119,7 @@ impl SemanticRequest for SignatureHelpRequest {
                     .primary()
                     .docs
                     .as_ref()
-                    .map(|docs| markdown_docs(docs.clone())),
+                    .map(|docs| markdown_docs(crate::docs::resolve_doc_text(ctx, docs))),
                 parameters: Some(params),
                 active_parameter: active_parameter.map(|x| x as u32),
             }],

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -7,7 +7,7 @@ use typst::foundations::{IntoValue, Module, Str, Type};
 use crate::{StrRef, adt::interner::Interned};
 use crate::{adt::snapshot_map::SnapshotMap, analysis::SharedContext};
 use crate::{
-    docs::{DocString, VarDoc, convert_docs, identify_pat_docs, identify_tidy_module_docs},
+    docs::{DocString, VarDoc, identify_pat_docs, identify_tidy_module_docs},
     prelude::*,
     syntax::{Decl, DefKind},
     ty::{BuiltinTy, DynTypeBounds, InsTy, PackageId, SigTy, Ty, TypeVar, TypeVarBounds},
@@ -57,7 +57,9 @@ static EMPTY_MODULE: LazyLock<Module> =
 
 impl DocsChecker<'_> {
     pub fn check_pat_docs(mut self, docs: String) -> Option<DocString> {
-        let converted = convert_docs(self.ctx, &docs, Some(self.fid))
+        let converted = self
+            .ctx
+            .convert_docs_cached(&docs, Some(self.fid), crate::docs::DocsContent::Plain)
             .and_then(|converted| identify_pat_docs(&converted));
 
         let converted = match Self::fallback_docs(converted, &docs) {
@@ -92,8 +94,10 @@ impl DocsChecker<'_> {
     }
 
     pub fn check_module_docs(self, docs: String) -> Option<DocString> {
-        let converted =
-            convert_docs(self.ctx, &docs, Some(self.fid)).and_then(identify_tidy_module_docs);
+        let converted = self
+            .ctx
+            .convert_docs_cached(&docs, Some(self.fid), crate::docs::DocsContent::Plain)
+            .and_then(identify_tidy_module_docs);
 
         let converted = match Self::fallback_docs(converted, &docs) {
             Ok(docs) => docs,

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -2,7 +2,6 @@ use std::{collections::BTreeMap, ops::Deref, sync::LazyLock};
 
 use ecow::eco_format;
 use tinymist_analysis::stats::GLOBAL_STATS;
-use typst::diag::StrResult;
 use typst::foundations::{IntoValue, Module, Str, Type};
 
 use crate::{StrRef, adt::interner::Interned};
@@ -58,8 +57,8 @@ static EMPTY_MODULE: LazyLock<Module> =
 
 impl DocsChecker<'_> {
     pub fn check_pat_docs(mut self, docs: String) -> Option<DocString> {
-        let converted = self
-            .convert_docs(&docs)
+        let docs_text = crate::docs::DocText::plain(docs.as_str().into());
+        let converted = crate::docs::convert_docs(self.ctx, &docs_text, Some(self.fid))
             .and_then(|converted| identify_pat_docs(&converted));
 
         let converted = match Self::fallback_docs(converted, &docs) {
@@ -94,7 +93,9 @@ impl DocsChecker<'_> {
     }
 
     pub fn check_module_docs(self, docs: String) -> Option<DocString> {
-        let converted = self.convert_docs(&docs).and_then(identify_tidy_module_docs);
+        let docs_text = crate::docs::DocText::plain(docs.as_str().into());
+        let converted = crate::docs::convert_docs(self.ctx, &docs_text, Some(self.fid))
+            .and_then(identify_tidy_module_docs);
 
         let converted = match Self::fallback_docs(converted, &docs) {
             Ok(docs) => docs,
@@ -363,14 +364,5 @@ impl DocsChecker<'_> {
             }
             _ => None,
         }
-    }
-
-    fn convert_docs(&self, docs: &str) -> StrResult<EcoString> {
-        crate::docs::convert_docs(
-            self.ctx,
-            docs,
-            Some(self.fid),
-            crate::docs::DocsContent::Plain,
-        )
     }
 }

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, ops::Deref, sync::LazyLock};
 
 use ecow::eco_format;
 use tinymist_analysis::stats::GLOBAL_STATS;
+use typst::diag::StrResult;
 use typst::foundations::{IntoValue, Module, Str, Type};
 
 use crate::{StrRef, adt::interner::Interned};
@@ -58,8 +59,7 @@ static EMPTY_MODULE: LazyLock<Module> =
 impl DocsChecker<'_> {
     pub fn check_pat_docs(mut self, docs: String) -> Option<DocString> {
         let converted = self
-            .ctx
-            .convert_docs_cached(&docs, Some(self.fid))
+            .convert_docs(&docs)
             .and_then(|converted| identify_pat_docs(&converted));
 
         let converted = match Self::fallback_docs(converted, &docs) {
@@ -94,10 +94,7 @@ impl DocsChecker<'_> {
     }
 
     pub fn check_module_docs(self, docs: String) -> Option<DocString> {
-        let converted = self
-            .ctx
-            .convert_docs_cached(&docs, Some(self.fid))
-            .and_then(identify_tidy_module_docs);
+        let converted = self.convert_docs(&docs).and_then(identify_tidy_module_docs);
 
         let converted = match Self::fallback_docs(converted, &docs) {
             Ok(docs) => docs,
@@ -366,5 +363,14 @@ impl DocsChecker<'_> {
             }
             _ => None,
         }
+    }
+
+    fn convert_docs(&self, docs: &str) -> StrResult<EcoString> {
+        crate::docs::convert_docs(
+            self.ctx,
+            docs,
+            Some(self.fid),
+            crate::docs::DocsContent::Plain,
+        )
     }
 }

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -59,7 +59,7 @@ impl DocsChecker<'_> {
     pub fn check_pat_docs(mut self, docs: String) -> Option<DocString> {
         let converted = self
             .ctx
-            .convert_docs_cached(&docs, Some(self.fid), crate::docs::DocsContent::Plain)
+            .convert_docs_cached(&docs, Some(self.fid))
             .and_then(|converted| identify_pat_docs(&converted));
 
         let converted = match Self::fallback_docs(converted, &docs) {
@@ -96,7 +96,7 @@ impl DocsChecker<'_> {
     pub fn check_module_docs(self, docs: String) -> Option<DocString> {
         let converted = self
             .ctx
-            .convert_docs_cached(&docs, Some(self.fid), crate::docs::DocsContent::Plain)
+            .convert_docs_cached(&docs, Some(self.fid))
             .and_then(identify_tidy_module_docs);
 
         let converted = match Self::fallback_docs(converted, &docs) {

--- a/crates/typlite/src/fixtures/integration/snaps/convert@issue-1844.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert@issue-1844.typ.snap
@@ -53,7 +53,9 @@ Who loves to lie with me,
 ```)
 ````
 
-Source in grid <table x="test"><tr><td>Placeholder for<br />
+Source in grid
+
+<table x="test"><tr><td>Placeholder for<br />
 separately rendered SVG</td><td>
 
 ````

--- a/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1844.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/convert_tex@issue-1844.typ.snap
@@ -51,7 +51,9 @@ Who loves to lie with me,
 ```)
 ````
 
-Source in grid \begin{table}[htbp]
+Source in grid
+
+\begin{table}[htbp]
 \centering
 \begin{tabular}{cc}
 \hline

--- a/crates/typlite/src/fixtures/integration/snaps/docx_generation_hash@issue-1844.typ.snap
+++ b/crates/typlite/src/fixtures/integration/snaps/docx_generation_hash@issue-1844.typ.snap
@@ -3,4 +3,4 @@ source: crates/typlite/src/tests.rs
 expression: hash
 input_file: crates/typlite/src/fixtures/integration/issue-1844.typ
 ---
-siphash128_13:fb7e599b599c388c1295acebb7d5f9e8
+siphash128_13:8c47029add90f2b7b1bce3dd3ac315c1

--- a/crates/typlite/src/parser/core.rs
+++ b/crates/typlite/src/parser/core.rs
@@ -96,10 +96,10 @@ impl HtmlToAstParser {
                 Ok(())
             }
 
-            // md_tag::parbreak => {
-            //     self.flush_inline_buffer();
-            //     Ok(())
-            // }
+            md_tag::parbreak => {
+                self.flush_inline_buffer();
+                Ok(())
+            }
             md_tag::heading => {
                 self.flush_inline_buffer();
                 let attrs = HeadingAttr::parse(&element.attrs)?;


### PR DESCRIPTION
- convert official Typst function and parameter docs to Markdown before assigning them into signatures
- keep extracted user docs on the plain-docs path without leaking official helper definitions
- add a hover regression fixture for docs-table conversion and update hover/signature snapshots
