### PR TITLE
refactor: use cached DOM state for SVG resize anchoring

### DIFF
--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -12,11 +12,14 @@ export interface ContainerDOMState {
     left: number;
     top: number;
   };
-  /// cached scroll top of the scroll container that owns the document root
+  /// cached scroll top of the scroll container.
+  /// In the default DOM retriever, this is
+  /// `hookedElem.parentElement.scrollTop` if `hookedElem.parentElement` is an HTMLElement,
+  /// otherwise `0`.
   scrollTop?: number;
   /// cached CSS-pixel offset from the scroll container content top to the
   /// document root top, computed as
-  /// `documentRootRect.top - scrollContainerRect.top + scrollTop`.
+  /// `contentRect.top - scrollRect.top + scrollTop`.
   contentTopOffset?: number;
 }
 

--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -12,6 +12,12 @@ export interface ContainerDOMState {
     left: number;
     top: number;
   };
+  /// cached scroll top of the scroll container that owns the document root
+  scrollTop?: number;
+  /// cached CSS-pixel offset from the scroll container content top to the
+  /// document root top, computed as
+  /// `documentRootRect.top - scrollContainerRect.top + scrollTop`.
+  contentTopOffset?: number;
 }
 
 export type RenderMode = "svg" | "canvas";
@@ -135,6 +141,8 @@ export class TypstDocumentContext<O = any> {
       left: 0,
       top: 0,
     },
