### PR TITLE
feat(dap): add scopes and stack frames

### DIFF
--- a/crates/tinymist-dap/src/lib.rs
+++ b/crates/tinymist-dap/src/lib.rs
@@ -16,7 +16,10 @@
 
 pub use tinymist_debug::BreakpointKind;
 
-use std::sync::{Arc, mpsc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, mpsc},
+};
 
 use comemo::Track;
 use comemo::Tracked;
@@ -28,7 +31,7 @@ use typst::{
     __bail as bail, World,
     diag::{SourceResult, Warned},
     engine::{Engine, Route, Sink, Traced},
-    foundations::{Context, Scopes, Value},
+    foundations::{Binding, Context, Repr, Scope, Scopes, Value},
     introspection::EmptyIntrospector,
     syntax::{Span, ast, parse_code},
 };
@@ -40,8 +43,138 @@ type RequestId = i64;
 pub enum DebugRequest {
     /// Evaluates an expression.
     Evaluate(RequestId, String),
+    /// Retrieves stack frames.
+    StackTrace(RequestId, DebugStackTraceArguments),
+    /// Retrieves variable scopes for a stack frame.
+    Scopes(RequestId, DebugScopesArguments),
+    /// Retrieves variables for a variables reference.
+    Variables(RequestId, DebugVariablesArguments),
     /// Continues the execution.
     Continue,
+}
+
+/// Arguments for a stack trace request.
+#[derive(Debug, Clone, Default)]
+pub struct DebugStackTraceArguments {
+    /// The index of the first frame to return.
+    pub start_frame: Option<u64>,
+    /// The maximum number of frames to return. `None` or zero means all frames.
+    pub levels: Option<u64>,
+}
+
+/// Arguments for a scopes request.
+#[derive(Debug, Clone)]
+pub struct DebugScopesArguments {
+    /// The requested frame id.
+    pub frame_id: u64,
+}
+
+/// Arguments for a variables request.
+#[derive(Debug, Clone)]
+pub struct DebugVariablesArguments {
+    /// The requested variables reference.
+    pub variables_reference: u32,
+    /// The index of the first variable to return.
+    pub start: Option<u64>,
+    /// The maximum number of variables to return. `None` or zero means all variables.
+    pub count: Option<u64>,
+    /// Optional child filter.
+    pub filter: Option<DebugVariablesFilter>,
+}
+
+/// Variable child filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugVariablesFilter {
+    /// Return indexed children.
+    Indexed,
+    /// Return named children.
+    Named,
+}
+
+/// Result type for debugger data requests.
+pub type DebugResult<T> = Result<T, String>;
+
+/// A stack trace response.
+#[derive(Debug, Clone, Default)]
+pub struct DebugStackTraceResponse {
+    /// Stack frames available for the current pause.
+    pub stack_frames: Vec<DebugStackFrame>,
+    /// The total number of frames available before paging.
+    pub total_frames: u64,
+}
+
+/// A stack frame.
+#[derive(Debug, Clone)]
+pub struct DebugStackFrame {
+    /// Stable frame id for the current pause.
+    pub id: u64,
+    /// Frame display name.
+    pub name: String,
+    /// Source span for the frame.
+    pub span: Span,
+    /// Breakpoint kind that produced this frame.
+    pub kind: BreakpointKind,
+}
+
+/// A scopes response.
+#[derive(Debug, Clone, Default)]
+pub struct DebugScopesResponse {
+    /// Scopes available for the requested frame.
+    pub scopes: Vec<DebugScope>,
+}
+
+/// A variable scope.
+#[derive(Debug, Clone)]
+pub struct DebugScope {
+    /// Scope display name.
+    pub name: String,
+    /// Variables reference for the scope.
+    pub variables_reference: u32,
+    /// Number of named variables.
+    pub named_variables: Option<u32>,
+    /// Number of indexed variables.
+    pub indexed_variables: Option<u32>,
+    /// Whether variables in this scope are expensive to fetch.
+    pub expensive: bool,
+    /// Optional scope presentation hint.
+    pub presentation_hint: Option<DebugScopePresentationHint>,
+    /// Source span covered by this scope, if known.
+    pub span: Span,
+}
+
+/// Scope presentation hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugScopePresentationHint {
+    /// Scope contains function arguments.
+    Arguments,
+    /// Scope contains local variables.
+    Locals,
+}
+
+/// A variables response.
+#[derive(Debug, Clone, Default)]
+pub struct DebugVariablesResponse {
+    /// Variables returned for the requested reference.
+    pub variables: Vec<DebugVariable>,
+}
+
+/// A variable.
+#[derive(Debug, Clone)]
+pub struct DebugVariable {
+    /// Variable display name.
+    pub name: String,
+    /// Variable value representation.
+    pub value: String,
+    /// Variable type representation.
+    pub ty: Option<String>,
+    /// Child variables reference, or zero if this value has no children.
+    pub variables_reference: u32,
+    /// Number of named child variables.
+    pub named_variables: Option<u32>,
+    /// Number of indexed child variables.
+    pub indexed_variables: Option<u32>,
+    /// Evaluatable expression for this variable.
+    pub evaluate_name: Option<String>,
 }
 
 /// A handler for debug events.
@@ -54,8 +187,14 @@ pub trait DebugAdaptor: Send + Sync {
     fn terminate(&self);
     /// Responds to a debug request.
     fn stopped(&self, ctx: &BreakpointContext);
-    /// Responds to a debug request.
-    fn respond(&self, id: RequestId, result: SourceResult<Value>);
+    /// Responds to an evaluate request.
+    fn respond_evaluate(&self, id: RequestId, result: SourceResult<Value>);
+    /// Responds to a stack trace request.
+    fn respond_stack_trace(&self, id: RequestId, result: DebugResult<DebugStackTraceResponse>);
+    /// Responds to a scopes request.
+    fn respond_scopes(&self, id: RequestId, result: DebugResult<DebugScopesResponse>);
+    /// Responds to a variables request.
+    fn respond_variables(&self, id: RequestId, result: DebugResult<DebugVariablesResponse>);
 }
 
 /// Starts a debug session.
