### PR TITLE
feat(lsif): support hover queries

### DIFF
--- a/crates/tinymist-index/src/lib.rs
+++ b/crates/tinymist-index/src/lib.rs
@@ -16,9 +16,10 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use lsp_types::GotoDefinitionParams;
+use lsp_types::{GotoDefinitionParams, HoverParams};
 use tinymist_query::{
-    CompilerQueryRequest, GotoDefinitionRequest, index::query::IndexQueryCtx, url_to_path,
+    CompilerQueryRequest, GotoDefinitionRequest, HoverRequest, index::query::IndexQueryCtx,
+    url_to_path,
 };
 #[cfg(all(feature = "typst-plugin", target_arch = "wasm32"))]
 use wasm_minimal_protocol::*;
@@ -52,6 +53,9 @@ pub fn query_index(kind: &[u8], request: &[u8]) -> StrResult<Vec<u8>> {
     };
     match response {
         None => Ok("null".as_bytes().to_vec()),
+        Some(tinymist_query::CompilerQueryResponse::Hover(response)) => {
+            serde_json::to_vec(&response).map_err(to_string)
+        }
         Some(tinymist_query::CompilerQueryResponse::GotoDefinition(response)) => {
             serde_json::to_vec(&response).map_err(to_string)
         }
@@ -61,6 +65,13 @@ pub fn query_index(kind: &[u8], request: &[u8]) -> StrResult<Vec<u8>> {
 
 fn parse_request(kind: &str, request: &[u8]) -> StrResult<CompilerQueryRequest> {
     Ok(match kind {
+        "hover" => CompilerQueryRequest::Hover({
+            let req: HoverParams = serde_json::from_slice(request).map_err(to_string)?;
+            HoverRequest {
+                path: url_to_path(&req.text_document_position_params.text_document.uri),
+                position: req.text_document_position_params.position,
+            }
+        }),
         "goto_definition" => CompilerQueryRequest::GotoDefinition({
             let req: GotoDefinitionParams = serde_json::from_slice(request).map_err(to_string)?;
             GotoDefinitionRequest {

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -28,6 +28,76 @@ pub struct HoverRequest {
     pub position: LspPosition,
 }
 
+pub(crate) fn hover_from_definition(
+    ctx: &mut LocalContext,
+    def: &Definition,
+    range: Option<LspRange>,
+) -> Option<Hover> {
+    let mut contents = vec![];
+
+    use Decl::*;
+    match def.decl.as_ref() {
+        Label(..) => {
+            if let Some(val) = def.term.as_ref().and_then(|v| v.value()) {
+                contents.push(format!("Ref: `{}`\n", def.name()));
+                contents.push(format!("```typc\n{}\n```", truncated_repr(&val)));
+            } else {
+                contents.push(format!("Label: `{}`\n", def.name()));
+            }
+        }
+        BibEntry(..) => {
+            contents.push(format!("Bibliography: `{}`", def.name()));
+        }
+        _ => {
+            let sym_docs = ctx.def_docs(def);
+
+            if matches!(
+                def.decl.kind(),
+                DefKind::Function | DefKind::Variable | DefKind::Constant
+            ) && !def.name().is_empty()
+            {
+                let mut type_doc = String::new();
+                type_doc.push_str("let ");
+                type_doc.push_str(def.name());
+
+                match &sym_docs {
+                    Some(DefDocs::Variable(docs)) => {
+                        push_result_ty(def.name(), docs.return_ty.as_ref(), &mut type_doc);
+                    }
+                    Some(DefDocs::Function(docs)) => {
+                        let _ = docs.print(&mut type_doc);
+                        push_result_ty(def.name(), docs.ret_ty.as_ref(), &mut type_doc);
+                    }
+                    _ => {}
+                }
+
+                contents.push(format!("```typc\n{type_doc};\n```"));
+            }
+
+            if let Some(doc) = sym_docs {
+                let hover_docs = doc.hover_docs();
+
+                if !hover_docs.trim().is_empty() {
+                    contents.push(hover_docs.into());
+                }
+            }
+
+            if let Some(link) = ExternalDocLink::get(def) {
+                contents.push(link.to_string());
+            }
+        }
+    }
+
+    if contents.is_empty() {
+        return None;
+    }
+
+    Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(contents.join("\n\n---\n\n"))),
+        range,
+    })
+}
+
 impl SemanticRequest for HoverRequest {
     type Response = Hover;
 

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -13,7 +13,7 @@ use crate::index::protocol::ResultSet;
 use crate::prelude::Definition;
 use crate::{LocalContext, path_to_url};
 use ecow::EcoString;
-use lsp_types::Url;
+use lsp_types::{Hover, Url};
 use tinymist_analysis::syntax::classify_syntax;
 use tinymist_std::error::WithContextUntyped;
 use tinymist_std::hash::FxHashMap;
@@ -58,6 +58,7 @@ impl fmt::Display for KnowledgeWithContext<'_> {
             id: IdCounter::new(),
             files: &mut files,
             results: FxHashMap::default(),
+            hover_results: FxHashMap::default(),
         };
 
         encoder
@@ -107,6 +108,7 @@ struct LsifEncoder<'a, W: fmt::Write> {
     id: IdCounter,
     files: &'a mut FxHashMap<FileId, i32>,
     results: FxHashMap<Span, i32>,
+    hover_results: FxHashMap<String, i32>,
 }
 
 impl<'a, W: fmt::Write> LsifEncoder<'a, W> {
@@ -177,17 +179,24 @@ impl<'a, W: fmt::Write> LsifEncoder<'a, W> {
             })))?;
 
             let mut tokens_id = vec![];
-            for (s, def) in &file.references {
+            for (s, reference) in &file.references {
+                let def = &reference.definition;
                 if let Some(range_id) = self.emit_span(*s, &source) {
                     let res_id = self.alloc_result_id(*s)?;
                     self.emit_element(p::Element::Edge(p::Edge::Next(p::EdgeData {
                         out_v: range_id,
                         in_v: res_id,
                     })))?;
+                    if let Some(hover) = &reference.hover {
+                        self.emit_hover(res_id, hover)?;
+                    }
                     tokens_id.push(range_id);
                 }
 
                 if let Some(def_range_id) = self.emit_def_span(def, &source, false) {
+                    if let Some(hover) = &reference.hover {
+                        self.emit_hover(def_range_id, hover)?;
+                    }
                     tokens_id.push(def_range_id);
                 }
             }
@@ -196,7 +205,8 @@ impl<'a, W: fmt::Write> LsifEncoder<'a, W> {
                 in_vs: tokens_id,
             })))?;
 
