### PR TITLE
feat(index): support SCIP indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,6 +4975,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +5803,15 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "scip"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46becf967b98a434bf7f19c8be30ca74bff57702ea7ef6af3628cbf52f57be0"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]
@@ -7057,12 +7086,14 @@ dependencies = [
  "lsp-types",
  "parking_lot",
  "percent-encoding",
+ "protobuf",
  "rayon",
  "regex",
  "rpds",
  "rust_iso3166",
  "rust_iso639",
  "rustc-hash 2.1.2",
+ "scip",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,8 @@ serde_repr = "0.1"
 serde_with = { version = "3.6", features = ["base64"] }
 serde_yaml = "0.9"
 serde-wasm-bindgen = "^0.6"
+protobuf = "=3.7.2"
+scip = "0.8.1"
 tar = "0.4"
 toml = { version = "0.8", default-features = false, features = [
     "parse",

--- a/crates/tinymist-index/src/lib.rs
+++ b/crates/tinymist-index/src/lib.rs
@@ -11,14 +11,12 @@
     allow(missing_docs)
 )]
 
-use std::{
-    io::BufReader,
-    sync::{Mutex, OnceLock},
-};
+use std::sync::{Mutex, OnceLock};
 
 use lsp_types::{GotoDefinitionParams, HoverParams};
 use tinymist_query::{
-    CompilerQueryRequest, GotoDefinitionRequest, HoverRequest, index::query::IndexQueryCtx,
+    CompilerQueryRequest, CompilerQueryResponse, GotoDefinitionRequest, HoverRequest,
+    index::scip_query::{ScipPublicSymbol, ScipQueryCtx},
     url_to_path,
 };
 #[cfg(all(feature = "typst-plugin", target_arch = "wasm32"))]
@@ -33,7 +31,37 @@ static INDEX: OnceLock<Mutex<IndexCtx>> = OnceLock::new();
 
 struct IndexCtx {
     /// The database for the index.
-    index: IndexQueryCtx,
+    index: ScipQueryCtx,
+}
+
+enum IndexRequest {
+    Compiler(CompilerQueryRequest),
+    PublicSymbols(String),
+}
+
+enum IndexResponse {
+    Compiler(Option<CompilerQueryResponse>),
+    PublicSymbols(Vec<ScipPublicSymbol>),
+}
+
+impl IndexCtx {
+    fn request(&mut self, request: IndexRequest) -> IndexResponse {
+        match request {
+            IndexRequest::Compiler(request) => IndexResponse::Compiler(self.index.request(request)),
+            IndexRequest::PublicSymbols(path) => {
+                IndexResponse::PublicSymbols(self.index.public_symbols(&path))
+            }
+        }
+    }
+}
+
+impl IndexResponse {
+    fn to_bytes(&self) -> StrResult<Vec<u8>> {
+        match self {
+            Self::Compiler(response) => serde_json::to_vec(response).map_err(to_string),
+            Self::PublicSymbols(response) => serde_json::to_vec(response).map_err(to_string),
+        }
+    }
 }
 
 /// Creates an index.
@@ -49,43 +77,53 @@ pub fn query_index(kind: &[u8], request: &[u8]) -> StrResult<Vec<u8>> {
     let request = parse_request(kind, request)?;
     let response = {
         let mut index = INDEX.get().ok_or("index was not created")?.lock().unwrap();
-        index.index.request(request)
+        index.request(request)
     };
-    match response {
-        None => Ok("null".as_bytes().to_vec()),
-        Some(tinymist_query::CompilerQueryResponse::Hover(response)) => {
-            serde_json::to_vec(&response).map_err(to_string)
-        }
-        Some(tinymist_query::CompilerQueryResponse::GotoDefinition(response)) => {
-            serde_json::to_vec(&response).map_err(to_string)
-        }
-        _ => Err("unknown response kind".to_owned())?,
-    }
+    response.to_bytes()
 }
 
-fn parse_request(kind: &str, request: &[u8]) -> StrResult<CompilerQueryRequest> {
+fn parse_request(kind: &str, request: &[u8]) -> StrResult<IndexRequest> {
     Ok(match kind {
-        "hover" => CompilerQueryRequest::Hover({
-            let req: HoverParams = serde_json::from_slice(request).map_err(to_string)?;
-            HoverRequest {
-                path: url_to_path(&req.text_document_position_params.text_document.uri),
-                position: req.text_document_position_params.position,
-            }
-        }),
-        "goto_definition" => CompilerQueryRequest::GotoDefinition({
-            let req: GotoDefinitionParams = serde_json::from_slice(request).map_err(to_string)?;
-            GotoDefinitionRequest {
-                path: url_to_path(&req.text_document_position_params.text_document.uri),
-                position: req.text_document_position_params.position,
-            }
-        }),
+        "textDocument/hover" => IndexRequest::Compiler(parse_hover_request(request)?),
+        "textDocument/definition" => {
+            IndexRequest::Compiler(parse_goto_definition_request(request)?)
+        }
+        "public_symbols" => {
+            IndexRequest::PublicSymbols(serde_json::from_slice(request).map_err(to_string)?)
+        }
         kind => Err(format!("unknown request kind: {kind}"))?,
     })
 }
 
+fn parse_hover_request(request: &[u8]) -> StrResult<CompilerQueryRequest> {
+    if let Ok(symbol) = serde_json::from_slice(request) {
+        return Ok(CompilerQueryRequest::HoverSymbol(symbol));
+    }
+
+    let req: HoverParams = serde_json::from_slice(request).map_err(to_string)?;
+    Ok(CompilerQueryRequest::Hover(HoverRequest {
+        path: url_to_path(&req.text_document_position_params.text_document.uri),
+        position: req.text_document_position_params.position,
+    }))
+}
+
+fn parse_goto_definition_request(request: &[u8]) -> StrResult<CompilerQueryRequest> {
+    if let Ok(symbol) = serde_json::from_slice(request) {
+        return Ok(CompilerQueryRequest::GotoDefinitionSymbol(symbol));
+    }
+
+    let req: GotoDefinitionParams = serde_json::from_slice(request).map_err(to_string)?;
+    Ok(CompilerQueryRequest::GotoDefinition(
+        GotoDefinitionRequest {
+            path: url_to_path(&req.text_document_position_params.text_document.uri),
+            position: req.text_document_position_params.position,
+        },
+    ))
+}
+
 /// Creates an index.
 fn create_index_inner(db: &[u8], opts: &[u8]) -> StrResult<()> {
-    let index = IndexQueryCtx::read(&mut BufReader::new(db)).map_err(to_string)?;
+    let index = ScipQueryCtx::read(db).map_err(to_string)?;
     let _ = opts;
 
     let index = INDEX.set(Mutex::new(IndexCtx { index }));

--- a/crates/tinymist-query/Cargo.toml
+++ b/crates/tinymist-query/Cargo.toml
@@ -28,12 +28,14 @@ log.workspace = true
 lsp-types.workspace = true
 parking_lot.workspace = true
 percent-encoding.workspace = true
+protobuf.workspace = true
 rayon.workspace = true
 regex.workspace = true
 rpds.workspace = true
 rust_iso639 = { workspace = true, optional = true }
 rust_iso3166 = { workspace = true, optional = true }
 rustc-hash.workspace = true
+scip.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -14,6 +14,7 @@ use crate::prelude::Definition;
 use crate::{LocalContext, path_to_url};
 use ecow::EcoString;
 use lsp_types::{Hover, Url};
+use tinymist_analysis::docs::DefDocs;
 use tinymist_analysis::syntax::classify_syntax;
 use tinymist_std::error::WithContextUntyped;
 use tinymist_std::hash::FxHashMap;
@@ -23,6 +24,7 @@ use typst_shim::syntax::source_range;
 
 pub mod protocol;
 pub mod query;
+mod scip_utils;
 use protocol as p;
 
 /// The dumped knowledge.
@@ -48,6 +50,10 @@ pub struct KnowledgeWithContext<'a> {
     knowledge: &'a Knowledge,
     ctx: &'a Arc<SharedContext>,
 }
+
+pub mod scip;
+pub mod scip_query;
+pub use scip::{ScipPublicApi, ScipPublicModule};
 
 impl fmt::Display for KnowledgeWithContext<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -301,6 +307,8 @@ pub struct ReferenceIndex {
     pub definition: Definition,
     /// The static hover result for the referenced definition.
     pub hover: Option<Hover>,
+    /// The typed documentation for the referenced definition.
+    pub def_docs: Option<DefDocs>,
 }
 
 /// Dumps typst knowledge in [LSIF] format from workspace.
@@ -330,6 +338,7 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
         strings: FxHashMap::default(),
         references: FxHashMap::default(),
         hovers: FxHashMap::default(),
+        def_docs: FxHashMap::default(),
     };
     let files = files
         .iter()
@@ -360,6 +369,8 @@ struct DumpWorker<'a> {
     references: FxHashMap<Span, ReferenceIndex>,
     /// The static hover results collected so far.
     hovers: FxHashMap<Definition, Option<Hover>>,
+    /// The typed documentation collected so far.
+    def_docs: FxHashMap<Definition, Option<DefDocs>>,
 }
 
 impl DumpWorker<'_> {