@@ -163,6 +302,7 @@ fn step_global(kind: BreakpointKind, world: &dyn World) {
         scopes,
         span,
         kind,
+        function_name: None,
     };
 
     step(&context, resource.as_mut().unwrap());
@@ -177,12 +317,18 @@ pub struct BreakpointContext<'a, 'b, 'c> {
     context: Tracked<'a, Context<'b>>,
     scopes: Scopes<'a>,
     span: Span,
+    function_name: Option<String>,
 }
 
 impl BreakpointContext<'_, '_, '_> {
     /// The original source span that caused the breakpoint stop.
     pub fn source_span(&self) -> Span {
         self.span
+    }
+
+    /// The function name associated with this breakpoint, if known.
+    pub fn function_name(&self) -> Option<&str> {
+        self.function_name.as_deref()
     }
 
     fn evaluate(&self, expr: &str) -> SourceResult<Value> {
@@ -219,14 +365,318 @@ impl BreakpointContext<'_, '_, '_> {
     }
 }
 
+const CURRENT_FRAME_ID: u64 = 1;
+
+#[derive(Clone)]
+struct VariableEntry {
+    name: String,
+    value: Value,
+    evaluate_name: Option<String>,
+    indexed: bool,
+}
+
+#[derive(Clone)]
+struct VariableHandle {
+    variables: Vec<VariableEntry>,
+}
+
+struct ValueChildren {
+    variables: Vec<VariableEntry>,
+    named_variables: Option<u32>,
+    indexed_variables: Option<u32>,
+}
+
+struct PausedState {
+    frames: Vec<DebugStackFrame>,
+    scopes: HashMap<u64, Vec<DebugScope>>,
+    handles: Vec<VariableHandle>,
+}
+
+impl PausedState {
+    fn new(ctx: &BreakpointContext) -> Self {
+        let mut state = Self {
+            frames: vec![DebugStackFrame {
+                id: CURRENT_FRAME_ID,
+                name: frame_name(ctx),
+                span: ctx.span,
+                kind: ctx.kind,
+            }],
+            scopes: HashMap::new(),
+            handles: vec![],
+        };
+
+        let mut scopes = vec![];
+
+        let top_variables = collect_scope_variables(&ctx.scopes.top);
+        let (top_name, top_hint) = if matches!(ctx.kind, BreakpointKind::Function) {
+            ("Arguments", DebugScopePresentationHint::Arguments)
+        } else {
+            ("Locals", DebugScopePresentationHint::Locals)
+        };
+        scopes.push(state.scope(top_name, top_variables, false, Some(top_hint), ctx.span));
+
+        for (idx, scope) in ctx.scopes.scopes.iter().rev().enumerate() {
+            let variables = collect_scope_variables(scope);
+            if variables.is_empty() {
+                continue;
+            }
+
+            scopes.push(state.scope(
+                format!("Outer {}", idx + 1),
+                variables,
+                false,
+                Some(DebugScopePresentationHint::Locals),
+                ctx.span,
+            ));
+        }
+
+        if let Some(base) = ctx.scopes.base {
+            let mut variables = collect_scope_variables(base.global.scope());
+            variables.push(binding_variable("std", &base.std));
+            scopes.push(state.scope("Globals", variables, true, None, ctx.span));
+        }
+
+        state.scopes.insert(CURRENT_FRAME_ID, scopes);
+        state
+    }
+
+    fn scope(
+        &mut self,
+        name: impl Into<String>,
+        variables: Vec<VariableEntry>,
+        expensive: bool,
+        presentation_hint: Option<DebugScopePresentationHint>,
+        span: Span,
+    ) -> DebugScope {
+        let named_variables = count_variables(variables.iter().filter(|it| !it.indexed).count());
+        let indexed_variables = count_variables(variables.iter().filter(|it| it.indexed).count());
+        let variables_reference = self.add_handle(variables);
+
+        DebugScope {
+            name: name.into(),
+            variables_reference,
+            named_variables,
+            indexed_variables,
+            expensive,
+            presentation_hint,
+            span,
+        }
+    }
+
+    fn stack_trace(&self, args: DebugStackTraceArguments) -> DebugStackTraceResponse {
+        let start = args.start_frame.unwrap_or_default().min(usize::MAX as u64) as usize;
+        let count = args.levels.filter(|levels| *levels > 0);
+        let frames = paged(self.frames.iter().cloned(), start, count).collect();
+
+        DebugStackTraceResponse {
+            stack_frames: frames,
+            total_frames: self.frames.len().min(u64::MAX as usize) as u64,
+        }
+    }
+
+    fn scopes(&self, args: DebugScopesArguments) -> DebugResult<DebugScopesResponse> {
+        let Some(scopes) = self.scopes.get(&args.frame_id) else {
+            return Err(format!("unknown stack frame: {}", args.frame_id));
+        };
+
+        Ok(DebugScopesResponse {
+            scopes: scopes.clone(),
+        })
+    }
+
+    fn variables(&mut self, args: DebugVariablesArguments) -> DebugResult<DebugVariablesResponse> {
+        let Some(handle) = self.handle(args.variables_reference).cloned() else {
+            return Err(format!(
+                "unknown variables reference: {}",
+                args.variables_reference
+            ));
+        };
+
+        let start = args.start.unwrap_or_default().min(usize::MAX as u64) as usize;
+        let count = args.count.filter(|count| *count > 0);
+        let variables = paged(
+            handle
+                .variables
+                .into_iter()
+                .filter(|entry| match args.filter {
+                    Some(DebugVariablesFilter::Indexed) => entry.indexed,
+                    Some(DebugVariablesFilter::Named) => !entry.indexed,
+                    None => true,
+                }),
+            start,
+            count,
+        )
+        .map(|entry| self.variable(entry))
+        .collect();
+
+        Ok(DebugVariablesResponse { variables })
+    }
+
+    fn variable(&mut self, entry: VariableEntry) -> DebugVariable {
+        let children = value_children(&entry.value);
+        let (variables_reference, named_variables, indexed_variables) =
+            if let Some(children) = children {
+                (
+                    self.add_handle(children.variables),
+                    children.named_variables,
+                    children.indexed_variables,
+                )
+            } else {
+                (0, None, None)
+            };
+
+        DebugVariable {
+            name: entry.name,
+            value: entry.value.repr().to_string(),
+            ty: Some(entry.value.ty().repr().to_string()),
+            variables_reference,
+            named_variables,
+            indexed_variables,
+            evaluate_name: entry.evaluate_name,
+        }
+    }
+
+    fn add_handle(&mut self, variables: Vec<VariableEntry>) -> u32 {
+        self.handles.push(VariableHandle { variables });
+        self.handles.len().min(u32::MAX as usize) as u32
+    }
+
+    fn handle(&self, reference: u32) -> Option<&VariableHandle> {
+        let index = reference.checked_sub(1)? as usize;
+        self.handles.get(index)
+    }
+}
+
+fn frame_name(ctx: &BreakpointContext) -> String {
+    if let Some(name) = ctx.function_name() {
+        return name.to_owned();
+    }
+
+    match ctx.kind {
+        BreakpointKind::BeforeCompile => "document start".into(),
+        BreakpointKind::AfterCompile => "document end".into(),
+        BreakpointKind::Function => "function".into(),
+        BreakpointKind::BlockStart | BreakpointKind::BlockEnd => "block".into(),
+        BreakpointKind::ShowStart | BreakpointKind::ShowEnd => "show rule".into(),
+        kind => kind.to_str().replace('_', " "),
+    }
+}
+
+fn collect_scope_variables(scope: &Scope) -> Vec<VariableEntry> {
+    scope
+        .iter()
+        .map(|(name, binding)| binding_variable(name.as_str(), binding))
+        .collect()
+}
+
+fn binding_variable(name: &str, binding: &Binding) -> VariableEntry {
+    VariableEntry {
+        name: name.to_owned(),
+        value: binding.read().clone(),
+        evaluate_name: Some(name.to_owned()),
+        indexed: false,
+    }
+}
+
+fn value_children(value: &Value) -> Option<ValueChildren> {
+    match value {
+        Value::Array(array) => {
+            let variables = array
+                .iter()
+                .enumerate()
+                .map(|(idx, value)| VariableEntry {
+                    name: idx.to_string(),
+                    value: value.clone(),
+                    evaluate_name: None,
+                    indexed: true,
+                })
+                .collect::<Vec<_>>();
+            if variables.is_empty() {
+                return None;
+            }
+
+            Some(ValueChildren {
+                indexed_variables: count_variables(variables.len()),
+                named_variables: None,
+                variables,
+            })
+        }
+        Value::Dict(dict) => {
+            let variables = dict
+                .iter()
+                .map(|(name, value)| VariableEntry {
+                    name: name.as_str().to_owned(),
+                    value: value.clone(),
+                    evaluate_name: None,
+                    indexed: false,
+                })
+                .collect::<Vec<_>>();
+            if variables.is_empty() {
+                return None;
+            }
+
+            Some(ValueChildren {
+                named_variables: count_variables(variables.len()),
+                indexed_variables: None,
+                variables,
+            })
+        }
+        value => {
+            let scope = value.scope()?;
+            let variables = collect_scope_variables(scope);
+            if variables.is_empty() {
+                return None;
+            }
+
+            Some(ValueChildren {
+                named_variables: count_variables(variables.len()),
+                indexed_variables: None,
+                variables,
+            })
+        }
+    }
+}
+
+fn count_variables(count: usize) -> Option<u32> {
+    if count == 0 {
+        None
+    } else {
+        Some(count.min(u32::MAX as usize) as u32)
+    }
+}
+
+fn paged<T>(
+    iter: impl Iterator<Item = T>,
+    start: usize,
+    count: Option<u64>,
+) -> impl Iterator<Item = T> {
+    iter.skip(start)
+        .take(count.unwrap_or(u64::MAX).min(usize::MAX as u64) as usize)
+}
+
 fn step(ctx: &BreakpointContext, resource: &mut Resource) {
+    let mut state = PausedState::new(ctx);
+
     resource.adaptor.stopped(ctx);
     loop {
         match resource.rx.recv() {
             Ok(DebugRequest::Evaluate(id, expr)) => {
                 let res = ctx.evaluate(&expr);
                 eprintln!("evaluate: {expr} => {res:?}");
-                resource.adaptor.respond(id, res);
+                resource.adaptor.respond_evaluate(id, res);
+            }
+            Ok(DebugRequest::StackTrace(id, args)) => {
+                resource
+                    .adaptor
+                    .respond_stack_trace(id, Ok(state.stack_trace(args)));
+            }
+            Ok(DebugRequest::Scopes(id, args)) => {
+                resource.adaptor.respond_scopes(id, state.scopes(args));
+            }
+            Ok(DebugRequest::Variables(id, args)) => {
+                resource
+                    .adaptor
+                    .respond_variables(id, state.variables(args));
             }
             Ok(DebugRequest::Continue) => {
                 break;
@@ -248,6 +698,7 @@ impl DebugSessionHandler for DebugContext {
         scopes: Scopes,
         span: Span,
         kind: BreakpointKind,
+        function_name: Option<String>,
     ) {
         let mut resource = RESOURCES.lock();
         let context = BreakpointContext {
@@ -256,6 +707,7 @@ impl DebugSessionHandler for DebugContext {
             scopes,
             span,
             kind,
+            function_name,
         };
         step(&context, resource.as_mut().unwrap());
     }

--- a/crates/tinymist-debug/src/debugger.rs
+++ b/crates/tinymist-debug/src/debugger.rs
@@ -136,6 +136,7 @@ pub trait DebugSessionHandler: Send + Sync {
         scopes: Scopes,
         span: Span,
         kind: BreakpointKind,
+        function_name: Option<String>,
     );
 }
 
@@ -363,6 +364,7 @@ fn is_source_breakpoint_target(kind: BreakpointKind) -> bool {
         BreakpointKind::Function
             | BreakpointKind::BlockStart
             | BreakpointKind::ShowStart
+            | BreakpointKind::Return
             | BreakpointKind::BlockEnd
     )
 }
@@ -372,8 +374,9 @@ fn source_breakpoint_kind_priority(kind: BreakpointKind) -> u8 {
         BreakpointKind::Function => 0,
         BreakpointKind::BlockStart => 1,
         BreakpointKind::ShowStart => 2,
-        BreakpointKind::BlockEnd => 3,
-        _ => 4,
+        BreakpointKind::Return => 3,
+        BreakpointKind::BlockEnd => 4,
+        _ => 5,
     }
 }
 
@@ -441,7 +444,7 @@ fn soft_breakpoint_handle(
 ) -> Option<()> {
     let fid = span.id()?;
 
-    let (handler, origin_span) = {
+    let (handler, origin_span, function_name) = {
         let session = DEBUG_SESSION.read();
         let session = session.as_ref()?;
 
@@ -451,7 +454,11 @@ fn soft_breakpoint_handle(
         }
 
         let item = session.breakpoints.get(&fid)?.meta.get(id)?;
-        (session.handler.clone(), item.origin_span)
+        (
+            session.handler.clone(),
+            item.origin_span,
+            item.function_name.clone(),
+        )
     };
 
     let mut scopes = Scopes::new(Some(engine.world.library()));
@@ -461,7 +468,7 @@ fn soft_breakpoint_handle(
         }
     }
 
-    handler.on_breakpoint(engine, context, scopes, origin_span, kind);
+    handler.on_breakpoint(engine, context, scopes, origin_span, kind, function_name);
     Some(())
 }
 

--- a/crates/tinymist-debug/src/debugger/instr.rs
+++ b/crates/tinymist-debug/src/debugger/instr.rs
@@ -92,6 +92,10 @@ impl InstrumentWorker {
                     }
                     return;
                 }
+                ast::Expr::FuncReturn(ret) => {
+                    self.instrument_return(node, ret);
+                    return;
+                }
                 ast::Expr::Text(..)
                 | ast::Expr::Space(..)
                 | ast::Expr::Linebreak(..)
@@ -145,8 +149,7 @@ impl InstrumentWorker {
                 | ast::Expr::ModuleImport(..)
                 | ast::Expr::ModuleInclude(..)
                 | ast::Expr::LoopBreak(..)
-                | ast::Expr::LoopContinue(..)
-                | ast::Expr::FuncReturn(..) => {}
+                | ast::Expr::LoopContinue(..) => {}
             }
         }
 
