### PR TITLE
feat(package-docs): render docs from LSIF index

### DIFF
--- a/crates/tinymist-query/src/docs/module.rs
+++ b/crates/tinymist-query/src/docs/module.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use ecow::{EcoString, EcoVec, eco_vec};
 use itertools::Itertools;
+use lsp_types::Position;
 use serde::{Deserialize, Serialize};
 use typst::diag::StrResult;
 use typst::syntax::FileId;
@@ -75,20 +76,33 @@ pub struct DefInfo {
     /// The kind of the definition.
     pub kind: DefKind,
     /// The location (file, start, end) of the definition.
+    #[serde(skip)]
     pub loc: Option<(usize, usize, usize)>,
+    /// The source position for LSIF-backed queries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<SourceQuery>,
+    /// Source positions for function parameters.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub param_sources: HashMap<EcoString, SourceQuery>,
     /// Whether the definition external to the module.
     pub is_external: bool,
     /// The module link to the definition
     pub module_link: Option<String>,
+    /// The bundle-mode link to the definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle_link: Option<String>,
     /// The symbol link to the definition
     pub symbol_link: Option<String>,
     /// The link to the definition if it is external.
     pub external_link: Option<String>,
     /// The one-line documentation of the definition.
+    #[serde(skip_serializing)]
     pub oneliner: Option<String>,
     /// The raw documentation of the definition.
+    #[serde(skip_serializing)]
     pub docs: Option<EcoString>,
     /// The parsed documentation of the definition.
+    #[serde(skip_serializing)]
     pub parsed_docs: Option<DefDocs>,
     /// The value of the definition.
     #[serde(skip)]
@@ -99,6 +113,15 @@ pub struct DefInfo {
     pub decl: Option<Interned<Decl>>,
     /// The children of the definition.
     pub children: Vec<DefInfo>,
+}
+
+/// A source position that can be used to query an LSIF index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceQuery {
+    /// The source file index in the package document file table.
+    pub file: usize,
+    /// The source position for a `textDocument/definition` query.
+    pub position: Position,
 }
 
 /// Information about the definitions in a package.
@@ -219,8 +242,11 @@ impl ScanDefCtx<'_> {
             decl: Some(decl.clone()),
             children: children.unwrap_or_default(),
             loc: None,
+            source: None,
+            param_sources: HashMap::new(),
             is_external: false,
             module_link: None,
+            bundle_link: None,
             symbol_link: None,
             external_link: None,
             oneliner: None,

--- a/crates/tinymist-query/src/docs/package-doc.typ
+++ b/crates/tinymist-query/src/docs/package-doc.typ
@@ -1,4 +1,5 @@
 #import "@preview/cmarker:0.1.6": render
+#import "/typ/packages/tinymist-index/lib.typ": create_index, query
 // re-export page template
 #import "/typ/packages/package-docs/template.typ": project
 
@@ -12,8 +13,13 @@
   let it = name.replace(regex("[\s\:]"), "-").replace(regex("[.()]"), "").replace(regex("-+"), "-").replace("M", "m")
   label(it)
 }