@@ -402,8 +413,15 @@ impl DumpWorker<'_> {
                 return;
             };
             let hover = self.hover(&definition);
-            self.references
-                .insert(span, ReferenceIndex { definition, hover });
+            let def_docs = self.def_docs(&definition);
+            self.references.insert(
+                span,
+                ReferenceIndex {
+                    definition,
+                    hover,
+                    def_docs,
+                },
+            );
 
             return;
         }
@@ -421,5 +439,15 @@ impl DumpWorker<'_> {
         let hover = crate::hover::hover_from_definition(self.ctx, definition, None);
         self.hovers.insert(definition.clone(), hover.clone());
         hover
+    }
+
+    fn def_docs(&mut self, definition: &Definition) -> Option<DefDocs> {
+        if let Some(docs) = self.def_docs.get(definition) {
+            return docs.clone();
+        }
+
+        let docs = self.ctx.def_docs(definition);
+        self.def_docs.insert(definition.clone(), docs.clone());
+        docs
     }
 }

--- a/crates/tinymist-query/src/index/query.rs
+++ b/crates/tinymist-query/src/index/query.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::protocol::*;
 use lsp_types::{GotoDefinitionResponse, Hover, LocationLink, Position, Range, Url};
 
-/// The context for querying the index.
+/// The context for querying an LSIF JSONL index.
 #[derive(Default)]
 pub struct IndexQueryCtx {
     meta: Option<MetaData>,

--- a/crates/tinymist-query/src/index/scip.rs
+++ b/crates/tinymist-query/src/index/scip.rs
@@ -1,0 +1,729 @@
+//! SCIP index encoding.
+
+use core::fmt::Write as _;
+use std::sync::Arc;
+
+use crate::analysis::SharedContext;
+use crate::prelude::Definition;
+use crate::syntax::DefKind;
+use lsp_types::{Hover, HoverContents, MarkedString, Range};
+use protobuf::{Enum, EnumOrUnknown, Message, MessageField};
+use scip::types::{
+    Descriptor as ScipDescriptor, Document as ScipDocument, Index as ScipIndex,
+    Metadata as ScipMetadata, Occurrence as ScipOccurrence, Package as ScipPackage,
+    PositionEncoding as ScipPositionEncoding, Relationship as ScipRelationship, Signature,
+    Symbol as ScipSymbol, SymbolInformation as ScipSymbolInformation, SymbolRole as ScipSymbolRole,
+    TextEncoding as ScipTextEncoding, ToolInfo as ScipToolInfo, descriptor, symbol_information,
+};
+use tinymist_analysis::docs::{DefDocs, ParamDocs, SignatureDocs};
+use tinymist_std::error::WithContextUntyped;
+use tinymist_std::hash::FxHashMap;
+use typst::syntax::{FileId, Source, Span};
+use typst_shim::syntax::source_range;
+
+use super::scip_utils::{ScipParamGroup, merge_symbol_information, push_relationship_unique};
+use super::{FileIndex, KnowledgeWithContext};
+
+/// Public package API information encoded as SCIP relationships.
+#[derive(Debug, Clone, Default)]
+pub struct ScipPublicApi {
+    /// Public modules in the package docs tree.
+    pub modules: Vec<ScipPublicModule>,
+}
+
+/// Public symbols exported by one module.
+#[derive(Debug, Clone, Default)]
+pub struct ScipPublicModule {
+    /// The module file path, relative to the package root.
+    pub file_path: Option<String>,
+    /// The SCIP symbol of the module.
+    pub module_symbol: Option<String>,
+    /// Public SCIP symbols exported by the module.
+    pub public_symbols: Vec<String>,
+}
+
+impl KnowledgeWithContext<'_> {
+    /// Dumps the knowledge in SCIP protobuf format.
+    pub fn to_scip_bytes(&self) -> tinymist_std::Result<Vec<u8>> {
+        let index = self.to_scip_index()?;
+        index
+            .write_to_bytes()
+            .context_ut("cannot serialize SCIP index")
+    }
+
+    /// Dumps the knowledge in SCIP protobuf format with public package API data.
+    pub fn to_scip_bytes_with_public_api(
+        &self,
+        public_api: &ScipPublicApi,
+    ) -> tinymist_std::Result<Vec<u8>> {
+        let index = self.to_scip_index_with_public_api(public_api)?;
+        index
+            .write_to_bytes()
+            .context_ut("cannot serialize SCIP index")
+    }
+
+    /// Dumps the knowledge as a SCIP index.
+    pub fn to_scip_index(&self) -> tinymist_std::Result<ScipIndex> {
+        self.to_scip_index_with_public_api(&ScipPublicApi::default())
+    }
+
+    /// Dumps the knowledge as a SCIP index with public package API data.
+    pub fn to_scip_index_with_public_api(
+        &self,
+        public_api: &ScipPublicApi,
+    ) -> tinymist_std::Result<ScipIndex> {
+        let mut encoder = ScipEncoder::new(self.ctx);
+        encoder.emit_files(&self.knowledge.files)?;
+        encoder.emit_public_api(public_api);
+        let (documents, external_symbols) = encoder.finish();
+        Ok(ScipIndex {
+            metadata: MessageField::some(ScipMetadata {
+                tool_info: MessageField::some(ScipToolInfo {
+                    name: "tinymist".to_owned(),
+                    version: env!("CARGO_PKG_VERSION").to_owned(),
+                    ..Default::default()
+                }),
+                project_root: self.knowledge.meta.project_root.to_string(),
+                text_document_encoding: EnumOrUnknown::new(ScipTextEncoding::UTF8),
+                ..Default::default()
+            }),
+            documents,
+            external_symbols,
+            ..Default::default()
+        })
+    }
+}
+
+struct ScipEncoder<'a> {
+    ctx: &'a Arc<SharedContext>,
+    documents: Vec<ScipDocumentBuilder>,
+    document_by_fid: FxHashMap<FileId, usize>,
+    symbols: FxHashMap<Definition, String>,
+    external_symbols: FxHashMap<String, ScipSymbolInformation>,
+}
+
+struct ScipDocumentBuilder {
+    relative_path: String,
+    occurrences: FxHashMap<ScipOccurrenceKey, ScipOccurrence>,
+    symbols: FxHashMap<String, ScipSymbolInformation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ScipOccurrenceKey {
+    range: Vec<i32>,
+    symbol: String,
+}
+
+impl<'a> ScipEncoder<'a> {
+    fn new(ctx: &'a Arc<SharedContext>) -> Self {
+        Self {
+            ctx,
+            documents: Vec::new(),
+            document_by_fid: FxHashMap::default(),
+            symbols: FxHashMap::default(),
+            external_symbols: FxHashMap::default(),
+        }
+    }
+
+    fn emit_files(&mut self, files: &[FileIndex]) -> tinymist_std::Result<()> {
+        for file in files {
+            let _ = self.document_index(file.fid)?;
+        }
+
+        for (idx, file) in files.iter().enumerate() {
+            eprintln!("emit scip file: {:?}, {idx} of {}", file.fid, files.len());
+            let source = self
+                .ctx
+                .source_by_id(file.fid)
+                .context_ut("cannot get source")?;
+            let document_index = self.document_index(file.fid)?;
+
+            for (span, reference) in &file.references {
+                let symbol = self.symbol(&reference.definition)?;
+                let docs = reference.hover.as_ref().and_then(hover_to_markdown);
+                let def_docs = reference.def_docs.as_ref();
+
+                if let Some(range) = lsp_range(self.ctx, *span, &source) {
+                    self.documents[document_index].push_occurrence(ScipOccurrence {
+                        range: scip_range(range),
+                        symbol: symbol.clone(),
+                        ..Default::default()
+                    });
+                }
+
+                if let Some((def_fid, def_range)) = self.definition_range(&reference.definition) {
+                    let def_document_index = self.document_index(def_fid)?;
+                    self.documents[def_document_index].push_occurrence(ScipOccurrence {
+                        range: scip_range(def_range),
+                        symbol: symbol.clone(),
+                        symbol_roles: ScipSymbolRole::Definition.value(),
+                        ..Default::default()
+                    });
+                    for info in symbol_infos(&reference.definition, &symbol, def_docs, docs) {
+                        self.documents[def_document_index].push_symbol(info);
+                    }
+                } else if let Some(info) =
+                    symbol_info_external(&reference.definition, &symbol, def_docs, docs)
+                {
+                    for item in info {
+                        self.external_symbols
+                            .entry(item.symbol.clone())
+                            .or_insert(item);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn document_index(&mut self, fid: FileId) -> tinymist_std::Result<usize> {
+        if let Some(index) = self.document_by_fid.get(&fid) {
+            return Ok(*index);
+        }
+
+        let _ = self
+            .ctx
+            .source_by_id(fid)
+            .context_ut("cannot get source for SCIP document")?;
+        let index = self.documents.len();
+        self.documents.push(ScipDocumentBuilder {
+            relative_path: fid.vpath().get_without_slash().to_owned(),
+            occurrences: FxHashMap::default(),
+            symbols: FxHashMap::default(),
+        });
+        self.document_by_fid.insert(fid, index);
+        Ok(index)
+    }
+
+    fn symbol(&mut self, definition: &Definition) -> tinymist_std::Result<String> {
+        if let Some(symbol) = self.symbols.get(definition) {
+            return Ok(symbol.clone());
+        }
+
+        let symbol = scip_symbol(self.ctx, definition)?;
+        self.symbols.insert(definition.clone(), symbol.clone());
+        Ok(symbol)
+    }
+
+    fn definition_range(&self, definition: &Definition) -> Option<(FileId, Range)> {
+        let fid = definition.file_id()?;
+        let source = self.ctx.source_by_id(fid).ok()?;
+        let span = definition.decl.span();
+        if span.is_detached() {
+            return None;
+        }
+
+        Some((fid, lsp_range(self.ctx, span, &source)?))
+    }
+
+    fn emit_public_api(&mut self, public_api: &ScipPublicApi) {
+        for module in &public_api.modules {
+            let Some(module_symbol) = module.module_symbol.as_ref() else {
+                continue;
+            };
+
+            if let Some(document_index) = module
+                .file_path
+                .as_deref()
+                .and_then(|path| self.document_index_by_path(path))
+            {
+                self.documents[document_index].push_symbol(public_module_symbol_info(
+                    module_symbol,
+                    &module.public_symbols,
+                ));
+            }
+
+            for public_symbol in &module.public_symbols {
+                self.push_symbol_relationship(
+                    public_symbol,
+                    ScipRelationship {
+                        symbol: module_symbol.clone(),
+                        is_reference: true,
+                        ..Default::default()
+                    },
+                );
+            }
+        }
+    }
+
+    fn document_index_by_path(&self, path: &str) -> Option<usize> {
+        self.documents
+            .iter()
+            .position(|document| document.relative_path == path)
+    }
+
+    fn push_symbol_relationship(&mut self, symbol: &str, relationship: ScipRelationship) {
+        for document in &mut self.documents {
+            if document.push_relationship(symbol, relationship.clone()) {
+                return;
+            }
+        }
+
+        if let Some(info) = self.external_symbols.get_mut(symbol) {
+            push_relationship_unique(&mut info.relationships, relationship);
+            return;
+        }
+
+        self.external_symbols.insert(
+            symbol.to_owned(),
+            ScipSymbolInformation {
+                symbol: symbol.to_owned(),
+                relationships: vec![relationship],
+                ..Default::default()
+            },
+        );
+    }
+
+    fn finish(self) -> (Vec<ScipDocument>, Vec<ScipSymbolInformation>) {
+        let documents = self
+            .documents
+            .into_iter()
+            .map(ScipDocumentBuilder::finish)
+            .collect();
+        let mut external_symbols = self.external_symbols.into_values().collect::<Vec<_>>();
+        external_symbols.sort_by(|left, right| left.symbol.cmp(&right.symbol));
+        (documents, external_symbols)
+    }
+}
+
+impl ScipDocumentBuilder {
+    fn push_occurrence(&mut self, occurrence: ScipOccurrence) {
+        let key = ScipOccurrenceKey {
+            range: occurrence.range.clone(),
+            symbol: occurrence.symbol.clone(),
+        };
+        if let Some(current) = self.occurrences.get_mut(&key) {
+            current.symbol_roles |= occurrence.symbol_roles;
+            if current.override_documentation.is_empty() {
+                current.override_documentation = occurrence.override_documentation;
+            }
+            return;
+        }
+
+        self.occurrences.insert(key, occurrence);
+    }
+
+    fn push_symbol(&mut self, symbol: ScipSymbolInformation) {
+        if let Some(current) = self.symbols.get_mut(&symbol.symbol) {
+            merge_symbol_information(current, symbol);
+            return;
+        }
+
+        self.symbols.insert(symbol.symbol.clone(), symbol);
+    }
+
+    fn push_relationship(&mut self, symbol: &str, relationship: ScipRelationship) -> bool {
+        let Some(current) = self.symbols.get_mut(symbol) else {
+            return false;
+        };
+        push_relationship_unique(&mut current.relationships, relationship);
+        true
+    }
+
+    fn finish(self) -> ScipDocument {
+        let mut occurrences = self.occurrences.into_values().collect::<Vec<_>>();
+        occurrences.sort_by(|left, right| {
+            left.range
+                .cmp(&right.range)
+                .then_with(|| left.symbol.cmp(&right.symbol))
+        });
+        let mut symbols = self.symbols.into_values().collect::<Vec<_>>();
+        symbols.sort_by(|left, right| left.symbol.cmp(&right.symbol));
+        ScipDocument {
+            language: "typst".to_owned(),
+            relative_path: self.relative_path,
+            occurrences,
+            symbols,
+            position_encoding: EnumOrUnknown::new(
+                ScipPositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }
+    }
+}
+
+fn lsp_range(ctx: &SharedContext, span: Span, source: &Source) -> Option<Range> {
+    let range = source_range(source, span)?;
+    Some(ctx.to_lsp_range(range, source))
+}
+
+fn scip_range(range: Range) -> Vec<i32> {
+    if range.start.line == range.end.line {
+        vec![
+            range.start.line as i32,
+            range.start.character as i32,
+            range.end.character as i32,
+        ]
+    } else {
+        vec![
+            range.start.line as i32,
+            range.start.character as i32,
+            range.end.line as i32,
+            range.end.character as i32,
+        ]
+    }
+}
+
+pub(crate) fn scip_symbol(
+    ctx: &SharedContext,
+    definition: &Definition,
+) -> tinymist_std::Result<String> {
+    let mut descriptors = Vec::new();
+    if let Some(fid) = definition.file_id() {
+        let path = fid.vpath().get_without_slash();
+        for part in path.split('/') {
+            if !part.is_empty() {
+                descriptors.push(scip_descriptor(part, descriptor::Suffix::Namespace, ""));
+            }
+        }
+    } else {
+        descriptors.push(scip_descriptor(
+            "external",
+            descriptor::Suffix::Namespace,
+            "",
+        ));
+    }
+
+    descriptors.push(scip_descriptor(
+        &definition_disambiguator(ctx, definition),
+        descriptor::Suffix::Meta,
+        "",
+    ));
+    descriptors.push(scip_descriptor(
+        definition.name().as_ref(),
+        scip_symbol_suffix(definition.decl.kind()),
+        "",
+    ));
+
+    let symbol = ScipSymbol {
+        scheme: "typst".to_owned(),
+        package: MessageField::some(ScipPackage {
+            manager: "tinymist".to_owned(),
+            name: "workspace".to_owned(),
+            ..Default::default()
+        }),
+        descriptors,
+        ..Default::default()
+    };
+    Ok(scip::symbol::format_symbol(symbol))
+}
+
+fn definition_disambiguator(ctx: &SharedContext, definition: &Definition) -> String {
+    if let Some(fid) = definition.file_id()
+        && let Ok(source) = ctx.source_by_id(fid)
+        && let Some(range) = lsp_range(ctx, definition.decl.span(), &source)
+    {
+        return format!("L{}_C{}", range.start.line, range.start.character);
+    }
+
+    format!("{:x}", definition.decl.span().into_raw())
+}
+
+fn scip_descriptor(name: &str, suffix: descriptor::Suffix, disambiguator: &str) -> ScipDescriptor {
+    ScipDescriptor {
+        name: if name.is_empty() {
+            "_".to_owned()
+        } else {
+            name.to_owned()
+        },
+        disambiguator: disambiguator.to_owned(),
+        suffix: EnumOrUnknown::new(suffix),
+        ..Default::default()
+    }
+}
+
+fn scip_symbol_suffix(kind: DefKind) -> descriptor::Suffix {
+    match kind {
+        DefKind::Function => descriptor::Suffix::Method,
+        DefKind::Module => descriptor::Suffix::Namespace,
+        _ => descriptor::Suffix::Term,
+    }
+}
+
+fn symbol_infos(
+    definition: &Definition,
+    symbol: &str,
+    def_docs: Option<&DefDocs>,
+    docs: Option<String>,
+) -> Vec<ScipSymbolInformation> {
+    if let Some(DefDocs::Function(docs)) = def_docs {
+        return function_symbol_infos(definition, symbol, docs);
+    }
+
+    vec![ScipSymbolInformation {
+        symbol: symbol.to_owned(),
+        documentation: docs.into_iter().collect(),
+        kind: EnumOrUnknown::new(scip_symbol_kind(definition.decl.kind())),
+        display_name: definition.name().to_string(),
+        ..Default::default()
+    }]
+}
+
+fn symbol_info_external(
+    definition: &Definition,
+    symbol: &str,
+    def_docs: Option<&DefDocs>,
+    docs: Option<String>,
+) -> Option<Vec<ScipSymbolInformation>> {
+    if def_docs.is_none() {
+        docs.as_ref()?;
+    }
+
+    Some(symbol_infos(definition, symbol, def_docs, docs))
+}
+
+fn scip_symbol_kind(kind: DefKind) -> symbol_information::Kind {
+    match kind {
+        DefKind::Function => symbol_information::Kind::Function,
+        DefKind::Module => symbol_information::Kind::Module,
+        DefKind::Constant => symbol_information::Kind::Constant,
+        DefKind::Variable => symbol_information::Kind::Variable,
+        _ => symbol_information::Kind::UnspecifiedKind,
+    }
+}
+
+fn public_module_symbol_info(
+    module_symbol: &str,
+    public_symbols: &[String],
+) -> ScipSymbolInformation {
+    ScipSymbolInformation {
+        symbol: module_symbol.to_owned(),
+        relationships: public_symbols
+            .iter()
+            .map(|symbol| ScipRelationship {
+                symbol: symbol.clone(),
+                is_reference: true,
+                is_definition: true,
+                ..Default::default()
+            })
+            .collect(),
+        kind: EnumOrUnknown::new(symbol_information::Kind::Module),
+        ..Default::default()
+    }
+}
+
+fn function_symbol_infos(
+    definition: &Definition,
+    symbol: &str,
+    docs: &SignatureDocs,
+) -> Vec<ScipSymbolInformation> {
+    let signature_text = function_signature_text(definition.name().as_ref(), docs);
+    let params = function_parameters(docs);
+    let mut signature = Signature {
+        language: "typc".to_owned(),
+        text: signature_text.clone(),
+        ..Default::default()
+    };
+    let mut infos = Vec::with_capacity(params.len() + 1);
+
+    for param in params {
+        let Some(param_symbol) =
+            scip_parameter_symbol(symbol, param.group, param.docs.name.as_ref())
+        else {
+            continue;
+        };
+        if let Some(range) =
+            signature_parameter_range(&signature_text, param.docs.name.as_ref(), param.group)
+        {
+            signature.occurrences.push(ScipOccurrence {
+                range,
+                symbol: param_symbol.clone(),
+                symbol_roles: ScipSymbolRole::Definition.value(),
+                ..Default::default()
+            });
+        }
+
+        infos.push(parameter_symbol_info(symbol, &param_symbol, param.docs));
+    }
+
+    infos.insert(
+        0,
+        ScipSymbolInformation {
+            symbol: symbol.to_owned(),
+            documentation: non_empty_docs(docs.docs.trim()),
+            kind: EnumOrUnknown::new(symbol_information::Kind::Function),
+            display_name: definition.name().to_string(),
+            signature_documentation: MessageField::some(signature),
+            ..Default::default()
+        },
+    );
+    infos
+}
+
+fn function_signature_text(name: &str, docs: &SignatureDocs) -> String {
+    let mut text = String::new();
+    text.push_str("let ");
+    text.push_str(name);
+    let _ = docs.print(&mut text);
+    if let Some((short, _, _)) = docs.ret_ty.as_ref()
+        && short != name
+    {
+        let _ = write!(text, " = {short}");
+    }
+    text.push(';');
+    text
+}
+
+struct ScipParamRef<'a> {
+    group: ScipParamGroup,
+    docs: &'a ParamDocs,
+}
+
+fn function_parameters(docs: &SignatureDocs) -> Vec<ScipParamRef<'_>> {
+    let mut params =
+        Vec::with_capacity(docs.pos.len() + docs.named.len() + usize::from(docs.rest.is_some()));
+    params.extend(docs.pos.iter().map(|docs| ScipParamRef {
+        group: ScipParamGroup::Positional,
+        docs,
+    }));
+    if let Some(docs) = docs.rest.as_ref() {
+        params.push(ScipParamRef {
+            group: ScipParamGroup::Rest,
+            docs,
+        });
+    }
+    params.extend(docs.named.values().map(|docs| ScipParamRef {
+        group: ScipParamGroup::Named,
+        docs,
+    }));
+    params
+}
+
+fn scip_parameter_symbol(
+    function_symbol: &str,
+    group: ScipParamGroup,
+    name: &str,
+) -> Option<String> {
+    let mut symbol = scip::symbol::parse_symbol(function_symbol).ok()?;
+    symbol.descriptors.push(scip_descriptor(
+        group.descriptor(),
+        descriptor::Suffix::Meta,
+        "",
+    ));
+    symbol
+        .descriptors
+        .push(scip_descriptor(name, descriptor::Suffix::Parameter, ""));
+    Some(scip::symbol::format_symbol(symbol))
+}
+
+fn signature_parameter_range(
+    signature: &str,
+    name: &str,
+    group: ScipParamGroup,
+) -> Option<Vec<i32>> {
+    let mut line_offset = 0usize;
+    for line in signature.lines() {
+        let trimmed = line.trim_start();
+        let candidate = match group {
+            ScipParamGroup::Rest => {
+                let Some(candidate) = trimmed.strip_prefix("..") else {
+                    line_offset += 1;
+                    continue;
+                };
+                candidate
+            }
+            _ => trimmed,
+        };
+
+        let matches = candidate.strip_prefix(name).is_some_and(|rest| {
+            matches!(
+                rest.chars().next(),
+                Some(':') | Some(',') | Some(' ') | Some('=') | None
+            )
+        });
+        if matches {
+            let leading_chars = line.chars().count() - trimmed.chars().count();
+            let prefix_chars = if group == ScipParamGroup::Rest { 2 } else { 0 };
+            let start = leading_chars + prefix_chars;
+            let end = start + name.chars().count();
+            return Some(vec![line_offset as i32, start as i32, end as i32]);
+        }
+
+        line_offset += 1;
+    }
+
+    None
+}
+
+fn parameter_symbol_info(
+    function_symbol: &str,
+    symbol: &str,
+    docs: &ParamDocs,
+) -> ScipSymbolInformation {
+    ScipSymbolInformation {
+        symbol: symbol.to_owned(),
+        documentation: parameter_documentation(docs),
+        kind: EnumOrUnknown::new(symbol_information::Kind::Parameter),
+        display_name: docs.name.to_string(),
+        enclosing_symbol: function_symbol.to_owned(),
+        ..Default::default()
+    }
+}
+
+fn parameter_documentation(docs: &ParamDocs) -> Vec<String> {
+    let mut output = Vec::new();
+    if let Some((_, _, ty)) = docs.cano_type.as_ref()
+        && !ty.trim().is_empty()
+    {
+        output.push(format!("```typc\ntype: {}\n```", ty.trim()));
+    }
+    output.extend(non_empty_docs(docs.docs.trim()));
+    output
+}
+
+fn non_empty_docs(docs: &str) -> Vec<String> {
+    if docs.trim().is_empty() {
+        Vec::new()
+    } else {
+        vec![docs.trim().to_owned()]
+    }
+}
+
+fn hover_to_markdown(hover: &Hover) -> Option<String> {
+    hover_contents_to_markdown(&hover.contents)
+}
+
+fn hover_contents_to_markdown(contents: &HoverContents) -> Option<String> {
+    match contents {
+        HoverContents::Scalar(marked) => marked_string_to_markdown(marked),
+        HoverContents::Array(parts) => {
+            let parts = parts
+                .iter()
+                .filter_map(marked_string_to_markdown)
+                .filter(|part| !part.trim().is_empty())
+                .collect::<Vec<_>>();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n\n---\n\n"))
+            }
+        }
+        HoverContents::Markup(markup) => {
+            if markup.value.trim().is_empty() {
+                None
+            } else {
+                Some(markup.value.clone())
+            }
+        }
+    }
+}
+
+fn marked_string_to_markdown(marked: &MarkedString) -> Option<String> {
+    match marked {
+        MarkedString::String(value) => {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            }
+        }
+        MarkedString::LanguageString(value) => {
+            if value.value.trim().is_empty() {
+                None
+            } else {
+                Some(format!("```{}\n{}\n```", value.language, value.value))
+            }
+        }
+    }
+}

--- a/crates/tinymist-query/src/index/scip_query.rs
+++ b/crates/tinymist-query/src/index/scip_query.rs
@@ -1,0 +1,807 @@
+//! Offline query SCIP indexes.
+
+use serde::Serialize;
+use tinymist_std::error::{WithContextUntyped, prelude::*};
+use tinymist_std::hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    CompilerQueryRequest, CompilerQueryResponse, GotoDefinitionRequest, HoverRequest, path_to_url,
+    url_to_path,
+};
+
+use lsp_types::{
+    GotoDefinitionResponse, Hover, HoverContents, LocationLink, MarkedString, Position, Range, Url,
+};
+use protobuf::{Enum, Message};
+
+use super::scip_utils::{ScipParamGroup, merge_symbol_information};
+
+/// The context for querying a SCIP index.
+#[derive(Default)]
+pub struct ScipQueryCtx {
+    documents_by_uri: FxHashMap<Url, ScipDocumentQuery>,
+    definitions: FxHashMap<String, Vec<ScipDefinition>>,
+    public_symbols_by_path: FxHashMap<String, Vec<ScipPublicSymbol>>,
+    symbol_hovers: FxHashMap<String, Hover>,
+}
+
+/// A public package symbol exported by a module.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScipPublicSymbol {
+    /// SCIP symbol.
+    pub symbol: String,
+    /// Display name.
+    pub name: String,
+    /// Package docs definition kind.
+    pub kind: String,
+}
+
+#[derive(Debug, Clone)]
+struct ScipDocumentQuery {
+    uri: Url,
+    occurrences: Vec<ScipOccurrence>,
+}
+
+#[derive(Debug, Clone)]
+struct ScipOccurrence {
+    range: Range,
+    symbol: String,
+    is_definition: bool,
+    hover: Option<Hover>,
+}
+
+#[derive(Debug, Clone)]
+struct ScipDefinition {
+    uri: Url,
+    range: Range,
+}
+
+impl ScipQueryCtx {
+    /// Reads the index from SCIP protobuf bytes.
+    pub fn read(db: &[u8]) -> Result<Self> {
+        let index =
+            scip::types::Index::parse_from_bytes(db).context_ut("failed to parse SCIP index")?;
+        Ok(Self::build_query_tables(index))
+    }
+
+    fn build_query_tables(index: scip::types::Index) -> Self {
+        let project_root = index
+            .metadata
+            .as_ref()
+            .and_then(|metadata| Url::parse(&metadata.project_root).ok());
+        let symbol_infos = collect_symbol_infos(&index);
+        let mut this = Self {
+            symbol_hovers: collect_symbol_hovers(&symbol_infos),
+            ..Default::default()
+        };
+
+        for document in index.documents {
+            let relative_path = document.relative_path.clone();
+            let Some(uri) = scip_document_uri(project_root.as_ref(), &document.relative_path)
+            else {
+                continue;
+            };
+            let public_symbols = scip_public_symbols(&document, &symbol_infos);
+            let mut occurrences = Vec::with_capacity(document.occurrences.len());
+            for occurrence in document.occurrences {
+                let Some(range) = scip_range_to_lsp(&occurrence.range) else {
+                    continue;
+                };
+                let is_definition =
+                    occurrence.symbol_roles & scip::types::SymbolRole::Definition.value() != 0;
+                let hover = hover_from_scip_docs(&occurrence.override_documentation);
+                let symbol = occurrence.symbol;
+
+                if !symbol.is_empty() && is_definition {
+                    this.definitions
+                        .entry(symbol.clone())
+                        .or_default()
+                        .push(ScipDefinition {
+                            uri: uri.clone(),
+                            range,
+                        });
+                }
+
+                occurrences.push(ScipOccurrence {
+                    range,
+                    symbol,
+                    is_definition,
+                    hover,
+                });
+            }
+
+            if !public_symbols.is_empty() {
+                this.public_symbols_by_path
+                    .insert(relative_path.clone(), public_symbols);
+            }
+            this.documents_by_uri
+                .insert(uri.clone(), ScipDocumentQuery { uri, occurrences });
+        }
+
+        this
+    }
+
+    /// Requests the index for a compiler query.
+    pub fn request(&mut self, request: CompilerQueryRequest) -> Option<CompilerQueryResponse> {
+        match request {
+            CompilerQueryRequest::Hover(request) => {
+                Some(CompilerQueryResponse::Hover(self.hover(request)))
+            }
+            CompilerQueryRequest::HoverSymbol(symbol) => {
+                Some(CompilerQueryResponse::Hover(self.hover_symbol(&symbol)))
+            }
+            CompilerQueryRequest::GotoDefinition(request) => Some(
+                CompilerQueryResponse::GotoDefinition(self.goto_definition(request)),
+            ),
+            CompilerQueryRequest::GotoDefinitionSymbol(symbol) => Some(
+                CompilerQueryResponse::GotoDefinition(self.goto_definition_symbol(&symbol)),
+            ),
+            _ => None,
+        }
+    }
+
+    fn hover(&self, request: HoverRequest) -> Option<Hover> {
+        let uri = path_to_url(&request.path).ok()?;
+        let document = self.documents_by_uri.get(&uri)?;
+        let occurrence = find_scip_occurrence(document, request.position)?;
+        let mut hover = occurrence
+            .hover
+            .clone()
+            .or_else(|| self.symbol_hovers.get(&occurrence.symbol).cloned())?;
+        hover.range.get_or_insert(occurrence.range);
+        Some(hover)
+    }
+
+    /// Requests the hover information for a SCIP symbol.
+    pub fn hover_symbol(&self, symbol: &str) -> Option<Hover> {
+        self.symbol_hovers.get(symbol).cloned()
+    }
+
+    /// Requests the public symbols exported by a SCIP document path.
+    pub fn public_symbols(&self, path: &str) -> Vec<ScipPublicSymbol> {
+        self.public_symbols_by_path
+            .get(path)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn goto_definition(&self, request: GotoDefinitionRequest) -> Option<GotoDefinitionResponse> {
+        let uri = path_to_url(&request.path).ok()?;
+        let document = self.documents_by_uri.get(&uri)?;
+        let occurrence = find_scip_occurrence(document, request.position)?;
+        let origin_selection_range = occurrence.range;
+
+        let links = if occurrence.is_definition {
+            vec![LocationLink {
+                origin_selection_range: Some(origin_selection_range),
+                target_uri: document.uri.clone(),
+                target_range: occurrence.range,
+                target_selection_range: occurrence.range,
+            }]
+        } else {
+            self.definitions
+                .get(&occurrence.symbol)?
+                .iter()
+                .map(|definition| LocationLink {
+                    origin_selection_range: Some(origin_selection_range),
+                    target_uri: definition.uri.clone(),
+                    target_range: definition.range,
+                    target_selection_range: definition.range,
+                })
+                .collect()
+        };
+
+        if links.is_empty() {
+            None
+        } else {
+            Some(GotoDefinitionResponse::Link(links))
+        }
+    }
+
+    /// Requests the definition for a SCIP symbol.
+    pub fn goto_definition_symbol(&self, symbol: &str) -> Option<GotoDefinitionResponse> {
+        let links = self
+            .definitions
+            .get(symbol)?
+            .iter()
+            .map(|definition| LocationLink {
+                origin_selection_range: None,
+                target_uri: definition.uri.clone(),
+                target_range: definition.range,
+                target_selection_range: definition.range,
+            })
+            .collect::<Vec<_>>();
+
+        if links.is_empty() {
+            None
+        } else {
+            Some(GotoDefinitionResponse::Link(links))
+        }
+    }
+}
+
+fn collect_symbol_infos(
+    index: &scip::types::Index,
+) -> FxHashMap<String, scip::types::SymbolInformation> {
+    let mut symbol_infos = FxHashMap::default();
+    for symbol in index.external_symbols.iter().chain(
+        index
+            .documents
+            .iter()
+            .flat_map(|document| document.symbols.iter()),
+    ) {
+        if let Some(current) = symbol_infos.get_mut(&symbol.symbol) {
+            merge_symbol_information(current, symbol.clone());
+        } else {
+            symbol_infos.insert(symbol.symbol.clone(), symbol.clone());
+        }
+    }
+    symbol_infos
+}
+
+fn collect_symbol_hovers(
+    symbol_infos: &FxHashMap<String, scip::types::SymbolInformation>,
+) -> FxHashMap<String, Hover> {
+    symbol_infos
+        .values()
+        .filter_map(|symbol| {
+            hover_from_scip_symbol(symbol, symbol_infos).map(|hover| (symbol.symbol.clone(), hover))
+        })
+        .collect()
+}
+
+fn scip_public_symbols(
+    document: &scip::types::Document,
+    symbol_infos: &FxHashMap<String, scip::types::SymbolInformation>,
+) -> Vec<ScipPublicSymbol> {
+    let mut symbols = Vec::new();
+    let mut seen = FxHashSet::default();
+
+    for symbol in &document.symbols {
+        if scip_package_docs_kind(symbol) != "module" {
+            continue;
+        }
+
+        for relationship in &symbol.relationships {
+            if !relationship.is_definition || !seen.insert(relationship.symbol.clone()) {
+                continue;
+            }
+
+            let Some(info) = symbol_infos.get(&relationship.symbol) else {
+                continue;
+            };
+            symbols.push(ScipPublicSymbol {
+                symbol: relationship.symbol.clone(),
+                name: scip_symbol_display_name(info, &relationship.symbol),
+                kind: scip_package_docs_kind(info).to_owned(),
+            });
+        }
+    }
+
+    symbols
+}
+
+fn scip_symbol_display_name(info: &scip::types::SymbolInformation, symbol: &str) -> String {
+    if !info.display_name.is_empty() {
+        return info.display_name.clone();
+    }
+
+    scip::symbol::parse_symbol(symbol)
+        .ok()
+        .and_then(|symbol| {
+            symbol
+                .descriptors
+                .last()
+                .map(|descriptor| descriptor.name.clone())
+        })
+        .unwrap_or_default()
+}
+
+fn scip_package_docs_kind(info: &scip::types::SymbolInformation) -> &'static str {
+    match info.kind.enum_value().ok() {
+        Some(scip::types::symbol_information::Kind::Module) => "module",
+        Some(scip::types::symbol_information::Kind::Function) => "function",
+        Some(scip::types::symbol_information::Kind::Constant) => "constant",
+        Some(scip::types::symbol_information::Kind::Variable) => "variable",
+        Some(scip::types::symbol_information::Kind::Parameter) => "parameter",
+        _ => "unknown",
+    }
+}
+
+fn find_scip_occurrence(
+    document: &ScipDocumentQuery,
+    position: Position,
+) -> Option<&ScipOccurrence> {
+    document
+        .occurrences
+        .iter()
+        .filter(|occurrence| contains_position(&occurrence.range, position))
+        .min_by_key(|occurrence| range_len_key(&occurrence.range))
+}
+
+fn scip_document_uri(project_root: Option<&Url>, relative_path: &str) -> Option<Url> {
+    if let Some(project_root) = project_root
+        && project_root.scheme() == "file"
+    {
+        let mut path = url_to_path(project_root);
+        path.push(relative_path);
+        if let Ok(uri) = path_to_url(&path) {
+            return Some(uri);
+        }
+    }
+
+    if let Some(project_root) = project_root
+        && let Ok(uri) = project_root.join(relative_path)
+    {
+        return Some(uri);
+    }
+
+    let path = std::path::Path::new(relative_path);
+    if path.is_absolute() {
+        path_to_url(path).ok()
+    } else {
+        None
+    }
+}
+
+fn scip_range_to_lsp(range: &[i32]) -> Option<Range> {
+    let line = as_u32(*range.first()?)?;
+    let start_character = as_u32(*range.get(1)?)?;
+    let (end_line, end_character) = match range.len() {
+        3 => (line, as_u32(range[2])?),
+        4 => (as_u32(range[2])?, as_u32(range[3])?),
+        _ => return None,
+    };
+
+    Some(Range {
+        start: Position {
+            line,
+            character: start_character,
+        },
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    })
+}
+
+fn as_u32(value: i32) -> Option<u32> {
+    u32::try_from(value).ok()
+}
+
+fn hover_from_scip_symbol(
+    symbol: &scip::types::SymbolInformation,
+    symbol_infos: &FxHashMap<String, scip::types::SymbolInformation>,
+) -> Option<Hover> {
+    if let Some(signature) = symbol.signature_documentation.as_ref()
+        && !signature.text.trim().is_empty()
+    {
+        return hover_from_scip_signature_symbol(symbol, signature, symbol_infos);
+    }
+
+    hover_from_scip_docs(&symbol.documentation)
+}
+
+fn hover_from_scip_signature_symbol(
+    symbol: &scip::types::SymbolInformation,
+    signature: &scip::types::Signature,
+    symbol_infos: &FxHashMap<String, scip::types::SymbolInformation>,
+) -> Option<Hover> {
+    let mut docs = Vec::new();
+    let language = if signature.language.trim().is_empty() {
+        "typc"
+    } else {
+        signature.language.as_str()
+    };
+    docs.push(format!("```{language}\n{}\n```", signature.text));
+    docs.extend(symbol.documentation.iter().cloned());
+
+    let params = scip_signature_params(signature, symbol_infos);
+    extend_scip_param_section(
+        &mut docs,
+        "# Positional Parameters",
+        "positional",
+        &params.positional,
+    );
+    extend_scip_param_section(&mut docs, "# Rest Parameters", "rest", &params.rest);
+    extend_scip_param_section(&mut docs, "# Named Parameters", "named", &params.named);
+
+    let markdown = docs
+        .into_iter()
+        .filter(|doc| !doc.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if markdown.trim().is_empty() {
+        return None;
+    }
+
+    Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(markdown)),
+        range: None,
+    })
+}
+
+#[derive(Default)]
+struct ScipSignatureParams {
+    positional: Vec<ScipSignatureParam>,
+    rest: Vec<ScipSignatureParam>,
+    named: Vec<ScipSignatureParam>,
+}
+
+struct ScipSignatureParam {
+    name: String,
+    documentation: Vec<String>,
+}
+
+fn scip_signature_params(
+    signature: &scip::types::Signature,
+    symbol_infos: &FxHashMap<String, scip::types::SymbolInformation>,
+) -> ScipSignatureParams {
+    let mut occurrences = signature.occurrences.iter().collect::<Vec<_>>();
+    occurrences.sort_by(|left, right| {
+        left.range
+            .cmp(&right.range)
+            .then_with(|| left.symbol.cmp(&right.symbol))
+    });
+
+    let mut seen = FxHashSet::default();
+    let mut params = ScipSignatureParams::default();
+    for occurrence in occurrences {
+        if !seen.insert(occurrence.symbol.clone()) {
+            continue;
+        }
+        let Some(group) = scip_parameter_group(&occurrence.symbol) else {
+            continue;
+        };
+        let Some(info) = symbol_infos.get(&occurrence.symbol) else {
+            continue;
+        };
+        let param = ScipSignatureParam {
+            name: if info.display_name.is_empty() {
+                scip_parameter_name(&occurrence.symbol).unwrap_or_default()
+            } else {
+                info.display_name.clone()
+            },
+            documentation: info.documentation.clone(),
+        };
+
+        match group {
+            ScipParamGroup::Positional => params.positional.push(param),
+            ScipParamGroup::Rest => params.rest.push(param),
+            ScipParamGroup::Named => params.named.push(param),
+        }
+    }
+
+    params
+}
+
+fn scip_parameter_group(symbol: &str) -> Option<ScipParamGroup> {
+    let symbol = scip::symbol::parse_symbol(symbol).ok()?;
+    let mut saw_parameter = false;
+    for descriptor in symbol.descriptors.iter().rev() {
+        match descriptor.suffix.enum_value().ok()? {
+            scip::types::descriptor::Suffix::Parameter => saw_parameter = true,
+            scip::types::descriptor::Suffix::Meta if saw_parameter => {
+                return ScipParamGroup::from_descriptor(&descriptor.name);
+            }
+            _ if saw_parameter => return None,
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn scip_parameter_name(symbol: &str) -> Option<String> {
+    let symbol = scip::symbol::parse_symbol(symbol).ok()?;
+    symbol.descriptors.iter().rev().find_map(|descriptor| {
+        matches!(
+            descriptor.suffix.enum_value().ok()?,
+            scip::types::descriptor::Suffix::Parameter
+        )
+        .then(|| descriptor.name.clone())
+    })
+}
+
+fn extend_scip_param_section(
+    docs: &mut Vec<String>,
+    title: &str,
+    kind: &str,
+    params: &[ScipSignatureParam],
+) {
+    if params.is_empty() {
+        return;
+    }
+
+    let mut section = title.to_owned();
+    for (idx, param) in params.iter().enumerate() {
+        let heading = if idx == 0 {
+            param.name.clone()
+        } else {
+            format!("{} ({kind})", param.name)
+        };
+        section.push_str("\n\n## ");
+        section.push_str(&heading);
+
+        let body = param
+            .documentation
+            .iter()
+            .filter(|doc| !doc.trim().is_empty())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if !body.trim().is_empty() {
+            section.push_str("\n\n");
+            section.push_str(&body);
+        }
+    }
+    docs.push(section);
+}
+
+fn hover_from_scip_docs(docs: &[String]) -> Option<Hover> {
+    let docs = docs
+        .iter()
+        .filter(|doc| !doc.trim().is_empty())
+        .cloned()
+        .collect::<Vec<_>>();
+    if docs.is_empty() {
+        return None;
+    }
+
+    Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(docs.join("\n\n---\n\n"))),
+        range: None,
+    })
+}
+
+fn contains_position(range: &Range, position: Position) -> bool {
+    position_after_or_eq(position, range.start) && position_before(position, range.end)
+}
+
+fn position_after_or_eq(a: Position, b: Position) -> bool {
+    (a.line, a.character) >= (b.line, b.character)
+}
+
+fn position_before(a: Position, b: Position) -> bool {
+    (a.line, a.character) < (b.line, b.character)
+}
+
+fn range_len_key(range: &Range) -> (u32, u32) {
+    (
+        range.end.line.saturating_sub(range.start.line),
+        range.end.character.saturating_sub(range.start.character),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use lsp_types::{HoverContents, MarkedString};
+    use protobuf::{Enum, EnumOrUnknown, Message, MessageField};
+    use scip::types::{
+        Document as ScipDocument, Index as ScipIndex, Metadata as ScipMetadata,
+        Occurrence as ScipOccurrence, PositionEncoding as ScipPositionEncoding,
+        Relationship as ScipRelationship, Signature as ScipSignature,
+        SymbolInformation as ScipSymbolInformation, SymbolRole as ScipSymbolRole,
+        TextEncoding as ScipTextEncoding, ToolInfo as ScipToolInfo, symbol_information,
+    };
+
+    use super::*;
+
+    #[test]
+    fn scip_hover_and_definition() {
+        let path = fixture_path();
+        let symbol = "local value";
+        let bytes = test_index(vec![main_document(
+            vec![
+                definition_occurrence(vec![0, 0, 4], symbol),
+                occurrence(vec![1, 0, 4], symbol),
+            ],
+            vec![symbol_info(symbol, "value", &["hello"])],
+        )]);
+        let mut index = ScipQueryCtx::read(&bytes).unwrap();
+
+        let hover = index.request(CompilerQueryRequest::Hover(HoverRequest {
+            path: path.clone(),
+            position: Position {
+                line: 1,
+                character: 1,
+            },
+        }));
+        let Some(CompilerQueryResponse::Hover(Some(hover))) = hover else {
+            panic!("expected SCIP hover response");
+        };
+        assert_eq!(
+            hover.contents,
+            HoverContents::Scalar(MarkedString::String("hello".to_owned()))
+        );
+
+        let definition = index.request(CompilerQueryRequest::GotoDefinition(
+            GotoDefinitionRequest {
+                path,
+                position: Position {
+                    line: 1,
+                    character: 1,
+                },
+            },
+        ));
+        let Some(CompilerQueryResponse::GotoDefinition(Some(GotoDefinitionResponse::Link(links)))) =
+            definition
+        else {
+            panic!("expected SCIP definition response");
+        };
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].target_selection_range,
+            Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn scip_signature_hover_uses_parameter_symbols() {
+        let path = fixture_path();
+        let symbol = "typst tinymist workspace . main.typ/L0_C0:foo().";
+        let param_symbol = "typst tinymist workspace . main.typ/L0_C0:foo().positional:(arg)";
+        let mut function = symbol_info(symbol, "foo", &["Function docs."]);
+        function.signature_documentation = MessageField::some(ScipSignature {
+            language: "typc".to_owned(),
+            text: "let foo(\n  arg: int,\n) = none;".to_owned(),
+            occurrences: vec![definition_occurrence(vec![1, 2, 5], param_symbol)],
+            ..Default::default()
+        });
+        let mut parameter = symbol_info(
+            param_symbol,
+            "arg",
+            &["```typc\ntype: int\n```", "Arg docs."],
+        );
+        parameter.enclosing_symbol = symbol.to_owned();
+        let bytes = test_index(vec![main_document(
+            vec![occurrence(vec![1, 0, 3], symbol)],
+            vec![function, parameter],
+        )]);
+        let mut index = ScipQueryCtx::read(&bytes).unwrap();
+
+        let hover = index.request(CompilerQueryRequest::Hover(HoverRequest {
+            path,
+            position: Position {
+                line: 1,
+                character: 1,
+            },
+        }));
+        let Some(CompilerQueryResponse::Hover(Some(hover))) = hover else {
+            panic!("expected SCIP hover response");
+        };
+        assert_eq!(
+            hover.contents,
+            HoverContents::Scalar(MarkedString::String(
+                "```typc\nlet foo(\n  arg: int,\n) = none;\n```\n\nFunction docs.\n\n# Positional Parameters\n\n## arg\n\n```typc\ntype: int\n```\n\nArg docs.".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn scip_public_symbols_from_module_document() {
+        let module_symbol = "typst tinymist workspace . main.typ/1:main/";
+        let function_symbol = "typst tinymist workspace . main.typ/L0_C0:foo().";
+        let mut module =
+            typed_symbol_info(module_symbol, "main", symbol_information::Kind::Module, &[]);
+        module.relationships = vec![public_relationship(function_symbol)];
+        let function = typed_symbol_info(
+            function_symbol,
+            "foo",
+            symbol_information::Kind::Function,
+            &["Function docs."],
+        );
+        let bytes = test_index(vec![main_document(vec![], vec![module, function])]);
+        let index = ScipQueryCtx::read(&bytes).unwrap();
+
+        let symbols = index.public_symbols("main.typ");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].symbol, function_symbol.to_owned());
+        assert_eq!(symbols[0].name, "foo");
+        assert_eq!(symbols[0].kind, "function");
+    }
+
+    fn test_index(documents: Vec<ScipDocument>) -> Vec<u8> {
+        let path = fixture_path();
+        let root = path.parent().unwrap();
+        ScipIndex {
+            metadata: MessageField::some(ScipMetadata {
+                tool_info: MessageField::some(ScipToolInfo {
+                    name: "tinymist".to_owned(),
+                    version: "test".to_owned(),
+                    ..Default::default()
+                }),
+                project_root: path_to_url(root).unwrap().to_string(),
+                text_document_encoding: EnumOrUnknown::new(ScipTextEncoding::UTF8),
+                ..Default::default()
+            }),
+            documents,
+            ..Default::default()
+        }
+        .write_to_bytes()
+        .unwrap()
+    }
+
+    fn main_document(
+        occurrences: Vec<ScipOccurrence>,
+        symbols: Vec<ScipSymbolInformation>,
+    ) -> ScipDocument {
+        ScipDocument {
+            language: "typst".to_owned(),
+            relative_path: "main.typ".to_owned(),
+            occurrences,
+            symbols,
+            position_encoding: EnumOrUnknown::new(
+                ScipPositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }
+    }
+
+    fn occurrence(range: Vec<i32>, symbol: &str) -> ScipOccurrence {
+        ScipOccurrence {
+            range,
+            symbol: symbol.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn definition_occurrence(range: Vec<i32>, symbol: &str) -> ScipOccurrence {
+        ScipOccurrence {
+            symbol_roles: ScipSymbolRole::Definition.value(),
+            ..occurrence(range, symbol)
+        }
+    }
+
+    fn symbol_info(
+        symbol: &str,
+        display_name: &str,
+        documentation: &[&str],
+    ) -> ScipSymbolInformation {
+        typed_symbol_info(
+            symbol,
+            display_name,
+            symbol_information::Kind::UnspecifiedKind,
+            documentation,
+        )
+    }
+
+    fn typed_symbol_info(
+        symbol: &str,
+        display_name: &str,
+        kind: symbol_information::Kind,
+        documentation: &[&str],
+    ) -> ScipSymbolInformation {
+        ScipSymbolInformation {
+            symbol: symbol.to_owned(),
+            documentation: documentation.iter().map(|doc| (*doc).to_owned()).collect(),
+            kind: EnumOrUnknown::new(kind),
+            display_name: display_name.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn public_relationship(symbol: &str) -> ScipRelationship {
+        ScipRelationship {
+            symbol: symbol.to_owned(),
+            is_reference: true,
+            is_definition: true,
+            ..Default::default()
+        }
+    }
+
+    fn fixture_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("main.typ")
+    }
+}

--- a/crates/tinymist-query/src/index/scip_utils.rs
+++ b/crates/tinymist-query/src/index/scip_utils.rs
@@ -1,0 +1,73 @@
+//! Shared helpers for SCIP protobuf data.
+
+use scip::types::{
+    Relationship as ScipRelationship, SymbolInformation as ScipSymbolInformation,
+    symbol_information,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ScipParamGroup {
+    Positional,
+    Rest,
+    Named,
+}
+
+impl ScipParamGroup {
+    pub(super) fn descriptor(self) -> &'static str {
+        match self {
+            Self::Positional => "positional",
+            Self::Rest => "rest",
+            Self::Named => "named",
+        }
+    }
+
+    pub(super) fn from_descriptor(descriptor: &str) -> Option<Self> {
+        match descriptor {
+            "positional" => Some(Self::Positional),
+            "rest" => Some(Self::Rest),
+            "named" => Some(Self::Named),
+            _ => None,
+        }
+    }
+}
+
+pub(super) fn merge_symbol_information(
+    current: &mut ScipSymbolInformation,
+    incoming: ScipSymbolInformation,
+) {
+    if current.documentation.is_empty() {
+        current.documentation = incoming.documentation;
+    }
+    if current.signature_documentation.is_none() {
+        current.signature_documentation = incoming.signature_documentation;
+    }
+    if current.display_name.is_empty() {
+        current.display_name = incoming.display_name;
+    }
+    if current.kind.enum_value().ok() == Some(symbol_information::Kind::UnspecifiedKind) {
+        current.kind = incoming.kind;
+    }
+    if current.enclosing_symbol.is_empty() {
+        current.enclosing_symbol = incoming.enclosing_symbol;
+    }
+    for relationship in incoming.relationships {
+        push_relationship_unique(&mut current.relationships, relationship);
+    }
+}
+
+pub(super) fn push_relationship_unique(
+    relationships: &mut Vec<ScipRelationship>,
+    relationship: ScipRelationship,
+) {
+    if relationships.iter().any(|current| {
+        current.symbol == relationship.symbol
+            && current.is_reference == relationship.is_reference
+            && current.is_implementation == relationship.is_implementation
+            && current.is_type_definition == relationship.is_type_definition
+            && current.is_definition == relationship.is_definition
+    }) {
+        return;
+    }
+
+    relationships.push(relationship);
+}

--- a/crates/tinymist-query/src/lib.rs
+++ b/crates/tinymist-query/src/lib.rs
@@ -234,8 +234,12 @@ mod polymorphic {
         OnExportMd(OnExportMdRequest),
         /// A request to get the hover information.
         Hover(HoverRequest),
+        /// A request to get the hover information for a symbol.
+        HoverSymbol(String),
         /// A request to go to the definition.
         GotoDefinition(GotoDefinitionRequest),
+        /// A request to go to the definition of a symbol.
+        GotoDefinitionSymbol(String),
         /// A request to go to the declaration.
         GotoDeclaration(GotoDeclarationRequest),
         /// A request to get the references.
@@ -300,7 +304,9 @@ mod polymorphic {
                 Self::OnExport(..) => Mergeable,
                 Self::OnExportMd(..) => Mergeable,
                 Self::Hover(..) => PinnedFirst,
+                Self::HoverSymbol(..) => PinnedFirst,
                 Self::GotoDefinition(..) => PinnedFirst,
+                Self::GotoDefinitionSymbol(..) => PinnedFirst,
                 Self::GotoDeclaration(..) => PinnedFirst,
                 Self::References(..) => PinnedFirst,
                 Self::InlayHint(..) => Unique,
@@ -338,7 +344,9 @@ mod polymorphic {
                 Self::OnExport(..) => return None,
                 Self::OnExportMd(..) => return None,
                 Self::Hover(req) => &req.path,
+                Self::HoverSymbol(..) => return None,
                 Self::GotoDefinition(req) => &req.path,
+                Self::GotoDefinitionSymbol(..) => return None,
                 Self::GotoDeclaration(req) => &req.path,
                 Self::References(req) => &req.path,
                 Self::InlayHint(req) => &req.path,


### PR DESCRIPTION
Adds standalone SCIP support to the indexing layer, based directly on `main`.

- add SCIP protobuf dependencies and SCIP index encoding from `tinymist-query::index::Knowledge`
- keep existing LSIF JSONL display output while adding `to_scip_bytes` / `to_scip_index` APIs
- add `ScipQueryCtx` for SCIP-backed hover and goto-definition queries
- preserve signature parameter documentation in SCIP `SymbolInformation.signature_documentation`
- expose symbol-based hover/definition and module public-symbol relationship queries for later package-doc integration
- switch `tinymist-index` plugin loading/querying to SCIP bytes
