### PR TITLE
feat: support DAP line breakpoints

### DIFF
--- a/crates/tinymist-dap/src/lib.rs
+++ b/crates/tinymist-dap/src/lib.rs
@@ -21,9 +21,9 @@ use std::sync::{Arc, mpsc};
 use comemo::Track;
 use comemo::Tracked;
 use parking_lot::Mutex;
-use tinymist_debug::{DebugSession, DebugSessionHandler, set_debug_session};
+use tinymist_debug::{DebugSession, DebugSessionHandler, SourceBreakpoint, set_debug_session};
 use tinymist_std::typst_shim::eval::{Eval, Vm};
-use tinymist_world::{CompilerFeat, CompilerWorld};
+use tinymist_world::{CompilerFeat, CompilerWorld, vfs::FileId};
 use typst::{
     __bail as bail, World,
     diag::{SourceResult, Warned},
@@ -64,6 +64,7 @@ pub fn start_session<F: CompilerFeat>(
     adaptor: Arc<dyn DebugAdaptor>,
     rx: mpsc::Receiver<DebugRequest>,
     function_breakpoints: Vec<String>,
+    source_breakpoints: Vec<(FileId, Vec<SourceBreakpoint>)>,
 ) {
     let context = Arc::new(DebugContext {});
 
@@ -72,6 +73,9 @@ pub fn start_session<F: CompilerFeat>(
 
         let mut session = DebugSession::new(context);
         session.set_function_breakpoints(function_breakpoints);
+        for (fid, breakpoints) in source_breakpoints {
+            session.set_source_breakpoints(fid, breakpoints);
+        }
 
         if !set_debug_session(Some(session)) {
             adaptor.terminate();

--- a/crates/tinymist-debug/src/debugger.rs
+++ b/crates/tinymist-debug/src/debugger.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use comemo::Tracked;
 use parking_lot::RwLock;
+use tinymist_analysis::location::{PositionEncoding, to_lsp_position};
 use tinymist_std::hash::{FxHashMap, FxHashSet};
 use tinymist_world::vfs::FileId;
 use typst::World;
@@ -13,6 +14,7 @@ use typst::diag::FileResult;
 use typst::engine::Engine;
 use typst::foundations::{Binding, Context, Dict, Scopes, func};
 use typst::syntax::{Source, Span};
+use typst_shim::syntax::source_range;
 
 use crate::instrument::Instrumenter;
 
@@ -87,6 +89,41 @@ pub struct BreakpointItem {
     pub origin_span: Span,
 }
 
+/// A source breakpoint requested by line and optional column.
+///
+/// Lines and columns are zero-based. Columns are measured as UTF-16 code units.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceBreakpoint {
+    /// The requested source line.
+    pub line: u32,
+    /// The requested source column.
+    pub column: Option<u32>,
+}
+
+/// The result of resolving a source breakpoint to a structural breakpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceBreakpointResolution {
+    /// The original requested breakpoint.
+    pub requested: SourceBreakpoint,
+    /// The structural breakpoint this request maps to, if any.
+    pub resolved: Option<ResolvedSourceBreakpoint>,
+    /// Whether the source breakpoint is waiting for instrumentation metadata.
+    pub pending: bool,
+}
+
+/// A structural breakpoint selected for a source breakpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedSourceBreakpoint {
+    /// The structural breakpoint id within the instrumented source metadata.
+    pub id: usize,
+    /// The kind of structural breakpoint.
+    pub kind: BreakpointKind,
+    /// The resolved zero-based source line.
+    pub line: u32,
+    /// The resolved zero-based UTF-16 source column.
+    pub column: u32,
+}
+
 static DEBUG_SESSION: RwLock<Option<DebugSession>> = RwLock::new(None);
 
 /// The debug session handler.
@@ -104,8 +141,10 @@ pub trait DebugSessionHandler: Send + Sync {
 
 /// The debug session.
 pub struct DebugSession {
-    enabled: FxHashSet<(FileId, usize, BreakpointKind)>,
+    enabled_function_breakpoints: FxHashSet<(FileId, usize, BreakpointKind)>,
+    enabled_source_breakpoints: FxHashSet<(FileId, usize, BreakpointKind)>,
     function_breakpoints: FxHashSet<String>,
+    source_breakpoints: FxHashMap<FileId, Vec<SourceBreakpoint>>,
     /// The breakpoint meta.
     breakpoints: FxHashMap<FileId, Arc<BreakpointInfo>>,
 
@@ -117,8 +156,10 @@ impl DebugSession {
     /// Creates a new debug session.
     pub fn new(handler: Arc<dyn DebugSessionHandler>) -> Self {
         Self {
-            enabled: FxHashSet::default(),
+            enabled_function_breakpoints: FxHashSet::default(),
+            enabled_source_breakpoints: FxHashSet::default(),
             function_breakpoints: FxHashSet::default(),
+            source_breakpoints: FxHashMap::default(),
             breakpoints: FxHashMap::default(),
             handler,
         }
@@ -127,15 +168,58 @@ impl DebugSession {
     /// Replaces the currently enabled function breakpoints by name.
     pub fn set_function_breakpoints(&mut self, names: impl IntoIterator<Item = String>) {
         self.function_breakpoints = names.into_iter().collect();
-        self.enabled
-            .retain(|(_, _, kind)| *kind != BreakpointKind::Function);
+        self.enabled_function_breakpoints.clear();
 
         for (fid, info) in self.breakpoints.clone() {
-            self.enable_breakpoints_for(fid, &info);
+            self.enable_function_breakpoints_for(fid, &info);
         }
     }
 
-    fn enable_breakpoints_for(&mut self, fid: FileId, info: &BreakpointInfo) {
+    /// Replaces source breakpoints for a file id.
+    pub fn set_source_breakpoints(
+        &mut self,
+        fid: FileId,
+        breakpoints: impl IntoIterator<Item = SourceBreakpoint>,
+    ) {
+        let breakpoints = breakpoints.into_iter().collect::<Vec<_>>();
+
+        if breakpoints.is_empty() {
+            self.source_breakpoints.remove(&fid);
+        } else {
+            self.source_breakpoints.insert(fid, breakpoints);
+        }
+
+        self.enabled_source_breakpoints
+            .retain(|(enabled_fid, _, _)| *enabled_fid != fid);
+    }
+
+    /// Replaces source breakpoints for a source and resolves them if metadata is available.
+    pub fn set_source_breakpoints_for(
+        &mut self,
+        source: &Source,
+        breakpoints: impl IntoIterator<Item = SourceBreakpoint>,
+    ) -> Vec<SourceBreakpointResolution> {
+        let fid = source.id();
+        self.set_source_breakpoints(fid, breakpoints);
+
+        let Some(info) = self.breakpoints.get(&fid).cloned() else {
+            return self.pending_source_breakpoints(fid);
+        };
+
+        self.enable_source_breakpoints_for(source, &info)
+    }
+
+    fn enable_breakpoints_for(
+        &mut self,
+        source: &Source,
+        info: &BreakpointInfo,
+    ) -> Vec<SourceBreakpointResolution> {
+        let fid = source.id();
+        self.enable_function_breakpoints_for(fid, info);
+        self.enable_source_breakpoints_for(source, info)
+    }
+
+    fn enable_function_breakpoints_for(&mut self, fid: FileId, info: &BreakpointInfo) {
         for (id, item) in info.meta.iter().enumerate() {
             if !matches!(item.kind, BreakpointKind::Function) {
                 continue;
@@ -146,9 +230,150 @@ impl DebugSession {
                 .as_ref()
                 .is_some_and(|name| self.function_breakpoints.contains(name))
             {
-                self.enabled.insert((fid, id, BreakpointKind::Function));
+                self.enabled_function_breakpoints
+                    .insert((fid, id, BreakpointKind::Function));
             }
         }
+    }
+
+    fn enable_source_breakpoints_for(
+        &mut self,
+        source: &Source,
+        info: &BreakpointInfo,
+    ) -> Vec<SourceBreakpointResolution> {
+        let fid = source.id();
+        self.enabled_source_breakpoints
+            .retain(|(enabled_fid, _, _)| *enabled_fid != fid);
+
+        let Some(breakpoints) = self.source_breakpoints.get(&fid).cloned() else {
+            return vec![];
+        };
+
+        let candidates = SourceBreakpointCandidate::collect(source, info);
+
+        breakpoints
+            .into_iter()
+            .map(|requested| {
+                let resolved =
+                    best_source_breakpoint_candidate(&requested, &candidates).map(|candidate| {
+                        self.enabled_source_breakpoints
+                            .insert((fid, candidate.id, candidate.kind));
+
+                        ResolvedSourceBreakpoint {
+                            id: candidate.id,
+                            kind: candidate.kind,
+                            line: candidate.line,
+                            column: candidate.column,
+                        }
+                    });
+
+                SourceBreakpointResolution {
+                    requested,
+                    resolved,
+                    pending: false,
+                }
+            })
+            .collect()
+    }
+
+    fn pending_source_breakpoints(&self, fid: FileId) -> Vec<SourceBreakpointResolution> {
+        self.source_breakpoints
+            .get(&fid)
+            .into_iter()
+            .flatten()
+            .cloned()
+            .map(|requested| SourceBreakpointResolution {
+                requested,
+                resolved: None,
+                pending: true,
+            })
+            .collect()
+    }
+
+    fn breakpoint_enabled(&self, bp: &(FileId, usize, BreakpointKind)) -> bool {
+        self.enabled_function_breakpoints.contains(bp)
+            || self.enabled_source_breakpoints.contains(bp)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SourceBreakpointCandidate {
+    id: usize,
+    kind: BreakpointKind,
+    line: u32,
+    column: u32,
+}
+
+impl SourceBreakpointCandidate {
+    fn collect(source: &Source, info: &BreakpointInfo) -> Vec<Self> {
+        info.meta
+            .iter()
+            .enumerate()
+            .filter_map(|(id, item)| {
+                if !is_source_breakpoint_target(item.kind) {
+                    return None;
+                }
+
+                let range = source_range(source, item.origin_span)?;
+                let position = to_lsp_position(range.start, PositionEncoding::Utf16, source);
+
+                Some(Self {
+                    id,
+                    kind: item.kind,
+                    line: position.line,
+                    column: position.character,
+                })
+            })
+            .collect()
+    }
+}
+
+fn best_source_breakpoint_candidate(
+    breakpoint: &SourceBreakpoint,
+    candidates: &[SourceBreakpointCandidate],
+) -> Option<SourceBreakpointCandidate> {
+    candidates
+        .iter()
+        .min_by_key(|candidate| {
+            let line_bucket = if matches!(candidate.kind, BreakpointKind::BlockEnd) {
+                3
+            } else if candidate.line == breakpoint.line {
+                0
+            } else if candidate.line > breakpoint.line {
+                1
+            } else {
+                2
+            };
+            let column = breakpoint.column.unwrap_or(0);
+
+            (
+                line_bucket,
+                candidate.line.abs_diff(breakpoint.line),
+                source_breakpoint_kind_priority(candidate.kind),
+                candidate.column.abs_diff(column),
+                candidate.id,
+            )
+        })
+        .copied()
+}
+
+fn is_source_breakpoint_target(kind: BreakpointKind) -> bool {
+    matches!(
+        kind,
+        BreakpointKind::Function
+            | BreakpointKind::BlockStart
+            | BreakpointKind::ShowStart
+            | BreakpointKind::BlockEnd
+    )
+}
+
+fn source_breakpoint_kind_priority(kind: BreakpointKind) -> u8 {
+    match kind {
+        BreakpointKind::Function => 0,
+        BreakpointKind::BlockStart => 1,
+        BreakpointKind::ShowStart => 2,
+        BreakpointKind::BlockEnd => 3,
+        _ => 4,
     }
 }
 
@@ -183,6 +408,17 @@ pub fn set_debug_function_breakpoints(names: impl IntoIterator<Item = String>) -
     true
 }
 
+/// Updates source breakpoints for an active debug session, if any.
+pub fn set_debug_source_breakpoints(
+    source: Source,
+    breakpoints: impl IntoIterator<Item = SourceBreakpoint>,
+) -> Option<Vec<SourceBreakpointResolution>> {
+    let mut session = DEBUG_SESSION.write();
+    let session = session.as_mut()?;
+
+    Some(session.set_source_breakpoints_for(&source, breakpoints))
+}
+
 /// Software breakpoints
 fn check_soft_breakpoint(span: Span, id: usize, kind: BreakpointKind) -> Option<bool> {
     let fid = span.id()?;
@@ -191,7 +427,7 @@ fn check_soft_breakpoint(span: Span, id: usize, kind: BreakpointKind) -> Option<
     let session = session.as_ref()?;
 
     let bp_feature = (fid, id, kind);
-    Some(session.enabled.contains(&bp_feature))
+    Some(session.breakpoint_enabled(&bp_feature))
 }
 
 /// Software breakpoints
@@ -210,7 +446,7 @@ fn soft_breakpoint_handle(
         let session = session.as_ref()?;
 
         let bp_feature = (fid, id, kind);
-        if !session.enabled.contains(&bp_feature) {
+        if !session.breakpoint_enabled(&bp_feature) {
             return None;
         }
 

--- a/crates/tinymist-debug/src/debugger/instr.rs
+++ b/crates/tinymist-debug/src/debugger/instr.rs
@@ -5,15 +5,15 @@ use typst::syntax::ast::{self, AstNode};
 use super::*;
 
 impl Instrumenter for BreakpointInstr {
-    fn instrument(&self, _source: Source) -> FileResult<Source> {
-        let (new, meta) = instrument_breakpoints(_source)?;
+    fn instrument(&self, source: Source) -> FileResult<Source> {
+        let (new, meta) = instrument_breakpoints(source.clone())?;
 
         let mut session = DEBUG_SESSION.write();
         let session = session
             .as_mut()
             .ok_or_else(|| FileError::Other(Some("No active debug session".into())))?;
 
-        session.enable_breakpoints_for(new.id(), &meta);
+        session.enable_breakpoints_for(&source, &meta);
         session.breakpoints.insert(new.id(), meta);
 
         Ok(new)
@@ -423,5 +423,46 @@ mod tests {
         __it => {if __breakpoint_show_start(0) {__breakpoint_show_start_handle(0, (:)); };
         __bp_functor(__it); } }
         ");
+    }
+
+    struct NoopHandler;
+
+    impl DebugSessionHandler for NoopHandler {
+        fn on_breakpoint(
+            &self,
+            _engine: &Engine,
+            _context: Tracked<Context>,
+            _scopes: Scopes,
+            _span: Span,
+            _kind: BreakpointKind,
+        ) {
+        }
+    }
+
+    #[test]
+    fn test_source_breakpoint_resolves_to_block_start() {
+        let source = Source::detached(
+            r#"#let answer = {
+  let x = 40
+  x + 2
+}
+#answer"#,
+        );
+        let (_new, meta) = instrument_breakpoints(source.clone()).unwrap();
+        let mut session = DebugSession::new(Arc::new(NoopHandler));
+        session.breakpoints.insert(source.id(), meta);
+
+        let resolutions = session.set_source_breakpoints_for(
+            &source,
+            vec![SourceBreakpoint {
+                line: 1,
+                column: None,
+            }],
+        );
+
+        assert_eq!(resolutions.len(), 1);
+        let resolved = resolutions[0].resolved.unwrap();
+        assert_eq!(resolved.kind, BreakpointKind::BlockStart);
+        assert_eq!(resolved.line, 0);
     }
 }

--- a/crates/tinymist-debug/src/lib.rs
+++ b/crates/tinymist-debug/src/lib.rs
@@ -2,8 +2,9 @@
 
 pub use cov::CoverageResult;
 pub use debugger::{
-    BreakpointKind, DebugSession, DebugSessionHandler, set_debug_function_breakpoints,
-    set_debug_session, with_debug_session,
+    BreakpointKind, DebugSession, DebugSessionHandler, ResolvedSourceBreakpoint, SourceBreakpoint,
+    SourceBreakpointResolution, set_debug_function_breakpoints, set_debug_session,
+    set_debug_source_breakpoints, with_debug_session,
 };
 
 mod cov;

--- a/crates/tinymist/src/dap.rs
+++ b/crates/tinymist/src/dap.rs
@@ -4,6 +4,8 @@ mod event;
 mod init;
 mod request;
 
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dapts::StoppedEventReason;
@@ -28,6 +30,7 @@ use crate::{ConstDapConfig, ServerState};
 pub(crate) struct DebugState {
     pub(crate) session: Option<DebugSession>,
     pub(crate) function_breakpoints: Vec<String>,
+    pub(crate) source_breakpoints: HashMap<PathBuf, Vec<tinymist_debug::SourceBreakpoint>>,
 }
 
 impl DebugState {
@@ -151,8 +154,7 @@ impl DebugAdaptor for Debuggee {
         // this.sendResponse(response);
         // }
 
-        // Since we haven't implemented breakpoints, we can only stop intermediately and
-        // response completions in repl console.
+        // Stop at the end of compilation so the REPL can inspect module scope.
         self.client
             .send_dap_event::<dapts::event::Stopped>(dapts::StoppedEvent {
                 all_threads_stopped: Some(true),

--- a/crates/tinymist/src/dap/request.rs
+++ b/crates/tinymist/src/dap/request.rs
@@ -1,6 +1,10 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use dapts::{ProcessEventStartMethod, ThreadEventReason};
+use dapts::{BreakpointReason, ProcessEventStartMethod, ThreadEventReason};
+use lsp_types::Url;
 use reflexo::ImmutPath;
 use reflexo_typst::{EntryReader, TaskInputs};
 use serde::Deserialize;
@@ -152,14 +156,23 @@ impl ServerState {
             adaptor.clone(),
             adaptor_rx,
             self.debug.function_breakpoints.clone(),
+            self.debug
+                .source_breakpoints
+                .iter()
+                .filter_map(|(path, breakpoints)| {
+                    Some((
+                        snapshot.world.file_id_by_path(path).ok()?,
+                        breakpoints.clone(),
+                    ))
+                })
+                .collect(),
         );
 
         self.debug.session = Some(DebugSession {
             config: self.config.const_dap_config.clone(),
             adaptor,
             snapshot,
-            // Since we haven't implemented breakpoints, we can only stop intermediately and
-            // response completions in repl console.
+            // Keep the main source and EOF position as the fallback stack frame.
             source,
             position: main_eof,
         });
@@ -184,6 +197,114 @@ impl ServerState {
 }
 
 impl ServerState {
+    pub(crate) fn set_breakpoints(
+        &mut self,
+        args: dapts::SetBreakpointsArguments,
+    ) -> SchedulableResponse<dapts::SetBreakpointsResponse> {
+        let requested = source_breakpoints_from_args(args.breakpoints, args.lines);
+        let Some(path) = self.dap_source_path(&args.source) else {
+            return just_ok(dapts::SetBreakpointsResponse {
+                breakpoints: requested
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, breakpoint)| {
+                        failed_source_breakpoint(
+                            idx,
+                            &args.source,
+                            breakpoint.line,
+                            breakpoint.column,
+                            "source breakpoints require source.path",
+                        )
+                    })
+                    .collect(),
+            });
+        };
+
+        let mut unsupported = Vec::with_capacity(requested.len());
+        let mut source_breakpoints = Vec::new();
+        for breakpoint in &requested {
+            let unsupported_message = unsupported_source_breakpoint_message(breakpoint);
+            unsupported.push(unsupported_message);
+
+            if unsupported_message.is_none() {
+                source_breakpoints.push(tinymist_debug::SourceBreakpoint {
+                    line: self.dap_line_to_zero_based(breakpoint.line),
+                    column: breakpoint
+                        .column
+                        .map(|column| self.dap_column_to_zero_based(column)),
+                });
+            }
+        }
+
+        if source_breakpoints.is_empty() {
+            self.debug.source_breakpoints.remove(&path);
+        } else {
+            self.debug
+                .source_breakpoints
+                .insert(path.clone(), source_breakpoints.clone());
+        }
+
+        let active_resolutions = self
+            .debug
+            .session
+            .as_ref()
+            .and_then(|session| session.snapshot.world.source_by_path(&path).ok())
+            .and_then(|source| {
+                tinymist_debug::set_debug_source_breakpoints(source, source_breakpoints.clone())
+            });
+        let mut active_resolutions = active_resolutions.into_iter().flatten();
+
+        let breakpoints = requested
+            .iter()
+            .zip(unsupported)
+            .enumerate()
+            .map(|(idx, (breakpoint, unsupported_message))| {
+                if let Some(message) = unsupported_message {
+                    return failed_source_breakpoint(
+                        idx,
+                        &args.source,
+                        breakpoint.line,
+                        breakpoint.column,
+                        message,
+                    );
+                }
+
+                let Some(resolution) = active_resolutions.next() else {
+                    return pending_source_breakpoint(idx, &args.source, breakpoint);
+                };
+
+                let Some(resolved) = resolution.resolved else {
+                    if resolution.pending {
+                        return pending_source_breakpoint(idx, &args.source, breakpoint);
+                    }
+
+                    return failed_source_breakpoint(
+                        idx,
+                        &args.source,
+                        breakpoint.line,
+                        breakpoint.column,
+                        "no block/function breakpoint location found near this line",
+                    );
+                };
+
+                dapts::Breakpoint {
+                    id: Some((idx + 1) as u64),
+                    line: Some(self.zero_based_line_to_dap(resolved.line)),
+                    column: Some(self.zero_based_column_to_dap(resolved.column)),
+                    message: Some(format!(
+                        "Mapped to nearest Typst {} breakpoint",
+                        resolved.kind.to_str()
+                    )),
+                    source: Some(args.source.clone()),
+                    verified: true,
+                    ..dapts::Breakpoint::default()
+                }
+            })
+            .collect();
+
+        just_ok(dapts::SetBreakpointsResponse { breakpoints })
+    }
+
     pub(crate) fn set_function_breakpoints(
         &mut self,
         args: dapts::SetFunctionBreakpointsArguments,
@@ -209,6 +330,128 @@ impl ServerState {
                 })
                 .collect(),
         })
+    }
+}
+
+impl ServerState {
+    fn dap_source_path(&self, source: &dapts::Source) -> Option<PathBuf> {
+        let path = source.path.as_ref()?;
+        match self.config.const_dap_config.path_format {
+            crate::DapPathFormat::Uri => {
+                let uri = Url::parse(path).ok()?;
+                Some(tinymist_query::url_to_path(&uri))
+            }
+            crate::DapPathFormat::Path | crate::DapPathFormat::Unknown => Some(PathBuf::from(path)),
+            _ => Some(PathBuf::from(path)),
+        }
+    }
+
+    fn dap_line_to_zero_based(&self, line: u32) -> u32 {
+        if self.config.const_dap_config.lines_start_at1 {
+            line.saturating_sub(1)
+        } else {
+            line
+        }
+    }
+
+    fn dap_column_to_zero_based(&self, column: u32) -> u32 {
+        if self.config.const_dap_config.columns_start_at1 {
+            column.saturating_sub(1)
+        } else {
+            column
+        }
+    }
+
+    fn zero_based_line_to_dap(&self, line: u32) -> u32 {
+        if self.config.const_dap_config.lines_start_at1 {
+            line.saturating_add(1)
+        } else {
+            line
+        }
+    }
+
+    fn zero_based_column_to_dap(&self, column: u32) -> u32 {
+        if self.config.const_dap_config.columns_start_at1 {
+            column.saturating_add(1)
+        } else {
+            column
+        }
+    }
+}
+
+fn source_breakpoints_from_args(
+    breakpoints: Option<Vec<dapts::SourceBreakpoint>>,
+    lines: Option<Vec<u64>>,
+) -> Vec<dapts::SourceBreakpoint> {
+    if let Some(breakpoints) = breakpoints {
+        return breakpoints;
+    }
+
+    lines
+        .unwrap_or_default()
+        .into_iter()
+        .map(|line| dapts::SourceBreakpoint {
+            column: None,
+            condition: None,
+            hit_condition: None,
+            line: line.min(u32::MAX as u64) as u32,
+            log_message: None,
+            mode: None,
+        })
+        .collect()
+}
+
+fn unsupported_source_breakpoint_message(
+    breakpoint: &dapts::SourceBreakpoint,
+) -> Option<&'static str> {
+    if breakpoint.condition.is_some() {
+        return Some("conditional source breakpoints are not supported");
+    }
+    if breakpoint.hit_condition.is_some() {
+        return Some("hit-count source breakpoints are not supported");
+    }
+    if breakpoint.log_message.is_some() {
+        return Some("logpoints are not supported");
+    }
+    if breakpoint.mode.is_some() {
+        return Some("breakpoint modes are not supported");
+    }
+
+    None
+}
+
+fn pending_source_breakpoint(
+    idx: usize,
+    source: &dapts::Source,
+    breakpoint: &dapts::SourceBreakpoint,
+) -> dapts::Breakpoint {
+    dapts::Breakpoint {
+        id: Some((idx + 1) as u64),
+        line: Some(breakpoint.line),
+        column: breakpoint.column,
+        message: Some("Line breakpoint will bind to the nearest Typst block/function hook".into()),
+        source: Some(source.clone()),
+        verified: true,
+        ..dapts::Breakpoint::default()
+    }
+}
+
+fn failed_source_breakpoint(
+    idx: usize,
+    source: &dapts::Source,
+    line: u32,
+    column: Option<u32>,
+    message: impl Into<String>,
+) -> dapts::Breakpoint {
+    dapts::Breakpoint {
+        id: Some((idx + 1) as u64),
+        line: Some(line),
+        column,
+        message: Some(message.into()),
+        reason: Some(BreakpointReason::Failed),
+        source: Some(source.clone()),
+        verified: false,
+        ..dapts::Breakpoint::default()
     }
 }
 

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -379,6 +379,7 @@ impl ServerState {
             .with_request::<request::TerminateThreads>(Self::terminate_debug_thread)
             .with_request::<request::Attach>(Self::attach_debug)
             .with_request::<request::Launch>(Self::launch_debug)
+            .with_request::<request::SetBreakpoints>(Self::set_breakpoints)
             .with_request::<request::SetFunctionBreakpoints>(Self::set_function_breakpoints)
             .with_request_::<request::Evaluate>(Self::evaluate_repl)
             .with_request::<request::Completions>(Self::complete_repl)

--- a/editors/neovim/spec/dap_spec.lua
+++ b/editors/neovim/spec/dap_spec.lua
@@ -213,4 +213,94 @@ describe('DAP breakpoints', function()
     assert.are.same(1, function_stack.line)
     assert.are.same(program, function_stack.source.path)
   end)
+
+  it('maps a source line breakpoint to a structural block breakpoint', function()
+    local root, program = prepare_program('source-line-breakpoint', {
+      '#let answer = {',
+      '  let x = 40',
+      '  x + 2',
+      '}',
+      '#answer',
+    })
+    local key = 'tinymist-dap-source-line-breakpoint'
+    local stopped = {}
+    local configured = false
+    local breakpoint_stack
+    local end_value
+    local failure
+
+    cleanup_listener(key)
+    dap.listeners.after.event_stopped[key] = function(session, body)
+      stopped[#stopped + 1] = body.reason or '<unknown>'
+
+      if body.reason == 'entry' then
+        request(session, 'setBreakpoints', {
+          source = { path = program },
+          breakpoints = {
+            { line = 2 },
+          },
+        }, function(err, response)
+          failure = failure or err
+          configured = response
+            and response.breakpoints
+            and response.breakpoints[1]
+            and response.breakpoints[1].verified
+            or false
+          continue_debug(session, body.threadId, function(continue_err)
+            failure = failure or continue_err
+          end)
+        end)
+        return
+      end
+
+      if body.reason == 'breakpoint' then
+        request(session, 'stackTrace', {
+          threadId = body.threadId or 1,
+        }, function(err, response)
+          failure = failure or err
+          breakpoint_stack = response and response.stackFrames and response.stackFrames[1] or breakpoint_stack
+          continue_debug(session, body.threadId, function(continue_err)
+            failure = failure or continue_err
+          end)
+        end)
+        return
+      end
+
+      if body.reason == 'pause' then
+        request(session, 'evaluate', {
+          expression = 'answer',
+          context = 'repl',
+          frameId = 1,
+        }, function(err, response)
+          failure = failure or err
+          end_value = response and response.result or end_value
+        end)
+      end
+    end
+
+    dap.run {
+      type = 'tinymist',
+      request = 'launch',
+      name = 'Tinymist source line breakpoint DAP spec',
+      program = program,
+      root = root,
+      stopOnEntry = true,
+    }
+
+    local ok = vim.wait(20000, function()
+      return failure ~= nil or end_value ~= nil
+    end, 50)
+
+    cleanup_listener(key)
+    finish_session()
+
+    assert.message(('timed out waiting for source breakpoint flow; stopped=%s'):format(vim.inspect(stopped))).is_true(ok)
+    assert.message(failure or 'source breakpoint DAP flow failed').is_nil(failure)
+    assert.is_true(configured)
+    assert.are.same('42', end_value)
+    assert.are.same({ 'entry', 'breakpoint', 'pause' }, stopped)
+    assert.is_not_nil(breakpoint_stack)
+    assert.are.same(1, breakpoint_stack.line)
+    assert.are.same(program, breakpoint_stack.source.path)
+  end)
 end)


### PR DESCRIPTION
Adds DAP setBreakpoints handling for Typst source line breakpoints. Maps requested lines to existing function/block/show breakpoint hooks instead of adding line-level instrumentation. Adds Neovim DAP coverage for the mapped breakpoint flow.