### PR TITLE
feat(completion): avoid deleting text after cursor

### DIFF
--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -30,8 +30,8 @@ use crate::adt::interner::Interned;
 use crate::analysis::{BuiltinTy, LocalContext, PathKind, Ty};
 use crate::completion::{
     Completion, CompletionCommand, CompletionContextKey, CompletionItem, CompletionKind,
-    DEFAULT_POSTFIX_SNIPPET, DEFAULT_PREFIX_SNIPPET, EcoTextEdit, ParsedSnippet, PostfixSnippet,
-    PostfixSnippetScope, PrefixSnippet,
+    DEFAULT_POSTFIX_SNIPPET, DEFAULT_PREFIX_SNIPPET, EcoCompletionTextEdit, EcoInsertReplaceEdit,
+    EcoTextEdit, ParsedSnippet, PostfixSnippet, PostfixSnippetScope, PrefixSnippet,
 };
 use crate::prelude::*;
 use crate::syntax::{
@@ -81,6 +81,9 @@ pub struct CompletionFeat {
     /// hints.
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub trigger_suggest_and_parameter_hints: bool,
+    /// Whether the client supports LSP insert/replace completion text edits.
+    #[serde(skip)]
+    pub insert_replace_edit: bool,
 
     /// The Way to complete symbols.
     pub symbol: Option<SymbolCompletionWay>,
@@ -319,6 +322,27 @@ impl<'a> CompletionCursor<'a> {
         lsp_rng
     }
 
+    fn insert_range_of(&self, replace: Range<usize>) -> Range<usize> {
+        let end = self.cursor.clamp(replace.start, replace.end);
+        replace.start..end
+    }
+
+    fn completion_text_edit(
+        &mut self,
+        insert: Range<usize>,
+        replace: Range<usize>,
+        new_text: EcoString,
+    ) -> EcoCompletionTextEdit {
+        let insert = self.lsp_range_of(insert);
+        let replace = self.lsp_range_of(replace);
+
+        if self.ctx.analysis.completion_feat.insert_replace_edit && insert != replace {
+            EcoInsertReplaceEdit::new(insert, replace, new_text).into()
+        } else {
+            EcoTextEdit::new(replace, new_text).into()
+        }
+    }
+
     /// Makes a full completion item from a cursor-insensitive completion.
     fn lsp_item_of(&mut self, item: &Completion) -> LspCompletion {
         // Determine range to replace
@@ -338,7 +362,7 @@ impl<'a> CompletionCursor<'a> {
                     rng.end = self.cursor;
                 }
 
-                self.lsp_range_of(rng)
+                rng
             }
             Some(SelectedNode::Label(from_label)) => {
                 let mut rng = from_label.range();
@@ -349,7 +373,7 @@ impl<'a> CompletionCursor<'a> {
                     rng.end -= 1;
                 }
 
-                self.lsp_range_of(rng)
+                rng
             }
             Some(node @ (SelectedNode::At(from_ref) | SelectedNode::Ref(from_ref))) => {
                 let mut rng = if matches!(node, SelectedNode::At(..)) {
@@ -362,12 +386,13 @@ impl<'a> CompletionCursor<'a> {
                     rng.start += 1;
                 }
 
-                self.lsp_range_of(rng)
+                rng
             }
-            None => self.lsp_range_of(self.from..self.cursor),
+            None => self.from..self.cursor,
         };
 
-        let text_edit = EcoTextEdit::new(replace_range, snippet);
+        let insert_range = self.insert_range_of(replace_range.clone());
+        let text_edit = self.completion_text_edit(insert_range, replace_range, snippet);
 
         LspCompletion {
             label: item.label.clone(),
@@ -467,7 +492,7 @@ impl<'a> CompletionWorker<'a> {
     fn enrich(&mut self, prefix: &str, suffix: &str) {
         for LspCompletion { text_edit, .. } in &mut self.completions {
             let apply = match text_edit {
-                Some(EcoTextEdit { new_text, .. }) => new_text,
+                Some(text_edit) => text_edit.new_text_mut(),
                 _ => continue,
             };
 
@@ -559,10 +584,8 @@ impl<'a> CompletionWorker<'a> {
         }
 
         for item in &mut self.completions {
-            if let Some(EcoTextEdit {
-                ref mut new_text, ..
-            }) = item.text_edit
-            {
+            if let Some(text_edit) = &mut item.text_edit {
+                let new_text = text_edit.new_text_mut();
                 *new_text = to_lsp_snippet(new_text);
             }
         }

--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -343,6 +343,19 @@ impl<'a> CompletionCursor<'a> {
         }
     }
 
+    fn capture_suffix_as_first_arg(&self, snippet: &mut EcoString, replace: Range<usize>) -> bool {
+        if self.cursor >= replace.end {
+            return false;
+        }
+
+        let suffix = &self.text[self.cursor..replace.end];
+        if suffix.is_empty() || !suffix.chars().all(is_id_continue) {
+            return false;
+        }
+
+        fill_first_empty_placeholder(snippet, suffix)
+    }
+
     /// Makes a full completion item from a cursor-insensitive completion.
     fn lsp_item_of(&mut self, item: &Completion) -> LspCompletion {
         // Determine range to replace
@@ -391,8 +404,15 @@ impl<'a> CompletionCursor<'a> {
             None => self.from..self.cursor,
         };
 
-        let insert_range = self.insert_range_of(replace_range.clone());
-        let text_edit = self.completion_text_edit(insert_range, replace_range, snippet);
+        let text_edit = if item.capture_suffix
+            && self.capture_suffix_as_first_arg(&mut snippet, replace_range.clone())
+        {
+            let replace_range = self.lsp_range_of(replace_range);
+            EcoTextEdit::new(replace_range, snippet).into()
+        } else {
+            let insert_range = self.insert_range_of(replace_range.clone());
+            self.completion_text_edit(insert_range, replace_range, snippet)
+        };
 
         LspCompletion {
             label: item.label.clone(),
@@ -979,6 +999,25 @@ fn slice_at(s: &str, mut rng: Range<usize>) -> &str {
     }
 
     &s[rng]
+}
+
+fn fill_first_empty_placeholder(snippet: &mut EcoString, text: &str) -> bool {
+    let Some(pos) = snippet.find("${}") else {
+        return false;
+    };
+
+    let escaped = text
+        .replace('\\', "\\\\")
+        .replace('$', "\\$")
+        .replace('}', "\\}");
+    let mut filled = EcoString::new();
+    filled.push_str(&snippet[..pos]);
+    filled.push_str("${");
+    filled.push_str(&escaped);
+    filled.push('}');
+    filled.push_str(&snippet[pos + "${}".len()..]);
+    *snippet = filled;
+    true
 }
 
 static TYPST_SNIPPET_PLACEHOLDER_RE: LazyLock<Regex> =

--- a/crates/tinymist-query/src/analysis/completion/func.rs
+++ b/crates/tinymist-query/src/analysis/completion/func.rs
@@ -86,6 +86,7 @@ impl CompletionPair<'_, '_, '_> {
                     );
                 self.push_completion(Completion {
                     apply: Some(eco_format!("{name}(${{}})")),
+                    capture_suffix: true,
                     label: paren_label(&name, &fn_feat, is_set),
                     ..base.clone()
                 });

--- a/crates/tinymist-query/src/analysis/completion/path.rs
+++ b/crates/tinymist-query/src/analysis/completion/path.rs
@@ -139,7 +139,7 @@ impl CompletionPair<'_, '_, '_> {
                         label: typst_completion.0,
                         kind: typst_completion.1,
                         detail: None,
-                        text_edit: Some(text_edit),
+                        text_edit: Some(text_edit.into()),
                         // don't sort me
                         sort_text: Some(sort_text),
                         filter_text: Some("".into()),

--- a/crates/tinymist-query/src/completion.rs
+++ b/crates/tinymist-query/src/completion.rs
@@ -244,7 +244,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(
-                    item.text_edit.as_ref().unwrap().new_text.as_str(),
+                    item.text_edit.as_ref().unwrap().new_text().as_str(),
                     "label(\"DBLP:books/lib/Knuth86a\")"
                 );
 

--- a/crates/tinymist-query/src/completion/proto.rs
+++ b/crates/tinymist-query/src/completion/proto.rs
@@ -104,6 +104,10 @@ pub struct Completion {
     ///
     /// Should default to the `label` if `None`.
     pub apply: Option<EcoString>,
+    /// Whether the completion may capture the right-side identifier suffix as
+    /// the first snippet argument.
+    #[serde(skip)]
+    pub capture_suffix: bool,
     /// An optional short description, at most one sentence.
     pub detail: Option<EcoString>,
     /// An optional array of additional text edits that are applied when

--- a/crates/tinymist-query/src/completion/proto.rs
+++ b/crates/tinymist-query/src/completion/proto.rs
@@ -178,6 +178,64 @@ impl EcoTextEdit {
     }
 }
 
+/// A textual edit with separate insert and replace ranges.
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcoInsertReplaceEdit {
+    /// The string to be inserted.
+    pub new_text: EcoString,
+    /// The range if insert mode is requested.
+    pub insert: LspRange,
+    /// The range if replace mode is requested.
+    pub replace: LspRange,
+}
+
+impl EcoInsertReplaceEdit {
+    pub fn new(insert: LspRange, replace: LspRange, new_text: EcoString) -> EcoInsertReplaceEdit {
+        EcoInsertReplaceEdit {
+            new_text,
+            insert,
+            replace,
+        }
+    }
+}
+
+/// The main edit for a completion item.
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum EcoCompletionTextEdit {
+    Edit(EcoTextEdit),
+    InsertAndReplace(EcoInsertReplaceEdit),
+}
+
+impl EcoCompletionTextEdit {
+    pub fn new_text(&self) -> &EcoString {
+        match self {
+            EcoCompletionTextEdit::Edit(edit) => &edit.new_text,
+            EcoCompletionTextEdit::InsertAndReplace(edit) => &edit.new_text,
+        }
+    }
+
+    pub fn new_text_mut(&mut self) -> &mut EcoString {
+        match self {
+            EcoCompletionTextEdit::Edit(edit) => &mut edit.new_text,
+            EcoCompletionTextEdit::InsertAndReplace(edit) => &mut edit.new_text,
+        }
+    }
+}
+
+impl From<EcoTextEdit> for EcoCompletionTextEdit {
+    fn from(edit: EcoTextEdit) -> Self {
+        EcoCompletionTextEdit::Edit(edit)
+    }
+}
+
+impl From<EcoInsertReplaceEdit> for EcoCompletionTextEdit {
+    fn from(edit: EcoInsertReplaceEdit) -> Self {
+        EcoCompletionTextEdit::InsertAndReplace(edit)
+    }
+}
+
 /// Represents a completion item.
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -257,7 +315,7 @@ pub struct CompletionItem {
     ///
     /// @since 3.16.0 additional type `InsertReplaceEdit`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub text_edit: Option<EcoTextEdit>,
+    pub text_edit: Option<EcoCompletionTextEdit>,
 
     /// An optional array of additional text edits that are applied when
     /// selecting this completion. Edits must not overlap with the main edit

--- a/crates/tinymist-query/src/fixtures/completion/insert_replace.typ
+++ b/crates/tinymist-query/src/fixtures/completion/insert_replace.typ
@@ -1,0 +1,5 @@
+/// contains: underbrace
+/// insert_replace: true
+
+#let underbrace(body) = body
+#underbrsum/* range -3..-2 */

--- a/crates/tinymist-query/src/fixtures/completion/insert_replace.typ
+++ b/crates/tinymist-query/src/fixtures/completion/insert_replace.typ
@@ -2,4 +2,4 @@
 /// insert_replace: true
 
 #let underbrace(body) = body
-#underbrsum/* range -3..-2 */
+$ underbrsum/* range -3..-2 */ $

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@bracket_strong.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@bracket_strong.typ.snap
@@ -20,7 +20,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/bracket_strong.typ
     },
     "sortText": "198",
     "textEdit": {
-     "newText": "strong(${1:})",
+     "newText": "strong(${1:t})",
      "range": {
       "end": {
        "character": 26,

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_params.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_params.typ.snap
@@ -20,7 +20,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_params.typ
     },
     "sortText": "000",
     "textEdit": {
-     "newText": "aa(${1:})",
+     "newText": "aa(${1:c})",
      "range": {
       "end": {
        "character": 5,

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_star_typing.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_star_typing.typ.snap
@@ -20,7 +20,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/import_star_typing.typ
     },
     "sortText": "218",
     "textEdit": {
-     "newText": "todo(${1:})",
+     "newText": "todo(${1:o})",
      "range": {
       "end": {
        "character": 3,

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_typing.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_typing.typ.snap
@@ -20,7 +20,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/import_typing.typ
     },
     "sortText": "217",
     "textEdit": {
-     "newText": "todo(${1:})",
+     "newText": "todo(${1:o})",
      "range": {
       "end": {
        "character": 3,

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@insert_replace.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@insert_replace.typ.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tinymist-query/src/completion.rs
-description: Completion on s (88..89)
+description: Completion on s (89..90)
 expression: "JsonRepr::new_pure(results)"
 input_file: crates/tinymist-query/src/fixtures/completion/insert_replace.typ
 ---
@@ -18,26 +18,16 @@ input_file: crates/tinymist-query/src/fixtures/completion/insert_replace.typ
     "labelDetails": {
      "description": "(any) => any"
     },
-    "sortText": "221",
+    "sortText": "373",
     "textEdit": {
-     "insert": {
+     "newText": "underbrace(${1:sum})",
+     "range": {
       "end": {
-       "character": 8,
+       "character": 12,
        "line": 4
       },
       "start": {
-       "character": 1,
-       "line": 4
-      }
-     },
-     "newText": "underbrace(${1:})",
-     "replace": {
-      "end": {
-       "character": 11,
-       "line": 4
-      },
-      "start": {
-       "character": 1,
+       "character": 2,
        "line": 4
       }
      }

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@insert_replace.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@insert_replace.typ.snap
@@ -1,0 +1,48 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on s (88..89)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/insert_replace.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "command": {
+     "command": "tinymist.triggerSuggestAndParameterHints",
+     "title": ""
+    },
+    "kind": 3,
+    "label": "underbrace",
+    "labelDetails": {
+     "description": "(any) => any"
+    },
+    "sortText": "221",
+    "textEdit": {
+     "insert": {
+      "end": {
+       "character": 8,
+       "line": 4
+      },
+      "start": {
+       "character": 1,
+       "line": 4
+      }
+     },
+     "newText": "underbrace(${1:})",
+     "replace": {
+      "end": {
+       "character": 11,
+       "line": 4
+      },
+      "start": {
+       "character": 1,
+       "line": 4
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/tests.rs
+++ b/crates/tinymist-query/src/tests.rs
@@ -96,6 +96,10 @@ pub fn run_with_ctx_<T>(
             trigger_suggest: true,
             trigger_parameter_hints: true,
             trigger_suggest_and_parameter_hints: true,
+            insert_replace_edit: properties
+                .get("insert_replace")
+                .map(|v| v.trim() == "true")
+                .unwrap_or(false),
             ..Default::default()
         },
         ..Analysis::default()

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -878,6 +878,8 @@ pub struct ConstConfig {
     pub doc_line_folding_only: bool,
     /// Allow dynamic registration of document formatting.
     pub doc_fmt_dynamic_registration: bool,
+    /// Allow insert/replace text edits in completion items.
+    pub completion_insert_replace_support: bool,
     /// The locale of the editor.
     pub locale: Option<String>,
 }
@@ -914,6 +916,7 @@ impl From<&InitializeParams> for ConstConfig {
         let sema = try_(|| doc?.semantic_tokens.as_ref());
         let fold = try_(|| doc?.folding_range.as_ref());
         let format = try_(|| doc?.formatting.as_ref());
+        let completion_item = try_(|| doc?.completion.as_ref()?.completion_item.as_ref());
 
         let locale = params
             .initialization_options
@@ -930,6 +933,10 @@ impl From<&InitializeParams> for ConstConfig {
             tokens_multiline_token_support: try_or(|| sema?.multiline_token_support, false),
             doc_line_folding_only: try_or(|| fold?.line_folding_only, true),
             doc_fmt_dynamic_registration: try_or(|| format?.dynamic_registration, false),
+            completion_insert_replace_support: try_or(
+                || completion_item?.insert_replace_support,
+                false,
+            ),
             locale: locale.map(ToOwned::to_owned),
         }
     }
@@ -1635,9 +1642,34 @@ mod tests {
 
     #[test]
     fn test_default_lsp_config_initialize() {
-        let (_conf, err) =
+        let (conf, err) =
             Config::extract_lsp_params(InitializeParams::default(), CompileFontArgs::default());
         assert!(err.is_none());
+        assert!(!conf.const_config.completion_insert_replace_support);
+    }
+
+    #[test]
+    fn test_lsp_config_completion_insert_replace_support() {
+        let params = InitializeParams {
+            capabilities: ClientCapabilities {
+                text_document: Some(TextDocumentClientCapabilities {
+                    completion: Some(CompletionClientCapabilities {
+                        completion_item: Some(CompletionItemCapability {
+                            insert_replace_support: Some(true),
+                            ..CompletionItemCapability::default()
+                        }),
+                        ..CompletionClientCapabilities::default()
+                    }),
+                    ..TextDocumentClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+            ..InitializeParams::default()
+        };
+
+        let (conf, err) = Config::extract_lsp_params(params, CompileFontArgs::default());
+        assert!(err.is_none());
+        assert!(conf.const_config.completion_insert_replace_support);
     }
 
     #[test]

--- a/crates/tinymist/src/project.rs
+++ b/crates/tinymist/src/project.rs
@@ -150,6 +150,8 @@ impl ServerState {
         #[cfg(all(not(feature = "system"), feature = "web"))] resolve_fn: js_sys::Function,
     ) -> ProjectState {
         let const_config = &config.const_config;
+        let mut completion_feat = config.completion.clone();
+        completion_feat.insert_replace_edit = const_config.completion_insert_replace_support;
 
         // Run Export actors before preparing cluster to avoid loss of events
         #[cfg(feature = "export")]
@@ -176,7 +178,7 @@ impl ServerState {
                 remove_html: !config.support_html_in_markdown,
                 support_client_codelens: config.support_client_codelens,
                 extended_code_action: config.extended_code_action,
-                completion_feat: config.completion.clone(),
+                completion_feat,
                 color_theme: match config.color_theme.as_deref() {
                     Some("dark") => tinymist_query::ColorTheme::Dark,
                     _ => tinymist_query::ColorTheme::Light,

--- a/tests/e2e/e2e/lsp.rs
+++ b/tests/e2e/e2e/lsp.rs
@@ -22,7 +22,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:b47252f8903fe7767fdee13c21777ed9");
+        insta::assert_snapshot!(hash, @"siphash128_13:55108ba6479fea30ddf2edd4a5347457");
     }
 
     {
@@ -33,7 +33,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("vscode"));
-        insta::assert_snapshot!(hash, @"siphash128_13:e501e554d8e3daae789f125bc7e107ef");
+        insta::assert_snapshot!(hash, @"siphash128_13:20190eede2c69def771599513a0f3f08");
     }
 
     {
@@ -44,7 +44,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("vscode-syntax-only"));
-        insta::assert_snapshot!(hash, @"siphash128_13:12f461c65b15bf65ad30352f297db52e");
+        insta::assert_snapshot!(hash, @"siphash128_13:fc145d62fa6a84c7f05d8f02688a158a");
     }
 }
 


### PR DESCRIPTION
Closes #2514.

This change teaches completion to emit LSP `InsertReplaceEdit` when the client advertises `completionItem.insertReplaceSupport`. This lets clients insert at the cursor while still replacing the full completion token when appropriate, avoiding accidental deletion of text after the cursor.

It also lets function-style completions capture the identifier suffix after the cursor as the first snippet argument. For example, completing `underbr|sum` can produce `underbrace(sum)`.

Clients without `insertReplaceSupport` keep receiving the existing `TextEdit` form.
