### PR TITLE
fix(preview): keep address logs visible by default

### DIFF
--- a/crates/tinymist-cli/src/cmd/preview.rs
+++ b/crates/tinymist-cli/src/cmd/preview.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use futures::{SinkExt, StreamExt};
 use hyper_tungstenite::tungstenite::Message;
 use tinymist::{
+    PREVIEW_COMPAT_LOG_TARGET,
     project::ProjectPreviewState,
     tool::{
         preview::{PreviewCliArgs, ProjectPreviewHandler, bind_streams, make_http_server},
@@ -79,7 +80,11 @@ pub async fn preview_main(args: PreviewCliArgs) -> Result<()> {
 
         let srv =
             make_http_server(String::default(), args.control_plane_host, control_sock_tx).await;
-        log::info!("Control panel server listening on: {}", srv.addr);
+        log::info!(
+            target: PREVIEW_COMPAT_LOG_TARGET,
+            "Control panel server listening on: {}",
+            srv.addr
+        );
 
         let control_websocket = control_sock_rx.recv().await.unwrap();
         let ws = control_websocket.await.unwrap();
@@ -178,10 +183,17 @@ pub async fn preview_main(args: PreviewCliArgs) -> Result<()> {
     };
 
     let srv = make_http_server(frontend_html, args.data_plane_host, websocket_tx).await;
-    log::info!("Data plane server listening on: {}", srv.addr);
+    log::info!(
+        target: PREVIEW_COMPAT_LOG_TARGET,
+        "Data plane server listening on: {}",
+        srv.addr
+    );
 
     let static_server_addr = static_server.as_ref().map(|s| s.addr).unwrap_or(srv.addr);
-    log::info!("Static file server listening on: {static_server_addr}");
+    log::info!(
+        target: PREVIEW_COMPAT_LOG_TARGET,
+        "Static file server listening on: {static_server_addr}"
+    );
 
     #[cfg(feature = "open")]
     if open_in_browser {

--- a/crates/tinymist/src/log.rs
+++ b/crates/tinymist/src/log.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
+/// Log target for preview address announcements that external tools parse.
+pub const PREVIEW_COMPAT_LOG_TARGET: &str = "tinymist::compat::preview";
+
 /// Options for initializing the logger.
 pub struct InitLogOpts {
     /// Whether the command should use verbose logging.
@@ -54,19 +57,33 @@ pub fn init_log(
         });
     }
 
+    configure_log_filters(&mut builder, base_level, filter.as_deref());
+
+    Ok(builder.try_init()?)
+}
+
+fn configure_log_filters(
+    builder: &mut env_logger::Builder,
+    base_level: log::LevelFilter,
+    filter: Option<&str>,
+) {
+    use log::LevelFilter::*;
+
     builder
         .filter_module("tinymist", base_level)
         .filter_module("tinymist_preview", base_level)
         .filter_module("typlite", base_level)
         .filter_module("reflexo", base_level)
         .filter_module("sync_ls", base_level)
-        .filter_module("reflexo_typst::diag::console", base_level);
+        .filter_module("reflexo_typst::diag::console", base_level)
+        // typst-preview.nvim and similar tools discover preview URLs by parsing
+        // these INFO lines. Keep only this narrow compatibility target visible
+        // in non-verbose CLI mode.
+        .filter_module(PREVIEW_COMPAT_LOG_TARGET, Info);
 
     if let Some(f) = filter {
-        builder.parse_filters(&f);
+        builder.parse_filters(f);
     }
-
-    Ok(builder.try_init()?)
 }
 
 struct LogNotification(LspClient, Vec<u8>);
@@ -106,4 +123,42 @@ struct Log {
 impl lsp_types::notification::Notification for Log {
     const METHOD: &'static str = "tmLog";
     type Params = Self;
+}
+
+#[cfg(test)]
+mod tests {
+    use log::{Level, Log, Metadata};
+
+    use super::*;
+
+    fn test_logger(verbose: bool, filter: Option<&str>) -> env_logger::Logger {
+        use log::LevelFilter::*;
+
+        let base_level = if verbose { Info } else { Warn };
+        let mut builder = env_logger::builder();
+        configure_log_filters(&mut builder, base_level, filter);
+        builder.build()
+    }
+
+    fn enabled(logger: &env_logger::Logger, target: &str, level: Level) -> bool {
+        logger.enabled(&Metadata::builder().target(target).level(level).build())
+    }
+
+    #[test]
+    fn non_verbose_keeps_only_preview_address_info_enabled() {
+        let logger = test_logger(false, None);
+
+        assert!(enabled(&logger, PREVIEW_COMPAT_LOG_TARGET, Level::Info));
+        assert!(!enabled(&logger, "tinymist::tool::preview", Level::Info));
+        assert!(enabled(&logger, "tinymist::tool::preview", Level::Warn));
+    }
+
+    #[test]
+    fn explicit_filter_can_override_preview_address_info() {
+        let filter = format!("{PREVIEW_COMPAT_LOG_TARGET}=warn");
+        let logger = test_logger(false, Some(&filter));
+
+        assert!(!enabled(&logger, PREVIEW_COMPAT_LOG_TARGET, Level::Info));
+        assert!(enabled(&logger, PREVIEW_COMPAT_LOG_TARGET, Level::Warn));
+    }
 }

--- a/crates/tinymist/src/tool/preview.rs
+++ b/crates/tinymist/src/tool/preview.rs
@@ -532,7 +532,10 @@ impl PreviewState {
 
             let srv = make_http_server(frontend_html, args.data_plane_host, websocket_tx).await;
             let addr = srv.addr;
-            log::info!("PreviewTask({task_id}): preview server listening on: {addr}");
+            log::info!(
+                target: crate::PREVIEW_COMPAT_LOG_TARGET,
+                "PreviewTask({task_id}): preview server listening on: {addr}"
+            );
 
             let resp = StartPreviewResponse {
                 static_server_port: Some(addr.port()),


### PR DESCRIPTION
- Restore default preview address announcements for external preview clients.
- Keep other non-verbose INFO logging suppressed behind --verbose or log filters.
- Refs chomosuke/typst-preview.nvim#135