-            for (s, def) in &file.references {
+            for (s, reference) in &file.references {
+                let def = &reference.definition;
                 let res_id = self.alloc_result_id(*s)?;
                 let def_id = self.emit_element(p::Element::Vertex(p::Vertex::DefinitionResult))?;
                 let Some(def_range) = self.emit_def_span(def, &source, true) else {
@@ -222,6 +232,28 @@ impl<'a, W: fmt::Write> LsifEncoder<'a, W> {
             }
         }
         Ok(())
+    }
+
+    fn emit_hover(&mut self, out_v: i32, hover: &Hover) -> tinymist_std::Result<()> {
+        let hover_id = self.alloc_hover_id(hover)?;
+        self.emit_element(p::Element::Edge(p::Edge::Hover(p::EdgeData {
+            out_v,
+            in_v: hover_id,
+        })))?;
+        Ok(())
+    }
+
+    fn alloc_hover_id(&mut self, hover: &Hover) -> tinymist_std::Result<i32> {
+        let key = serde_json::to_string(hover).context_ut("cannot serialize hover")?;
+        if let Some(id) = self.hover_results.get(&key) {
+            return Ok(*id);
+        }
+
+        let id = self.emit_element(p::Element::Vertex(p::Vertex::HoverResult {
+            result: hover.clone(),
+        }))?;
+        self.hover_results.insert(key, id);
+        Ok(id)
     }
 
     fn emit_span(&mut self, span: Span, source: &Source) -> Option<i32> {
@@ -260,7 +292,15 @@ pub struct FileIndex {
     /// The documentation of the file.
     pub documentation: Option<EcoString>,
     /// The references in the file.
-    pub references: FxHashMap<Span, Definition>,
+    pub references: FxHashMap<Span, ReferenceIndex>,
+}
+
+/// The index of a reference.
+pub struct ReferenceIndex {
+    /// The definition referenced by the source span.
+    pub definition: Definition,
+    /// The static hover result for the referenced definition.
+    pub hover: Option<Hover>,
 }
 
 /// Dumps typst knowledge in [LSIF] format from workspace.
@@ -289,6 +329,7 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
         ctx,
         strings: FxHashMap::default(),
         references: FxHashMap::default(),
+        hovers: FxHashMap::default(),
     };
     let files = files
         .iter()
@@ -316,7 +357,9 @@ struct DumpWorker<'a> {
     /// A string interner.
     strings: FxHashMap<EcoString, EcoString>,
     /// The references collected so far.
-    references: FxHashMap<Span, Definition>,
+    references: FxHashMap<Span, ReferenceIndex>,
+    /// The static hover results collected so far.
+    hovers: FxHashMap<Definition, Option<Hover>>,
 }
 
 impl DumpWorker<'_> {