-#let labelled-heading(depth, it) = {
-  heading(depth: depth, html.elem("span", attrs: (id: str(heading-label(it))), it))
+#let labelled-heading(depth, it, dest: none) = {
+  let body = if dest == none {
+    it
+  } else {
+    html.elem("a", attrs: (href: dest, class: "symbol-link"), it)
+  }
+  heading(depth: depth, html.elem("span", attrs: (id: str(heading-label(it))), body))
 }
 #let markdown-docs = render.with(
   scope: (
@@ -37,6 +43,1145 @@
 #let keyword = code.with(attrs: (class: "code-kw"))
 #let builtin-ty = code.with(attrs: (class: "type-builtin"))
 
+#let file-by-uri(files, uri) = {
+  for file in files {
+    if file.at("uri", default: none) == uri {
+      return file
+    }
+  }
+  none
+}
+
+#let lsif-definition(symbol-ctx, info) = {
+  let db = symbol-ctx.at("lsif", default: none)
+  let source = info.at("source", default: none)
+  if db == none or source == none {
+    return none
+  }
+
+  let file = symbol-ctx.files.at(source.file, default: none)
+  if file == none or file.at("uri", default: none) == none {
+    return none
+  }
+
+  let result = query(db, "goto_definition", (
+    textDocument: (uri: file.uri),
+    position: source.position,
+  ))
+  if result == none or result.len() == 0 {
+    return none
+  }
+
+  result.at(0)
+}
+
+#let hover-markdown(value) = {
+  if value == none {
+    return none
+  }
+  if type(value) == str {
+    return value
+  }
+  if type(value) == dictionary {
+    let contents = value.at("contents", default: none)
+    if contents != none {
+      return hover-markdown(contents)
+    }
+
+    let text = value.at("value", default: none)
+    if text != none {
+      let language = value.at("language", default: none)
+      if language != none {
+        return "```" + str(language) + "\n" + text + "\n```"
+      }
+      return text
+    }
+
+    return none
+  }
+  if type(value) == array {
+    let parts = ()
+    for item in value {
+      let part = hover-markdown(item)
+      if part != none and part.len() > 0 {
+        parts.push(part)
+      }
+    }
+    if parts.len() > 0 {
+      return parts.join("\n\n---\n\n")
+    }
+  }
+
+  none
+}
+
+#let lsif-hover(symbol-ctx, info) = {
+  let db = symbol-ctx.at("lsif", default: none)
+  let source = info.at("source", default: none)
+  if db == none or source == none {
+    return none
+  }
+
+  let file = symbol-ctx.files.at(source.file, default: none)
+  if file == none or file.at("uri", default: none) == none {
+    return none
+  }
+
+  let result = query(db, "hover", (
+    textDocument: (uri: file.uri),
+    position: source.position,
+  ))
+
+  hover-markdown(result)
+}
+
+#let path-parts(path) = {
+  let parts = ()
+  for part in str(path).split("/") {
+    if part != "" and part != "." {
+      parts.push(part)
+    }
+  }
+  parts
+}
+
+#let relative-path(from, to) = {
+  if from == none or to == none {
+    return to
+  }
+
+  let from-parts = path-parts(from)
+  if from-parts.len() > 0 {
+    from-parts = from-parts.slice(0, -1)
+  }
+
+  let to-parts = path-parts(to)
+  while (
+    from-parts.len() > 0 and
+    to-parts.len() > 0 and
+    from-parts.at(0) == to-parts.at(0)
+  ) {
+    from-parts = from-parts.slice(1)
+    to-parts = to-parts.slice(1)
+  }
+
+  let rel = ()
+  for part in from-parts {
+    rel.push("..")
+  }
+  for part in to-parts {
+    rel.push(part)
+  }
+
+  if rel.len() == 0 {
+    "."
+  } else {
+    rel.join("/")
+  }
+}
+
+#let symbol-dest(symbol-ctx, info) = {
+  if symbol-ctx.at("bundle", default: false) and info.at("bundle_link", default: none) != none {
+    return relative-path(symbol-ctx.at("path", default: none), info.bundle_link)
+  }
+  if info.at("symbol_link", default: none) != none {
+    return info.symbol_link
+  }
+  if info.at("module_link", default: none) != none {
+    return info.module_link
+  }
+
+  none
+}
+
+#let module-heading-title(info) = {
+  if info.prefix.len() > 0 {
+    "Module: " + info.prefix
+  } else {
+    "Package Exports"
+  }
+}
+
+#let module-title(info) = {
+  if info.prefix.len() > 0 {
+    "Module: " + info.prefix
+  } else {
+    "Package Exports"
+  }
+}
+
+#let module-nav-title(info) = {
+  if info.prefix.len() == 0 {
+    return "Package Exports"
+  }
+
+  let path = info.at("path", default: none)
+  if path == none {
+    return module-title(info)
+  }
+
+  path = str(path)
+  if path.ends-with(".typ") {
+    path.slice(0, -4)
+  } else {
+    path
+  }
+}
+
+#let module-anchor(info) = {
+  "#" + str(heading-label(module-heading-title(info)))
+}
+
+#let module-output-path(index, info) = {
+  if index == 0 {
+    return "index.html"
+  }
+
+  let path = info.at("path", default: none)
+  if path == none {
+    return "module-" + str(index) + ".html"
+  }
+
+  path = str(path)
+  if path.ends-with(".typ") {
+    path.slice(0, -4) + ".html"
+  } else {
+    path + ".html"
+  }
+}
+
+#let module-path-stem(index, info) = {
+  if index == 0 {
+    return none
+  }
+
+  let path = info.at("path", default: none)
+  if path == none {
+    return "module-" + str(index)
+  }
+
+  path = str(path)
+  if path.ends-with(".typ") {
+    path.slice(0, -4)
+  } else {
+    path
+  }
+}
+
+#let symbol-file-stem(raw) = {
+  let stem = str(raw).replace(regex("[^A-Za-z0-9_-]+"), "-").replace(regex("-+"), "-")
+  if stem == "" or stem == "-" {
+    "symbol"
+  } else {
+    stem
+  }
+}
+
+#let module-symbol-output-path(index, info, section, symbol) = {
+  let file = symbol-file-stem(symbol) + ".html"
+  if index == 0 {
+    return section + "/" + file
+  }
+
+  module-path-stem(index, info) + "/" + section + "/" + file
+}
+
+#let module-source-output-path(info) = {
+  let path = info.at("path", default: none)
+  if path == none {
+    return none
+  }
+
+  str(path) + ".html"
+}
+
+#let module-nav-dest(symbol-ctx, index, info) = {
+  if symbol-ctx.at("bundle", default: false) {
+    let output = module-output-path(index, info)
+    if symbol-ctx.at("path", default: none) == output {
+      return module-anchor(info)
+    }
+
+    return relative-path(symbol-ctx.at("path", default: none), output)
+  }
+
+  module-anchor(info)
+}
+
+#let module-source-dest(symbol-ctx, info) = {
+  if not symbol-ctx.at("bundle", default: false) {
+    return none
+  }
+
+  let output = module-source-output-path(info)
+  if output == none {
+    return none
+  }
+
+  relative-path(symbol-ctx.at("path", default: none), output)
+}
+
+#let source-line-id(line) = {
+  "L" + str(line)
+}
+
+#let source-line-fragment(line) = {
+  "#" + source-line-id(line)
+}
+
+#let module-source-line-dest(symbol-ctx, line) = {
+  let module-info = symbol-ctx.at("module-info", default: none)
+  if module-info == none {
+    return none
+  }
+
+  let dest = module-source-dest(symbol-ctx, module-info)
+  if dest == none {
+    return none
+  }
+
+  dest + source-line-fragment(line)
+}
+
+#let source-query-line-dest(symbol-ctx, source, line) = {
+  if not symbol-ctx.at("bundle", default: false) {
+    return none
+  }
+
+  let file = symbol-ctx.files.at(source.file, default: none)
+  if file != none and file.at("path", default: none) != none {
+    return relative-path(symbol-ctx.at("path", default: none), str(file.path) + ".html") + source-line-fragment(line)
+  }
+
+  module-source-line-dest(symbol-ctx, line)
+}
+
+#let module-section-list = (
+  ("constants", "Constants"),
+  ("functions", "Functions"),
+)
+
+#let section-title(section) = {
+  for (id, title) in module-section-list {
+    if id == section {
+      return title
+    }
+  }
+
+  section
+}
+
+#let symbol-section(info) = {
+  if info.kind == "function" and not info.name.starts-with("_") {
+    return "functions"
+  }
+  if (info.kind == "variable" or info.kind == "constant") and not info.name.starts-with("_") {
+    return "constants"
+  }
+
+  none
+}
+
+#let module-section-items(m, section) = {
+  let items = ()
+  for child in m.children {
+    if symbol-section(child) == section {
+      items.push(child)
+    }
+  }
+
+  items
+}
+
+#let module-has-section(m, section) = {
+  module-section-items(m, section).len() > 0
+}
+
+#let symbol-heading-anchor(in-module, info) = {
+  "#" + str(heading-label(info.kind + ": " + info.name + " in " + in-module))
+}
+
+#let sidebar-symbol-label(info) = {
+  info.name
+}
+
+#let symbol-anchor(symbol-ctx, info) = {
+  symbol-heading-anchor(symbol-ctx.in-module, info)
+}
+
+#let symbol-section-dest(symbol-ctx, info) = {
+  let dest = symbol-dest(symbol-ctx, info)
+  if dest != none {
+    return dest
+  }
+
+  let section = symbol-section(info)
+  if section == none {
+    return none
+  }
+
+  let module-index = symbol-ctx.at("module-index", default: none)
+  let module-info = symbol-ctx.at("module-info", default: none)
+  if module-index == none or module-info == none {
+    return symbol-anchor(symbol-ctx, info)
+  }
+
+  module-symbol-output-path(module-index, module-info, section, info.name)
+}
+
+#let package-sidebar(info, symbol-ctx, active-module-index: none, active-section: none, active-symbol-index: none) = {
+  let package-link = if symbol-ctx.at("bundle", default: false) {
+    let output = module-output-path(0, info.modules.at(0).at(2))
+    if symbol-ctx.at("path", default: none) == output {
+      module-anchor(info.modules.at(0).at(2))
+    } else {
+      relative-path(symbol-ctx.at("path", default: none), output)
+    }
+  } else {
+    module-anchor(info.modules.at(0).at(2))
+  }
+
+  html.elem("aside", attrs: (class: "package-sidebar"), [
+    #html.elem("nav", attrs: (class: "package-sidebar-nav", "aria-label": "Package modules"), [
+      #html.elem("a", attrs: (class: "package-sidebar-title", href: package-link), [
+        #html.elem("span", attrs: (class: "package-sidebar-package"), "@" + info.meta.namespace + "/" + info.meta.name)
+        #html.elem("span", attrs: (class: "package-sidebar-version"), info.meta.version)
+      ])
+      #html.elem("div", attrs: (class: "package-sidebar-section"), "Modules")
+      #html.elem("ul", attrs: (class: "package-sidebar-list"), [
+        #let index = 0
+        #for module-entry in info.modules {
+          let module-info = module-entry.at(2)
+          let module-def = module-entry.at(1)
+          let class = "package-sidebar-link"
+          if active-module-index == index {
+            class = class + " is-active"
+          }
+
+          html.elem("li", attrs: (class: "package-sidebar-item"), [
+            #html.elem(
+              "a",
+              attrs: (class: class, href: module-nav-dest(symbol-ctx, index, module-info)),
+              module-nav-title(module-info),
+            )
+            #if active-module-index == index {
+              html.elem("ul", attrs: (class: "package-sidebar-sublist"), [
+                #for (section, title) in module-section-list {
+                  let items = module-section-items(module-def, section)
+                  if items.len() > 0 {
+                    let section-class = "package-sidebar-sublink"
+                    if active-section == section {
+                      section-class = section-class + " is-active"
+                    }
+                    let section-symbol-ctx = (
+                      in-module: module-info.prefix,
+                      module-index: index,
+                      module-info: module-info,
+                      ..symbol-ctx,
+                    )
+                    html.elem("li", attrs: (class: "package-sidebar-subitem"), [
+                      #html.elem("span", attrs: (class: section-class), title)
+                      #html.elem("ul", attrs: (class: "package-sidebar-symbol-list"), [
+                        #let item-index = 0
+                        #for child in items {
+                          let symbol-class = "package-sidebar-symbol-link"
+                          if active-section == section and active-symbol-index == item-index {
+                            symbol-class = symbol-class + " is-active"
+                          }
+                          html.elem("li", attrs: (class: "package-sidebar-symbol-item"), [
+                            #html.elem(
+                              "a",
+                              attrs: (
+                                class: symbol-class,
+                                href: symbol-section-dest(section-symbol-ctx, child),
+                              ),
+                              sidebar-symbol-label(child),
+                            )
+                          ])
+                          item-index += 1
+                        }
+                      ])
+                    ])
+                  }
+                }
+              ])
+            }
+          ])
+          index += 1
+        }
+      ])
+    ])
+  ])
+}
+
+#let package-on-this-page() = {
+  html.elem("aside", attrs: (class: "package-on-this-page", "data-ready": "false"), [
+    #html.elem("nav", attrs: (class: "package-on-this-page-nav", "aria-label": "On this page"), [
+      #html.elem("div", attrs: (class: "package-on-this-page-title"), "On this page")
+      #html.elem("div", attrs: (class: "package-on-this-page-body"), [
+        #html.elem("span", attrs: (class: "package-on-this-page-indicator", "aria-hidden": "true"))
+        #html.elem("ul", attrs: (class: "package-on-this-page-list"))
+      ])
+    ])
+    #html.elem("script", attrs: (type: "module"), read("/typ/packages/package-docs/on-this-page.js"))
+  ])
+}
+
+#let package-layout(info, symbol-ctx, active-module-index: none, active-section: none, active-symbol-index: none, body) = {
+  html.elem("div", attrs: (class: "package-doc-layout"), [
+    #package-sidebar(
+      info,
+      symbol-ctx,
+      active-module-index: active-module-index,
+      active-section: active-section,
+      active-symbol-index: active-symbol-index,
+    )
+    #html.elem("main", attrs: (class: "package-doc-main"), body)
+    #package-on-this-page()
+  ])
+}
+
+#let hover-oneliner(symbol-ctx, info) = {
+  let docs = lsif-hover(symbol-ctx, info)
+  if docs != none {
+    let in-code = false
+    for line in str(docs).split("\n") {
+      let text = line.trim()
+      if text.starts-with("```") {
+        in-code = not in-code
+      } else if not in-code and text != "" and text != "---" and not text.starts-with("#") {
+        return text
+      }
+    }
+  }
+
+  info.at("oneliner", default: none)
+}
+
+#let symbol-defined-path(symbol-ctx, info) = {
+  let source = info.at("source", default: none)
+  if source != none {
+    let file = symbol-ctx.files.at(source.file, default: none)
+    if file != none and file.at("path", default: none) != none {
+      return str(file.path)
+    }
+  }
+
+  let bundle-link = info.at("bundle_link", default: none)
+  if bundle-link != none {
+    let path = str(bundle-link)
+    if path.ends-with(".html") {
+      path = path.slice(0, -5) + ".typ"
+    }
+    if path.starts-with("symbols/") {
+      return none
+    }
+    return path
+  }
+
+  let module-info = symbol-ctx.at("module-info", default: none)
+  if module-info != none and module-info.at("path", default: none) != none {
+    return str(module-info.path)
+  }
+
+  none
+}
+
+#let symbol-reference-summary(symbol-ctx, info) = {
+  let summary = hover-oneliner(symbol-ctx, info)
+  if summary != none {
+    return summary
+  }
+
+  let path = symbol-defined-path(symbol-ctx, info)
+  if path != none {
+    return [Defined in #code(path).]
+  }
+
+  none
+}
+
+#let symbol-reference(symbol-ctx, info) = {
+  let dest = symbol-section-dest(symbol-ctx, info)
+  let summary = symbol-reference-summary(symbol-ctx, info)
+  let title = if info.kind == "function" {
+    info.name + "()"
+  } else {
+    info.name
+  }
+
+  html.elem("li", attrs: (class: "symbol-reference doc-symbol-" + info.kind), [
+    #html.elem("a", attrs: (class: "symbol-reference-link", href: dest), code(title))
+    #if summary != none {
+      html.elem("span", attrs: (class: "symbol-reference-summary"), summary)
+    }
+  ])
+}
+
+#let symbol-reference-list(symbol-ctx, items) = {
+  html.elem("ul", attrs: (class: "symbol-reference-list"), [
+    #for child in items {
+      symbol-reference(symbol-ctx, child)
+    }
+  ])
+}
+
+#let function-hover-join(lines) = {
+  if lines.len() == 0 {
+    ""
+  } else {
+    lines.join("\n").trim()
+  }
+}
+
+#let function-hover-param-name(raw) = {
+  str(raw).replace(" (positional)", "").replace(" (named)", "").replace(" (rest)", "").trim()
+}
+
+#let function-hover-param(body, name) = {
+  (
+    name: function-hover-param-name(name),
+    body: function-hover-join(body),
+  )
+}
+
+#let function-hover-signature-param-name(line) = {
+  let text = line.trim()
+  if text == "" or text.starts-with("let ") or text.starts-with(")") {
+    return none
+  }
+  if text.ends-with(",") {
+    text = text.slice(0, -1)
+  }
+  if text.starts-with("..") {
+    text = text.slice(2)
+  }
+
+  let parts = text.split(":")
+  if parts.len() == 0 {
+    return none
+  }
+
+  parts.at(0).trim()
+}
+
+#let function-hover-signature-param-line(signature, name) = {
+  for line in signature.split("\n") {
+    let found = function-hover-signature-param-name(line)
+    if found == name {
+      let text = line.trim()
+      if text.ends-with(",") {
+        text = text.slice(0, -1)
+      }
+      return text
+    }
+  }
+
+  none
+}
+
+#let function-hover-signature-param-line-offset(signature, name) = {
+  let found-offset = none
+  let param-count = 0
+  let index = 0
+
+  for line in signature.split("\n") {
+    let found = function-hover-signature-param-name(line)
+    if found != none {
+      param-count += 1
+      if found == name {
+        found-offset = index
+      }
+    }
+    index += 1
+  }
+
+  if found-offset == none {
+    return 0
+  }
+
+  if param-count == 1 {
+    return 0
+  }
+
+  found-offset
+}
+
+#let function-hover-signature-param-meta(signature, name) = {
+  let line = function-hover-signature-param-line(signature, name)
+  if line == none {
+    return (ty: none, default: none, required: true)
+  }
+
+  let parts = line.split(":")
+  if parts.len() < 2 {
+    return (ty: none, default: none, required: true)
+  }
+
+  let right = parts.slice(1).join(":").trim()
+  let default = none
+  let ty = right
+  let default-parts = right.split(" = ")
+  if default-parts.len() > 1 {
+    ty = function-hover-join(default-parts.slice(0, -1))
+    default = default-parts.at(default-parts.len() - 1).trim()
+  }
+
+  (ty: ty, default: default, required: default == none)
+}
+
+#let function-param-body-data(body) = {
+  let lines = str(body).split("\n")
+  let ty = none
+  let docs = ()
+  let i = 0
+
+  if lines.len() > 0 and lines.at(0).starts-with("```") {
+    i = 1
+    let type-lines = ()
+    while i < lines.len() and not lines.at(i).starts-with("```") {
+      type-lines.push(lines.at(i))
+      i += 1
+    }
+    if i < lines.len() {
+      i += 1
+    }
+
+    let type-text = function-hover-join(type-lines)
+    if type-text.starts-with("type:") {
+      type-text = type-text.slice(5).trim()
+    }
+    if type-text != "" {
+      ty = type-text
+    }
+  }
+
+  while i < lines.len() and lines.at(i).trim() == "" {
+    i += 1
+  }
+  while i < lines.len() {
+    docs.push(lines.at(i))
+    i += 1
+  }
+
+  (ty: ty, docs: function-hover-join(docs))
+}
+
+#let function-hover-data(markdown) = {
+  let lines = str(markdown).split("\n")
+  let signature = ()
+  let docs = ()
+  let positional = ()
+  let named = ()
+  let rest = ()
+
+  let i = 0
+  if lines.len() > 0 and lines.at(0).starts-with("```") {
+    i = 1
+    while i < lines.len() and not lines.at(i).starts-with("```") {
+      signature.push(lines.at(i))
+      i += 1
+    }
+    if i < lines.len() {
+      i += 1
+    }
+  }
+
+  while i < lines.len() and (lines.at(i).trim() == "" or lines.at(i).trim() == "---") {
+    i += 1
+  }
+
+  let section = none
+  let param-name = none
+  let param-lines = ()
+
+  while i < lines.len() {
+    let line = lines.at(i)
+    let text = line.trim()
+
+    if text == "# Positional Parameters" or text == "# Named Parameters" or text == "# Rest Parameters" {
+      if param-name != none {
+        let item = function-hover-param(param-lines, param-name)
+        if section == "positional" {
+          positional.push(item)
+        } else if section == "named" {
+          named.push(item)
+        } else if section == "rest" {
+          rest.push(item)
+        }
+      }
+
+      section = if text == "# Positional Parameters" {
+        "positional"
+      } else if text == "# Named Parameters" {
+        "named"
+      } else {
+        "rest"
+      }
+      param-name = none
+      param-lines = ()
+    } else if section != none and text.starts-with("## ") {
+      if param-name != none {
+        let item = function-hover-param(param-lines, param-name)
+        if section == "positional" {
+          positional.push(item)
+        } else if section == "named" {
+          named.push(item)
+        } else if section == "rest" {
+          rest.push(item)
+        }
+      }
+
+      param-name = text.slice(3)
+      param-lines = ()
+    } else if section == none {
+      docs.push(line)
+    } else if param-name != none {
+      param-lines.push(line)
+    }
+
+    i += 1
+  }
+
+  if param-name != none {
+    let item = function-hover-param(param-lines, param-name)
+    if section == "positional" {
+      positional.push(item)
+    } else if section == "named" {
+      named.push(item)
+    } else if section == "rest" {
+      rest.push(item)
+    }
+  }
+
+  (
+    signature: function-hover-join(signature),
+    docs: function-hover-join(docs),
+    positional: positional,
+    named: named,
+    rest: rest,
+  )
+}
+
+#let function-param-id(info, group, param) = {
+  str(heading-label("parameter " + group + " " + param.name + " in " + info.name))
+}
+
+#let function-heading-id(info) = {
+  str(heading-label("Function " + info.name))
+}
+
+#let function-section-id(info, group) = {
+  str(heading-label(group + " parameters in " + info.name))
+}
+
+#let function-toc-heading(level, text, id, toc-depth: 0) = {
+  html.elem(
+    "h" + str(level),
+    attrs: (
+      id: id,
+      class: "package-function-heading",
+      "data-toc-label": text,
+      "data-toc-depth": str(toc-depth),
+    ),
+    text,
+  )
+}
+
+#let function-find-param(data, name) = {
+  for param in data.positional {
+    if param.name == name {
+      return (group: "positional", ..param)
+    }
+  }
+  for param in data.named {
+    if param.name == name {
+      return (group: "named", ..param)
+    }
+  }
+  for param in data.rest {
+    if param.name == name {
+      return (group: "rest", ..param)
+    }
+  }
+
+  none
+}
+
+#let function-param-in(items, name) = {
+  for item in items {
+    if item.name == name {
+      return true
+    }
+  }
+
+  false
+}
+
+#let function-ordered-params(data) = {
+  let items = ()
+  for line in data.signature.split("\n") {
+    let name = function-hover-signature-param-name(line)
+    if name != none and not function-param-in(items, name) {
+      let param = function-find-param(data, name)
+      if param != none {
+        items.push(param)
+      }
+    }
+  }
+
+  for param in data.positional {
+    if not function-param-in(items, param.name) {
+      items.push((group: "positional", ..param))
+    }
+  }
+  for param in data.named {
+    if not function-param-in(items, param.name) {
+      items.push((group: "named", ..param))
+    }
+  }
+  for param in data.rest {
+    if not function-param-in(items, param.name) {
+      items.push((group: "rest", ..param))
+    }
+  }
+
+  items
+}
+
+#let function-param-label(data, param) = {
+  if param.group == "named" {
+    let meta = function-hover-signature-param-meta(data.signature, param.name)
+    if meta.required {
+      param.name
+    } else {
+      param.name + "?"
+    }
+  } else if param.group == "rest" {
+    ".." + param.name
+  } else {
+    param.name
+  }
+}
+
+#let function-param-mods(group, meta) = {
+  let mods = ()
+  if meta.required and group != "rest" {
+    mods.push("required")
+  }
+
+  mods
+}
+
+#let function-param-type-parts(ty) = {
+  let ty = str(ty)
+  if ty.contains("=>") {
+    return (ty,)
+  }
+
+  let parts = ()
+  for chunk in ty.split("|") {
+    for part in chunk.split(",") {
+      let part = part.trim()
+      if part != "" {
+        parts.push(part)
+      }
+    }
+  }
+
+  parts
+}
+
+#let function-param-pill-class(part) = {
+  let part = str(part).trim()
+  if part == "content" {
+    "function-param-pill-content"
+  } else if part == "str" or part == "string" {
+    "function-param-pill-string"
+  } else if part == "auto" or part == "none" or part == "bool" or part == "boolean" {
+    "function-param-pill-keyword"
+  } else if part == "int" or part == "float" or part == "number" or part == "length" or part == "ratio" or part == "angle" {
+    "function-param-pill-number"
+  } else if part == "array" or part == "dictionary" or part == "arguments" {
+    "function-param-pill-collection"
+  } else if part == "function" or part.contains("=>") {
+    "function-param-pill-function"
+  } else {
+    "function-param-pill-object"
+  }
+}
+
+#let function-inline-code-text(value) = {
+  html.elem("code", str(value))
+}
+
+#let function-inline-typc(value) = {
+  let value = str(value)
+  if value == "(:)" {
+    function-inline-code-text(value)
+  } else {
+    raw(value, lang: "typc")
+  }
+}
+
+#let function-param-type-list(ty) = {
+  let parts = function-param-type-parts(ty)
+  if parts.len() == 0 {
+    parts.push(str(ty))
+  }
+
+  html.elem("span", attrs: (class: "function-param-type-list"), [
+    #let first = true
+    #for part in parts {
+      if not first {
+        html.elem("small", attrs: (class: "function-param-type-or"), "or")
+      }
+      first = false
+      html.elem(
+        "code",
+        attrs: (class: "function-param-pill " + function-param-pill-class(part)),
+        part,
+      )
+    }
+  ])
+}
+
+#let function-param-source-dest(symbol-ctx, info, data, param) = {
+  let param-sources = info.at("param_sources", default: (:))
+  let param-source = param-sources.at(param.name, default: none)
+  if param-source != none {
+    return source-query-line-dest(symbol-ctx, param-source, param-source.position.line + 1)
+  }
+
+  let source = info.at("source", default: none)
+  if source == none {
+    return none
+  }
+
+  let line = source.position.line + 1 + function-hover-signature-param-line-offset(data.signature, param.name)
+  source-query-line-dest(symbol-ctx, source, line)
+}
+
+#let function-param-heading(symbol-ctx, info, data, group, param, meta, ty) = {
+  let source-dest = function-param-source-dest(symbol-ctx, info, data, param)
+
+  html.elem(
+    "h4",
+    attrs: (
+      id: function-param-id(info, group, param),
+      class: "package-function-heading function-param-heading",
+      "data-toc-label": param.name,
+      "data-toc-depth": "1",
+    ),
+    [
+      #html.elem("code", attrs: (class: "function-param-name"), param.name)
+      #html.elem(
+        "div",
+        attrs: (class: "function-param-additional-info"),
+        [
+          #function-param-type-list(ty)
+          #for mod in function-param-mods(group, meta) {
+            html.elem("small", attrs: (class: "function-param-mod"), mod)
+          }
+          #if source-dest != none {
+            html.elem("a", attrs: (class: "function-param-source-link", href: source-dest), "Source")
+          }
+        ],
+      )
+      #if meta.default != none and group != "rest" {
+        html.elem("span", attrs: (class: "function-param-default"), [
+          #html.elem("span", attrs: (class: "function-param-default-label"), "Default")
+          #html.elem("span", attrs: (class: "function-param-default-code"), function-inline-typc(meta.default))
+        ])
+      }
+    ],
+  )
+}
+
+#let function-signature-nav(symbol-ctx, info, data) = {
+  let params = function-ordered-params(data)
+
+  html.elem("div", attrs: (class: "function-signature-nav"), [
+    #html.elem("code", [
+      #html.elem("span", attrs: (class: "function-signature-name"), info.name)
+      #html.elem("span", "(")
+      #let first = true
+      #for param in params {
+        if not first {
+          html.elem("span", attrs: (class: "function-signature-punctuation"), ", ")
+        }
+        first = false
+        let href = "#" + function-param-id(info, param.group, param)
+        html.elem("a", attrs: (class: "function-signature-param", href: href), function-param-label(data, param))
+      }
+      #html.elem("span", ")")
+    ])
+  ])
+}
+
+#let function-signature-block(signature) = {
+  if signature != "" {
+    html.elem("div", attrs: (class: "function-signature-block"), [
+      #raw(signature, lang: "typc", block: true)
+    ])
+  }
+}
+
+#let function-param-doc(symbol-ctx, info, data, group, param) = {
+  let body = function-param-body-data(param.body)
+  let meta = function-hover-signature-param-meta(data.signature, param.name)
+  let ty = if body.ty != none {
+    body.ty
+  } else if meta.ty != none and meta.ty != "" {
+    meta.ty
+  } else {
+    "unknown"
+  }
+
+  html.elem("section", attrs: (class: "function-param-doc function-param-" + group), [
+    #function-param-heading(symbol-ctx, info, data, group, param, meta, ty)
+    #if body.docs != "" {
+      html.elem("div", attrs: (class: "function-param-body"), [
+        #markdown-docs(body.docs)
+      ])
+    }
+  ])
+}
+
+#let function-param-section(symbol-ctx, info, data, group, title, params) = {
+  if params.len() > 0 {
+    function-toc-heading(3, title, function-section-id(info, group), toc-depth: 0)
+    for param in params {
+      function-param-doc(symbol-ctx, info, data, group, param)
+    }
+  }
+}
+
+#let function-symbol-page(symbol-ctx, info) = {
+  let plain-docs = lsif-hover(symbol-ctx, info)
+  let data = if plain-docs == none {
+    (signature: "", docs: "", positional: (), named: (), rest: ())
+  } else {
+    function-hover-data(plain-docs)
+  }
+
+  html.elem("article", attrs: (class: "package-function-doc"), [
+    #function-toc-heading(2, "Function " + info.name, function-heading-id(info), toc-depth: 0)
+    #html.elem("div", attrs: (class: "detail-header doc-symbol-function function-signature-header"), [
+      #function-signature-nav(symbol-ctx, info, data)
+    ])
+    #if data.docs != "" {
+      html.elem("div", attrs: (class: "function-docs"), [
+        #markdown-docs(data.docs)
+      ])
+    }
+    #function-signature-block(data.signature)
+    #function-param-section(symbol-ctx, info, data, "positional", "Positional Parameters", data.positional)
+    #function-param-section(symbol-ctx, info, data, "named", "Named Parameters", data.named)
+    #function-param-section(symbol-ctx, info, data, "rest", "Rest Parameters", data.rest)
+  ])
+}
+
 #let symbol-doc(symbol-ctx, info) = {
   // let ident = if !primary.is_empty() {
   //     eco_format!("symbol-{}-{primary}.{}", child.kind, child.name)
