### PR TITLE
ci: share cargo-dist cache with rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy, rustfmt
+          cache-shared-key: x86_64-unknown-linux-gnu
+          cache-save-if: false
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -146,6 +148,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.92.0 # check-min-version
+          cache-shared-key: x86_64-pc-windows-msvc
+          cache-save-if: false
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.4/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.5/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v7
         with:
@@ -163,8 +163,9 @@ jobs:
           fi
       - uses: swatinem/rust-cache@v2
         with:
-          key: ${{ join(matrix.targets, '-') }}
+          shared-key: ${{ join(matrix.targets, '-') }}
           cache-provider: ${{ matrix.cache_provider }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,9 +4,9 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.32.0-tinymist.4"
+cargo-dist-version = "0.32.0-tinymist.5"
 # A URL to use to install `cargo-dist` (with the installer script)
-cargo-dist-url-override = "https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.4"
+cargo-dist-url-override = "https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.5"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
- update tinymist to use cargo-dist v0.32.0-tinymist.5
- generate release workflow from the released cargo-dist fork
- make cargo-dist artifact caches use target shared keys and save only on main
- make Linux/Windows Rust checks restore the corresponding shared target caches without saving new check-specific caches
