### PR TITLE
build: pin typst deps to tinymist/v0.15.0 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7733,7 +7733,7 @@ dependencies = [
 [[package]]
 name = "typst"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "arrayvec",
  "comemo",
@@ -7775,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "typst-bundle"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "comemo",
  "ecow",
@@ -7803,7 +7803,7 @@ source = "git+https://github.com/typst/typst-dev-assets?tag=v0.15.0#29753d606934
 [[package]]
 name = "typst-eval"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "comemo",
  "ecow",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "typst-html"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "az",
  "bumpalo",
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "typst-layout"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "az",
  "bumpalo",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "typst-library"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "arrayvec",
  "az",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "typst-macros"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7956,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "typst-pdf"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "az",
  "bytemuck",
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "typst-realize"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "typst-render"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "bytemuck",
  "comemo",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "typst-svg"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "typst-syntax"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "ecow",
  "rustc-hash 2.1.2",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "typst-timing"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "parking_lot",
  "serde",
@@ -8132,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "typst-utils"
 version = "0.15.0"
-source = "git+https://github.com/Myriad-Dreamin/typst.git?rev=391c2dcd698aabf2917db0336868d16f197057d9#391c2dcd698aabf2917db0336868d16f197057d9"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.15.0#391c2dcd698aabf2917db0336868d16f197057d9"
 dependencies = [
  "libm",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,20 +320,20 @@ extend-exclude = ["/.git", "fixtures"]
 # These patches use a different version of `typst`, which only exports some private functions and information for code analysis.
 #
 # A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
-typst = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-bundle = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-layout = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-library = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-macros = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-realize = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
-typst-utils = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "391c2dcd698aabf2917db0336868d16f197057d9" }
+typst = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-bundle = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-layout = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-library = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-macros = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-realize = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
+typst-utils = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.15.0" }
 
 typst-ansi-hl = { git = "https://github.com/Myriad-Dreamin/typst-ansi-hl.git", rev = "3867cb7229ec6b3e3c8f5b1222af96f98bba9bff" }
 typstyle-core = { git = "https://github.com/Myriad-Dreamin/typstyle.git", rev = "992f36112200bc0ea61df8a7c2af6d9ae56781dd" }


### PR DESCRIPTION
- Update `typst` git dependencies in `Cargo.toml` to use the `tinymist/v0.15.0` tag instead of a raw revision
- Refresh `Cargo.lock` entries to match the tagged source URL