@@ -44,25 +1189,42 @@
   //     eco_format!("symbol-{}-{}", child.kind, child.name)
   // };
 
-  let symlink(body) = if info.symbol_link != none {
-    // let _ = writeln!(out, "#link({})[Symbol Docs]\n", TypstLink(lnk));
-    html.elem("a", attrs: (href: info.symbol_link, class: "symbol-link"), body)
+  let symlink(body) = if symbol-dest(symbol-ctx, info) != none {
+    html.elem("a", attrs: (href: symbol-dest(symbol-ctx, info), class: "symbol-link"), body)
   } else {
     body
   }
 
   if info.is_external {
-    let fid = info.loc.at(0, default: none)
-    let file = symbol-ctx.files.at(fid, default: none)
-    let package = symbol-ctx.packages.at(file.package, default: none)
+    let definition = lsif-definition(symbol-ctx, info)
+    let file = if definition != none {
+      file-by-uri(symbol-ctx.files, str(definition.targetUri))
+    } else {
+      none
+    }
+    if file == none and info.at("source", default: none) != none {
+      file = symbol-ctx.files.at(info.source.file, default: none)
+    }
+    let package = if file != none {
+      symbol-ctx.packages.at(file.package, default: none)
+    } else {
+      none
+    }
+    let file-title = if file != none {
+      code(file.path)
+    } else if definition != none {
+      code(str(definition.targetUri))
+    } else {
+      code(info.name)
+    }
 
     let title = if info.kind == "module" {
-      let title = if package != none and file.package > 0 {
+      let title = if file != none and package != none and file.package > 0 {
         span(attrs: (title: display-package-spec(package)), "external")
         code(" ")
         code(file.path)
       } else {
-        code(file.path)
+        file-title
       }
 
       symlink(code(title))
@@ -80,112 +1242,28 @@
 
     html.elem("div", attrs: (class: "detail-header doc-symbol-" + info.kind), [=== #title])
 
-    if info.oneliner != none {
-      markdown-docs(info.oneliner)
+    let plain-docs = lsif-hover(symbol-ctx, info)
+    if plain-docs != none {
+      markdown-docs(plain-docs)
     }
 
     return
   }
 
-  labelled-heading(3, info.kind + ": " + info.name + " in " + symbol-ctx.in-module)
+  labelled-heading(
+    3,
+    info.kind + ": " + info.name + " in " + symbol-ctx.in-module,
+    dest: symbol-dest(symbol-ctx, info),
+  )
 
   // if info.symbol_link != none {
   //   // let _ = writeln!(out, "#link({})[Symbol Docs]\n", TypstLink(lnk));
   //   par(symlink("Symbol Docs"))
   // }
 
-  //     let convert_err = None::<EcoString>;
-  if info.parsed_docs != none {
-    if info.parsed_docs.kind == "func" {
-      //     if let Some(DefDocs::Function(sig)) = &info.parsed_docs {
-      //         // let _ = writeln!(out, "<!-- begin:sig -->");
-      //         let _ = writeln!(out, "```typc");
-      //         let _ = write!(out, "let {}", info.name);
-      //         let _ = sig.print(&mut out);
-      //         let _ = writeln!(out, ";");
-      //         let _ = writeln!(out, "```");
-      //         // let _ = writeln!(out, "<!-- end:sig -->");
-      //     }
-      // repr(info.parsed_docs)
-    }
-  }
-
-  let printed_docs = false
-  if not info.is_external {
-    //     let convert_err = None::<EcoString>;
-    if info.parsed_docs != none {
-      let docs = info.parsed_docs
-      if docs.docs != none and docs.docs.len() > 0 {
-        // remove_list_annotations(docs.docs())
-        printed_docs = true
-        markdown-docs(docs.docs)
-      }
-      if docs.kind == "func" {
-        labelled-heading(4, "Resultant")
-
-        docs.ret_ty.at(0)
-
-        labelled-heading(4, "Parameters")
-
-        let pos = docs.at("pos", default: ())
-        let named = docs.at("named", default: (:)).values()
-        let rest = docs.at("rest", default: none)
-
-        let params = pos + named
-        if rest != none {
-          params.push(rest)
-        }
-
-        for param in params {
-          labelled-heading(5, param.name)
-
-          let param-head = (param.name, ": ", param.cano_type.at(0))
-          if param.positional {
-            param-head.push(" (Positional)")
-          }
-          if param.variadic {
-            param-head.push(" (Variadic)")
-          }
-          if param.settable {
-            param-head.push(" (Settable)")
-          }
-          if param.named {
-            param-head.push(" (Named, default: ")
-            param-head.push(param.default)
-            param-head.push(")")
-          }
-          raw(block: true, param-head.join())
-
-          markdown-docs(param.docs)
-        }
-      }
-    }
-  }
-
-  if not printed_docs {
-    let plain_docs = info.docs
-    if plain_docs == none {
-      plain_docs = info.oneliner
-    }
-    // todo: eval with error tolerance?
-    // if plain_docs != none {
-    //   eval(plain_docs, mode: "markup")
-    // }
-
-    //     if let Some(lnk) = &child.module_link {
-    //         match lnk.as_str() {
-    //             "builtin" => {
-    //                 let _ = writeln!(out, "A Builtin Module");
-    //             }
-    //             _lnk => {
-    //                 // let _ = writeln!(out, "#link({})[Module Docs]\n",
-    //                 // TypstLink(lnk));
-    //             }
-    //         }
-    //     }
-
-    //     // let _ = writeln!(out, "<!-- end:symbol {ident} -->");
-    //     let _ = writeln!(out, "]),");
+  let plain-docs = lsif-hover(symbol-ctx, info)
+  if plain-docs != none {
+    markdown-docs(plain-docs)
   }
 }
 
@@ -206,9 +1284,13 @@
     if child.kind == "module" {
       modules.push(child)
     } else if child.kind == "function" {
-      functions.push(child)
-    } else if child.kind == "variable" {
-      constants.push(child)
+      if not child.name.starts-with("_") {
+        functions.push(child)
+      }
+    } else if child.kind == "variable" or child.kind == "constant" {
+      if not child.name.starts-with("_") {
+        constants.push(child)
+      }
     } else {
       unknowns.push(child)
     }
@@ -222,40 +1304,58 @@
   )
 }
 
-#let module-doc(info: none, name: none, symbol-ctx, m) = {
+#let module-doc(info: none, name: none, symbol-ctx, m, module-index: none, references-only: false) = {
   let m = analyze-module(m)
 
   if info.prefix.len() > 0 {
-    let primary = info.prefix
-    let title = "Module: " + primary + " in " + info.prefix
-
     module-divider
-    labelled-heading(1, title)
+    labelled-heading(1, module-heading-title(info))
   } else {
-    labelled-heading(1, "Package Exports")
+    labelled-heading(1, module-heading-title(info))
+  }
+
+  let source-dest = module-source-dest(symbol-ctx, info)
+  if source-dest != none {
+    html.elem("p", attrs: (class: "module-source-meta"), [
+      #html.elem("a", attrs: (class: "module-source-link", href: source-dest), "Source")
+    ])
   }
 
   let symbol-ctx = (
     in-module: info.prefix,
+    module-index: module-index,
+    module-info: info,
     ..symbol-ctx,
   )
 
   if m.modules.len() > 0 {
-    [== Modules]
-    for child in m.modules {
-      symbol-doc(symbol-ctx, child)
+    labelled-heading(2, "Modules")
+    if references-only {
+      symbol-reference-list(symbol-ctx, m.modules)
+    } else {
+      for child in m.modules {
+        symbol-doc(symbol-ctx, child)
+      }
     }
   }
   if m.constants.len() > 0 {
-    [== Constants]
-    for child in m.constants {
-      symbol-doc(symbol-ctx, child)
+    labelled-heading(2, "Constants")
+    if references-only {
+      symbol-reference-list(symbol-ctx, m.constants)
+    } else {
+      for child in m.constants {
+        symbol-doc(symbol-ctx, child)
+      }
     }
   }
   if m.functions.len() > 0 {
-    [== Functions]
-    for child in m.functions {
-      symbol-doc(symbol-ctx, child)
+    labelled-heading(2, "Functions")
+    if references-only {
+      symbol-reference-list(symbol-ctx, m.functions)
+    } else {
+      for child in m.functions {
+        symbol-doc(symbol-ctx, child)
+      }
     }
   }
   if m.unknowns.len() > 0 {
@@ -265,14 +1365,16 @@
     }
   }
 }
-#let package-doc(info) = {
-  let info = json(info)
-  let title = "@" + info.meta.namespace + "/" + info.meta.name + " " + info.meta.version
+#let package-title(info) = {
+  "@" + info.meta.namespace + "/" + info.meta.name + " " + info.meta.version
+}
 
+#let package-setup(title) = {
   show: project.with(title: title)
   html.elem("style", read("/typ/packages/package-docs/global.css"))
-  show: html.elem.with("main")
+}
 
+#let package-header(info, title) = {
   strong[
     This documentation is generated locally. Please submit issues to #link("https://github.com/Myriad-Dreamin/tinymist")[tinymist] if you see incorrect information in it.
   ]
@@ -289,11 +1391,192 @@
   if description != none {
     description
   }
+}
 
-  let symbol-ctx = analyze-package(info)
+#let symbol-context(info, lsif, bundle: false, path: none) = {
+  (
+    lsif: lsif,
+    bundle: bundle,
+    path: path,
+    ..analyze-package(info),
+  )
+}
 
+#let package-module-page(info, lsif, module-index: none, show-header: true, bundle: false, path: none) = {
+  let title = "@" + info.meta.namespace + "/" + info.meta.name + " " + info.meta.version
 
-  for (name, m, info) in info.modules {
-    module-doc(info: info, name: name, symbol-ctx, m)
+  package-setup(title)
+  let symbol-ctx = symbol-context(info, lsif, bundle: bundle, path: path)
+  let module-entry = info.modules.at(module-index)
+
+  if show-header {
+    package-layout(info, symbol-ctx, active-module-index: module-index)[
+      #package-header(info, title)
+      #module-doc(
+        info: module-entry.at(2),
+        name: module-entry.at(0),
+        symbol-ctx,
+        module-entry.at(1),
+        module-index: module-index,
+        references-only: bundle,
+      )
+    ]
+  } else {
+    package-layout(info, symbol-ctx, active-module-index: module-index)[
+      #module-doc(
+        info: module-entry.at(2),
+        name: module-entry.at(0),
+        symbol-ctx,
+        module-entry.at(1),
+        module-index: module-index,
+        references-only: bundle,
+      )
+    ]
   }
