### PR TITLE
fix: avoid resolving lockfiles under Typst file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,26 @@ jobs:
     with:
       tag: ${{ (startsWith(github.ref, 'refs/tags/') && needs.prepare-build.outputs.tag) || '' }}
       targets: ${{ (!startsWith(github.ref, 'refs/tags/') && 'aarch64-apple-darwin,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu') || 'all' }}
+
+  checks-neovim:
+    name: Neovim Spec Tests
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      RUST_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download tinymist binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-build-local-${{ env.RUST_TARGET }}
+          path: prebuilts
+      - name: Unzip tinymist binary artifact
+        run: |
+          tar -xvf prebuilts/tinymist-${{ env.RUST_TARGET }}.tar.gz -C prebuilts
+          mv prebuilts/tinymist-${{ env.RUST_TARGET }}/tinymist prebuilts/tinymist
+          chmod +x prebuilts/tinymist
+      - name: Run Neovim specs
+        run: ./editors/neovim/bootstrap.sh test
+        env:
+          TINYMIST_BIN: ${{ github.workspace }}/prebuilts/tinymist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,11 +197,31 @@ jobs:
   checks-neovim:
     name: Neovim Spec Tests
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [prepare-build]
+    permissions:
+      actions: read
+      contents: read
     env:
       RUST_TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
+      - name: Wait for tinymist binary artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: artifacts-build-local-${{ env.RUST_TARGET }}
+        run: |
+          set -euo pipefail
+          for attempt in {1..720}; do
+            if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+              --jq '.artifacts[].name' | grep -Fxq "$ARTIFACT_NAME"; then
+              echo "Found artifact: $ARTIFACT_NAME"
+              exit 0
+            fi
+            echo "Waiting for $ARTIFACT_NAME ($attempt/720)"
+            sleep 30
+          done
+          echo "Timed out waiting for artifact: $ARTIFACT_NAME" >&2
+          exit 1
       - name: Download tinymist binary artifact
         uses: actions/download-artifact@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@ This is the tinymist language service, integrated with editor frontends and othe
 - List the validation you ran.
 - Call out anything you could not verify locally.
 
+## Commit and PR Conventions
+
+- Write commit messages in Conventional Commits format, such as `fix(query): handle missing labels`.
+- Keep PR content limited to a list of modified features and issue operations, such as `Close #123`.
+- Do not include validation logs, command transcripts, or detailed execution notes in PR content.
+
 ## Rust Conventions
 
 - Follow workspace lints in `Cargo.toml`. `missing_docs`, `missing_safety_doc`, and `undocumented_unsafe_blocks` are all watched in this repo.