@@ -227,6 +230,24 @@ impl InstrumentWorker {
         self.instrumented.push_str("__bp_functor(__it); } }\n");
     }
 
+    fn instrument_return(&mut self, node: &SyntaxNode, ret: ast::FuncReturn) {
+        self.instrumented.push_str("{\n");
+
+        if let Some(body) = ret.body() {
+            self.instrumented.push_str("let __tinymist_return_value = ");
+            self.visit_node(body.to_untyped());
+            self.instrumented.push_str(";\n");
+            self.make_cov(node.span(), BreakpointKind::Return);
+            self.instrumented
+                .push_str("return __tinymist_return_value\n");
+        } else {
+            self.make_cov(node.span(), BreakpointKind::Return);
+            self.instrumented.push_str("return\n");
+        }
+
+        self.instrumented.push_str("}\n");
+    }
+
     fn instrument_closure(&mut self, node: &SyntaxNode, closure: ast::Closure) {
         let body = closure.body().span();
         let name = closure.name();
@@ -243,7 +264,17 @@ impl InstrumentWorker {
                     &scope,
                     function_name.clone(),
                 );
-                self.visit_node(child);
+                let body_is_code_block = is_code_block(child);
+                if body_is_code_block {
+                    self.visit_node(child);
+                    self.instrumented.push('\n');
+                } else {
+                    self.instrumented.push('(');
+                    self.visit_node(child);
+                    self.instrumented.push(')');
+                    self.instrumented.push_str(";\n");
+                }
+                self.make_cov(body, BreakpointKind::Return);
                 self.instrumented.push_str("\n}\n");
             } else {
                 self.visit_node(child);
@@ -294,6 +325,10 @@ impl InstrumentWorker {
             bindings.push(binding.to_owned());
         }
     }