+}
+
+#let package-module-document(info, lsif, module-index: none, path: none) = {
+  let module-entry = info.modules.at(module-index)
+  let info-title = package-title(info)
+  let title = info-title + " - " + module-title(module-entry.at(2))
+
+  document(path, title: title)[
+    #package-module-page(
+      info,
+      lsif,
+      module-index: module-index,
+      show-header: module-index == 0,
+      bundle: true,
+      path: path,
+    )
+  ]
+}
+
+#let package-module-symbol-page(info, lsif, module-index: none, section: none, symbol-index: none, path: none) = {
+  let title = package-title(info)
+
+  package-setup(title)
+  let symbol-ctx = symbol-context(info, lsif, bundle: true, path: path)
+  let module-entry = info.modules.at(module-index)
+  let module-info = module-entry.at(2)
+  let m = analyze-module(module-entry.at(1))
+  let items = m.at(section, default: ())
+  let child = items.at(symbol-index)
+
+  package-layout(
+    info,
+    symbol-ctx,
+    active-module-index: module-index,
+    active-section: section,
+    active-symbol-index: symbol-index,
+  )[
+    #let module-link = module-nav-dest(symbol-ctx, module-index, module-info)
+    #html.elem("p", attrs: (class: "module-source-meta"), [
+      #html.elem("a", attrs: (class: "module-source-link", href: module-link), "Module Docs")
+    ])
+    #let symbol-ctx = (
+      in-module: module-info.prefix,
+      module-index: module-index,
+      module-info: module-info,
+      ..symbol-ctx,
+    )
+    #if child.kind == "function" {
+      function-symbol-page(symbol-ctx, child)
+    } else {
+      labelled-heading(1, module-heading-title(module-info))
+      labelled-heading(2, section-title(section))
+      symbol-doc(symbol-ctx, child)
+    }
+  ]
+}
+
+#let package-module-symbol-document(info, lsif, module-index: none, section: none, symbol-index: none, path: none) = {
+  let module-entry = info.modules.at(module-index)
+  let m = analyze-module(module-entry.at(1))
+  let child = m.at(section, default: ()).at(symbol-index)
+  let info-title = package-title(info)
+  let title = info-title + " - " + module-title(module-entry.at(2)) + " - " + child.name
+
+  document(path, title: title)[
+    #package-module-symbol-page(
+      info,
+      lsif,
+      module-index: module-index,
+      section: section,
+      symbol-index: symbol-index,
+      path: path,
+    )
+  ]
+}
+
+#let source-line-numbers(source) = {
+  [
+    #for line in range(1, source.split("\n").len() + 1) {
+      html.elem(
+        "a",
+        attrs: (id: source-line-id(line), class: "package-source-line-number", href: source-line-fragment(line)),
+        str(line),
+      )
+    }
+  ]
+}
+
+#let package-source-page(info, module-index: none, path: none, source-path: none, source: none) = {
+  let title = package-title(info)
+
+  package-setup(title)
+  let symbol-ctx = symbol-context(info, none, bundle: true, path: path)
+  let module-entry = info.modules.at(module-index)
+  let module-info = module-entry.at(2)
+
+  package-layout(info, symbol-ctx, active-module-index: module-index)[
+    #let module-link = module-nav-dest(symbol-ctx, module-index, module-info)
+    #html.elem("p", attrs: (class: "module-source-meta"), [
+      #html.elem("a", attrs: (class: "module-source-link", href: module-link), "Module Docs")
+    ])
+    #labelled-heading(1, "Source: " + str(source-path))
+    #html.elem("div", attrs: (class: "package-source-code", "data-source-path": str(source-path)), [
+      #html.elem("div", attrs: (class: "package-source-body"), [
+        #html.elem("pre", attrs: (class: "package-source-lines", "aria-hidden": "true"), source-line-numbers(source))
+        #html.elem("div", attrs: (class: "package-source-scroll"), [
+          #raw(source, lang: "typ", block: true)
+        ])
+      ])
+    ])
+  ]
+}
+
+#let package-source-document(info, module-index: none, path: none, source-path: none, source: none) = {
+  let title = package-title(info) + " - Source: " + str(source-path)
+
+  document(path, title: title)[
+    #package-source-page(
+      info,
+      module-index: module-index,
+      path: path,
+      source-path: source-path,
+      source: source,
+    )
+  ]
+}
+
+#let package-doc(info, lsif: none) = {
+  let info = json(info)
+  let lsif = if lsif == none {
+    none
+  } else {
+    create_index(lsif)
+  }
+  let title = package-title(info)
+
+  package-setup(title)
+
+  let symbol-ctx = symbol-context(info, lsif)
+
+  package-layout(info, symbol-ctx)[
+    #package-header(info, title)
+    #for (name, m, info) in info.modules {
+      module-doc(info: info, name: name, symbol-ctx, m)
+    }
+  ]
 }

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -1,11 +1,13 @@
 use core::fmt::Write;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ecow::{EcoString, EcoVec};
 use indexmap::IndexSet;