@@ -355,10 +398,12 @@ impl DumpWorker<'_> {
                 return;
             }
 
-            let Some(def) = self.ctx.def_of_syntax(source, syntax) else {
+            let Some(definition) = self.ctx.def_of_syntax(source, syntax) else {
                 return;
             };
-            self.references.insert(span, def);
+            let hover = self.hover(&definition);
+            self.references
+                .insert(span, ReferenceIndex { definition, hover });
 
             return;
         }
@@ -366,5 +411,15 @@ impl DumpWorker<'_> {
         for child in node.children() {
             self.walk(source, &child);
         }
+    }
+
+    fn hover(&mut self, definition: &Definition) -> Option<Hover> {
+        if let Some(hover) = self.hovers.get(definition) {
+            return hover.clone();
+        }
+
+        let hover = crate::hover::hover_from_definition(self.ctx, definition, None);
+        self.hovers.insert(definition.clone(), hover.clone());
+        hover
     }
 }

--- a/crates/tinymist-query/src/index/query.rs
+++ b/crates/tinymist-query/src/index/query.rs
@@ -328,7 +328,7 @@ fn range_len_key(range: &Range) -> (u32, u32) {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use lsp_types::{HoverContents, MarkedString};
 
@@ -336,41 +336,55 @@ mod tests {
 
     #[test]
     fn hover_from_result_set() {
-        let mut index = read_index(&[
-            r#"{"id":1,"type":"vertex","label":"document","uri":"file:///workspace/main.typ","languageId":"typst"}"#,
-            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#,
-            r#"{"id":3,"type":"vertex","label":"resultSet"}"#,
-            r#"{"id":4,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#,
-            r#"{"id":5,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#,
-            r#"{"id":6,"type":"edge","label":"next","outV":2,"inV":3}"#,
-            r#"{"id":7,"type":"edge","label":"textDocument/hover","outV":3,"inV":4}"#,
+        let path = fixture_path();
+        let mut index = read_index([
+            document_line(&path),
+            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#.to_owned(),
+            r#"{"id":3,"type":"vertex","label":"resultSet"}"#.to_owned(),
+            r#"{"id":4,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#.to_owned(),
+            r#"{"id":5,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#.to_owned(),
+            r#"{"id":6,"type":"edge","label":"next","outV":2,"inV":3}"#.to_owned(),
+            r#"{"id":7,"type":"edge","label":"textDocument/hover","outV":3,"inV":4}"#.to_owned(),
         ]);
 
-        assert_hover(&mut index);
+        assert_hover(&mut index, path);
     }
 
     #[test]
     fn hover_from_range() {
-        let mut index = read_index(&[
-            r#"{"id":1,"type":"vertex","label":"document","uri":"file:///workspace/main.typ","languageId":"typst"}"#,
-            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#,
-            r#"{"id":3,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#,
-            r#"{"id":4,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#,
-            r#"{"id":5,"type":"edge","label":"textDocument/hover","outV":2,"inV":3}"#,
+        let path = fixture_path();
+        let mut index = read_index([
+            document_line(&path),
+            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#.to_owned(),
+            r#"{"id":3,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#.to_owned(),
+            r#"{"id":4,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#.to_owned(),
+            r#"{"id":5,"type":"edge","label":"textDocument/hover","outV":2,"inV":3}"#.to_owned(),
         ]);
 
-        assert_hover(&mut index);
+        assert_hover(&mut index, path);
     }
 
-    fn read_index(lines: &[&str]) -> IndexQueryCtx {
-        let mut input = lines.join("\n");
+    fn fixture_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("main.typ")
+    }
+
+    fn document_line(path: &Path) -> String {
+        let uri = path_to_url(path).unwrap();
+        format!(
+            r#"{{"id":1,"type":"vertex","label":"document","uri":{},"languageId":"typst"}}"#,
+            serde_json::to_string(uri.as_str()).unwrap()
+        )
+    }
+
+    fn read_index(lines: impl IntoIterator<Item = String>) -> IndexQueryCtx {
+        let mut input = lines.into_iter().collect::<Vec<_>>().join("\n");
         input.push('\n');
         IndexQueryCtx::read(&mut BufReader::new(input.as_bytes())).unwrap()
     }
 
-    fn assert_hover(index: &mut IndexQueryCtx) {
+    fn assert_hover(index: &mut IndexQueryCtx, path: PathBuf) {
         let response = index.request(CompilerQueryRequest::Hover(HoverRequest {
-            path: PathBuf::from("/workspace/main.typ"),
+            path,
             position: Position {
                 line: 0,
                 character: 1,

--- a/crates/tinymist-query/src/index/query.rs
+++ b/crates/tinymist-query/src/index/query.rs
@@ -11,10 +11,12 @@ use std::io::{BufRead, Read};
 use tinymist_std::error::prelude::*;
 use tinymist_std::hash::{FxHashMap, FxHashSet};
 
-use crate::{CompilerQueryRequest, CompilerQueryResponse, GotoDefinitionRequest, path_to_url};
+use crate::{
+    CompilerQueryRequest, CompilerQueryResponse, GotoDefinitionRequest, HoverRequest, path_to_url,
+};
 
 use super::protocol::*;
-use lsp_types::{GotoDefinitionResponse, LocationLink, Position, Range, Url};
+use lsp_types::{GotoDefinitionResponse, Hover, LocationLink, Position, Range, Url};
 
 /// The context for querying the index.
 #[derive(Default)]
@@ -81,11 +83,28 @@ impl IndexQueryCtx {
     /// Requests the index for a compiler query.
     pub fn request(&mut self, request: CompilerQueryRequest) -> Option<CompilerQueryResponse> {
         match request {
+            CompilerQueryRequest::Hover(request) => {
+                Some(CompilerQueryResponse::Hover(self.hover(request)))
+            }
             CompilerQueryRequest::GotoDefinition(request) => Some(
                 CompilerQueryResponse::GotoDefinition(self.goto_definition(request)),
             ),
             _ => None,
         }
+    }
+
+    fn hover(&self, request: HoverRequest) -> Option<Hover> {
+        let uri = path_to_url(&request.path).ok()?;
+        let doc_id = *self.document_by_uri.get(&uri)?;
+        let source_range_id = self.find_range(doc_id, request.position)?;
+        let source_range = self.range_of(source_range_id)?;
+        let hover_result_id = self.hover_result(source_range_id).or_else(|| {
+            let result_id = self.next_result(source_range_id)?;
+            self.hover_result(result_id)
+        })?;
+        let mut hover = self.hover_value(hover_result_id)?;
+        hover.range.get_or_insert(source_range);
+        Some(hover)
     }
 
     fn goto_definition(&self, request: GotoDefinitionRequest) -> Option<GotoDefinitionResponse> {
@@ -177,6 +196,20 @@ impl IndexQueryCtx {
                 Edge::Definition(data) => Some(data.in_v),
                 _ => None,
             })
+    }
+
+    fn hover_result(&self, out_v: Id) -> Option<Id> {
+        self.edges.get(&out_v)?.iter().find_map(|edge| match edge {
+            Edge::Hover(data) => Some(data.in_v),
+            _ => None,
+        })
+    }
+
+    fn hover_value(&self, hover_result_id: Id) -> Option<Hover> {
+        match self.graph.get(&hover_result_id)? {
+            Vertex::HoverResult { result } => Some(result.clone()),
+            _ => None,
+        }
     }
 
     fn definition_links(
@@ -290,4 +323,80 @@ fn range_len_key(range: &Range) -> (u32, u32) {
         range.end.line.saturating_sub(range.start.line),
         range.end.character.saturating_sub(range.start.character),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::BufReader;
+    use std::path::PathBuf;
+
+    use lsp_types::{HoverContents, MarkedString};
+
+    use super::*;
+
+    #[test]
+    fn hover_from_result_set() {
+        let mut index = read_index(&[
+            r#"{"id":1,"type":"vertex","label":"document","uri":"file:///workspace/main.typ","languageId":"typst"}"#,
+            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#,
+            r#"{"id":3,"type":"vertex","label":"resultSet"}"#,
+            r#"{"id":4,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#,
+            r#"{"id":5,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#,
+            r#"{"id":6,"type":"edge","label":"next","outV":2,"inV":3}"#,
+            r#"{"id":7,"type":"edge","label":"textDocument/hover","outV":3,"inV":4}"#,
+        ]);
+
+        assert_hover(&mut index);
+    }
+
+    #[test]
+    fn hover_from_range() {
+        let mut index = read_index(&[
+            r#"{"id":1,"type":"vertex","label":"document","uri":"file:///workspace/main.typ","languageId":"typst"}"#,
+            r#"{"id":2,"type":"vertex","label":"range","start":{"line":0,"character":0},"end":{"line":0,"character":4}}"#,
+            r#"{"id":3,"type":"vertex","label":"hoverResult","result":{"contents":"hello"}}"#,
+            r#"{"id":4,"type":"edge","label":"contains","outV":1,"inVs":[2]}"#,
+            r#"{"id":5,"type":"edge","label":"textDocument/hover","outV":2,"inV":3}"#,
+        ]);
+
+        assert_hover(&mut index);
+    }
+
+    fn read_index(lines: &[&str]) -> IndexQueryCtx {
+        let mut input = lines.join("\n");
+        input.push('\n');
+        IndexQueryCtx::read(&mut BufReader::new(input.as_bytes())).unwrap()
+    }
+
+    fn assert_hover(index: &mut IndexQueryCtx) {
+        let response = index.request(CompilerQueryRequest::Hover(HoverRequest {
+            path: PathBuf::from("/workspace/main.typ"),
+            position: Position {
+                line: 0,
+                character: 1,
+            },
+        }));
+
+        let Some(CompilerQueryResponse::Hover(Some(hover))) = response else {
+            panic!("expected hover response");
+        };
+
+        assert_eq!(
+            hover.range,
+            Some(Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            })
+        );
+        assert_eq!(
+            hover.contents,
+            HoverContents::Scalar(MarkedString::String("hello".to_owned()))
+        );
+    }
 }


### PR DESCRIPTION
- emit static `hoverResult` data in LSIF dumps for references and definition ranges
- add offline LSIF hover query support to `IndexQueryCtx`
- expose `hover` through the `tinymist-index` Typst plugin API
- add unit coverage for hover queries resolved through direct range edges and result sets