+}
+
+fn is_code_block(node: &SyntaxNode) -> bool {
+    matches!(node.cast::<ast::Expr>(), Some(ast::Expr::CodeBlock(_)))
 }
 
 #[cfg(test)]
@@ -350,16 +385,20 @@ mod tests {
         if __breakpoint_block_end(8) {__breakpoint_block_end_handle(8, (:)); };
         }
 
+        if __breakpoint_return(9) {__breakpoint_return_handle(9, (:)); };
+
         }
 
-        __it => {if __breakpoint_show_start(9) {__breakpoint_show_start_handle(9, (:)); };
+        __it => {if __breakpoint_show_start(10) {__breakpoint_show_start_handle(10, (:)); };
         __bp_functor(__it); } }
 
 
           document
         }
-        if __breakpoint_block_end(10) {__breakpoint_block_end_handle(10, (:)); };
+        if __breakpoint_block_end(11) {__breakpoint_block_end_handle(11, (:)); };
         }
+
+        if __breakpoint_return(12) {__breakpoint_return_handle(12, (:)); };
 
         }
         "#);
@@ -400,17 +439,69 @@ mod tests {
         );
         let (new, _meta) = instrument_breakpoints(source).unwrap();
         assert!(new.root().errors_and_warnings().0.is_empty());