+use lsp_types::Position;
 use serde::{Deserialize, Serialize};
 use tinymist_analysis::docs::tidy::remove_list_annotations;
+use tinymist_std::path::unix_slash;
 use tinymist_world::package::PackageSpec;
 use typst::diag::{StrResult, eco_format};
 use typst::syntax::package::PackageManifest;
@@ -13,8 +15,9 @@ use typst::syntax::{FileId, Span, VirtualRoot};
 use typst_shim::syntax::{RootedPathExt, source_range};
 
 use crate::LocalContext;
-use crate::docs::{DefDocs, PackageDefInfo, file_id_repr, module_docs};
+use crate::docs::{DefDocs, PackageDefInfo, SourceQuery, file_id_repr, module_docs};
 use crate::package::{PackageInfo, get_manifest_id, package_entrypoint_id};
+use crate::syntax::DefKind;
 
 /// Documentation Information about a package.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,9 +33,76 @@ pub struct PackageDoc {
 struct ModuleInfo {
     prefix: EcoString,
     name: EcoString,
-    loc: Option<usize>,
     parent_ident: EcoString,
     aka: EcoVec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<PathBuf>,
+    #[serde(skip)]
+    source: Option<EcoString>,
+}
+
+/// A generated Typst source file for bundle-mode package docs.
+#[derive(Debug, Clone)]
+pub struct PackageDocTypFile {
+    /// The path of the generated file, relative to the bundle source root.
+    pub path: PathBuf,
+    /// The Typst source content.
+    pub content: String,
+}
+
+struct BundleModulePath {
+    module_source: PathBuf,
+    module_source_import: String,
+    module_common_import: String,
+    module_output: String,
+    module_func: String,
+    symbol_paths: Vec<BundleSymbolPath>,
+    source_source: Option<PathBuf>,
+    source_source_import: Option<String>,
+    source_common_import: Option<String>,
+    source_output: Option<String>,
+    source_func: String,
+    source_path: Option<String>,
+    source_text: Option<EcoString>,
+}
+
+struct BundleSymbolPath {
+    section: &'static str,
+    symbol_index: usize,
+    source: PathBuf,
+    source_import: String,
+    common_import: String,
+    output: String,
+    func: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BundleSection {
+    Constants,
+    Functions,
+}
+
+impl BundleSection {
+    const ALL: [Self; 2] = [Self::Constants, Self::Functions];
+
+    fn id(self) -> &'static str {
+        match self {
+            Self::Constants => "constants",
+            Self::Functions => "functions",
+        }
+    }
+
+    fn accepts(self, child: &crate::docs::DefInfo) -> bool {
+        match self {
+            Self::Constants => {
+                matches!(child.kind, DefKind::Constant | DefKind::Variable)
+                    && !child.name.as_str().starts_with('_')
+            }
+            Self::Functions => {
+                matches!(child.kind, DefKind::Function) && !child.name.as_str().starts_with('_')
+            }
+        }
+    }
 }
 
 /// Generate full documents in markdown format
@@ -95,14 +165,17 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
             // do sanitization here.
             let primary = aka.first().cloned().unwrap_or_default();
 
-            let persist_fid = fid.map(|fid| file_ids.insert_full(fid).0);
+            if let Some(fid) = fid {
+                file_ids.insert_full(fid);
+            }
 
             let module_info = ModuleInfo {
                 prefix: primary.as_str().into(),
                 name: def.name.clone(),
-                loc: persist_fid,
                 parent_ident: parent_ident.clone(),
                 aka,
+                path: fid.map(|fid| fid.vpath().get_without_slash().to_owned().into()),
+                source: fid.and_then(|fid| ctx.source_by_id(fid).ok().map(|src| src.text().into())),
             };
 
             for child in def.children.iter_mut() {
@@ -112,6 +185,19 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
                         let allocated = file_ids.insert_full(fid).0;
                         let src = ctx.source_by_id(fid).ok()?;
                         let rng = source_range(&src, v)?;
+                        let start = ctx.to_lsp_range(rng.clone(), &src).start;
+                        child.source = Some(SourceQuery {
+                            file: allocated,
+                            position: start,
+                        });
+                        if matches!(child.kind, DefKind::Function) {
+                            child.param_sources = function_param_sources(
+                                src.text(),
+                                child.name.as_str(),
+                                allocated,
+                                start,
+                            );
+                        }
                         Some((allocated, rng.start, rng.end))
                     })
                 });
@@ -144,7 +230,12 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
                             "#symbol-{}-{sub_primary}.{}",
                             child.kind, child.name
                         ));
-                        format!("#{}-{}-in-{sub_primary}", child.kind, child.name).replace(".", "")
+                        if matches!(child.kind, DefKind::Module) {
+                            module_heading_anchor(&sub_primary)
+                        } else {
+                            format!("#{}-{}-in-{sub_primary}", child.kind, child.name)
+                                .replace(".", "")
+                        }
                     } else if let VirtualRoot::Package(spec) = fid.root() {
                         let lnk = format!(
                             "https://typst.app/universe/package/{}/{}",
@@ -174,8 +265,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
                                 modules_to_generate.push((ident.clone(), child));
                             }
 
-                            let link = format!("module-{primary}").replace(".", "");
-                            format!("#{link}")
+                            module_heading_anchor(&primary)
                         }
                         None => "builtin".to_owned(),
                     };
@@ -190,6 +280,19 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
         }
     }
 
+    let mut bundle_links = HashMap::new();
+    for (idx, (parent_ident, _, info)) in modules.iter().enumerate() {
+        let path = module_output_path(idx, info);
+        bundle_links.insert(parent_ident.clone(), path.clone());
+        for aka in &info.aka {
+            bundle_links.insert(eco_format!("symbol-module-{aka}"), path.clone());
+        }
+    }
+    for (idx, (_, def, info)) in modules.iter_mut().enumerate() {
+        apply_bundle_links(def, &bundle_links);
+        apply_symbol_bundle_links(idx, def, info);
+    }
+
     let mut packages = IndexSet::new();
 
     let files = file_ids
@@ -202,6 +305,7 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
             FileMeta {
                 package: pkg,
                 path: fid.vpath().get_without_slash().to_owned().into(),
+                uri: ctx.uri_for_id(fid).ok().map(|uri| uri.to_string()),
             }
         })
         .collect();