+    scrollTop: 0,
+    contentTopOffset: 0,
   };
 
   constructor(opts: Options & O) {
@@ -153,10 +161,19 @@ export class TypstDocumentContext<O = any> {
       this.retrieveDOMState =
         retrieveDOMState ??
         (() => {
+          const scrollEl = this.hookedElem.parentElement;
+          const contentElem = this.hookedElem.firstElementChild || this.hookedElem;
+          const contentRect = contentElem.getBoundingClientRect();
+          const scrollTop = scrollEl instanceof HTMLElement ? scrollEl.scrollTop : 0;
+          const scrollRect =
+            scrollEl instanceof HTMLElement ? scrollEl.getBoundingClientRect() : contentRect;
+          const contentTopOffset = contentRect.top - scrollRect.top + scrollTop;
           return {
             width: this.hookedElem.offsetWidth,
             height: this.hookedElem.offsetHeight,
             boundingRect: this.hookedElem.getBoundingClientRect(),
+            scrollTop,
+            contentTopOffset,
           };
         });
       this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue(
@@ -355,7 +372,7 @@ export class TypstDocumentContext<O = any> {
       return 0;
     }
 
-    const container = this.cachedDOMState;
+    const domState = this.cachedDOMState;
 
     const svgWidth = Number.parseFloat(
       svg.getAttribute("data-width") || svg.getAttribute("width") || "1",
@@ -365,8 +382,8 @@ export class TypstDocumentContext<O = any> {
     );
     this.currentRealScale =
       this.previewMode === PreviewMode.Slide
-        ? Math.min(container.width / svgWidth, container.height / svgHeight)
-        : container.width / svgWidth;
+        ? Math.min(domState.width / svgWidth, domState.height / svgHeight)
+        : domState.width / svgWidth;
 
     return this.currentRealScale * this.currentScaleRatio;
   }

--- a/tools/typst-dom/src/typst-doc.mts
+++ b/tools/typst-dom/src/typst-doc.mts
@@ -17,10 +17,19 @@ export interface ContainerDOMState {
   /// `hookedElem.parentElement.scrollTop` if `hookedElem.parentElement` is an HTMLElement,
   /// otherwise `0`.
   scrollTop?: number;
+  /// cached scroll left of the scroll container.
+  /// In the default DOM retriever, this is
+  /// `hookedElem.parentElement.scrollLeft` if `hookedElem.parentElement` is an HTMLElement,
+  /// otherwise `0`.
+  scrollLeft?: number;
   /// cached CSS-pixel offset from the scroll container content top to the
   /// document root top, computed as
   /// `contentRect.top - scrollRect.top + scrollTop`.
   contentTopOffset?: number;
+  /// cached CSS-pixel offset from the scroll container content left to the
+  /// document root left, computed as
+  /// `contentRect.left - scrollRect.left + scrollLeft`.
+  contentLeftOffset?: number;
 }
 
 export type RenderMode = "svg" | "canvas";
@@ -145,7 +154,9 @@ export class TypstDocumentContext<O = any> {
       top: 0,
     },
     scrollTop: 0,
+    scrollLeft: 0,
     contentTopOffset: 0,
+    contentLeftOffset: 0,
   };
 
   constructor(opts: Options & O) {
@@ -168,15 +179,19 @@ export class TypstDocumentContext<O = any> {
           const contentElem = this.hookedElem.firstElementChild || this.hookedElem;
           const contentRect = contentElem.getBoundingClientRect();
           const scrollTop = scrollEl instanceof HTMLElement ? scrollEl.scrollTop : 0;
+          const scrollLeft = scrollEl instanceof HTMLElement ? scrollEl.scrollLeft : 0;
           const scrollRect =
             scrollEl instanceof HTMLElement ? scrollEl.getBoundingClientRect() : contentRect;
           const contentTopOffset = contentRect.top - scrollRect.top + scrollTop;
+          const contentLeftOffset = contentRect.left - scrollRect.left + scrollLeft;
           return {
             width: this.hookedElem.offsetWidth,
             height: this.hookedElem.offsetHeight,
             boundingRect: this.hookedElem.getBoundingClientRect(),
             scrollTop,
+            scrollLeft,
             contentTopOffset,
+            contentLeftOffset,
           };
         });
       this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue(

--- a/tools/typst-dom/src/typst-doc.resize-anchor.mts
+++ b/tools/typst-dom/src/typst-doc.resize-anchor.mts
@@ -1,0 +1,178 @@
+export const SVG_SCALE_EPSILON = 1e-6;
+
+export interface SvgResizePageAnchor {
+  kind: "page";
+  pageNumber: number;
+  pageLocalY: number;
+  pageHeight: number;
+}
+
+export interface SvgResizeGapAnchor {
+  kind: "gap";
+  beforePageNumber?: number;
+  afterPageNumber?: number;
+  gapRatio: number;
+}
+
+export type SvgResizeAnchor = SvgResizePageAnchor | SvgResizeGapAnchor;
+
+export interface SvgAnchorPage {
+  pageNumber: number;
+  y: number;
+  height: number;
+}
+
+const finite = (value: number | undefined): value is number =>
+  value !== undefined && Number.isFinite(value);
+
+export function hasSvgScaleRatioChanged(
+  previousScaleRatio: number | undefined,
+  currentScaleRatio: number,
+  epsilon = SVG_SCALE_EPSILON,
+) {
+  return (
+    previousScaleRatio !== undefined && Math.abs(currentScaleRatio - previousScaleRatio) >= epsilon
+  );
+}
+
+export function resolveViewportStart(
+  scroll: number | undefined,
+  contentOffset: number | undefined,
+  appliedScale: number | undefined,
+) {
+  if (!finite(scroll) || !finite(contentOffset) || !finite(appliedScale) || appliedScale <= 0) {
+    return undefined;
+  }
+
+  return (scroll - contentOffset) / appliedScale;
+}
+
+export function resolveScrollForViewportStart(
+  viewportStart: number,
+  appliedScale: number,
+  contentOffset: number,
+  scrollSize?: number,
+  clientSize?: number,
+) {
+  if (!Number.isFinite(viewportStart) || !Number.isFinite(appliedScale) || appliedScale <= 0) {
+    return undefined;
+  }
+  if (!Number.isFinite(contentOffset)) {
+    return undefined;
+  }
+
+  const target = viewportStart * appliedScale + contentOffset;
+  if (!Number.isFinite(target)) {
+    return undefined;
+  }
+
+  if (finite(scrollSize) && finite(clientSize)) {
+    const max = Math.max(0, scrollSize - clientSize);
+    return Math.max(0, Math.min(max, target));
+  }
+
+  return Math.max(0, target);
+}
+
+export function captureSvgResizeYAnchor(
+  pages: SvgAnchorPage[],
+  svgHeight: number,
+  viewportTopY: number,
+): SvgResizeAnchor | undefined {
+  if (!Number.isFinite(svgHeight) || svgHeight <= 0 || !Number.isFinite(viewportTopY)) {
+    return undefined;
+  }
+
+  const containingPage = pages.find(
+    (page) => viewportTopY >= page.y && viewportTopY <= page.y + page.height,
+  );
+  if (containingPage) {
+    return {
+      kind: "page",
+      pageNumber: containingPage.pageNumber,
+      pageLocalY: viewportTopY - containingPage.y,
+      pageHeight: containingPage.height,
+    };
+  }
+
+  let beforePage: SvgAnchorPage | undefined;
+  let afterPage: SvgAnchorPage | undefined;
+  for (const page of pages) {
+    if (viewportTopY < page.y) {
+      afterPage = page;
+      break;
+    }
+    if (viewportTopY > page.y + page.height) {
+      beforePage = page;
+    }
+  }
+
+  const gapStartY = beforePage ? beforePage.y + beforePage.height : 0;
+  const gapEndY = afterPage ? afterPage.y : svgHeight;
+  if (
+    !Number.isFinite(gapStartY) ||
+    !Number.isFinite(gapEndY) ||
+    gapEndY < gapStartY ||
+    viewportTopY < gapStartY ||
+    viewportTopY > gapEndY
+  ) {
+    return undefined;
+  }
+
+  const gapLength = gapEndY - gapStartY;
+  const gapAnchor: SvgResizeGapAnchor = {
+    kind: "gap",
+    gapRatio: gapLength > 0 ? Math.max(0, Math.min(1, (viewportTopY - gapStartY) / gapLength)) : 0,
+  };
+  if (beforePage) {
+    gapAnchor.beforePageNumber = beforePage.pageNumber;
+  }
+  if (afterPage) {
+    gapAnchor.afterPageNumber = afterPage.pageNumber;
+  }
+  return gapAnchor;
+}
+
+export function resolveSyntheticYForResizeAnchor(
+  anchor: SvgResizeAnchor,
+  pages: SvgAnchorPage[],
+  svgHeight: number,
+) {
+  if (!Number.isFinite(svgHeight) || svgHeight <= 0) {
+    return undefined;
+  }
+
+  if (anchor.kind === "gap") {
+    const beforePage =
+      anchor.beforePageNumber !== undefined
+        ? pages.find((page) => page.pageNumber === anchor.beforePageNumber)
+        : undefined;
+    const afterPage =
+      anchor.afterPageNumber !== undefined
+        ? pages.find((page) => page.pageNumber === anchor.afterPageNumber)
+        : undefined;
+
+    if (
+      (anchor.beforePageNumber !== undefined && beforePage === undefined) ||
+      (anchor.afterPageNumber !== undefined && afterPage === undefined)
+    ) {
+      return undefined;
+    }
+
+    const gapStartY = beforePage ? beforePage.y + beforePage.height : 0;
+    const gapEndY = afterPage ? afterPage.y : svgHeight;
+    if (!Number.isFinite(gapStartY) || !Number.isFinite(gapEndY) || gapEndY < gapStartY) {
+      return undefined;
+    }
+
+    const gapRatio = Math.max(0, Math.min(1, anchor.gapRatio));
+    return gapStartY + gapRatio * (gapEndY - gapStartY);
+  }
+
+  const page = pages.find((page) => page.pageNumber === anchor.pageNumber);
+  if (!page || anchor.pageHeight <= 0) {
+    return undefined;
+  }
+
+  return page.y + (anchor.pageLocalY * page.height) / anchor.pageHeight;
+}

--- a/tools/typst-dom/src/typst-doc.resize-anchor.mts
+++ b/tools/typst-dom/src/typst-doc.resize-anchor.mts
@@ -35,6 +35,13 @@ export function hasSvgScaleRatioChanged(
   );
 }
 
+export function shouldRestoreHorizontalResizeAnchor(
+  currentScaleRatio: number,
+  epsilon = SVG_SCALE_EPSILON,
+) {
+  return currentScaleRatio > 1 + epsilon;
+}
+
 export function resolveViewportStart(
   scroll: number | undefined,
   contentOffset: number | undefined,

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -1,7 +1,7 @@
 import { PreviewMode } from "./typst-doc.mjs";
 import { TypstCancellationToken } from "./typst-cancel.mjs";
 import { TypstPatchAttrs, isDummyPatchElem } from "./typst-patch.mjs";
-import type { GConstructor, TypstDocumentContext } from "./typst-doc.mjs";
+import type { ContainerDOMState, GConstructor, TypstDocumentContext } from "./typst-doc.mjs";
 import type { CanvasPage, TypstCanvasDocument } from "./typst-doc.canvas.mjs";
 import { patchSvgToContainer } from "./typst-patch.svg.mjs";
 import { ElementPoint, resolveSourceLeaf } from "./typst-debug-info.mjs";
@@ -352,28 +352,37 @@ export function provideSvgDoc<
       return Number.isFinite(height) && height > 0 ? height : undefined;
     }
 
-    private resolveViewportTopY(svg: SVGElement, scrollEl: HTMLElement) {
+    private resolveAppliedSvgScaleY(svg: SVGElement) {
       const svgHeight = this.resolveSvgDocumentHeight(svg);
-      if (svgHeight === undefined) {
-        return undefined;
+      const appliedHeight = Number.parseFloat(svg.getAttribute("height") || "NaN");
+      if (svgHeight !== undefined && Number.isFinite(appliedHeight) && appliedHeight > 0) {
+        return appliedHeight / svgHeight;
       }
 
-      const svgRect = svg.getBoundingClientRect();
-      const actualScaleY = svgRect.height / svgHeight;
-      if (!Number.isFinite(actualScaleY) || actualScaleY <= 0) {
-        return undefined;
-      }
-
-      return (scrollEl.getBoundingClientRect().top - svgRect.top) / actualScaleY;
+      return undefined;
     }
 
-    private captureViewportTopResizeAnchor(svg: SVGElement, scrollEl: HTMLElement) {
-      const viewportTopY = this.resolveViewportTopY(svg, scrollEl);
-      if (viewportTopY === undefined) {
+    private resolveViewportTopY(domState: ContainerDOMState, appliedScaleY: number) {
+      const { scrollTop, contentTopOffset } = domState;
+      if (
+        scrollTop === undefined ||
+        contentTopOffset === undefined ||
+        !Number.isFinite(scrollTop) ||
+        !Number.isFinite(contentTopOffset) ||
+        !Number.isFinite(appliedScaleY) ||
+        appliedScaleY <= 0
+      ) {
         return undefined;
       }
 
-      const pages = this.collectSvgAnchorPages(svg);
+      return (scrollTop - contentTopOffset) / appliedScaleY;
+    }
+
+    private captureViewportTopResizeAnchor(
+      pages: SvgAnchorPage[],
+      svgHeight: number,
+      viewportTopY: number,
+    ) {
       const containingPage = pages.find(
         (page) => viewportTopY >= page.y && viewportTopY <= page.y + page.height,
       );
@@ -386,19 +395,14 @@ export function provideSvgDoc<
         } satisfies SvgResizePageAnchor;
       }
 
-      return this.captureSvgGapAnchor(svg, pages, viewportTopY);
+      return this.captureSvgGapAnchor(pages, svgHeight, viewportTopY);
     }
 
     private captureSvgGapAnchor(
-      svg: SVGElement,
       pages: SvgAnchorPage[],
+      svgHeight: number,
       viewportTopY: number,
     ): SvgResizeGapAnchor | undefined {
-      const svgHeight = this.resolveSvgDocumentHeight(svg);
-      if (svgHeight === undefined) {
-        return undefined;
-      }
-
       let beforePage: SvgAnchorPage | undefined;
       let afterPage: SvgAnchorPage | undefined;
       for (const page of pages) {
@@ -439,15 +443,12 @@ export function provideSvgDoc<
       return gapAnchor;
     }
 
-    private resolveSyntheticYForResizeAnchor(svg: SVGElement, anchor: SvgResizeAnchor) {
-      const pages = this.collectSvgAnchorPages(svg);
-
+    private resolveSyntheticYForResizeAnchor(
+      anchor: SvgResizeAnchor,
+      pages: SvgAnchorPage[],
+      svgHeight: number,
+    ) {
       if (anchor.kind === "gap") {
-        const svgHeight = this.resolveSvgDocumentHeight(svg);
-        if (svgHeight === undefined) {
-          return undefined;
-        }
-
         const beforePage =
           anchor.beforePageNumber !== undefined
             ? pages.find((page) => page.pageNumber === anchor.beforePageNumber)
@@ -490,25 +491,27 @@ export function provideSvgDoc<
 
     // Note: one should retrieve dom state before rescale
     rescale$svg() {
-      // get dom state from cache, so we are free from layout reflowing
       const svg = this.hookedElem.firstElementChild as SVGElement;
       if (!svg) {
         return;
       }
 
+      // get dom state from cache, so we are free from layout reflowing
+      const domState = this.cachedDOMState;
       const scale = this.getSvgScaleRatio();
       if (scale === 0) {
         console.warn("determine scale as 0, skip rescale");
         return;
       }
 
-      // During panel resize, only the auto-fit scale should change 
+      // During panel resize, only the auto-fit scale should change
       // while the user-driven scale ratio does not. Keep the
       // same viewport-top anchor for the whole resize burst instead of
       // resampling after each intermediate frame to avoid accumulating jitter.
       const scrollElement = this.hookedElem.parentElement;
       const prevScale = this.lastSvgScale;
       const prevScaleRatio = this.lastSvgScaleRatio;
+      const prevAppliedScale = this.resolveAppliedSvgScaleY(svg);
       // Manual zoom changes currentScaleRatio and is handled by
       // installRescaleHandler's cursor-centered scroll adjustment.
       const scaleRatioChanged =
@@ -522,6 +525,8 @@ export function provideSvgDoc<
         scrollElement instanceof HTMLElement &&
         prevScale !== undefined &&
         prevScale > 0 &&
+        prevAppliedScale !== undefined &&
+        prevAppliedScale > 0 &&
         prevScaleRatio !== undefined &&
         !scaleRatioChanged &&
         (Math.abs(scale - prevScale) > SVG_SCALE_EPSILON || this.svgResizeAnchor !== undefined);
@@ -529,22 +534,30 @@ export function provideSvgDoc<
       let restoreScroll: (() => void) | undefined;
       if (shouldAnchor) {
         const scrollEl = scrollElement as HTMLElement;
-        const svgRect = svg.getBoundingClientRect();
-        const containerRect = scrollEl.getBoundingClientRect();
-        const fixedTopOffset = svgRect.top - containerRect.top + scrollEl.scrollTop;
-        const sampledContentY = (scrollEl.scrollTop - fixedTopOffset) / prevScale!;
+        const fixedTopOffset = domState.contentTopOffset;
+        const sampledContentY = this.resolveViewportTopY(domState, prevAppliedScale);
         const reusableAnchor =
           this.svgResizeAnchor &&
           Math.abs(this.svgResizeAnchor.scaleRatio - this.currentScaleRatio) < SVG_SCALE_EPSILON
             ? this.svgResizeAnchor
             : undefined;
         const contentY = reusableAnchor?.contentY ?? sampledContentY;
-        if (Number.isFinite(contentY)) {
+        if (
+          fixedTopOffset !== undefined &&
+          Number.isFinite(fixedTopOffset) &&
+          contentY !== undefined &&
+          Number.isFinite(contentY)
+        ) {
+          const pages = this.collectSvgAnchorPages(svg);
+          const svgHeight = this.resolveSvgDocumentHeight(svg);
           // A raw document y-coordinate is enough within page content. In page
           // margins, use a gap anchor so scale-dependent margin height does not
           // leak into the restored scroll position.
           const viewportAnchor =
-            reusableAnchor?.viewportAnchor ?? this.captureViewportTopResizeAnchor(svg, scrollEl);
+            reusableAnchor?.viewportAnchor ??
+            (svgHeight !== undefined
+              ? this.captureViewportTopResizeAnchor(pages, svgHeight, contentY)
+              : undefined);
           this.svgResizeAnchor = {
             contentY,
             scaleRatio: this.currentScaleRatio,
@@ -553,18 +566,18 @@ export function provideSvgDoc<
           this.keepSvgResizeAnchorAlive();
           restoreScroll = () => {
             const viewportAnchorY = viewportAnchor
-              ? this.resolveSyntheticYForResizeAnchor(svg, viewportAnchor)
+              ? svgHeight !== undefined
+                ? this.resolveSyntheticYForResizeAnchor(viewportAnchor, pages, svgHeight)
+                : undefined
               : undefined;
             const targetY = viewportAnchorY ?? contentY;
             const target = targetY * scale + fixedTopOffset;
-            const max = Math.max(0, scrollEl.scrollHeight - scrollEl.clientHeight);
-            scrollEl.scrollTop = Math.max(0, Math.min(max, target));
+            if (Number.isFinite(target)) {
+              scrollEl.scrollTop = Math.max(0, target);
+            }
           };
         }
       }
-
-      // get dom state from cache, so we are free from layout reflowing
-      const container = this.cachedDOMState;
 
       // apply scale
       const dataWidth = Number.parseFloat(svg.getAttribute("data-width")!);
@@ -574,10 +587,10 @@ export function provideSvgDoc<
 
       this.rescaleSvgOn(svg);
 
-      const widthAdjust = Math.max((container.width - scaledWidth) / 2, 0);
+      const widthAdjust = Math.max((domState.width - scaledWidth) / 2, 0);
       let transformAttr = "";
       if (this.previewMode === PreviewMode.Slide) {
-        const heightAdjust = Math.max((container.height - scaledHeight) / 2, 0);
+        const heightAdjust = Math.max((domState.height - scaledHeight) / 2, 0);
         transformAttr = `translate(${widthAdjust}px, ${heightAdjust}px)`;
       } else {
         transformAttr = `translate(${widthAdjust}px, 0px)`;
@@ -600,7 +613,7 @@ export function provideSvgDoc<
     }
 
     private decorateSvgElement(svg: SVGElement, mode: PreviewMode) {
-      const container = this.cachedDOMState;
+      const domState = this.cachedDOMState;
       const kShouldMixinCanvas = this.previewMode === PreviewMode.Doc && this.shouldMixinCanvas();
 
       // the <rect> could only have integer width and height
@@ -654,7 +667,7 @@ export function provideSvgDoc<
 
       /// Prepare scale
       // scale derived from svg width and container with.
-      const computedScale = container.width ? container.width / maxWidth : 1;
+      const computedScale = domState.width ? domState.width / maxWidth : 1;
       // respect current scale ratio
       const scale = 1 / (this.currentScaleRatio * computedScale);
       const fontSize = 12 * scale;

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -1,39 +1,25 @@
 import { PreviewMode } from "./typst-doc.mjs";
 import { TypstCancellationToken } from "./typst-cancel.mjs";
 import { TypstPatchAttrs, isDummyPatchElem } from "./typst-patch.mjs";
-import type { ContainerDOMState, GConstructor, TypstDocumentContext } from "./typst-doc.mjs";
+import type { GConstructor, TypstDocumentContext } from "./typst-doc.mjs";
 import type { CanvasPage, TypstCanvasDocument } from "./typst-doc.canvas.mjs";
 import { patchSvgToContainer } from "./typst-patch.svg.mjs";
 import { ElementPoint, resolveSourceLeaf } from "./typst-debug-info.mjs";
+import {
+  SVG_SCALE_EPSILON,
+  captureSvgResizeYAnchor,
+  hasSvgScaleRatioChanged,
+  resolveScrollForViewportStart,
+  resolveSyntheticYForResizeAnchor,
+  resolveViewportStart,
+} from "./typst-doc.resize-anchor.mjs";
+import type { SvgAnchorPage, SvgResizeAnchor } from "./typst-doc.resize-anchor.mjs";
 
 export interface TypstSvgDocument {
   setCursorPaths(paths: ElementPoint[][]): void;
 }
 
 const SVG_RESIZE_ANCHOR_TTL_MS = 600;
-const SVG_SCALE_EPSILON = 1e-6;
-
-interface SvgResizePageAnchor {
-  kind: "page";
-  pageNumber: number;
-  pageLocalY: number;
-  pageHeight: number;
-}
-
-interface SvgResizeGapAnchor {
-  kind: "gap";
-  beforePageNumber?: number;
-  afterPageNumber?: number;
-  gapRatio: number;
-}
-
-type SvgResizeAnchor = SvgResizePageAnchor | SvgResizeGapAnchor;
-
-interface SvgAnchorPage {
-  pageNumber: number;
-  y: number;
-  height: number;
-}
 
 export function provideSvgDoc<
   TBase extends GConstructor<TypstDocumentContext & Partial<TypstCanvasDocument>>,
@@ -60,11 +46,12 @@ export function provideSvgDoc<
     /// last currentScaleRatio captured alongside lastSvgScale; used to detect
     /// whether a scale change came from manual zoom (Ctrl+scroll) or panel resize.
     private lastSvgScaleRatio?: number;
-    /// document y-coordinate at the top of the viewport for the current resize
-    /// burst. Reused across consecutive resize frames so the anchor is the y
+    /// document coordinates at the top-left of the viewport for the current
+    /// resize burst. Reused across consecutive resize frames so the anchor is
     /// from before dragging started, not a value re-sampled mid-drag.
     private svgResizeAnchor?: {
-      contentY: number;
+      contentX?: number;
+      contentY?: number;
       scaleRatio: number;
       viewportAnchor?: SvgResizeAnchor;
     };
@@ -352,141 +339,24 @@ export function provideSvgDoc<
       return Number.isFinite(height) && height > 0 ? height : undefined;
     }
 
-    private resolveAppliedSvgScaleY(svg: SVGElement) {
-      const svgHeight = this.resolveSvgDocumentHeight(svg);
-      const appliedHeight = Number.parseFloat(svg.getAttribute("height") || "NaN");
-      if (svgHeight !== undefined && Number.isFinite(appliedHeight) && appliedHeight > 0) {
-        return appliedHeight / svgHeight;
+    private resolveSvgDocumentWidth(svg: SVGElement) {
+      const width = Number.parseFloat(
+        svg.getAttribute("data-width") || svg.getAttribute("width") || "NaN",
+      );
+      return Number.isFinite(width) && width > 0 ? width : undefined;
+    }
+
+    private resolveAppliedSvgScale(svg: SVGElement, axis: "x" | "y") {
+      const documentSize =
+        axis === "x" ? this.resolveSvgDocumentWidth(svg) : this.resolveSvgDocumentHeight(svg);
+      const appliedSize = Number.parseFloat(
+        svg.getAttribute(axis === "x" ? "width" : "height") || "NaN",
+      );
+      if (documentSize !== undefined && Number.isFinite(appliedSize) && appliedSize > 0) {
+        return appliedSize / documentSize;
       }
 
       return undefined;
-    }
-
-    private resolveViewportTopY(domState: ContainerDOMState, appliedScaleY: number) {
-      const { scrollTop, contentTopOffset } = domState;
-      if (
-        scrollTop === undefined ||
-        contentTopOffset === undefined ||
-        !Number.isFinite(scrollTop) ||
-        !Number.isFinite(contentTopOffset) ||
-        !Number.isFinite(appliedScaleY) ||
-        appliedScaleY <= 0
-      ) {
-        return undefined;
-      }
-
-      return (scrollTop - contentTopOffset) / appliedScaleY;
-    }
-
-    private captureViewportTopResizeAnchor(
-      pages: SvgAnchorPage[],
-      svgHeight: number,
-      viewportTopY: number,
-    ) {
-      const containingPage = pages.find(
-        (page) => viewportTopY >= page.y && viewportTopY <= page.y + page.height,
-      );
-      if (containingPage) {
-        return {
-          kind: "page",
-          pageNumber: containingPage.pageNumber,
-          pageLocalY: viewportTopY - containingPage.y,
-          pageHeight: containingPage.height,
-        } satisfies SvgResizePageAnchor;
-      }
-
-      return this.captureSvgGapAnchor(pages, svgHeight, viewportTopY);
-    }
-
-    private captureSvgGapAnchor(
-      pages: SvgAnchorPage[],
-      svgHeight: number,
-      viewportTopY: number,
-    ): SvgResizeGapAnchor | undefined {
-      let beforePage: SvgAnchorPage | undefined;
-      let afterPage: SvgAnchorPage | undefined;
-      for (const page of pages) {
-        if (viewportTopY < page.y) {
-          afterPage = page;
-          break;
-        }
-        if (viewportTopY > page.y + page.height) {
-          beforePage = page;
-        }
-      }
-
-      const gapStartY = beforePage ? beforePage.y + beforePage.height : 0;
-      const gapEndY = afterPage ? afterPage.y : svgHeight;
-      if (
-        !Number.isFinite(gapStartY) ||
-        !Number.isFinite(gapEndY) ||
-        gapEndY < gapStartY ||
-        viewportTopY < gapStartY ||
-        viewportTopY > gapEndY
-      ) {
-        return undefined;
-      }
-
-      // Store a relative position inside the gap instead of the raw y-coordinate.
-      const gapLength = gapEndY - gapStartY;
-      const gapAnchor: SvgResizeGapAnchor = {
-        kind: "gap",
-        gapRatio:
-          gapLength > 0 ? Math.max(0, Math.min(1, (viewportTopY - gapStartY) / gapLength)) : 0,
-      };
-      if (beforePage) {
-        gapAnchor.beforePageNumber = beforePage.pageNumber;
-      }
-      if (afterPage) {
-        gapAnchor.afterPageNumber = afterPage.pageNumber;
-      }
-      return gapAnchor;
-    }
-
-    private resolveSyntheticYForResizeAnchor(
-      anchor: SvgResizeAnchor,
-      pages: SvgAnchorPage[],
-      svgHeight: number,
-    ) {
-      if (anchor.kind === "gap") {
-        const beforePage =
-          anchor.beforePageNumber !== undefined
-            ? pages.find((page) => page.pageNumber === anchor.beforePageNumber)
-            : undefined;
-        const afterPage =
-          anchor.afterPageNumber !== undefined
-            ? pages.find((page) => page.pageNumber === anchor.afterPageNumber)
-            : undefined;
-
-        if (
-          (anchor.beforePageNumber !== undefined && beforePage === undefined) ||
-          (anchor.afterPageNumber !== undefined && afterPage === undefined)
-        ) {
-          return undefined;
-        }
-
-        const gapStartY = beforePage ? beforePage.y + beforePage.height : 0;
-        const gapEndY = afterPage ? afterPage.y : svgHeight;
-        if (!Number.isFinite(gapStartY) || !Number.isFinite(gapEndY) || gapEndY < gapStartY) {
-          return undefined;
-        }
-
-        const gapRatio = Math.max(0, Math.min(1, anchor.gapRatio));
-        return gapStartY + gapRatio * (gapEndY - gapStartY);
-      }
-
-      const page = pages.find((page) => page.pageNumber === anchor.pageNumber);
-      if (!page) {
-        return undefined;
-      }
-
-      const pageY = page.y;
-      const pageHeight = page.height;
-      if (anchor.pageHeight <= 0) {
-        return undefined;
-      }
-
-      return pageY + (anchor.pageLocalY * pageHeight) / anchor.pageHeight;
     }
 
     // Note: one should retrieve dom state before rescale
@@ -506,17 +376,16 @@ export function provideSvgDoc<
 
       // During panel resize, only the auto-fit scale should change
       // while the user-driven scale ratio does not. Keep the
-      // same viewport-top anchor for the whole resize burst instead of
+      // same viewport top-left anchor for the whole resize burst instead of
       // resampling after each intermediate frame to avoid accumulating jitter.
       const scrollElement = this.hookedElem.parentElement;
       const prevScale = this.lastSvgScale;
       const prevScaleRatio = this.lastSvgScaleRatio;
-      const prevAppliedScale = this.resolveAppliedSvgScaleY(svg);
+      const prevAppliedScaleX = this.resolveAppliedSvgScale(svg, "x");
+      const prevAppliedScaleY = this.resolveAppliedSvgScale(svg, "y");
       // Manual zoom changes currentScaleRatio and is handled by
       // installRescaleHandler's cursor-centered scroll adjustment.
-      const scaleRatioChanged =
-        prevScaleRatio !== undefined &&
-        Math.abs(this.currentScaleRatio - prevScaleRatio) >= SVG_SCALE_EPSILON;
+      const scaleRatioChanged = hasSvgScaleRatioChanged(prevScaleRatio, this.currentScaleRatio);
       if (scaleRatioChanged) {
         this.clearSvgResizeAnchor();
       }
@@ -525,55 +394,84 @@ export function provideSvgDoc<
         scrollElement instanceof HTMLElement &&
         prevScale !== undefined &&
         prevScale > 0 &&
-        prevAppliedScale !== undefined &&
-        prevAppliedScale > 0 &&
         prevScaleRatio !== undefined &&
         !scaleRatioChanged &&
         (Math.abs(scale - prevScale) > SVG_SCALE_EPSILON || this.svgResizeAnchor !== undefined);
 
-      let restoreScroll: (() => void) | undefined;
+      let restoreScroll: ((nextContentLeftOffset: number) => void) | undefined;
       if (shouldAnchor) {
         const scrollEl = scrollElement as HTMLElement;
-        const fixedTopOffset = domState.contentTopOffset;
-        const sampledContentY = this.resolveViewportTopY(domState, prevAppliedScale);
+        const fixedTopOffset =
+          domState.contentTopOffset !== undefined && Number.isFinite(domState.contentTopOffset)
+            ? domState.contentTopOffset
+            : undefined;
+        const sampledContentY = resolveViewportStart(
+          domState.scrollTop,
+          fixedTopOffset,
+          prevAppliedScaleY,
+        );
+        const sampledContentX = resolveViewportStart(
+          domState.scrollLeft,
+          domState.contentLeftOffset,
+          prevAppliedScaleX,
+        );
         const reusableAnchor =
           this.svgResizeAnchor &&
           Math.abs(this.svgResizeAnchor.scaleRatio - this.currentScaleRatio) < SVG_SCALE_EPSILON
             ? this.svgResizeAnchor
             : undefined;
         const contentY = reusableAnchor?.contentY ?? sampledContentY;
-        if (
-          fixedTopOffset !== undefined &&
-          Number.isFinite(fixedTopOffset) &&
-          contentY !== undefined &&
-          Number.isFinite(contentY)
-        ) {
-          const pages = this.collectSvgAnchorPages(svg);
-          const svgHeight = this.resolveSvgDocumentHeight(svg);
+        const contentX = reusableAnchor?.contentX ?? sampledContentX;
+        const anchoredContentY =
+          contentY !== undefined && Number.isFinite(contentY) ? contentY : undefined;
+        const anchoredContentX =
+          contentX !== undefined && Number.isFinite(contentX) ? contentX : undefined;
+        const canRestoreY = fixedTopOffset !== undefined && anchoredContentY !== undefined;
+        const canRestoreX = anchoredContentX !== undefined;
+        if (canRestoreY || canRestoreX) {
+          const pages = canRestoreY ? this.collectSvgAnchorPages(svg) : [];
+          const svgHeight = canRestoreY ? this.resolveSvgDocumentHeight(svg) : undefined;
           // A raw document y-coordinate is enough within page content. In page
           // margins, use a gap anchor so scale-dependent margin height does not
           // leak into the restored scroll position.
           const viewportAnchor =
-            reusableAnchor?.viewportAnchor ??
-            (svgHeight !== undefined
-              ? this.captureViewportTopResizeAnchor(pages, svgHeight, contentY)
-              : undefined);
+            canRestoreY && anchoredContentY !== undefined
+              ? (reusableAnchor?.viewportAnchor ??
+                (svgHeight !== undefined
+                  ? captureSvgResizeYAnchor(pages, svgHeight, anchoredContentY)
+                  : undefined))
+              : undefined;
           this.svgResizeAnchor = {
-            contentY,
+            contentX: anchoredContentX,
+            contentY: anchoredContentY,
             scaleRatio: this.currentScaleRatio,
             viewportAnchor,
           };
           this.keepSvgResizeAnchorAlive();
-          restoreScroll = () => {
-            const viewportAnchorY = viewportAnchor
-              ? svgHeight !== undefined
-                ? this.resolveSyntheticYForResizeAnchor(viewportAnchor, pages, svgHeight)
-                : undefined
-              : undefined;
-            const targetY = viewportAnchorY ?? contentY;
-            const target = targetY * scale + fixedTopOffset;
-            if (Number.isFinite(target)) {
-              scrollEl.scrollTop = Math.max(0, target);
+          restoreScroll = (nextContentLeftOffset: number) => {
+            if (canRestoreY && fixedTopOffset !== undefined && anchoredContentY !== undefined) {
+              const viewportAnchorY =
+                viewportAnchor && svgHeight !== undefined
+                  ? resolveSyntheticYForResizeAnchor(viewportAnchor, pages, svgHeight)
+                  : undefined;
+              const targetY = viewportAnchorY ?? anchoredContentY;
+              const target = targetY * scale + fixedTopOffset;
+              if (Number.isFinite(target)) {
+                scrollEl.scrollTop = Math.max(0, target);
+              }
+            }
+
+            if (canRestoreX && anchoredContentX !== undefined) {
+              const targetX = resolveScrollForViewportStart(
+                anchoredContentX,
+                scale,
+                nextContentLeftOffset,
+                scrollEl.scrollWidth,
+                scrollEl.clientWidth,
+              );
+              if (targetX !== undefined) {
+                scrollEl.scrollLeft = targetX;
+              }
             }
           };
         }
@@ -605,7 +503,7 @@ export function provideSvgDoc<
       }
 
       if (restoreScroll) {
-        restoreScroll();
+        restoreScroll(widthAdjust);
       }
 
       this.lastSvgScale = scale;
@@ -930,17 +828,38 @@ export function provideSvgDoc<
     }
 
     private statSvgFromDom() {
-      const { width: containerWidth, boundingRect: containerBRect } = this.cachedDOMState;
+      const { width: containerWidth, height: containerHeight } = this.cachedDOMState;
       // scale derived from svg width and container with.
       // svg.setAttribute("data-width", `${newWidth}`);
 
       const computedRevScale = containerWidth ? this.docWidth / containerWidth : 1;
       // respect current scale ratio
       const revScale = computedRevScale / this.currentScaleRatio;
-      const left = (this.hookedElem.parentElement!.scrollLeft - containerBRect.left) * revScale;
-      const top = (this.hookedElem.parentElement!.scrollTop - containerBRect.top) * revScale;
-      const width = this.windowElem.clientWidth * revScale;
-      const height = this.windowElem.clientHeight * revScale;
+      const scrollElement = this.hookedElem.parentElement!;
+      const stateScrollLeft = this.cachedDOMState.scrollLeft;
+      const stateScrollTop = this.cachedDOMState.scrollTop;
+      const stateContentLeftOffset = this.cachedDOMState.contentLeftOffset;
+      const stateContentTopOffset = this.cachedDOMState.contentTopOffset;
+      const scrollLeft =
+        stateScrollLeft !== undefined && Number.isFinite(stateScrollLeft)
+          ? stateScrollLeft
+          : scrollElement.scrollLeft;
+      const scrollTop =
+        stateScrollTop !== undefined && Number.isFinite(stateScrollTop)
+          ? stateScrollTop
+          : scrollElement.scrollTop;
+      const contentLeftOffset =
+        stateContentLeftOffset !== undefined && Number.isFinite(stateContentLeftOffset)
+          ? stateContentLeftOffset
+          : 0;
+      const contentTopOffset =
+        stateContentTopOffset !== undefined && Number.isFinite(stateContentTopOffset)
+          ? stateContentTopOffset
+          : 0;
+      const left = (scrollLeft - contentLeftOffset) * revScale;
+      const top = (scrollTop - contentTopOffset) * revScale;
+      const width = containerWidth * revScale;
+      const height = containerHeight * revScale;
 
       return { revScale, left, top, width, height };
     }

--- a/tools/typst-dom/src/typst-doc.svg.mts
+++ b/tools/typst-dom/src/typst-doc.svg.mts
@@ -12,6 +12,7 @@ import {
   resolveScrollForViewportStart,
   resolveSyntheticYForResizeAnchor,
   resolveViewportStart,
+  shouldRestoreHorizontalResizeAnchor,
 } from "./typst-doc.resize-anchor.mjs";
 import type { SvgAnchorPage, SvgResizeAnchor } from "./typst-doc.resize-anchor.mjs";
 
@@ -427,7 +428,9 @@ export function provideSvgDoc<
         const anchoredContentX =
           contentX !== undefined && Number.isFinite(contentX) ? contentX : undefined;
         const canRestoreY = fixedTopOffset !== undefined && anchoredContentY !== undefined;
-        const canRestoreX = anchoredContentX !== undefined;
+        const canRestoreX =
+          shouldRestoreHorizontalResizeAnchor(this.currentScaleRatio) &&
+          anchoredContentX !== undefined;
         if (canRestoreY || canRestoreX) {
           const pages = canRestoreY ? this.collectSvgAnchorPages(svg) : [];
           const svgHeight = canRestoreY ? this.resolveSvgDocumentHeight(svg) : undefined;

--- a/tools/typst-preview-frontend/src/ws.ts
+++ b/tools/typst-preview-frontend/src/ws.ts
@@ -58,12 +58,18 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
       kModule,
       previewMode,
       isContentPreview,
-      // set rescale target to `body`
+      // set rescale target to the scroll container
       retrieveDOMState() {
+        const contentElem = hookedElem.firstElementChild || hookedElem;
+        const contentRect = contentElem.getBoundingClientRect();
+        const resizeTargetRect = resizeTarget.getBoundingClientRect();
+        const contentTopOffset = contentRect.top - resizeTargetRect.top + resizeTarget.scrollTop;
         return {
           width: resizeTarget.clientWidth,
           height: resizeTarget.offsetHeight,
-          boundingRect: resizeTarget.getBoundingClientRect(),
+          boundingRect: resizeTargetRect,
+          scrollTop: resizeTarget.scrollTop,
+          contentTopOffset,
         };
       },
     });
@@ -212,16 +218,16 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
           }
           break;
         case "j":
-          resizeTarget.scrollBy({ top: + scrollDelta, behavior: "instant" });
+          resizeTarget.scrollBy({ top: +scrollDelta, behavior: "instant" });
           break;
         case "k":
-          resizeTarget.scrollBy({ top: - scrollDelta, behavior: "instant" });
+          resizeTarget.scrollBy({ top: -scrollDelta, behavior: "instant" });
           break;
         case "h":
-          resizeTarget.scrollBy({ top: - scrollDelta * 10, behavior: "smooth" });
+          resizeTarget.scrollBy({ top: -scrollDelta * 10, behavior: "smooth" });
           break;
         case "l":
-          resizeTarget.scrollBy({ top: + scrollDelta * 10, behavior: "smooth" });
+          resizeTarget.scrollBy({ top: +scrollDelta * 10, behavior: "smooth" });
           break;
         case "?":
           blurInput();

--- a/tools/typst-preview-frontend/src/ws.ts
+++ b/tools/typst-preview-frontend/src/ws.ts
@@ -64,12 +64,16 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
         const contentRect = contentElem.getBoundingClientRect();
         const resizeTargetRect = resizeTarget.getBoundingClientRect();
         const contentTopOffset = contentRect.top - resizeTargetRect.top + resizeTarget.scrollTop;
+        const contentLeftOffset =
+          contentRect.left - resizeTargetRect.left + resizeTarget.scrollLeft;
         return {
           width: resizeTarget.clientWidth,
           height: resizeTarget.offsetHeight,
           boundingRect: resizeTargetRect,
           scrollTop: resizeTarget.scrollTop,
+          scrollLeft: resizeTarget.scrollLeft,
           contentTopOffset,
+          contentLeftOffset,
         };
       },
     });


### PR DESCRIPTION
Use cached DOM state for SVG resize anchoring.

This PR avoids extra layout reads during resize handling by using the cached DOM state.

* Added optional `scrollTop`, `contentTopOffset`,`scrollLeft`, `contentLeftOffset` properties to `ContainerDOMState`.
* Updated `resolveViewportTopY` to use the cached values instead of reading from the live DOM.
* Extracted resize anchoring logic into `typst-doc.resize-anchor.mts`.
* Added a horizontal anchor to preserve the viewport position when resizing the preview panel with `currentScaleRatio > 1`.

This also fixes an issue that resizing the preview panel when `currentScaleRatio > 1` could cause unexpected horizontal drift.