--- a/crates/tinymist/src/route.rs
+++ b/crates/tinymist/src/route.rs
@@ -25,7 +25,8 @@ impl ProjectRouteState {
     }
 
     pub fn resolve(&mut self, leaf: &ImmutPath) -> Option<ProjectResolution> {
-        for path in std::iter::successors(Some(leaf.as_ref()), |p| p.parent()) {
+        let search_start = lock_search_start(leaf.as_ref())?;
+        for path in std::iter::successors(Some(search_start), |p| p.parent()) {
             if let Some(resolution) = self.resolve_at(path, leaf) {
                 return Some(resolution);
             }
@@ -164,6 +165,14 @@ impl ProjectRouteState {
 
         let material = serde_json::from_slice::<ProjectPathMaterial>(&data).ok()?;
         Some(material)
+    }
+}
+
+fn lock_search_start(leaf: &Path) -> Option<&Path> {
+    if leaf.is_dir() {
+        Some(leaf)
+    } else {
+        leaf.parent()
     }
 }
 

--- a/editors/neovim/CONTRIBUTING.md
+++ b/editors/neovim/CONTRIBUTING.md
@@ -29,12 +29,12 @@ The supported entry point is:
 ./bootstrap.sh test
 ```
 
-This builds/runs the `tinymist-nvim-spec-local` Neovim development container, mounts
-`tests/workspaces` as `/home/runner/dev/workspaces`, runs
-`tinymist compile` for the `book` fixture, then runs `spec/main.py` with
-headless Neovim and the `inanis` runner. The container must provide the Lua
-test dependencies on `/home/runner/packpath/*`, especially `inanis.nvim`,
-`plenary.nvim`, and `nvim-lspconfig`.
+This builds/runs the `tinymist-nvim-spec-local` Neovim development container,
+mounts `tests/workspaces` read-only, copies the `book` fixture into a tmpfs
+workspace at `/home/runner/dev/workspaces`, runs `tinymist compile` for that
+fixture, then runs `spec/main.py` with headless Neovim and the `inanis` runner.
+The container must provide the Lua test dependencies on `/home/runner/packpath/*`,
+especially `inanis.nvim`, `plenary.nvim`, and `nvim-lspconfig`.
 
 The Neovim development image intentionally does not bundle `tinymist`.
 `bootstrap.sh` mounts a host-built binary into the container as

--- a/editors/neovim/bootstrap.sh
+++ b/editors/neovim/bootstrap.sh
@@ -41,17 +41,16 @@ if [ ! -x "$tinymist_bin" ]; then
   exit 1
 fi
 
-mkdir -p "$script_dir/target/.local" "$script_dir/target/.cache"
-
 (cd "$script_dir/samples" && docker build -t "$image_name" -f lazyvim-dev/Dockerfile .)
 
 docker_run_args=(
   --rm
-  -v "$repo_root/tests/workspaces:/home/runner/dev/workspaces"
+  --tmpfs /home/runner/dev/workspaces:uid=1000,gid=1000,mode=755
+  --tmpfs /home/runner/.local:uid=1000,gid=1000,mode=755
+  --tmpfs /home/runner/.cache:uid=1000,gid=1000,mode=755
+  -v "$repo_root/tests/workspaces:/home/runner/workspaces-src:ro"
   -v "$script_dir:/home/runner/dev"
   -v "$tinymist_bin:/usr/local/bin/tinymist:ro"
-  -v "$script_dir/target/.local:/home/runner/.local"
-  -v "$script_dir/target/.cache:/home/runner/.cache"
   -w /home/runner/dev
 )
 
@@ -59,4 +58,8 @@ if [ -t 0 ] && [ -t 1 ]; then
   docker_run_args+=(-it)
 fi
 
-docker run "${docker_run_args[@]}" "$image_name" "${docker_args[@]}"
+docker run "${docker_run_args[@]}" "$image_name" bash -lc '
+  set -euo pipefail
+  cp -R /home/runner/workspaces-src/book /home/runner/dev/workspaces/book
+  exec "$@"
+' bash "${docker_args[@]}"

--- a/editors/neovim/spec/lockfile_path_spec.lua
+++ b/editors/neovim/spec/lockfile_path_spec.lua
@@ -1,0 +1,91 @@
+---@brief [[
+--- Regression coverage for tinymist#2489.
+---@brief ]]
+
+local fixtures = require 'spec.fixtures'
+
+local log_path = '/tmp/tinymist-lockfile-path.log'
+local wrapper_path = '/tmp/tinymist-lockfile-path-wrapper.sh'
+
+local function absolute_path(path)
+  return vim.fs.normalize(vim.fn.fnamemodify(path, ':p'))
+end
+
+local book_root = absolute_path(fixtures.project.root)
+local zed_like_root = absolute_path(fixtures.project.some_nested_existing_file)
+
+local function file_uri_from_path(path)
+  return 'file://' .. path:gsub('%%', '%%25'):gsub(' ', '%%20')
+end
+
+local function write_tinymist_wrapper()
+  vim.fn.mkdir(vim.fs.dirname(log_path), 'p')
+  vim.fn.delete(log_path)
+  vim.fn.writefile({
+    '#!/usr/bin/env sh',
+    ('TINYMIST_LOG="${TINYMIST_LOG:-tinymist::route=info,tinymist::input=info}" exec tinymist "$@" 2>>%s'):format(vim.fn.shellescape(log_path)),
+  }, wrapper_path)
+  vim.fn.setfperm(wrapper_path, 'rwxr-xr-x')
+end
+
+local function read_log()
+  if vim.uv.fs_stat(log_path) == nil then
+    return ''
+  end
+  return table.concat(vim.fn.readfile(log_path), '\n')
+end
+
+write_tinymist_wrapper()
+
+require('tinymist').setup {
+  lsp = {
+    cmd = { wrapper_path, 'lsp' },
+    init_options = {
+      projectResolution = 'lockDatabase',
+      development = true,
+      systemFonts = false,
+    },
+    before_init = function(params)
+      local root_uri = file_uri_from_path(zed_like_root)
+      params.rootUri = root_uri
+      params.rootPath = zed_like_root
+      params.workspaceFolders = {
+        {
+          uri = root_uri,
+          name = 'tinymist-issue-2489',
+        },
+      }
+    end,
+    root_dir = function()
+      return book_root
+    end,
+  },
+}
+
+describe('Lockfile path resolution', function()
+  assert.is.empty(vim.lsp.get_clients { bufnr = 0, name = 'tinymist', _uninitialized = true })
+
+  it('does not look for tinymist.lock under the opened Typst file', function()
+    local opened_path = zed_like_root
+    local wrong_lock_path = vim.fs.joinpath(opened_path, 'tinymist.lock')
+
+    vim.cmd.edit(opened_path)
+    local client_attached = vim.wait(15000, function()
+      return #vim.lsp.get_clients { bufnr = 0, name = 'tinymist', _uninitialized = true } > 0
+    end)
+    assert.message('tinymist LSP client did not attach').True(client_attached)
+
+    local resolved_task = vim.wait(15000, function()
+      local log = read_log()
+      return log:find('resolved task with state:', 1, true) ~= nil
+        and log:find(opened_path, 1, true) ~= nil
+    end)
+    assert.message(('tinymist did not resolve the opened file through lockDatabase. log:\n%s'):format(read_log())).True(resolved_task)
+
+    local log = read_log()
+    assert.is_nil(
+      log:find(wrong_lock_path, 1, true),
+      ('tinymist tried to load a lockfile below a Typst file path: %s\nlog:\n%s'):format(wrong_lock_path, log)
+    )
+  end)
+end)


### PR DESCRIPTION
- Add Neovim regression coverage for Zed-style file roots with `projectResolution = lockDatabase`.
- Run Neovim specs in CI using the existing Linux `tinymist` build artifact.
- Isolate Neovim fixture writes in tmpfs to avoid mutating or copying the checkout workspace.
- Resolve lock database routes from the parent directory when the focused path is a file.

Close #2489.