@@ -235,11 +339,536 @@ pub fn package_docs_typ(doc: &PackageDoc) -> StrResult<String> {
     let pi = &doc.meta;
     let _ = writeln!(
         out,
-        "#package-doc(bytes(read(\"{}-{}-{}.json\")))",
-        pi.namespace, pi.name, pi.version,
+        "#package-doc(bytes(read(\"{}-{}-{}.json\")), lsif: read(\"{}-{}-{}.lsif.jsonl\", encoding: none))",
+        pi.namespace, pi.name, pi.version, pi.namespace, pi.name, pi.version,
     );
 
     Ok(out)
+}
+
+/// Generate Typst source files for bundle-mode package docs.
+pub fn package_docs_bundle_typ(doc: &PackageDoc) -> StrResult<Vec<PackageDocTypFile>> {
+    let pi = &doc.meta;
+    let base = format!("{}-{}-{}", pi.namespace, pi.name, pi.version);
+
+    let module_paths = doc
+        .modules
+        .iter()
+        .enumerate()
+        .map(|(idx, (_, def, info))| {
+            let module_source = module_source_path(info);
+            let source_source = info.source.as_ref().map(|_| module_source_page_path(info));
+            let symbol_paths = BundleSection::ALL
+                .into_iter()
+                .flat_map(|section| {
+                    def.children
+                        .iter()
+                        .filter(move |child| section.accepts(child))
+                        .enumerate()
+                        .map(move |(symbol_index, child)| {
+                            let source = module_symbol_source_path(
+                                idx,
+                                info,
+                                section.id(),
+                                child.name.as_str(),
+                            );
+                            BundleSymbolPath {
+                                section: section.id(),
+                                symbol_index,
+                                source_import: unix_slash(&source),
+                                common_import: relative_import_to_common(&source),
+                                output: module_symbol_output_path(
+                                    idx,
+                                    info,
+                                    section.id(),
+                                    child.name.as_str(),
+                                ),
+                                func: format!(
+                                    "render-module-{idx}-{}-{symbol_index}",
+                                    section.id()
+                                ),
+                                source,
+                            }
+                        })
+                })
+                .collect();
+            BundleModulePath {
+                module_source_import: unix_slash(&module_source),
+                module_common_import: relative_import_to_common(&module_source),
+                module_output: module_output_path(idx, info),
+                module_func: format!("render-module-{idx}"),
+                symbol_paths,
+                source_source_import: source_source.as_ref().map(|path| unix_slash(path)),
+                source_common_import: source_source
+                    .as_ref()
+                    .map(|path| relative_import_to_common(path)),
+                source_output: info
+                    .source
+                    .as_ref()
+                    .map(|_| module_source_output_path(info)),
+                source_func: format!("render-source-{idx}"),
+                source_path: info.path.as_ref().map(|path| unix_slash(path)),
+                source_text: info.source.clone(),
+                source_source,
+                module_source,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut files = vec![];
+    files.push(PackageDocTypFile {
+        path: PathBuf::from("common.typ"),
+        content: include_str!("package-doc.typ").to_owned(),
+    });
+
+    let mut entry = String::new();
+    let _ = writeln!(
+        entry,
+        "#import \"/typ/packages/tinymist-index/lib.typ\": create_index"
+    );
+    for path in &module_paths {
+        let _ = writeln!(
+            entry,
+            "#import {}: {}",
+            typst_string(&path.module_source_import),
+            path.module_func
+        );
+        for symbol in &path.symbol_paths {
+            let _ = writeln!(
+                entry,
+                "#import {}: {}",
+                typst_string(&symbol.source_import),
+                symbol.func
+            );
+        }
+        if let Some(source_import) = &path.source_source_import {
+            let _ = writeln!(
+                entry,
+                "#import {}: {}",
+                typst_string(source_import),
+                path.source_func
+            );
+        }
+    }
+    let _ = writeln!(
+        entry,
+        "#let package-info = json(bytes(read(\"../{base}.json\")))"
+    );
+    let _ = writeln!(
+        entry,
+        "#let package-lsif = create_index(read(\"../{base}.lsif.jsonl\", encoding: none))"
+    );
+    for path in &module_paths {
+        let _ = writeln!(entry, "#{}(package-info, package-lsif)", path.module_func);
+        for symbol in &path.symbol_paths {
+            let _ = writeln!(entry, "#{}(package-info, package-lsif)", symbol.func);
+        }
+    }
+    for path in &module_paths {
+        if path.source_text.is_some() {
+            let _ = writeln!(entry, "#{}(package-info)", path.source_func);
+        }
+    }
+    files.push(PackageDocTypFile {
+        path: PathBuf::from("index.typ"),
+        content: entry,
+    });
+
+    for (idx, path) in module_paths.into_iter().enumerate() {
+        let mut content = String::new();
+        let _ = writeln!(
+            content,
+            "#import {}: package-module-document",
+            typst_string(&path.module_common_import)
+        );
+        let _ = writeln!(
+            content,
+            "#let {func}(package-info, package-lsif) = package-module-document(package-info, package-lsif, module-index: {idx}, path: {})",
+            typst_string(&path.module_output),
+            func = path.module_func,
+        );
+        files.push(PackageDocTypFile {
+            path: path.module_source,
+            content,
+        });
+
+        for symbol in path.symbol_paths {
+            let mut content = String::new();
+            let _ = writeln!(
+                content,
+                "#import {}: package-module-symbol-document",
+                typst_string(&symbol.common_import)
+            );
+            let _ = writeln!(
+                content,
+                "#let {func}(package-info, package-lsif) = package-module-symbol-document(package-info, package-lsif, module-index: {idx}, section: {}, symbol-index: {}, path: {})",
+                typst_string(symbol.section),
+                symbol.symbol_index,
+                typst_string(&symbol.output),
+                func = symbol.func,
+            );
+            files.push(PackageDocTypFile {
+                path: symbol.source,
+                content,
+            });
+        }
+
+        if let (
+            Some(source_source),
+            Some(source_common_import),
+            Some(source_output),
+            Some(source_path),
+            Some(source_text),
+        ) = (
+            path.source_source,
+            path.source_common_import,
+            path.source_output,
+            path.source_path,
+            path.source_text,
+        ) {
+            let mut content = String::new();
+            let _ = writeln!(
+                content,
+                "#import {}: package-source-document",
+                typst_string(&source_common_import)
+            );
+            let _ = writeln!(
+                content,
+                "#let {func}(package-info) = package-source-document(package-info, module-index: {idx}, path: {}, source-path: {}, source: {})",
+                typst_string(&source_output),
+                typst_string(&source_path),
+                typst_string(source_text.as_str()),
+                func = path.source_func,
+            );
+            files.push(PackageDocTypFile {
+                path: source_source,
+                content,
+            });
+        }
+    }
+
+    Ok(files)
+}
+
+fn module_source_path(info: &ModuleInfo) -> PathBuf {
+    PathBuf::from("modules").join(module_package_path(info))
+}
+
+fn module_source_page_path(info: &ModuleInfo) -> PathBuf {
+    PathBuf::from("sources").join(module_package_path(info))
+}
+
+fn module_symbol_source_path(
+    idx: usize,
+    info: &ModuleInfo,
+    section: &str,
+    symbol: &str,
+) -> PathBuf {
+    let mut path = PathBuf::from("symbols");
+    path.push(module_symbol_path(idx, info, section, symbol, "typ"));
+    path
+}
+
+fn module_package_path(info: &ModuleInfo) -> PathBuf {
+    info.path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(module_fallback_file_name(info)))
+}
+
+fn module_fallback_file_name(info: &ModuleInfo) -> String {
+    let raw = if !info.parent_ident.is_empty() {
+        info.parent_ident.as_str()
+    } else if !info.prefix.is_empty() {
+        info.prefix.as_str()
+    } else {
+        info.name.as_str()
+    };
+    let mut stem = String::new();
+    let mut prev_dash = false;
+    for ch in raw.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            stem.push(ch);
+            prev_dash = false;
+        } else if !prev_dash {
+            stem.push('-');
+            prev_dash = true;
+        }
+    }
+
+    let stem = stem.trim_matches('-');
+    if stem.is_empty() {
+        "module.typ".to_owned()
+    } else {
+        format!("{stem}.typ")
+    }
+}
+
+fn module_output_path(idx: usize, info: &ModuleInfo) -> String {
+    if idx == 0 {
+        "index.html".to_owned()
+    } else {
+        let mut output = module_package_path(info);
+        output.set_extension("html");
+        unix_slash(&output)
+    }
+}
+
+fn module_source_output_path(info: &ModuleInfo) -> String {
+    format!("{}.html", unix_slash(&module_package_path(info)))
+}
+
+fn module_symbol_output_path(idx: usize, info: &ModuleInfo, section: &str, symbol: &str) -> String {
+    unix_slash(&module_symbol_path(idx, info, section, symbol, "html"))
+}
+
+fn module_symbol_path(
+    idx: usize,
+    info: &ModuleInfo,
+    section: &str,
+    symbol: &str,
+    extension: &str,
+) -> PathBuf {
+    let file_name = format!("{}.{}", symbol_file_stem(symbol), extension);
+    if idx == 0 {
+        return PathBuf::from(section).join(file_name);
+    }
+
+    let path = module_package_path(info);
+    let stem = path
+        .file_stem()
+        .map(|stem| stem.to_owned())
+        .unwrap_or_else(|| info.name.as_str().into());
+    let mut output = path.parent().map(Path::to_owned).unwrap_or_default();
+    output.push(stem);
+    output.push(section);
+    output.push(file_name);
+    output
+}
+
+fn symbol_file_stem(raw: &str) -> String {
+    let mut stem = String::new();
+    let mut prev_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            stem.push(ch);
+            prev_dash = false;
+        } else if !prev_dash {
+            stem.push('-');
+            prev_dash = true;
+        }
+    }
+
+    let stem = stem.trim_matches('-');
+    if stem.is_empty() {
+        "symbol".to_owned()
+    } else {
+        stem.to_owned()
+    }
+}
+
+fn relative_import_to_common(source: &Path) -> String {
+    let mut path = PathBuf::new();
+    let depth = source
+        .parent()
+        .map(|parent| parent.components().count())
+        .unwrap_or(0);
+    for _ in 0..depth {
+        path.push("..");
+    }
+    path.push("common.typ");
+    unix_slash(&path)
+}
+
+fn typst_string(value: &str) -> String {
+    serde_json::to_string(value).expect("Typst string serialization must succeed")
+}
+
+fn function_param_sources(
+    source: &str,
+    function_name: &str,
+    file: usize,
+    start: Position,
+) -> HashMap<EcoString, SourceQuery> {
+    let mut result = HashMap::new();
+    let lines = source.lines().collect::<Vec<_>>();
+    let start_line = start.line as usize;
+    let search_start = start_line.saturating_sub(1);
+    let search_end = (start_line + 3).min(lines.len());
+
+    let Some((open_line, open_byte)) = (search_start..search_end).find_map(|line_idx| {
+        let line = lines.get(line_idx)?;
+        let name_at = line.find(function_name)?;
+        let after_name = name_at + function_name.len();
+        let open_at = line.get(after_name..)?.find('(')?;
+        Some((line_idx, after_name + open_at))
+    }) else {
+        return result;
+    };
+
+    let mut current = String::new();
+    let mut current_line = None;
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (line_idx, line) in lines.iter().enumerate().skip(open_line) {
+        let start_byte = if line_idx == open_line {
+            open_byte + '('.len_utf8()
+        } else {
+            0
+        };
+
+        let mut chars = line.char_indices().peekable();
+        while let Some((byte_idx, ch)) = chars.next() {
+            if byte_idx < start_byte {
+                continue;
+            }
+
+            if let Some(end_quote) = quote {
+                current.push(ch);
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == end_quote {
+                    quote = None;
+                }
+                continue;
+            }
+
+            if ch == '/' && matches!(chars.peek(), Some((_, '/'))) {
+                break;
+            }
+
+            if current_line.is_none() && !ch.is_whitespace() && ch != ',' {
+                current_line = Some(line_idx);
+            }
+
+            match ch {
+                '"' | '\'' => {
+                    quote = Some(ch);
+                    current.push(ch);
+                }
+                '(' | '[' | '{' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' if depth == 0 => {
+                    record_param_source(&mut result, file, &current, current_line);
+                    return result;
+                }
+                ')' | ']' | '}' => {
+                    depth = depth.saturating_sub(1);
+                    current.push(ch);
+                }
+                ',' if depth == 0 => {
+                    record_param_source(&mut result, file, &current, current_line);
+                    current.clear();
+                    current_line = None;
+                }
+                _ => current.push(ch),
+            }
+        }
+
+        if current_line.is_some() {
+            current.push('\n');
+        }
+    }
+
+    result
+}
+
+fn record_param_source(
+    result: &mut HashMap<EcoString, SourceQuery>,
+    file: usize,
+    segment: &str,
+    line: Option<usize>,
+) {
+    let Some(line) = line else {
+        return;
+    };
+    let Some(name) = source_param_name(segment) else {
+        return;
+    };
+
+    result.insert(
+        name.into(),
+        SourceQuery {
+            file,
+            position: Position {
+                line: line as u32,
+                character: 0,
+            },
+        },
+    );
+}
+
+fn source_param_name(segment: &str) -> Option<&str> {
+    let text = segment.trim();
+    if text.starts_with("//") {
+        return None;
+    }
+
+    let text = text.strip_prefix("..").unwrap_or(text).trim_start();
+    let end = text
+        .char_indices()
+        .find_map(|(idx, ch)| {
+            (ch.is_whitespace() || matches!(ch, ':' | '=' | ',' | ')')).then_some(idx)
+        })
+        .unwrap_or(text.len());
+    let name = text[..end].trim();
+    (!name.is_empty()).then_some(name)
+}
+
+fn module_heading_anchor(primary: &str) -> String {
+    let mut anchor = String::from("#");
+    let mut prev_dash = false;
+
+    for ch in format!("Module: {primary}").chars() {
+        if ch.is_whitespace() || matches!(ch, ':' | '-') {
+            if !prev_dash {
+                anchor.push('-');
+                prev_dash = true;
+            }
+        } else if matches!(ch, '.' | '(' | ')') {
+            continue;
+        } else {
+            if ch == 'M' {
+                anchor.push('m');
+            } else {
+                anchor.push(ch);
+            }
+            prev_dash = false;
+        }
+    }
+
+    anchor
+}
+
+fn apply_bundle_links(def: &mut crate::docs::DefInfo, links: &HashMap<EcoString, String>) {
+    for child in &mut def.children {
+        if matches!(child.kind, DefKind::Module)
+            && let Some(link) = links.get(&child.id)
+        {
+            child.bundle_link = Some(link.clone());
+        }
+    }
+}
+
+fn apply_symbol_bundle_links(idx: usize, def: &mut crate::docs::DefInfo, info: &ModuleInfo) {
+    for child in &mut def.children {
+        for section in BundleSection::ALL {
+            if section.accepts(child) {
+                child.bundle_link = Some(module_symbol_output_path(
+                    idx,
+                    info,
+                    section.id(),
+                    child.name.as_str(),
+                ));
+                break;
+            }
+        }
+    }
 }
 
 /// Generate full documents in markdown format
@@ -426,6 +1055,8 @@ pub struct PackageMetaEnd {
 pub struct FileMeta {
     package: Option<usize>,
     path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uri: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -435,9 +1066,14 @@ struct ConvertResult {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use tinymist_world::package::{PackageRegistry, PackageSpec, registry::PREVIEW_NS};
 
-    use super::{PackageInfo, package_docs, package_docs_md, package_docs_typ};
+    use super::{
+        PackageInfo, package_docs, package_docs_bundle_typ, package_docs_md, package_docs_typ,
+    };
+    use crate::analysis::Analysis;
     use crate::tests::*;
 
     fn test(pkg: PackageSpec) {
@@ -468,7 +1104,33 @@ mod tests {
                     pi.namespace, pi.name, pi.version
                 );
                 std::fs::write(dest, md).unwrap();
-            })
+                let bundle = package_docs_bundle_typ(&docs).unwrap();
+                let dest = std::path::PathBuf::from(format!(
+                    "../../target/{}-{}-{}.bundle",
+                    pi.namespace, pi.name, pi.version
+                ));
+                let _ = std::fs::remove_dir_all(&dest);
+                for file in bundle {
+                    let path = dest.join(file.path);
+                    if let Some(parent) = path.parent() {
+                        std::fs::create_dir_all(parent).unwrap();
+                    }
+                    std::fs::write(path, file.content).unwrap();
+                }
+            });
+            let analysis = Arc::new(Analysis::default());
+            let lsif = analysis
+                .query_snapshot(verse.computation(), None)
+                .run_within_package(&pi, |a| {
+                    let knowledge = crate::index::knowledge(a).unwrap();
+                    Ok(knowledge.bind(a.shared()).to_string())
+                })
+                .unwrap();
+            let dest = format!(
+                "../../target/{}-{}-{}.lsif.jsonl",
+                pi.namespace, pi.name, pi.version
+            );
+            std::fs::write(dest, lsif).unwrap();
         })
     }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:syntax": "node scripts/build.mjs build:syntax",
     "build:l10n": "node scripts/build.mjs build:l10n",
     "build:index": "node scripts/build.mjs build:index",
+    "watch:index": "watchexec -e rs -w crates -- node scripts/build.mjs build:index",
     "build:docker": "docker build -t myriaddreamin/tinymist:0.14.10 .",
     "build:web": "node scripts/build.mjs build:web",
     "test:vsc": "node scripts/build.mjs test:vsc",