-        insta::assert_snapshot!(new.text(), @r###"
+        insta::assert_snapshot!(new.text(), @r"
         #let add(x, y: 1, ..rest) = {
         if __breakpoint_function(0) {__breakpoint_function_handle(0, (x: x, y: y, rest: rest)); };
-        x + y
+        (x + y);
+        if __breakpoint_return(1) {__breakpoint_return_handle(1, (:)); };
+
         }
 
         #let inc = value => {
-        if __breakpoint_function(1) {__breakpoint_function_handle(1, (value: value)); };
-        value + 1
+        if __breakpoint_function(2) {__breakpoint_function_handle(2, (value: value)); };
+        (value + 1);
+        if __breakpoint_return(3) {__breakpoint_return_handle(3, (:)); };
+
         }
-        "###);
+        ");
+    }
+
+    #[test]
+    fn test_instrument_breakpoint_return() {
+        let source = Source::detached(
+            r#"#let f(x) = {
+  if x == 1 {
+    return x + 1
+  }
+  g(return)
+}
+"#,
+        );
+        let (new, _meta) = instrument_breakpoints(source).unwrap();
+        let errors = new.root().errors_and_warnings().0;
+        assert!(errors.is_empty(), "{errors:#?}\n{}", new.text());
+        insta::assert_snapshot!(new.text(), @r"
+        #let f(x) = {
+        if __breakpoint_function(0) {__breakpoint_function_handle(0, (x: x)); };
+        {
+        if __breakpoint_block_start(1) {__breakpoint_block_start_handle(1, (:)); };
+        {
+          if x == 1 {
+        if __breakpoint_block_start(2) {__breakpoint_block_start_handle(2, (:)); };
+        {
+            {
+        let __tinymist_return_value = x + 1;
+        if __breakpoint_return(3) {__breakpoint_return_handle(3, (:)); };
+        return __tinymist_return_value
+        }
+
+          }
+        if __breakpoint_block_end(4) {__breakpoint_block_end_handle(4, (:)); };
+        }
+
+          g({
+        if __breakpoint_return(5) {__breakpoint_return_handle(5, (:)); };
+        return
+        }
+        )
+        }
+        if __breakpoint_block_end(6) {__breakpoint_block_end_handle(6, (:)); };
+        }
+
+        if __breakpoint_return(7) {__breakpoint_return_handle(7, (:)); };
+
+        }
+        ");
     }
 
     #[test]
@@ -435,6 +526,7 @@ mod tests {
             _scopes: Scopes,
             _span: Span,
             _kind: BreakpointKind,
+            _function_name: Option<String>,
         ) {
         }
     }

--- a/crates/tinymist/src/dap.rs
+++ b/crates/tinymist/src/dap.rs
@@ -16,12 +16,17 @@ use reflexo_typst::vfs::PathResolution;
 use reflexo_typst::TypstPagedDocument;
 use serde::{Deserialize, Serialize};
 use sync_ls::{invalid_request, LspClient, LspResult};
-use tinymist_dap::{BreakpointContext, DebugAdaptor, DebugRequest};
+use tinymist_dap::{
+    BreakpointContext, DebugAdaptor, DebugRequest, DebugResult, DebugScope,
+    DebugScopePresentationHint, DebugScopesResponse, DebugStackFrame, DebugStackTraceResponse,
+    DebugVariable, DebugVariablesResponse,
+};
 use tinymist_query::PositionEncoding;
 use typst::diag::{SourceResult, Warned};
 use typst::foundations::{Repr, Value};
 // use sync_lsp::RequestId;
 use typst::syntax::{FileId, Source, Span};
+use typst::{World, WorldExt};
 
 use crate::project::LspCompileSnapshot;
 use crate::{ConstDapConfig, ServerState};
