### PR TITLE
test(query): expose named argument parameter rename gap

### DIFF
--- a/crates/tinymist-query/src/fixtures/rename/named_arg_param.typ
+++ b/crates/tinymist-query/src/fixtures/rename/named_arg_param.typ
@@ -1,0 +1,9 @@
+// Issue #2444: parameter rename misses named argument labels at call sites.
+// @typstyle off
+#let bubble(/* ident after */ side: left, content) = {
+  if side == left { [ok] }
+  content
+}
+
+#bubble(side: left)[A]
+#let bubble_left = bubble.with(side: left)

--- a/crates/tinymist-query/src/fixtures/rename/snaps/test@named_arg_param.typ.snap
+++ b/crates/tinymist-query/src/fixtures/rename/snaps/test@named_arg_param.typ.snap
@@ -1,0 +1,27 @@
+---
+source: crates/tinymist-query/src/rename.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/rename/named_arg_param.typ
+---
+{
+ "changes": {
+  "s0.typ": [
+   {
+    "newText": "new_name",
+    "range": "2:30:2:34"
+   },
+   {
+    "newText": "new_name",
+    "range": "3:5:3:9"
+   },
+   {
+    "newText": "new_name",
+    "range": "7:8:7:12"
+   },
+   {
+    "newText": "new_name",
+    "range": "8:31:8:35"
+   }
+  ]
+ }
+}


### PR DESCRIPTION
- Add a rename snapshot fixture for #2444 covering direct named calls and .with named argument labels.