--- a/scripts/dev-lsif.sh
+++ b/scripts/dev-lsif.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+default_input="target/preview-touying-0.6.0.typ"
+default_bundle_input="target/preview-touying-0.6.0.bundle/index.typ"
+mode="${1:-watch}"
+if [[ "$mode" == "bundle" || "$mode" == "bundle-once" || "$mode" == "watch-bundle" || "$mode" == "serve-bundle" ]]; then
+  input="${LSIF_INPUT:-$default_bundle_input}"
+  output="${LSIF_OUTPUT:-target/test-bundle}"
+else
+  input="${LSIF_INPUT:-$default_input}"
+  output="${LSIF_OUTPUT:-target/test.html}"
+fi
+x_target="${LSIF_X_TARGET:-html-ayu}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/dev-lsif.sh [once|watch|serve|bundle|watch-bundle|serve-bundle|build-index]
+
+Modes:
+  once          Compile the generated package-doc Typst file once.
+  watch         Watch and recompile without starting Typst's HTML TCP server.
+  serve         Watch and recompile with Typst's HTML server enabled.
+  bundle        Compile the generated bundle package-doc Typst entry once.
+  watch-bundle  Watch and recompile the bundle entry without Typst's HTML TCP server.
+  serve-bundle  Watch and recompile the bundle entry with Typst's HTML server enabled.
+  build-index   Build typ/packages/tinymist-index/tinymist_index.wasm.
+
+Environment:
+  LSIF_INPUT     Typst input file. Defaults to target/preview-touying-0.6.0.typ
+                 or target/preview-touying-0.6.0.bundle/index.typ in bundle modes.
+  LSIF_OUTPUT    HTML output file or bundle output directory. Defaults to target/test.html
+                 or target/test-bundle in bundle modes.
+  LSIF_X_TARGET  Typst x-target input. Defaults to html-ayu.
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: missing required command: $1" >&2
+    exit 127
+  fi
+}
+
+prepare_bundle_output() {
+  case "$output" in
+    ""|"/"|".")
+      echo "error: refusing to clean unsafe bundle output path: $output" >&2
+      exit 2
+      ;;
+  esac
+
+  rm -rf -- "$output"
+  mkdir -p "$(dirname -- "$output")"
+}
+
+ensure_input() {
+  local lsif="target/preview-touying-0.6.0.lsif.jsonl"
+  if [[ -f "$input" && ( "$input" != "$default_input" || -f "$lsif" ) && ( "$input" != "$default_bundle_input" || -f "$lsif" ) ]]; then
+    return
+  fi
+
+  if [[ "$input" == "$default_input" || "$input" == "$default_bundle_input" ]]; then
+    echo "Generating $input and $lsif with the package-doc touying fixture..."
+    require_cmd cargo
+    cargo test -p tinymist-query docs::package::tests::touying -- --nocapture
+  fi
+
+  if [[ ! -f "$input" ]]; then
+    echo "error: input file does not exist: $input" >&2
+    echo "hint: set LSIF_INPUT or generate package docs first." >&2
+    exit 1
+  fi
+}
+
+typst_args=(
+  --root .
+  --font-path assets/fonts
+  --input "x-target=$x_target"
+  "$input"
+  "$output"
+)
+
+case "$mode" in
+  once|compile)
+    require_cmd typst
+    ensure_input
+    mkdir -p "$(dirname -- "$output")"
+    typst compile --features html "${typst_args[@]}"
+    ;;
+  bundle|bundle-once)
+    require_cmd typst
+    ensure_input
+    prepare_bundle_output
+    typst compile --features bundle,html --format bundle "${typst_args[@]}"
+    ;;
+  watch)
+    require_cmd typst
+    ensure_input
+    mkdir -p "$(dirname -- "$output")"
+    typst watch --no-serve --features html "${typst_args[@]}"
+    ;;
+  watch-bundle)
+    require_cmd typst
+    ensure_input
+    prepare_bundle_output
+    typst watch --no-serve --features bundle,html --format bundle "${typst_args[@]}"
+    ;;
+  serve)
+    require_cmd typst
+    ensure_input
+    mkdir -p "$(dirname -- "$output")"
+    typst watch --features html "${typst_args[@]}"
+    ;;
+  serve-bundle)
+    require_cmd typst
+    ensure_input
+    prepare_bundle_output
+    typst watch --features bundle,html --format bundle "${typst_args[@]}"
+    ;;
+  build-index)
+    require_cmd node
+    node scripts/build.mjs build:index
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/typ/packages/package-docs/global.css
+++ b/typ/packages/package-docs/global.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,700;0,900;1,300;1,700&display=swap");
 
 main {
-  margin: 2em;
+  margin: 0;
 }
 :root.light {
   --main-color: #000;
@@ -13,6 +13,14 @@ main {
   --accent: oklch(51.51% 0.2307 257.85);
   --accent-dark: oklch(64.94% 0.1982 251.813);
   --black: #0f1219;
+  --source-bg-color: #ffffff;
+  --source-header-bg-color: #f6f8fa;
+  --source-fg-color: #24292f;
+  --source-border-color: #d0d7de;
+  --source-line-number-color: #6e7781;
+  --source-shadow-color: rgba(27, 31, 36, 0.08);
+  --scrollbar-thumb-color: rgba(101, 117, 133, 0.34);
+  --scrollbar-thumb-hover-color: rgba(101, 117, 133, 0.58);
 }
 
 :root {
@@ -26,6 +34,16 @@ main {
   --nav-bg-color: #212737;
   --accent: oklch(71.7% 0.1648 250.794);
   --accent-dark: oklch(51.51% 0.2307 257.85);
+  --source-bg-color: #0d1117;
+  --source-header-bg-color: #161b22;
+  --source-fg-color: #c9d1d9;
+  --source-border-color: #30363d;
+  --source-line-number-color: #8b949e;
+  --source-shadow-color: rgba(0, 0, 0, 0.28);
+  --scrollbar-thumb-color: rgba(147, 157, 163, 0.34);
+  --scrollbar-thumb-hover-color: rgba(147, 157, 163, 0.6);
+  --source-code-font-size: 0.875rem;
+  --source-code-line-height: 1.5rem;
   --vp-font-family-mono: ui-monospace, "Menlo", "Monaco", "Consolas", "Liberation Mono",
     "Courier New", monospace;
   --vp-font-family-base: 
@@ -56,6 +74,758 @@ body {
   overflow-wrap: break-word;
   color: var(--main-color);
   line-height: 1.7;
+}
+
+* {
+  scrollbar-color: var(--scrollbar-thumb-color) transparent;
+  scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: var(--scrollbar-thumb-color);
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover-color);
+  background-clip: padding-box;
+}
+
+.package-doc-layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 268px) minmax(0, 904px) minmax(220px, 268px);
+  gap: 0;
+  width: min(1440px, 100%);
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.package-doc-main {
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
+  max-width: none;
+  padding: 2rem;
+}
+
+.package-sidebar {
+  position: sticky;
+  top: 1.25rem;
+  box-sizing: border-box;
+  align-self: start;
+  max-height: calc(100vh - 2.5rem);
+  overflow: auto;
+  padding: 1rem 0.85rem 1rem 1rem;
+  border-right: 1px solid var(--raw-bg-color);
+  scrollbar-gutter: stable;
+}
+
+.package-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.package-sidebar-title {
+  display: grid;
+  gap: 0.15rem;
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-sidebar-title:hover {
+  text-decoration: none;
+}
+
+.package-sidebar-package {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.package-sidebar-version {
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
+.package-sidebar-section {
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.package-sidebar-list {
+  display: grid;
+  gap: 0.15rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.package-sidebar-item {
+  margin: 0;
+}
+
+.package-sidebar-link {
+  display: block;
+  padding: 0.28rem 0.45rem;
+  border-radius: 4px;
+  color: var(--main-color);
+  font-size: 0.92rem;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.package-sidebar-link:hover {
+  background: var(--raw-bg-color);
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-sidebar-link.is-active {
+  background: var(--raw-bg-color);
+  color: var(--main-hover-color);
+}
+
+.package-sidebar-sublist {
+  display: grid;
+  gap: 0.1rem;
+  list-style: none;
+  margin: 0.15rem 0 0.35rem;
+  padding: 0 0 0 0.85rem;
+}
+
+.package-sidebar-subitem {
+  margin: 0;
+}
+
+.package-sidebar-sublink {
+  display: block;
+  padding: 0.2rem 0.45rem;
+  border-radius: 4px;
+  color: var(--gray-color);
+  font-size: 0.84rem;
+  line-height: 1.3;
+  text-decoration: none;
+}
+
+.package-sidebar-sublink:hover,
+.package-sidebar-sublink.is-active {
+  background: var(--raw-bg-color);
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-sidebar-symbol-list {
+  display: grid;
+  gap: 0.04rem;
+  list-style: none;
+  margin: 0.12rem 0 0.35rem;
+  padding: 0 0 0 0.7rem;
+}
+
+.package-sidebar-symbol-item {
+  min-width: 0;
+  margin: 0;
+}
+
+.package-sidebar-symbol-link {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.12rem 0.35rem;
+  border-radius: 4px;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-base);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.package-sidebar-symbol-link:hover,
+.package-sidebar-symbol-link.is-active {
+  background: var(--raw-bg-color);
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-on-this-page {
+  position: sticky;
+  top: 1.25rem;
+  box-sizing: border-box;
+  align-self: start;
+  max-height: calc(100vh - 2.5rem);
+  overflow: hidden;
+  padding: 2rem 1rem 1rem 1.25rem;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-base);
+  animation: package-on-this-page-enter 180ms ease-out both;
+}
+
+.package-on-this-page[hidden] {
+  display: none;
+}
+
+.package-on-this-page-nav {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.package-on-this-page-title {
+  color: var(--main-hover-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.package-on-this-page-body {
+  position: relative;
+  min-width: 0;
+  padding-left: 0.65rem;
+}
+
+.package-on-this-page-body::before {
+  position: absolute;
+  top: 0.25rem;
+  bottom: 0.25rem;
+  left: 0;
+  width: 1px;
+  background: var(--raw-bg-color);
+  content: "";
+}
+
+.package-on-this-page-indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1rem;
+  background: var(--accent);
+  opacity: 0;
+  transform: translateY(0);
+  transition:
+    transform 180ms ease,
+    height 180ms ease,
+    opacity 120ms ease;
+}
+
+.package-on-this-page-list {
+  display: grid;
+  gap: 0.05rem;
+  max-height: calc(100vh - 7.25rem);
+  margin: 0;
+  overflow: auto;
+  padding: 0;
+  list-style: none;
+  scrollbar-gutter: stable;
+}
+
+.package-on-this-page-item {
+  min-width: 0;
+  margin: 0;
+}
+
+.package-on-this-page-link {
+  position: relative;
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.35rem 0.45rem;
+  border-radius: 4px;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-base);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
+  white-space: nowrap;
+}
+
+.package-on-this-page-link:hover {
+  background: var(--raw-bg-color);
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-on-this-page-link[data-active="true"] {
+  color: var(--main-hover-color);
+  transform: translateX(2px);
+}
+
+.package-on-this-page-link[data-depth="1"] {
+  padding-left: 0.9rem;
+}
+
+.package-on-this-page-link[data-depth="2"],
+.package-on-this-page-link[data-depth="3"] {
+  padding-left: 1.35rem;
+  font-size: 0.78rem;
+}
+
+@keyframes package-on-this-page-enter {
+  from {
+    opacity: 0;
+    transform: translateX(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 1180px) {
+  .package-doc-layout {
+    grid-template-columns: minmax(240px, 268px) minmax(0, 904px);
+    width: min(1172px, 100%);
+  }
+
+  .package-on-this-page {
+    display: none;
+  }
+}
+
+.module-source-meta {
+  margin: -0.25rem 0 1.25rem;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.86rem;
+}
+
+.module-source-link {
+  text-decoration: none;
+}
+
+.module-source-link:hover {
+  text-decoration: underline;
+}
+
+.symbol-reference-list {
+  display: grid;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0.75rem 0 1.5rem;
+  padding: 0;
+}
+
+.symbol-reference {
+  display: grid;
+  grid-template-columns: minmax(10rem, 18rem) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  margin: 0;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--raw-bg-color);
+}
+
+.symbol-reference-link {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.symbol-reference-link:hover {
+  text-decoration: underline;
+}
+
+.symbol-reference-link code {
+  color: var(--main-hover-color);
+}
+
+.symbol-reference-summary {
+  min-width: 0;
+  color: var(--gray-color);
+  font-size: 0.92rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.package-function-doc {
+  min-width: 0;
+}
+
+.package-function-heading {
+  text-align: left;
+}
+
+.function-signature-nav {
+  box-sizing: border-box;
+  min-width: 0;
+  margin: -0.25rem 0 1rem;
+  overflow-x: auto;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--raw-bg-color);
+  border-radius: 6px;
+  background: var(--raw-bg-color);
+  text-align: left;
+}
+
+.function-signature-nav code {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  background: transparent;
+  color: var(--main-hover-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.function-signature-nav code > * {
+  font-size: 0.9rem;
+}
+
+.function-signature-name {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.function-signature-param {
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.function-signature-param:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.function-signature-punctuation {
+  color: var(--gray-color);
+}
+
+.function-signature-block {
+  margin: 0 0 1.35rem;
+  overflow: hidden;
+  border: 1px solid var(--source-border-color);
+  border-radius: 8px;
+  background: var(--source-bg-color);
+  box-shadow: 0 10px 24px var(--source-shadow-color);
+}
+
+.function-signature-block pre {
+  margin: 0;
+  border-radius: 0;
+  background: var(--source-bg-color);
+}
+
+.function-docs {
+  margin-bottom: 1.4rem;
+}
+
+.function-param-doc {
+  margin: 0;
+  padding: 1.15rem 0 1.25rem;
+  border-top: 1px solid var(--raw-bg-color);
+}
+
+.function-param-doc:last-child {
+  border-bottom: 1px solid var(--raw-bg-color);
+}
+
+.function-param-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: baseline;
+  margin-top: 0;
+  margin-bottom: 0.55rem;
+  font-size: 1.08rem;
+  line-height: 1.4;
+}
+
+.function-param-name {
+  padding: 0;
+  background: transparent;
+  color: var(--main-hover-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 1.02em;
+  font-weight: 700;
+}
+
+.function-param-additional-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.65rem;
+  align-items: baseline;
+  flex: 1 1 18rem;
+  min-width: min(100%, 18rem);
+}
+
+.function-param-type-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.function-param-type-or {
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-base);
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.function-param-pill {
+  display: inline-block;
+  max-width: 100%;
+  padding: 0.08rem 0.36rem;
+  border-radius: 5px;
+  color: #15202b;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.45;
+  white-space: nowrap;
+}
+
+.function-param-pill-content {
+  background: #a6ebe6;
+}
+
+.function-param-pill-string {
+  background: #d1ffe2;
+}
+
+.function-param-pill-keyword {
+  background: #ffcbc4;
+}
+
+.function-param-pill-number {
+  background: #ffedc1;
+}
+
+.function-param-pill-object {
+  background: #eff0f3;
+}
+
+.function-param-pill-collection {
+  background: #f9dfff;
+}
+
+.function-param-pill-function {
+  background: #d1d4fd;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.function-param-mod {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0.05rem 0.38rem;
+  border: 1px solid var(--raw-bg-color);
+  border-radius: 999px;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  font-weight: 650;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.function-param-source-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0.05rem 0;
+  color: var(--accent);
+  font-family: var(--vp-font-family-base);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.function-param-source-link:hover {
+  color: var(--main-hover-color);
+  text-decoration: underline;
+}
+
+.function-param-default {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: baseline;
+  margin-left: auto;
+  color: var(--gray-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.76rem;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.function-param-default-code {
+  display: inline-flex;
+  align-items: center;
+}
+
+.function-param-default-code code {
+  padding: 0.08rem 0.32rem;
+  border-radius: 4px;
+  background: var(--source-bg-color);
+  color: var(--source-fg-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.function-param-body > :first-child {
+  margin-top: 0;
+}
+
+.function-param-body > :last-child {
+  margin-bottom: 0;
+}
+
+.package-source-code {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  margin-top: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--source-border-color);
+  border-radius: 8px;
+  background: var(--source-bg-color);
+  box-shadow: 0 12px 32px var(--source-shadow-color);
+}
+
+.package-source-code::before {
+  display: block;
+  box-sizing: border-box;
+  min-height: 2.5rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--source-border-color);
+  background: var(--source-header-bg-color);
+  color: var(--gray-color);
+  content: attr(data-source-path);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  text-align: left;
+}
+
+.package-source-body {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-width: 0;
+  background: var(--source-bg-color);
+}
+
+.package-source-lines {
+  box-sizing: border-box;
+  min-width: 3.5rem;
+  margin: 0;
+  padding: 1rem 0.75rem 1rem 0.5rem;
+  border-right: 1px solid var(--source-border-color);
+  background: var(--source-bg-color);
+  color: var(--source-line-number-color);
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--source-code-font-size);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--source-code-line-height);
+  text-align: right;
+  user-select: none;
+  white-space: pre;
+}
+
+.package-source-line-number {
+  display: block;
+  color: inherit;
+  scroll-margin-top: 1.25rem;
+  text-decoration: none;
+}
+
+.package-source-line-number:hover,
+.package-source-line-number:target {
+  color: var(--main-hover-color);
+}
+
+.package-source-line-number:target {
+  border-radius: 3px;
+  background: var(--raw-bg-color);
+}
+
+.package-source-scroll {
+  min-width: 0;
+  overflow: auto;
+  background: var(--source-bg-color);
+  scrollbar-color: var(--scrollbar-thumb-color) var(--source-bg-color);
+}
+
+.package-source-scroll pre {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 100%;
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0;
+  background: var(--source-bg-color);
+  color: var(--source-fg-color);
+  overflow: visible;
+  line-height: var(--source-code-line-height);
+  tab-size: 2;
+  text-align: left;
+}
+
+.package-source-scroll pre > code {
+  display: block;
+  width: 100%;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--source-code-font-size);
+  line-height: inherit;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.package-source-scroll::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.package-source-scroll::-webkit-scrollbar-track {
+  background: var(--source-bg-color);
+}
+
+.package-source-scroll::-webkit-scrollbar-thumb {
+  border: 3px solid var(--source-bg-color);
+  border-radius: 999px;
+  background: var(--scrollbar-thumb-color);
+  background-clip: padding-box;
+}
+
+.package-source-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover-color);
+  background-clip: padding-box;
 }
 
 h1 :target,
@@ -271,6 +1041,27 @@ figcaption {
   margin: 0;
 }
 
+.function-signature-header {
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.detail-header .function-signature-nav {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.detail-header .package-function-heading {
+  margin: 0;
+  color: var(--main-hover-color);
+  font-size: 1em;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
 .detail-header code {
   background-color: transparent;
   margin: 0;
@@ -320,4 +1111,51 @@ figcaption {
 .type-inferred-as:hover,
 .code-kw.type-inferred:hover {
   background-color: #344134;
+}
+
+@media (max-width: 900px) {
+  .package-doc-layout {
+    display: block;
+    padding: 1.25rem;
+  }
+
+  .package-doc-main {
+    padding: 0;
+  }
+
+  .package-on-this-page {
+    display: none;
+  }
+
+  .package-sidebar {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    margin-bottom: 1.5rem;
+    padding: 0 0 1rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--raw-bg-color);
+    scrollbar-gutter: auto;
+  }
+
+  .package-sidebar-list {
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  }
+
+  .package-sidebar-sublist {
+    padding-left: 0.5rem;
+  }
+
+  .package-sidebar-symbol-list {
+    padding-left: 0.45rem;
+  }
+
+  .symbol-reference {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.2rem;
+  }
+
+  .symbol-reference-summary {
+    white-space: normal;
+  }
 }

--- a/typ/packages/package-docs/on-this-page.js
+++ b/typ/packages/package-docs/on-this-page.js
@@ -1,0 +1,162 @@
+const TOC_SELECTOR = ".package-on-this-page";
+const HEADING_SELECTOR = ".package-doc-main h2, .package-doc-main h3, .package-doc-main h4, .package-doc-main h5";
+
+function slug(value, index) {
+  return `on-this-page-${index}-${value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "section"}`;
+}
+
+function headingTarget(heading, index) {
+  if (heading.id) {
+    return heading.id;
+  }
+
+  const child = heading.querySelector("[id]");
+  if (child && child.id) {
+    return child.id;
+  }
+
+  heading.id = slug(heading.textContent || "", index);
+  return heading.id;
+}
+
+function initToc(toc) {
+  if (toc.dataset.ready === "true") {
+    return;
+  }
+
+  const layout = toc.closest(".package-doc-layout");
+  const main = layout && layout.querySelector(".package-doc-main");
+  const list = toc.querySelector(".package-on-this-page-list");
+  const indicator = toc.querySelector(".package-on-this-page-indicator");
+  if (!main || !list || !indicator) {
+    return;
+  }
+
+  const explicitHeadings = Array.from(main.querySelectorAll("[data-toc-label]"));
+  const useExplicitHeadings = explicitHeadings.length > 0;
+  const headings = useExplicitHeadings
+    ? explicitHeadings
+    : Array.from(main.querySelectorAll(HEADING_SELECTOR));
+
+  const items = headings
+    .filter((heading) => !heading.closest(".package-source-code"))
+    .map((heading, index) => {
+      const title = (heading.dataset.tocLabel || heading.textContent || "").trim().replace(/\s+/g, " ");
+      if (!title) {
+        return null;
+      }
+
+      const level = useExplicitHeadings
+        ? Number(heading.dataset.tocDepth || 0)
+        : Number(heading.tagName.slice(1));
+
+      return {
+        heading,
+        id: headingTarget(heading, index),
+        level,
+        title,
+      };
+    })
+    .filter(Boolean);
+
+  if (items.length === 0 || (!useExplicitHeadings && items.length < 2)) {
+    toc.hidden = true;
+    return;
+  }
+
+  list.replaceChildren();
+
+  const links = items.map((item) => {
+    const row = document.createElement("li");
+    row.className = "package-on-this-page-item";
+
+    const link = document.createElement("a");
+    link.className = "package-on-this-page-link";
+    link.href = `#${item.id}`;
+    link.textContent = item.title;
+    link.dataset.active = "false";
+    link.dataset.depth = useExplicitHeadings
+      ? String(item.level)
+      : String(Math.max(0, item.level - items[0].level));
+    link.addEventListener("click", () => activate(item.id));
+
+    row.append(link);
+    list.append(row);
+    return { ...item, link };
+  });
+
+  let ticking = false;
+
+  function moveIndicator(link) {
+    indicator.style.opacity = "1";
+    indicator.style.height = `${Math.max(16, link.offsetHeight - 12)}px`;
+    indicator.style.transform = `translateY(${link.offsetTop + 6}px)`;
+  }
+
+  function activate(id) {
+    let activeLink = null;
+    for (const item of links) {
+      const active = item.id === id;
+      item.link.dataset.active = active ? "true" : "false";
+      if (active) {
+        activeLink = item.link;
+      }
+    }
+
+    if (activeLink) {
+      moveIndicator(activeLink);
+    }
+  }
+
+  function currentHeading() {
+    if (window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 2) {
+      return links[links.length - 1];
+    }
+
+    const offset = Math.min(180, window.innerHeight * 0.28);
+    let current = links[0];
+    for (const item of links) {
+      if (item.heading.getBoundingClientRect().top <= offset) {
+        current = item;
+      } else {
+        break;
+      }
+    }
+
+    return current;
+  }
+
+  function update() {
+    ticking = false;
+    activate(currentHeading().id);
+  }
+
+  function schedule() {
+    if (!ticking) {
+      ticking = true;
+      window.requestAnimationFrame(update);
+    }
+  }
+
+  toc.dataset.ready = "true";
+  toc.hidden = false;
+  update();
+
+  window.addEventListener("scroll", schedule, { passive: true });
+  window.addEventListener("resize", schedule);
+  window.addEventListener("hashchange", schedule);
+}
+
+function initAllTocs() {
+  document.querySelectorAll(TOC_SELECTOR).forEach(initToc);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initAllTocs, { once: true });
+} else {
+  initAllTocs();
+}

--- a/typ/packages/tinymist-index/typst.toml
+++ b/typ/packages/tinymist-index/typst.toml
@@ -1,0 +1,4 @@
+[package]
+name = "tinymist-index"
+version = "0.1.0"
+entrypoint = "lib.typ"


### PR DESCRIPTION
## Summary

- render package docs from `$package.json + $package.lsif.jsonl` using the LSIF hover/definition support now merged on `main`
- add bundle-mode package docs with one page per module/function/constant, source pages, sidebars, On this page navigation, line numbers, and parameter source links
- keep generated JSON smaller by omitting serialized `docs` / `parsed_docs` / `oneliner` fields
- add `scripts/dev-lsif.sh` helpers for regenerating, watching, serving, and bundle-compiling the Touying LSIF docs fixture

## Validation

- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `bash -n scripts/dev-lsif.sh`
- `node --check typ/packages/package-docs/on-this-page.js`
- `cargo test -p tinymist-query docs::package::tests::touying -- --nocapture`
- `scripts/dev-lsif.sh bundle`
- checked generated Touying docs: JSON has no serialized `docs` / `parsed_docs` / `oneliner`, bundle has 424 HTML files, no private `_*.html` symbol pages, and 1920 function parameter source links resolve to existing line anchors

## Notes

The LSIF/index runtime support was split out and has already landed in #2612. This PR now only carries the package-docs rendering, bundle output, and preview workflow changes. The package public API/export-surface model is still carried by the small package JSON module tree here. Moving module export surfaces to a smaller meta format and adding documentSymbol/signatureHelp-backed queries should be a follow-up, because `import "a.typ": *` re-exports cannot be represented by physical-file `documentSymbol` alone.