### PR TITLE
ci(announce): bump cargo-dist installer to v0.32.0-tinymist.2

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -29,7 +29,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.28.6-tinymist.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.2/cargo-dist-installer.sh | sh"
       - name: Install parse changelog
         uses: taiki-e/install-action@parse-changelog
       - name: Install Node.js


### PR DESCRIPTION
- Update the announce workflow to install `cargo-dist` from `v0.32.0-tinymist.2`
- Preserve release creation behavior; only the installer source and file formatting changed
