### PR TITLE
fix(preview): skip canvas cache hit waits

### DIFF
--- a/tools/typst-dom/src/typst-doc.canvas.mts
+++ b/tools/typst-dom/src/typst-doc.canvas.mts
@@ -173,6 +173,7 @@ export function provideCanvasDoc<
             body: true,
           },
         });
+        const canvasUpdated = !cached || cacheKey !== result.cacheKey;
         if (cacheKey !== result.cacheKey) {
           console.log("updateCanvas one miss", cacheKey, result.cacheKey);
           // console.log('renderCanvas', pageInfo.index, performance.now() - tt1, result);
@@ -185,7 +186,9 @@ export function provideCanvasDoc<
           pageInfo.elem.setAttribute("data-cache-key", result.cacheKey);
         }
 
-        await waitABit();
+        if (canvasUpdated) {
+          await waitABit();
+        }
       }
 
       console.log("updateCanvas done", performance.now() - perf);


### PR DESCRIPTION
- Skip per-page canvas wait when the cached canvas page did not redraw.
- Keep the existing wait path for cache misses and resized canvases.


case | no cache key frontend total | with cache key frontend total | frontend speedup | no cache key wall | with cache key wall | max longtask change
-- | -- | -- | -- | -- | -- | --
first render | 1660.5ms | 1633.0ms | 1.0x | 15206.1ms | 17029.4ms | 810.0ms -> 660.0ms
front edit | 194.2ms | 4.5ms | 43.2x | 1249.8ms | 1095.3ms | 0.0ms -> 0.0ms
middle edit | 186.7ms | 5.1ms | 36.6x | 1217.6ms | 1249.6ms | 984.0ms -> 215.0ms
back edit | 178.9ms | 3.7ms | 48.4x | 1204.0ms | 1099.5ms | 1033.0ms -> 184.0ms

