### PR TITLE
feat: remove legacy span pass usage from preview

### DIFF
--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -60,7 +60,6 @@ pub fn init_log(
         .filter_module("typlite", base_level)
         .filter_module("reflexo", base_level)
         .filter_module("sync_ls", base_level)
-        .filter_module("reflexo_typst2vec::pass::span2vec", Error)
         .filter_module("reflexo_typst::diag::console", base_level);
 
     if let Some(f) = filter {

--- a/crates/typst-preview/src/actor/editor.rs
+++ b/crates/typst-preview/src/actor/editor.rs
@@ -212,8 +212,12 @@ impl<T: EditorServer> EditorActor<T> {
                 Some(msg) = self.editor_conn.next() => {
                     match msg {
                         ControlPlaneMessage::ChangeCursorPosition(cursor_info) => {
-                            log::debug!("EditorActor: received message from editor: {cursor_info:?}");
-                            self.renderer_sender.send(RenderActorRequest::ChangeCursorPosition(cursor_info)).log_error("EditorActor");
+                            log::error!(
+                                "The experimental cursor indicator feature has been temporarily disabled to improve overall performance. It will be re-enabled once it is ready. Request ignored: {}:{}:{}",
+                                cursor_info.filepath.display(),
+                                cursor_info.line,
+                                cursor_info.character,
+                            );
                         }
                         ControlPlaneMessage::ResolveSourceLoc(jump_info) => {
                             log::debug!("EditorActor: received message from editor: {jump_info:?}");

--- a/crates/typst-preview/src/actor/render.rs
+++ b/crates/typst-preview/src/actor/render.rs
@@ -1,9 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use reflexo_typst::debug_loc::{
-    DocumentPosition, ElementPoint, LspPosition, SourceLocation, SourceSpanOffset,
-};
+use reflexo_typst::debug_loc::{DocumentPosition, LspPosition, SourceLocation, SourceSpanOffset};
 use reflexo_vec2svg::IncrSvgDocServer;
 use tinymist_std::typst::TypstDocument;
 use tokio::sync::{broadcast, mpsc};
@@ -12,20 +10,15 @@ use super::{editor::EditorActorRequest, webview::WebviewActorRequest};
 use crate::debug_loc::SpanInterner;
 use crate::outline::Outline;
 use crate::protocol;
-use crate::{ChangeCursorPositionRequest, CompileView, DocToSrcJumpInfo, ResolveSourceLocRequest};
-
-#[derive(Debug, Clone)]
-pub struct ResolveSpanRequest(pub Vec<ElementPoint>);
+use crate::{CompileView, DocToSrcJumpInfo, ResolveSourceLocRequest};
 
 #[derive(Debug, Clone)]
 pub enum RenderActorRequest {
     RenderFullLatest,
     RenderIncremental,
     EditorResolveSpanRange(Range<SourceSpanOffset>),
-    WebviewResolveSpan(ResolveSpanRequest),
     WebviewResolveFrameLoc(DocumentPosition),
     ResolveSourceLoc(ResolveSourceLocRequest),
-    ChangeCursorPosition(ChangeCursorPositionRequest),
 }
 
 impl RenderActorRequest {
@@ -34,10 +27,8 @@ impl RenderActorRequest {
             Self::RenderFullLatest => true,
             Self::RenderIncremental => false,
             Self::EditorResolveSpanRange(_) => false,
-            Self::WebviewResolveSpan(_) => false,
             Self::ResolveSourceLoc(_) => false,
             Self::WebviewResolveFrameLoc(_) => false,
-            Self::ChangeCursorPosition(_) => false,
         }
     }
 }
@@ -70,9 +61,7 @@ impl RenderActor {
     }
 
     fn new_renderer() -> IncrSvgDocServer {
-        let mut renderer = IncrSvgDocServer::default();
-        renderer.set_should_attach_debug_info(true);
-        renderer
+        IncrSvgDocServer::default()
     }
 
     async fn process_message(&mut self, msg: RenderActorRequest) -> bool {
@@ -85,27 +74,11 @@ impl RenderActor {
 
                 self.editor_resolve_span_range(span_range);
             }
-            RenderActorRequest::WebviewResolveSpan(ResolveSpanRequest(element_path)) => {
-                log::debug!("RenderActor: resolving WebviewResolveSpan: {element_path:?}");
-                let spans = match self.renderer.resolve_span_by_element_path(&element_path) {
-                    Ok(spans) => spans,
-                    Err(err) => {
-                        log::info!("RenderActor: failed to resolve span: {err}");
-                        return false;
-                    }
-                };
-
-                log::debug!("RenderActor: resolved WebviewResolveSpan: {spans:?}");
-                // end position is used
-                if let Some(spans) = spans {
-                    self.editor_resolve_span_range(spans.0..spans.1);
-                }
-            }
             RenderActorRequest::WebviewResolveFrameLoc(frame_loc) => {
                 log::debug!("RenderActor: resolving WebviewResolveFrameLoc: {frame_loc:?}");
                 let spans = self.resolve_span_by_frame_loc(&frame_loc);
 
-                log::debug!("RenderActor: resolved WebviewResolveSpan: {spans:?}");
+                log::debug!("RenderActor: resolved WebviewResolveFrameLoc: {spans:?}");
                 // end position is used
                 if let Some(spans) = spans {
                     self.editor_resolve_span_range(spans.0..spans.1);
@@ -115,11 +88,6 @@ impl RenderActor {
                 log::debug!("RenderActor: resolving ResolveSourceLoc: {req:?}");
 
                 self.resolve_source_loc(req);
-            }
-            RenderActorRequest::ChangeCursorPosition(req) => {
-                log::debug!("RenderActor: processing ChangeCursorPosition: {req:?}");
-
-                self.change_cursor_position(req);
             }
             RenderActorRequest::RenderFullLatest | RenderActorRequest::RenderIncremental => {}
         }
@@ -267,27 +235,6 @@ impl RenderActor {
             (.., Some(info)) | (Some(info), None) => Some(info),
             (None, None) => None,
         }
-    }
-
-    fn change_cursor_position(&mut self, req: ChangeCursorPositionRequest) -> Option<()> {
-        let span = self
-            .view()?
-            .resolve_source_span(crate::Location::Src(SourceLocation {
-                filepath: req.filepath.to_string_lossy().to_string(),
-                pos: LspPosition {
-                    line: req.line,
-                    character: req.character,
-                },
-            }))?;
-        log::info!("RenderActor: changing cursor position: {span:?}");
-
-        let paths = self.renderer.resolve_element_paths_by_span(span).ok()?;
-        log::info!("RenderActor: resolved element paths: {paths:?}");
-        let _ = self
-            .webview_sender
-            .send(WebviewActorRequest::CursorPaths(paths));
-
-        Some(())
     }
 
     fn resolve_source_loc(&self, req: ResolveSourceLocRequest) -> Option<()> {

--- a/crates/typst-preview/src/actor/webview.rs
+++ b/crates/typst-preview/src/actor/webview.rs
@@ -1,13 +1,10 @@
 use futures::{SinkExt, StreamExt};
-use reflexo_typst::debug_loc::{DocumentPosition, ElementPoint};
+use reflexo_typst::debug_loc::DocumentPosition;
 use tinymist_std::error::IgnoreLogging;
 use tokio::sync::{broadcast, mpsc};
 
 use super::{editor::EditorActorRequest, render::RenderActorRequest};
-use crate::{
-    ViewerWindowStateMessage, WsMessage,
-    actor::{editor::DocToSrcJumpResolveRequest, render::ResolveSpanRequest},
-};
+use crate::{ViewerWindowStateMessage, WsMessage, actor::editor::DocToSrcJumpResolveRequest};
 
 // pub type CursorPosition = DocumentPosition;
 pub type SrcToDocJumpInfo = DocumentPosition;
@@ -17,7 +14,6 @@ pub enum WebviewActorRequest {
     ViewportPosition(DocumentPosition),
     SrcToDocJump(Vec<SrcToDocJumpInfo>),
     // CursorPosition(CursorPosition),
-    CursorPaths(Vec<Vec<ElementPoint>>),
 }
 
 fn position_req(
@@ -97,16 +93,6 @@ where
                             self.webview_websocket_conn.send(WsMessage::Binary(msg.into()))
                               .await.log_error("WebViewActor");
                         }
-                        // WebviewActorRequest::CursorPosition(jump_info) => {
-                        //     let msg = position_req("cursor", jump_info);
-                        //     self.webview_websocket_conn.send(WsMessage::Binary(msg.into_bytes())).await.log_error("WebViewActor");
-                        // }
-                        WebviewActorRequest::CursorPaths(jump_info) => {
-                            let json = serde_json::to_string(&jump_info).unwrap();
-                            let msg = format!("cursor-paths,{json}");
-                            self.webview_websocket_conn.send(WsMessage::Binary(msg.into()))
-                              .await.log_error("WebViewActor");
-                        }
                     }
                 }
                 Some(svg) = self.svg_receiver.recv() => {
@@ -155,14 +141,6 @@ where
                         let pos = DocumentPosition { page_no, x, y };
 
                         self.broadcast_sender.send(WebviewActorRequest::ViewportPosition(pos)).log_error("WebViewActor");
-                    } else if msg.starts_with("srcpath") {
-                        let path = msg.split(' ').nth(1).unwrap();
-                        let path = serde_json::from_str(path);
-                        if let Ok(path) = path {
-                            let path: Vec<(u32, u32, String)> = path;
-                            let path = path.into_iter().map(ElementPoint::from).collect::<Vec<_>>();
-                            self.render_sender.send(RenderActorRequest::WebviewResolveSpan(ResolveSpanRequest(path))).log_error("WebViewActor");
-                        };
                     } else if msg.starts_with("src-point") {
                         let path = msg.split(' ').nth(1).unwrap();
                         let path = serde_json::from_str(path);


### PR DESCRIPTION
- Stop attaching span debug info in the preview renderer.
- Remove the legacy element-path span lookup path (srcpath/WebviewResolveSpan/ResolveSpanRequest/CursorPaths).
- Keep the cursor indicator protocol path, but report that the experimental cursor indicator is temporarily disabled before it reaches renderer span lookup.
- Remove the obsolete span2vec log filter.