@@ -107,7 +112,12 @@ pub struct DapPosition {
 
 struct Debuggee {
     tx: std::sync::mpsc::Sender<DebugRequest>,
-    current_span: Mutex<Option<Span>>,
+    config: ConstDapConfig,
+    snapshot: LspCompileSnapshot,
+    /// The main source file used for detached start/end frames.
+    source: Source,
+    /// The fallback position used for document-end frames.
+    position: usize,
     /// Whether the debugger should stop on entry.
     stop_on_entry: bool,
     /// A faked thread id. We don't support multiple threads, so we can use a
@@ -117,10 +127,171 @@ struct Debuggee {
     client: LspClient,
 }
 
+impl Debuggee {
+    fn respond_dap<T: Serialize>(&self, id: i64, result: DebugResult<T>) {
+        let req_id = sync_ls::RequestId::from(id as i32);
+        let response = match result {
+            Ok(body) => sync_ls::dap::Response::success(id, body),
+            Err(err) => sync_ls::dap::Response::error(id, Some(err), None),
+        };
+
+        self.client.respond(req_id, response.into());
+    }
+
+    fn to_dap_source(&self, id: FileId) -> dapts::Source {
+        use dapts::Source;
+        Source {
+            path: match self.snapshot.world.path_for_id(id).ok() {
+                Some(PathResolution::Resolved(path)) => Some(path.display().to_string()),
+                None | Some(PathResolution::Rootless(..)) => None,
+            },
+            ..Source::default()
+        }
+    }
+
+    fn to_dap_position(&self, pos: usize, source: &Source) -> DapPosition {
+        let mut lsp_pos = tinymist_query::to_lsp_position(pos, DAP_POS_ENCODING, source);
+
+        if self.config.lines_start_at1 {
+            lsp_pos.line += 1;
+        }
+        if self.config.columns_start_at1 {
+            lsp_pos.character += 1;
+        }
+
+        DapPosition {
+            line: lsp_pos.line as u64,
+            character: lsp_pos.character as u64,
+        }
+    }
+
+    fn fallback_position(&self, kind: tinymist_dap::BreakpointKind) -> usize {
+        if matches!(kind, tinymist_dap::BreakpointKind::BeforeCompile) {
+            0
+        } else {
+            self.position
+        }
+    }
+
+    fn frame_location(
+        &self,
+        span: Span,
+        kind: tinymist_dap::BreakpointKind,
+    ) -> (dapts::Source, DapPosition, Option<DapPosition>, u64) {
+        if let Some((source, start, end, line_count)) = self.span_location(span) {
+            return (source, start, Some(end), line_count);
+        }
+
+        let position = self.to_dap_position(self.fallback_position(kind), &self.source);
+        (
+            self.to_dap_source(self.source.id()),
+            position,
+            None,
+            self.source.text().lines().count().max(1) as u64,
+        )
+    }
+
+    fn scope_location(&self, span: Span) -> Option<(dapts::Source, DapPosition, DapPosition, u64)> {
+        self.span_location(span)
+    }
+
+    fn span_location(&self, span: Span) -> Option<(dapts::Source, DapPosition, DapPosition, u64)> {
+        let source = self.snapshot.world.source(span.id()?).ok()?;
+        let range = self.snapshot.world.range(span)?;
+        let start = self.to_dap_position(range.start, &source);
+        let end = self.to_dap_position(range.end, &source);
+        let line_count = source.text().lines().count().max(1) as u64;
+
+        Some((self.to_dap_source(source.id()), start, end, line_count))
+    }
+
+    fn clamp_line(&self, line: u64, line_count: u64) -> u32 {
+        let line = if self.config.lines_start_at1 {
+            line.clamp(1, line_count)
+        } else {
+            line.min(line_count.saturating_sub(1))
+        };
+
+        line.min(u32::MAX as u64) as u32
+    }
+
+    fn position_column(position: DapPosition) -> u32 {
+        position.character.min(u32::MAX as u64) as u32
+    }
+
+    fn stack_frame(&self, frame: DebugStackFrame) -> dapts::StackFrame {
+        let (source, start, end, line_count) = self.frame_location(frame.span, frame.kind);
+
+        dapts::StackFrame {
+            can_restart: Some(false),
+            column: Self::position_column(start),
+            end_column: end.map(Self::position_column),
+            end_line: end.map(|end| self.clamp_line(end.line, line_count)),
+            id: frame.id,
+            instruction_pointer_reference: None,
+            line: self.clamp_line(start.line, line_count),
+            module_id: None,
+            name: frame.name,
+            presentation_hint: Some(if frame.span.id().is_some() {
+                dapts::StackFramePresentationHint::Normal
+            } else {
+                dapts::StackFramePresentationHint::Subtle
+            }),
+            source: Some(source),
+        }
+    }
+
+    fn scope(&self, scope: DebugScope) -> dapts::Scope {
+        let location = self.scope_location(scope.span);
+        let (source, start, end, line_count) = match location {
+            Some(location) => {
+                let (source, start, end, line_count) = location;
+                (Some(source), Some(start), Some(end), Some(line_count))
+            }
+            None => (None, None, None, None),
+        };
+
+        dapts::Scope {
+            column: start.map(Self::position_column),
+            end_column: end.map(Self::position_column),
+            end_line: end
+                .zip(line_count)
+                .map(|(end, line_count)| self.clamp_line(end.line, line_count)),
+            expensive: scope.expensive,
+            indexed_variables: scope.indexed_variables,
+            line: start
+                .zip(line_count)
+                .map(|(start, line_count)| self.clamp_line(start.line, line_count)),
+            name: scope.name,
+            named_variables: scope.named_variables,
+            presentation_hint: scope.presentation_hint.map(|hint| match hint {
+                DebugScopePresentationHint::Arguments => dapts::ScopePresentationHint::Arguments,
+                DebugScopePresentationHint::Locals => dapts::ScopePresentationHint::Locals,
+            }),
+            source,
+            variables_reference: scope.variables_reference,
+        }
+    }
+
+    fn variable(&self, variable: DebugVariable) -> dapts::Variable {
+        dapts::Variable {
+            declaration_location_reference: None,
+            evaluate_name: variable.evaluate_name,
+            indexed_variables: variable.indexed_variables,
+            memory_reference: None,
+            name: variable.name,
+            named_variables: variable.named_variables,
+            presentation_hint: None,
+            ty: variable.ty,
+            value: variable.value,
+            value_location_reference: None,
+            variables_reference: variable.variables_reference,
+        }
+    }
+}
+
 impl DebugAdaptor for Debuggee {
     fn before_compile(&self) {
-        *self.current_span.lock() = None;
-
         if self.stop_on_entry {
             self.client
                 .send_dap_event::<dapts::event::Stopped>(dapts::StoppedEvent {
@@ -136,8 +307,6 @@ impl DebugAdaptor for Debuggee {
     }
 
     fn after_compile(&self, result: Warned<SourceResult<TypstPagedDocument>>) {
-        *self.current_span.lock() = None;
-
         // if args.compile_error {
         // simulate a compile/build error in "launch" request:
         // the error should not result in a modal dialog since 'showUser' is
@@ -172,11 +341,8 @@ impl DebugAdaptor for Debuggee {
     fn stopped(&self, ctx: &BreakpointContext) {
         let source_span = ctx.source_span();
         if source_span.id().is_none() {
-            *self.current_span.lock() = None;
             return;
         }
-
-        *self.current_span.lock() = Some(source_span);
 
         let reason = match ctx.kind {
             tinymist_dap::BreakpointKind::Function => StoppedEventReason::FunctionBreakpoint,
@@ -195,7 +361,7 @@ impl DebugAdaptor for Debuggee {
             });
     }
 
-    fn respond(&self, id: i64, result: SourceResult<Value>) {
+    fn respond_evaluate(&self, id: i64, result: SourceResult<Value>) {
         let req_id = sync_ls::RequestId::from(id as i32);
         let response = match result {
             Ok(val) => sync_ls::dap::Response::success(
@@ -210,5 +376,45 @@ impl DebugAdaptor for Debuggee {
         };
 
         self.client.respond(req_id, response.into());
+    }
+
+    fn respond_stack_trace(&self, id: i64, result: DebugResult<DebugStackTraceResponse>) {
+        self.respond_dap(
+            id,
+            result.map(|response| dapts::StackTraceResponse {
+                total_frames: Some(response.total_frames),
+                stack_frames: response
+                    .stack_frames
+                    .into_iter()
+                    .map(|frame| self.stack_frame(frame))
+                    .collect(),
+            }),
+        );
+    }
+
+    fn respond_scopes(&self, id: i64, result: DebugResult<DebugScopesResponse>) {
+        self.respond_dap(
+            id,
+            result.map(|response| dapts::ScopesResponse {
+                scopes: response
+                    .scopes
+                    .into_iter()
+                    .map(|scope| self.scope(scope))
+                    .collect(),
+            }),
+        );
+    }
+
+    fn respond_variables(&self, id: i64, result: DebugResult<DebugVariablesResponse>) {
+        self.respond_dap(
+            id,
+            result.map(|response| dapts::VariablesResponse {
+                variables: response
+                    .variables
+                    .into_iter()
+                    .map(|variable| self.variable(variable))
+                    .collect(),
+            }),
+        );
     }
 }

--- a/crates/tinymist/src/dap/request.rs
+++ b/crates/tinymist/src/dap/request.rs
@@ -11,7 +11,10 @@ use serde::Deserialize;
 use sync_ls::{
     internal_error, invalid_request, just_ok, RequestId, SchedulableResponse, ScheduledResult,
 };
-use tinymist_dap::DebugRequest;
+use tinymist_dap::{
+    DebugRequest, DebugScopesArguments, DebugStackTraceArguments, DebugVariablesArguments,
+    DebugVariablesFilter,
+};
 use tinymist_std::error::prelude::*;
 use typst::{World, WorldExt};
 
@@ -145,7 +148,10 @@ impl ServerState {
         let (adaptor_tx, adaptor_rx) = std::sync::mpsc::channel();
         let adaptor = Arc::new(Debuggee {
             tx: adaptor_tx,
-            current_span: Default::default(),
+            config: self.config.const_dap_config.clone(),
+            snapshot: snapshot.clone(),
+            source: source.clone(),
+            position: main_eof,
             stop_on_entry: args.stop_on_entry.unwrap_or_default(),
             thread_id: 1,
             client: self.client.clone().to_untyped(),
@@ -486,8 +492,9 @@ impl ServerState {
 
     pub(crate) fn debug_stack_trace(
         &mut self,
+        req_id: RequestId,
         args: dapts::StackTraceArguments,
-    ) -> SchedulableResponse<dapts::StackTraceResponse> {
+    ) -> ScheduledResult {
         let session = self.debug.session()?;
         if args.thread_id != session.adaptor.thread_id {
             return Err(invalid_request(format!(
@@ -496,46 +503,67 @@ impl ServerState {
             )));
         }
 
-        let current_span = *session.adaptor.current_span.lock();
-        let current_location = current_span.and_then(|span| {
-            let source = session.snapshot.world.source(span.id()?).ok()?;
-            Some((session.snapshot.world.range(span)?, source))
-        });
-        let (source, position, line_count) = if let Some((range, source)) = current_location {
-            (
-                session.to_dap_source(source.id()),
-                session.to_dap_position(range.start, &source),
-                source.text().lines().count().max(1) as u64,
-            )
-        } else {
-            (
-                session.to_dap_source(session.source.id()),
-                session.to_dap_position(session.position, &session.source),
-                session.source.text().lines().count().max(1) as u64,
-            )
-        };
-        let line = if session.config.lines_start_at1 {
-            position.line.clamp(1, line_count)
-        } else {
-            position.line.min(line_count.saturating_sub(1))
-        };
+        session
+            .adaptor
+            .tx
+            .send(DebugRequest::StackTrace(
+                RequestId::dap(req_id),
+                DebugStackTraceArguments {
+                    start_frame: args.start_frame,
+                    levels: args.levels,
+                },
+            ))
+            .map_err(|_| internal_error("debug session is closed"))?;
 
-        just_ok(dapts::StackTraceResponse {
-            stack_frames: vec![dapts::StackFrame {
-                can_restart: None,
-                column: position.character.min(u32::MAX as u64) as u32,
-                end_column: None,
-                end_line: None,
-                id: 1,
-                instruction_pointer_reference: None,
-                line: line.min(u32::MAX as u64) as u32,
-                module_id: None,
-                name: "main".into(),
-                presentation_hint: None,
-                source: Some(source),
-            }],
-            total_frames: Some(1),
-        })
+        Ok(Some(()))
+    }
+
+    pub(crate) fn debug_scopes(
+        &mut self,
+        req_id: RequestId,
+        args: dapts::ScopesArguments,
+    ) -> ScheduledResult {
+        let session = self.debug.session()?;
+
+        session
+            .adaptor
+            .tx
+            .send(DebugRequest::Scopes(
+                RequestId::dap(req_id),
+                DebugScopesArguments {
+                    frame_id: args.frame_id,
+                },
+            ))
+            .map_err(|_| internal_error("debug session is closed"))?;
+
+        Ok(Some(()))
+    }
+
+    pub(crate) fn debug_variables(
+        &mut self,
+        req_id: RequestId,
+        args: dapts::VariablesArguments,
+    ) -> ScheduledResult {
+        let session = self.debug.session()?;
+
+        session
+            .adaptor
+            .tx
+            .send(DebugRequest::Variables(
+                RequestId::dap(req_id),
+                DebugVariablesArguments {
+                    variables_reference: args.variables_reference,
+                    start: args.start,
+                    count: args.count,
+                    filter: args.filter.map(|filter| match filter {
+                        dapts::VariablesArgumentsFilter::Indexed => DebugVariablesFilter::Indexed,
+                        dapts::VariablesArgumentsFilter::Named => DebugVariablesFilter::Named,
+                    }),
+                },
+            ))
+            .map_err(|_| internal_error("debug session is closed"))?;
+
+        Ok(Some(()))
     }
 }
 

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -383,7 +383,9 @@ impl ServerState {
             .with_request::<request::SetFunctionBreakpoints>(Self::set_function_breakpoints)
             .with_request_::<request::Evaluate>(Self::evaluate_repl)
             .with_request::<request::Completions>(Self::complete_repl)
-            .with_request::<request::StackTrace>(Self::debug_stack_trace)
+            .with_request_::<request::StackTrace>(Self::debug_stack_trace)
+            .with_request_::<request::Scopes>(Self::debug_scopes)
+            .with_request_::<request::Variables>(Self::debug_variables)
             .with_request::<request::Threads>(Self::debug_threads)
     }
 

--- a/editors/neovim/spec/dap_spec.lua
+++ b/editors/neovim/spec/dap_spec.lua
@@ -16,6 +16,24 @@ local function request(session, command, args, callback)
   end)
 end
 
+local function find_variable(variables, name)
+  for _, variable in ipairs(variables or {}) do
+    if variable.name == name then
+      return variable
+    end
+  end
+end
+
+local function find_scope(scopes, names)
+  for _, scope in ipairs(scopes or {}) do
+    for _, name in ipairs(names) do
+      if scope.name == name then
+        return scope
+      end
+    end
+  end
+end
+
 local function continue_debug(session, thread_id, callback)
   request(session, 'continue', { threadId = thread_id or 1 }, callback or function() end)
 end
@@ -59,12 +77,15 @@ end
 describe('DAP breakpoints', function()
   it('stops at document end and evaluates module scope', function()
     local root, program = prepare_program('document-end', {
-      '#let answer = 40 + 2',
+      '#let points = (left: 40, right: 2)',
+      '#let answer = points.left + points.right',
       '#answer',
     })
     local key = 'tinymist-dap-document-end'
     local stopped = {}
     local result
+    local module_variables
+    local point_fields
     local failure
 
     cleanup_listener(key)
@@ -87,6 +108,47 @@ describe('DAP breakpoints', function()
           failure = failure or err
           result = response and response.result or result
         end)
+
+        request(session, 'stackTrace', {
+          threadId = body.threadId or 1,
+        }, function(stack_err, stack_response)
+          failure = failure or stack_err
+          local frame = stack_response and stack_response.stackFrames and stack_response.stackFrames[1]
+          if not frame then
+            failure = failure or 'missing document-end stack frame'
+            return
+          end
+
+          request(session, 'scopes', {
+            frameId = frame.id,
+          }, function(scopes_err, scopes_response)
+            failure = failure or scopes_err
+            local scope = find_scope(scopes_response and scopes_response.scopes, { 'Locals' })
+            if not scope then
+              failure = failure or 'missing document-end locals scope'
+              return
+            end
+
+            request(session, 'variables', {
+              variablesReference = scope.variablesReference,
+            }, function(vars_err, vars_response)
+              failure = failure or vars_err
+              module_variables = vars_response and vars_response.variables or module_variables
+              local points = find_variable(module_variables, 'points')
+              if not points or points.variablesReference == 0 then
+                failure = failure or 'missing expandable points variable'
+                return
+              end
+
+              request(session, 'variables', {
+                variablesReference = points.variablesReference,
+              }, function(fields_err, fields_response)
+                failure = failure or fields_err
+                point_fields = fields_response and fields_response.variables or point_fields
+              end)
+            end)
+          end)
+        end)
       end
     end
 
@@ -100,7 +162,7 @@ describe('DAP breakpoints', function()
     }
 
     local ok = vim.wait(20000, function()
-      return failure ~= nil or result ~= nil
+      return failure ~= nil or (result ~= nil and point_fields ~= nil)
     end, 50)
 
     cleanup_listener(key)
@@ -109,6 +171,9 @@ describe('DAP breakpoints', function()
     assert.message(('timed out waiting for document-end pause; stopped=%s'):format(vim.inspect(stopped))).is_true(ok)
     assert.message(failure or 'document-end DAP flow failed').is_nil(failure)
     assert.are.same('42', result)
+    assert.are.same('42', find_variable(module_variables, 'answer').value)
+    assert.are.same('40', find_variable(point_fields, 'left').value)
+    assert.are.same('2', find_variable(point_fields, 'right').value)
     assert.are.same({ 'entry', 'pause' }, stopped)
   end)
 
@@ -123,6 +188,7 @@ describe('DAP breakpoints', function()
     local configured = false
     local function_value
     local function_stack
+    local function_variables
     local end_value
     local failure
 
@@ -170,7 +236,36 @@ describe('DAP breakpoints', function()
           threadId = body.threadId or 1,
         }, function(err, response)
           function_stack = response and response.stackFrames and response.stackFrames[1] or function_stack
-          maybe_continue(err)
+          if err then
+            maybe_continue(err)
+            return
+          end
+          if not function_stack then
+            maybe_continue('missing function stack frame')
+            return
+          end
+
+          request(session, 'scopes', {
+            frameId = function_stack.id,
+          }, function(scopes_err, scopes_response)
+            if scopes_err then
+              maybe_continue(scopes_err)
+              return
+            end
+
+            local scope = find_scope(scopes_response and scopes_response.scopes, { 'Arguments', 'Locals' })
+            if not scope then
+              maybe_continue('missing function arguments scope')
+              return
+            end
+
+            request(session, 'variables', {
+              variablesReference = scope.variablesReference,
+            }, function(vars_err, vars_response)
+              function_variables = vars_response and vars_response.variables or function_variables
+              maybe_continue(vars_err)
+            end)
+          end)
         end)
         return
       end
@@ -210,8 +305,11 @@ describe('DAP breakpoints', function()
     assert.are.same('42', end_value)
     assert.are.same({ 'entry', 'function breakpoint', 'pause' }, stopped)
     assert.is_not_nil(function_stack)
+    assert.are.same('add', function_stack.name)
     assert.are.same(1, function_stack.line)
     assert.are.same(program, function_stack.source.path)
+    assert.are.same('40', find_variable(function_variables, 'x').value)
+    assert.are.same('2', find_variable(function_variables, 'y').value)
   end)
 
   it('maps a source line breakpoint to a structural block breakpoint', function()


### PR DESCRIPTION
- Add DAP stackTrace, scopes, and variables request handling.
- Build paused-state scope and variable handles for locals, arguments, globals, arrays, dictionaries, and value fields.
- Instrument return breakpoints and cover debugger scopes/variables in the Neovim DAP smoke spec.