### PR TITLE
feat(package-docs): enrich source pages from index

### DIFF
--- a/crates/tinymist-cli/src/cmd/package.rs
+++ b/crates/tinymist-cli/src/cmd/package.rs
@@ -1,6 +1,7 @@
 //! Package-related CLI commands.
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use clap::ValueHint;
@@ -10,6 +11,7 @@ use tinymist::project::{
 };
 use tinymist::tool::project::{ProjectOpts, start_project};
 use tinymist::{CompileFontArgs, CompileOnceArgs, Config, ExportTask};
+use tinymist_project::world::package::{PackageRegistry, PackageSpec};
 use tinymist_project::{Feature, WorldProvider};
 use tinymist_query::analysis::Analysis;
 use tinymist_query::package::PackageInfo;
@@ -120,6 +122,11 @@ struct PackageDocsContext {
     dist: PathBuf,
 }
 
+struct PackageDocsInput {
+    package_root: PathBuf,
+    namespace: Option<String>,
+}
+
 impl PackageDocsContext {
     fn new(args: PackageDocsArgs) -> Result<Self> {
         let repo_root = find_repo_root()?;
@@ -128,16 +135,17 @@ impl PackageDocsContext {
             .input
             .as_deref()
             .context("package docs requires INPUT package path")?;
-        let package_root = absolutize(Path::new(package_input))?;
+        let resolved_input = resolve_package_docs_input(&args, package_input)?;
+        let package_root = resolved_input.package_root;
         let manifest_path = package_root.join("typst.toml");
         let manifest_data = std::fs::read_to_string(&manifest_path)
             .context_ut("failed to read package manifest")?;
         let manifest: PackageManifest = toml::from_str(&manifest_data)
             .map_err(map_string_err("failed to parse package manifest"))?;
 
-        let namespace = args
+        let namespace = resolved_input
             .namespace
-            .clone()
+            .or_else(|| args.namespace.clone())
             .or_else(|| infer_namespace(&package_root, &manifest))
             .unwrap_or_else(|| "preview".to_owned());
         let package_name = manifest.package.name.to_string();
@@ -358,6 +366,30 @@ async fn export_docs_bundle(ctx: &PackageDocsContext) -> Result<()> {
     });
     ExportTask::do_export(task, artifact, None).await?;
     Ok(())
+}
+
+fn resolve_package_docs_input(args: &PackageDocsArgs, input: &str) -> Result<PackageDocsInput> {
+    if !input.starts_with('@') {
+        return Ok(PackageDocsInput {
+            package_root: absolutize(Path::new(input))?,
+            namespace: None,
+        });
+    }
+
+    let spec =
+        PackageSpec::from_str(input).map_err(map_string_err("failed to parse package spec"))?;
+    let registry = tinymist::world::system::SystemUniverseBuilder::resolve_package(
+        args.compile.cert.as_deref().map(From::from),
+        Some(&args.compile.package),
+    );
+    let package_root = registry
+        .resolve(&spec)
+        .map_err(|err| anyhow::anyhow!("failed to resolve package {input}: {err}"))?;
+
+    Ok(PackageDocsInput {
+        package_root: package_root.as_ref().to_path_buf(),
+        namespace: Some(spec.namespace.to_string()),
+    })
 }
 
 fn find_repo_root() -> Result<PathBuf> {

--- a/crates/tinymist-index/src/lib.rs
+++ b/crates/tinymist-index/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::{Mutex, OnceLock};
 use lsp_types::{GotoDefinitionParams, HoverParams};
 use tinymist_query::{
     CompilerQueryRequest, CompilerQueryResponse, GotoDefinitionRequest, HoverRequest,
-    index::scip_query::{ScipPublicSymbol, ScipQueryCtx},
+    index::scip_query::{ScipPublicSymbol, ScipQueryCtx, ScipSourceToken},
     url_to_path,
 };
 #[cfg(all(feature = "typst-plugin", target_arch = "wasm32"))]
@@ -37,11 +37,13 @@ struct IndexCtx {
 enum IndexRequest {
     Compiler(CompilerQueryRequest),
     PublicSymbols(String),
+    SourceTokens(String),
 }
 
 enum IndexResponse {
     Compiler(Option<CompilerQueryResponse>),
     PublicSymbols(Vec<ScipPublicSymbol>),
+    SourceTokens(Vec<ScipSourceToken>),
 }
 
 impl IndexCtx {
@@ -50,6 +52,9 @@ impl IndexCtx {
             IndexRequest::Compiler(request) => IndexResponse::Compiler(self.index.request(request)),
             IndexRequest::PublicSymbols(path) => {
                 IndexResponse::PublicSymbols(self.index.public_symbols(&path))
+            }
+            IndexRequest::SourceTokens(path) => {
+                IndexResponse::SourceTokens(self.index.source_tokens(&path))
             }
         }
     }
@@ -60,6 +65,7 @@ impl IndexResponse {
         match self {
             Self::Compiler(response) => serde_json::to_vec(response).map_err(to_string),
             Self::PublicSymbols(response) => serde_json::to_vec(response).map_err(to_string),
+            Self::SourceTokens(response) => serde_json::to_vec(response).map_err(to_string),
         }
     }
 }
@@ -90,6 +96,9 @@ fn parse_request(kind: &str, request: &[u8]) -> StrResult<IndexRequest> {
         }
         "public_symbols" => {
             IndexRequest::PublicSymbols(serde_json::from_slice(request).map_err(to_string)?)
+        }
+        "source_tokens" => {
+            IndexRequest::SourceTokens(serde_json::from_slice(request).map_err(to_string)?)
         }
         kind => Err(format!("unknown request kind: {kind}"))?,
     })

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -495,7 +495,7 @@ pub fn package_docs_bundle_typ(doc: &PackageDoc) -> StrResult<Vec<PackageDocTypF
     }
     for path in &module_paths {
         if path.source_text.is_some() {
-            let _ = writeln!(entry, "#{}(package-info)", path.source_func);
+            let _ = writeln!(entry, "#{}(package-info, package-index)", path.source_func);
         }
     }
     files.push(PackageDocTypFile {
@@ -563,7 +563,7 @@ pub fn package_docs_bundle_typ(doc: &PackageDoc) -> StrResult<Vec<PackageDocTypF
             );
             let _ = writeln!(
                 content,
-                "#let {func}(package-info) = package-source-document(package-info, module-index: {idx}, path: {}, source-path: {}, source: {})",
+                "#let {func}(package-info, package-index) = package-source-document(package-info, package-index, module-index: {idx}, path: {}, source-path: {}, source: {})",
                 typst_string(&source_output),
                 typst_string(&source_path),
                 typst_string(source_text.as_str()),

--- a/crates/tinymist-query/src/index/scip_query.rs
+++ b/crates/tinymist-query/src/index/scip_query.rs
@@ -20,6 +20,7 @@ use super::scip_utils::{ScipParamGroup, merge_symbol_information};
 #[derive(Default)]
 pub struct ScipQueryCtx {
     documents_by_uri: FxHashMap<Url, ScipDocumentQuery>,
+    documents_by_path: FxHashMap<String, Url>,
     definitions: FxHashMap<String, Vec<ScipDefinition>>,
     public_symbols_by_path: FxHashMap<String, Vec<ScipPublicSymbol>>,
     symbol_hovers: FxHashMap<String, Hover>,
@@ -34,6 +35,20 @@ pub struct ScipPublicSymbol {
     pub name: String,
     /// Package docs definition kind.
     pub kind: String,
+}
+
+/// A token on a source page that has index-backed interactions.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScipSourceToken {
+    /// Token range in LSP UTF-16 positions.
+    pub range: Range,
+    /// Hover information for the token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hover: Option<Hover>,
+    /// First definition target for the token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition: Option<LocationLink>,
 }
 
 #[derive(Debug, Clone)]
@@ -114,6 +129,7 @@ impl ScipQueryCtx {
                 this.public_symbols_by_path
                     .insert(relative_path.clone(), public_symbols);
             }
+            this.documents_by_path.insert(relative_path, uri.clone());
             this.documents_by_uri
                 .insert(uri.clone(), ScipDocumentQuery { uri, occurrences });
         }
@@ -165,37 +181,85 @@ impl ScipQueryCtx {
             .unwrap_or_default()
     }
 
+    /// Requests source-page tokens that have hover or definition information.
+    pub fn source_tokens(&self, path: &str) -> Vec<ScipSourceToken> {
+        let Some(uri) = self.documents_by_path.get(path) else {
+            return Vec::new();
+        };
+        let Some(document) = self.documents_by_uri.get(uri) else {
+            return Vec::new();
+        };
+
+        document
+            .occurrences
+            .iter()
+            .filter(|occurrence| !occurrence.symbol.is_empty())
+            .filter_map(|occurrence| {
+                let mut hover = occurrence
+                    .hover
+                    .clone()
+                    .or_else(|| self.symbol_hovers.get(&occurrence.symbol).cloned());
+                if let Some(hover) = &mut hover {
+                    hover.range.get_or_insert(occurrence.range);
+                }
+
+                let definition = self
+                    .definition_links_for_occurrence(document, occurrence)
+                    .into_iter()
+                    .next();
+
+                if hover.is_none() && definition.is_none() {
+                    return None;
+                }
+
+                Some(ScipSourceToken {
+                    range: occurrence.range,
+                    hover,
+                    definition,
+                })
+            })
+            .collect()
+    }
+
     fn goto_definition(&self, request: GotoDefinitionRequest) -> Option<GotoDefinitionResponse> {
         let uri = path_to_url(&request.path).ok()?;
         let document = self.documents_by_uri.get(&uri)?;
         let occurrence = find_scip_occurrence(document, request.position)?;
-        let origin_selection_range = occurrence.range;
-
-        let links = if occurrence.is_definition {
-            vec![LocationLink {
-                origin_selection_range: Some(origin_selection_range),
-                target_uri: document.uri.clone(),
-                target_range: occurrence.range,
-                target_selection_range: occurrence.range,
-            }]
-        } else {
-            self.definitions
-                .get(&occurrence.symbol)?
-                .iter()
-                .map(|definition| LocationLink {
-                    origin_selection_range: Some(origin_selection_range),
-                    target_uri: definition.uri.clone(),
-                    target_range: definition.range,
-                    target_selection_range: definition.range,
-                })
-                .collect()
-        };
+        let links = self.definition_links_for_occurrence(document, occurrence);
 
         if links.is_empty() {
             None
         } else {
             Some(GotoDefinitionResponse::Link(links))
         }
+    }
+
+    fn definition_links_for_occurrence(
+        &self,
+        document: &ScipDocumentQuery,
+        occurrence: &ScipOccurrence,
+    ) -> Vec<LocationLink> {
+        let origin_selection_range = occurrence.range;
+        if occurrence.is_definition {
+            return vec![LocationLink {
+                origin_selection_range: Some(origin_selection_range),
+                target_uri: document.uri.clone(),
+                target_range: occurrence.range,
+                target_selection_range: occurrence.range,
+            }];
+        }
+
+        self.definitions
+            .get(&occurrence.symbol)
+            .into_iter()
+            .flatten()
+            .map(|definition| LocationLink {
+                origin_selection_range: Some(origin_selection_range),
+                target_uri: definition.uri.clone(),
+                target_range: definition.range,
+                target_selection_range: definition.range,
+            })
+            .collect()
     }
 
     /// Requests the definition for a SCIP symbol.
@@ -710,6 +774,60 @@ mod tests {
         assert_eq!(symbols[0].symbol, function_symbol.to_owned());
         assert_eq!(symbols[0].name, "foo");
         assert_eq!(symbols[0].kind, "function");
+    }
+
+    #[test]
+    fn scip_source_tokens_include_hover_and_definition() {
+        let symbol = "local value";
+        let bytes = test_index(vec![main_document(
+            vec![
+                definition_occurrence(vec![0, 0, 4], symbol),
+                occurrence(vec![1, 0, 4], symbol),
+            ],
+            vec![symbol_info(symbol, "value", &["hello"])],
+        )]);
+        let index = ScipQueryCtx::read(&bytes).unwrap();
+
+        let tokens = index.source_tokens("main.typ");
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(
+            tokens[0]
+                .definition
+                .as_ref()
+                .unwrap()
+                .target_selection_range,
+            Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }
+        );
+        assert_eq!(
+            tokens[1].hover.as_ref().unwrap().contents,
+            HoverContents::Scalar(MarkedString::String("hello".to_owned()))
+        );
+        assert_eq!(
+            tokens[1]
+                .definition
+                .as_ref()
+                .unwrap()
+                .target_selection_range,
+            Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }
+        );
     }
 
     fn test_index(documents: Vec<ScipDocument>) -> Vec<u8> {

--- a/typ/packages/package-docs/function.typ
+++ b/typ/packages/package-docs/function.typ
@@ -424,8 +424,7 @@
 #let function-param-source-dest(symbol-ctx, info, data, param) = {
   let source = info.at("source", default: none)
   if source != none {
-    let line = source.position.line + 1 + function-hover-signature-param-line-offset(data.signature, param.name)
-    return source-query-line-dest(symbol-ctx, source, line)
+    return source-query-line-dest(symbol-ctx, source, source.position.line + 1)
   }
 
   let definition = index-definition(symbol-ctx, info)
@@ -442,8 +441,7 @@
     file: file.index,
     position: definition.targetSelectionRange.start,
   )
-  let line = definition.targetSelectionRange.start.line + 1 + function-hover-signature-param-line-offset(data.signature, param.name)
-  source-query-line-dest(symbol-ctx, source, line)
+  source-query-line-dest(symbol-ctx, source, definition.targetSelectionRange.start.line + 1)
 }
 
 #let function-param-heading(symbol-ctx, info, data, group, param, meta, ty) = {

--- a/typ/packages/package-docs/global.css
+++ b/typ/packages/package-docs/global.css
@@ -19,6 +19,12 @@ main {
   --source-border-color: #d0d7de;
   --source-line-number-color: #6e7781;
   --source-shadow-color: rgba(27, 31, 36, 0.08);
+  --source-hover-underline-color: rgba(101, 117, 133, 0.62);
+  --source-hover-popup-bg: #ffffff;
+  --source-hover-popup-fg: #24292f;
+  --source-hover-popup-muted: #57606a;
+  --source-hover-popup-border: #d0d7de;
+  --source-hover-popup-shadow: rgba(27, 31, 36, 0.12);
   --scrollbar-thumb-color: rgba(101, 117, 133, 0.34);
   --scrollbar-thumb-hover-color: rgba(101, 117, 133, 0.58);
 }
@@ -40,6 +46,12 @@ main {
   --source-border-color: #30363d;
   --source-line-number-color: #8b949e;
   --source-shadow-color: rgba(0, 0, 0, 0.28);
+  --source-hover-underline-color: rgba(147, 157, 163, 0.68);
+  --source-hover-popup-bg: #161b22;
+  --source-hover-popup-fg: #c9d1d9;
+  --source-hover-popup-muted: #8b949e;
+  --source-hover-popup-border: #30363d;
+  --source-hover-popup-shadow: rgba(0, 0, 0, 0.34);
   --scrollbar-thumb-color: rgba(147, 157, 163, 0.34);
   --scrollbar-thumb-hover-color: rgba(147, 157, 163, 0.6);
   --source-code-font-size: 0.875rem;
@@ -805,6 +817,122 @@ body {
   line-height: inherit;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+}
+
+.package-source-token {
+  border-bottom: 1px dotted transparent;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+
+.package-source-token.has-definition {
+  cursor: pointer;
+}
+
+.package-source-code.has-source-interactions:hover .package-source-token.has-hover,
+.package-source-token.has-hover:hover,
+.package-source-token.has-hover:focus-visible {
+  border-bottom-color: var(--source-hover-underline-color);
+}
+
+.package-source-token.has-definition:hover,
+.package-source-token.has-definition:focus-visible {
+  color: var(--main-hover-color);
+  text-decoration: none;
+}
+
+.package-source-token:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.package-source-floating-hover {
+  position: fixed;
+  z-index: 100;
+  box-sizing: border-box;
+  max-width: min(700px, calc(100vw - 24px));
+  overflow: hidden;
+  border: 1px solid var(--source-hover-popup-border);
+  border-radius: 6px;
+  background: var(--source-hover-popup-bg);
+  color: var(--source-hover-popup-fg);
+  box-shadow: 0 12px 32px var(--source-hover-popup-shadow);
+  text-align: left;
+}
+
+.package-source-floating-hover[hidden] {
+  display: none;
+}
+
+.package-source-hover-content {
+  max-height: min(520px, calc(100vh - 48px));
+  overflow: auto;
+  font-family: var(--vp-font-family-base);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.package-source-hover-content p {
+  margin: 0;
+  padding: 0.65rem 0.85rem;
+  color: var(--source-hover-popup-fg);
+  white-space: pre-wrap;
+}
+
+.package-source-hover-content p + p,
+.package-source-hover-content p + pre,
+.package-source-hover-content pre + p,
+.package-source-hover-content pre + pre,
+.package-source-hover-content .package-source-hover-heading + p,
+.package-source-hover-content .package-source-hover-heading + pre {
+  border-top: 1px solid var(--source-hover-popup-border);
+}
+
+.package-source-hover-content pre {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: min(32rem, calc(100vw - 48px));
+  margin: 0;
+  padding: 0.65rem 0.85rem;
+  overflow: auto;
+  border-radius: 0;
+  background: var(--source-bg-color);
+  color: var(--source-fg-color);
+  box-shadow: none;
+  white-space: pre;
+}
+
+.package-source-hover-content pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.package-source-hover-content hr {
+  height: 1px;
+  margin: 0;
+  border: 0;
+  background: var(--source-hover-popup-border);
+}
+
+.package-source-hover-heading {
+  padding: 0.58rem 0.85rem 0.35rem;
+  color: var(--source-hover-popup-muted);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.package-source-hover-heading.level-1 {
+  color: var(--source-hover-popup-fg);
+  font-size: 0.82rem;
 }
 
 .package-source-scroll::-webkit-scrollbar {

--- a/typ/packages/package-docs/source-interactions.js
+++ b/typ/packages/package-docs/source-interactions.js
@@ -1,0 +1,467 @@
+const sourceBlocks = document.querySelectorAll(".package-source-code");
+
+if (sourceBlocks.length > 0) {
+  const popup = document.createElement("div");
+  popup.className = "package-source-floating-hover";
+  popup.hidden = true;
+  document.body.append(popup);
+
+  let activeToken = null;
+  let hideTimer = 0;
+  let popupHovered = false;
+
+  popup.addEventListener("pointerenter", () => {
+    popupHovered = true;
+    clearHideTimer();
+  });
+
+  popup.addEventListener("pointerleave", () => {
+    popupHovered = false;
+    scheduleHide();
+  });
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (activeToken && !popup.hidden) {
+        positionPopup(activeToken, popup);
+      }
+    },
+    true,
+  );
+  window.addEventListener("resize", () => {
+    if (activeToken && !popup.hidden) {
+      positionPopup(activeToken, popup);
+    }
+    for (const block of sourceBlocks) {
+      syncSourceLineNumbers(block);
+    }
+  });
+
+  for (const block of sourceBlocks) {
+    initSourceBlock(block);
+  }
+
+  function initSourceBlock(block) {
+    const data = block.querySelector("script.package-source-token-data");
+    const code = block.querySelector(".package-source-scroll pre code");
+    if (!data || !code) {
+      return;
+    }
+
+    let rawTokens;
+    try {
+      rawTokens = JSON.parse(data.textContent || "[]");
+    } catch {
+      return;
+    }
+
+    const sourceText = code.textContent || "";
+    const lineStarts = computeLineStarts(sourceText);
+    const tokens = normalizeTokens(rawTokens, sourceText, lineStarts);
+    syncSourceLineNumbers(block, code, sourceText, lineStarts);
+    if (tokens.length === 0) {
+      return;
+    }
+
+    wrapCodeTokens(code, tokens);
+    block.classList.add("has-source-interactions");
+
+    block.addEventListener("pointerover", (event) => {
+      const token = event.target.closest(".package-source-token.has-hover");
+      if (!token || !block.contains(token)) {
+        return;
+      }
+
+      showPopup(token, tokens, popup);
+    });
+
+    block.addEventListener("pointerout", (event) => {
+      const token = event.target.closest(".package-source-token.has-hover");
+      if (!token || !block.contains(token)) {
+        return;
+      }
+      if (event.relatedTarget && (token.contains(event.relatedTarget) || popup.contains(event.relatedTarget))) {
+        return;
+      }
+
+      scheduleHide();
+    });
+
+    block.addEventListener("focusin", (event) => {
+      const token = event.target.closest(".package-source-token.has-hover");
+      if (token && block.contains(token)) {
+        showPopup(token, tokens, popup);
+      }
+    });
+
+    block.addEventListener("focusout", (event) => {
+      const token = event.target.closest(".package-source-token.has-hover");
+      if (!token || !block.contains(token)) {
+        return;
+      }
+      if (event.relatedTarget && (token.contains(event.relatedTarget) || popup.contains(event.relatedTarget))) {
+        return;
+      }
+
+      scheduleHide();
+    });
+  }
+
+  function syncSourceLineNumbers(block, code, sourceText, lineStarts) {
+    const codeElement = code || block.querySelector(".package-source-scroll pre code");
+    if (!codeElement) {
+      return;
+    }
+
+    const text = sourceText ?? codeElement.textContent ?? "";
+    const starts = lineStarts ?? computeLineStarts(text);
+    const lineNumbers = block.querySelectorAll(".package-source-line-number");
+    if (lineNumbers.length === 0) {
+      return;
+    }
+
+    const textIndex = buildTextIndex(codeElement);
+    for (let line = 0; line < lineNumbers.length; line += 1) {
+      const start = starts[line] ?? text.length;
+      const end = line + 1 < starts.length ? Math.max(start, starts[line + 1] - 1) : text.length;
+      const height = measureTextRangeHeight(codeElement, textIndex, start, end);
+      if (height != null) {
+        lineNumbers[line].style.height = `${height}px`;
+      }
+    }
+  }
+
+  function computeLineStarts(text) {
+    const starts = [0];
+    for (let index = 0; index < text.length; index += 1) {
+      if (text.charCodeAt(index) === 10) {
+        starts.push(index + 1);
+      }
+    }
+    return starts;
+  }
+
+  function normalizeTokens(rawTokens, sourceText, lineStarts) {
+    const byRange = new Map();
+    for (const raw of rawTokens) {
+      const range = raw && raw.range;
+      if (!range || !range.start || !range.end) {
+        continue;
+      }
+
+      const start = offsetOf(range.start, sourceText, lineStarts);
+      const end = offsetOf(range.end, sourceText, lineStarts);
+      if (start == null || end == null || end <= start) {
+        continue;
+      }
+
+      const hover = typeof raw.hover === "string" && raw.hover.trim() !== "" ? raw.hover : null;
+      const href = typeof raw.href === "string" && raw.href.trim() !== "" ? raw.href : null;
+      if (!hover && !href) {
+        continue;
+      }
+
+      const key = `${start}:${end}`;
+      const existing = byRange.get(key);
+      if (existing) {
+        existing.hover ||= hover;
+        existing.href ||= href;
+      } else {
+        byRange.set(key, {
+          start,
+          end,
+          hover,
+          href,
+        });
+      }
+    }
+
+    const sorted = [...byRange.values()].sort((left, right) => left.start - right.start || right.end - left.end);
+    const filtered = [];
+    let previousEnd = 0;
+    for (const token of sorted) {
+      if (token.start < previousEnd) {
+        continue;
+      }
+      filtered.push(token);
+      previousEnd = token.end;
+    }
+
+    return filtered;
+  }
+
+  function offsetOf(position, sourceText, lineStarts) {
+    const line = Number(position.line);
+    const character = Number(position.character);
+    if (!Number.isInteger(line) || !Number.isInteger(character) || line < 0 || character < 0) {
+      return null;
+    }
+    if (line >= lineStarts.length) {
+      return null;
+    }
+
+    const lineStart = lineStarts[line];
+    const lineEnd = line + 1 < lineStarts.length ? lineStarts[line + 1] - 1 : sourceText.length;
+    return Math.min(lineStart + character, lineEnd);
+  }
+
+  function wrapCodeTokens(code, tokens) {
+    for (let index = 0; index < tokens.length; index += 1) {
+      wrapTokenRange(code, tokens[index], index);
+    }
+  }
+
+  function locateTextOffset(root, offset, preferPrevious) {
+    return locateTextIndexOffset(buildTextIndex(root), offset, preferPrevious);
+  }
+
+  function buildTextIndex(root) {
+    const nodes = [];
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let cursor = 0;
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const start = cursor;
+      cursor += node.nodeValue.length;
+      nodes.push({
+        node,
+        start,
+        end: cursor,
+      });
+    }
+    return {
+      nodes,
+      length: cursor,
+    };
+  }
+
+  function locateTextIndexOffset(textIndex, offset, preferPrevious) {
+    let last = null;
+    for (const item of textIndex.nodes) {
+      if (offset < item.end || (preferPrevious && offset === item.end)) {
+        return {
+          node: item.node,
+          offset: Math.max(0, Math.min(item.node.nodeValue.length, offset - item.start)),
+        };
+      }
+      if (!preferPrevious && offset === item.start) {
+        return { node: item.node, offset: 0 };
+      }
+      last = item.node;
+    }
+
+    if (last && offset === textIndex.length) {
+      return {
+        node: last,
+        offset: last.nodeValue.length,
+      };
+    }
+    return null;
+  }
+
+  function measureTextRangeHeight(codeElement, textIndex, startOffset, endOffset) {
+    const start = locateTextIndexOffset(textIndex, startOffset, false);
+    const end = locateTextIndexOffset(textIndex, endOffset, true);
+    const lineHeight = Number.parseFloat(getComputedStyle(codeElement).lineHeight);
+    if (!start || !end || !Number.isFinite(lineHeight)) {
+      return null;
+    }
+
+    if (start.node === end.node && start.offset === end.offset) {
+      return lineHeight;
+    }
+
+    const range = document.createRange();
+    try {
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+    } catch {
+      return null;
+    }
+
+    const rects = Array.from(range.getClientRects()).filter((rect) => rect.width > 0 || rect.height > 0);
+    if (rects.length === 0) {
+      return lineHeight;
+    }
+
+    const rowTops = [];
+    for (const rect of rects) {
+      if (!rowTops.some((top) => Math.abs(top - rect.top) < lineHeight / 2)) {
+        rowTops.push(rect.top);
+      }
+    }
+    return Math.max(lineHeight, rowTops.length * lineHeight);
+  }
+
+  function wrapTokenRange(code, token, index) {
+    const start = locateTextOffset(code, token.start, false);
+    const end = locateTextOffset(code, token.end, true);
+    if (!start || !end) {
+      return;
+    }
+
+    const range = document.createRange();
+    try {
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+    } catch {
+      return;
+    }
+
+    if (range.collapsed) {
+      return;
+    }
+
+    const wrapper = createTokenElement(token, index);
+    wrapper.append(range.extractContents());
+    range.insertNode(wrapper);
+  }
+
+  function createTokenElement(token, index) {
+    const element = token.href ? document.createElement("a") : document.createElement("span");
+    element.className = "package-source-token";
+    element.dataset.sourceToken = String(index);
+    if (token.hover) {
+      element.classList.add("has-hover");
+      if (!token.href) {
+        element.tabIndex = 0;
+      }
+    }
+    if (token.href) {
+      element.classList.add("has-definition");
+      element.href = token.href;
+    }
+    return element;
+  }
+
+  function showPopup(tokenElement, tokens, popupElement) {
+    const token = tokens[Number(tokenElement.dataset.sourceToken)];
+    if (!token || !token.hover) {
+      return;
+    }
+
+    clearHideTimer();
+    activeToken = tokenElement;
+    renderHover(popupElement, token.hover);
+    popupElement.hidden = false;
+    popupElement.style.visibility = "hidden";
+    positionPopup(tokenElement, popupElement);
+    popupElement.style.visibility = "visible";
+  }
+
+  function renderHover(popupElement, markdown) {
+    popupElement.textContent = "";
+    const container = document.createElement("div");
+    container.className = "package-source-hover-content";
+    popupElement.append(container);
+
+    const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+    let index = 0;
+    while (index < lines.length) {
+      const line = lines[index];
+      if (line.trim() === "") {
+        index += 1;
+        continue;
+      }
+
+      if (line.startsWith("```")) {
+        const language = line.slice(3).trim();
+        const codeLines = [];
+        index += 1;
+        while (index < lines.length && !lines[index].startsWith("```")) {
+          codeLines.push(lines[index]);
+          index += 1;
+        }
+        if (index < lines.length) {
+          index += 1;
+        }
+        appendCodeBlock(container, codeLines.join("\n"), language);
+        continue;
+      }
+
+      if (line === "---") {
+        container.append(document.createElement("hr"));
+        index += 1;
+        continue;
+      }
+
+      const heading = line.match(/^(#{1,3})\s+(.+)$/);
+      if (heading) {
+        const element = document.createElement("div");
+        element.className = `package-source-hover-heading level-${heading[1].length}`;
+        element.textContent = heading[2];
+        container.append(element);
+        index += 1;
+        continue;
+      }
+
+      const paragraph = [line];
+      index += 1;
+      while (
+        index < lines.length &&
+        lines[index].trim() !== "" &&
+        !lines[index].startsWith("```") &&
+        lines[index] !== "---" &&
+        !lines[index].match(/^(#{1,3})\s+(.+)$/)
+      ) {
+        paragraph.push(lines[index]);
+        index += 1;
+      }
+      const element = document.createElement("p");
+      element.textContent = paragraph.join("\n");
+      container.append(element);
+    }
+  }
+
+  function appendCodeBlock(container, code, language) {
+    const pre = document.createElement("pre");
+    const codeElement = document.createElement("code");
+    if (language) {
+      codeElement.dataset.language = language;
+    }
+    codeElement.textContent = code;
+    pre.append(codeElement);
+    container.append(pre);
+  }
+
+  function positionPopup(tokenElement, popupElement) {
+    const rect = tokenElement.getBoundingClientRect();
+    const margin = 8;
+    const maxLeft = window.innerWidth - popupElement.offsetWidth - margin;
+    let left = Math.max(margin, Math.min(rect.left, maxLeft));
+    let top = rect.bottom + margin;
+    let placement = "bottom";
+
+    if (top + popupElement.offsetHeight > window.innerHeight - margin) {
+      top = rect.top - popupElement.offsetHeight - margin;
+      placement = "top";
+    }
+    if (top < margin) {
+      top = margin;
+      placement = "bottom";
+    }
+
+    popupElement.dataset.placement = placement;
+    popupElement.style.left = `${Math.round(left)}px`;
+    popupElement.style.top = `${Math.round(top)}px`;
+  }
+
+  function scheduleHide() {
+    clearHideTimer();
+    hideTimer = window.setTimeout(() => {
+      if (popupHovered) {
+        return;
+      }
+      popup.hidden = true;
+      activeToken = null;
+    }, 120);
+  }
+
+  function clearHideTimer() {
+    if (hideTimer) {
+      window.clearTimeout(hideTimer);
+      hideTimer = 0;
+    }
+  }
+}

--- a/typ/packages/package-docs/source.typ
+++ b/typ/packages/package-docs/source.typ
@@ -1,6 +1,7 @@
 #import "mod.typ": *
 #import "module.typ": package-title, package-setup, symbol-context
 #import "sidebar.typ": package-layout
+#import "/typ/packages/tinymist-index/lib.typ": file-by-uri, hover-markdown, index-source-tokens
 
 #let source-line-numbers(source) = {
   [
@@ -14,11 +15,59 @@
   ]
 }
 
-#let package-source-page(info, module-index: none, path: none, source-path: none, source: none) = {
+#let source-token-definition-dest(symbol-ctx, definition) = {
+  if definition == none {
+    return none
+  }
+
+  let uri = definition.at("targetUri", default: none)
+  let target = definition.at("targetSelectionRange", default: none)
+  if uri == none or target == none {
+    return none
+  }
+
+  let file = file-by-uri(symbol-ctx.files, str(uri))
+  if file == none or file.at("path", default: none) == none {
+    return none
+  }
+
+  relative-path(symbol-ctx.at("path", default: none), str(file.path) + ".html") + source-line-fragment(target.start.line + 1)
+}
+
+#let source-token-data(symbol-ctx, source-path) = {
+  let items = ()
+  for token in index-source-tokens(symbol-ctx, source-path) {
+    let hover = hover-markdown(token.at("hover", default: none))
+    let href = source-token-definition-dest(symbol-ctx, token.at("definition", default: none))
+    if hover != none or href != none {
+      items.push((
+        range: token.range,
+        hover: hover,
+        href: href,
+      ))
+    }
+  }
+  items
+}
+
+#let source-token-data-script(symbol-ctx, source-path) = {
+  let tokens = source-token-data(symbol-ctx, source-path)
+
+  [
+    #html.elem(
+      "script",
+      attrs: (type: "application/json", class: "package-source-token-data"),
+      json.encode(tokens),
+    )
+    #html.elem("script", attrs: (type: "module"), read("source-interactions.js"))
+  ]
+}
+
+#let package-source-page(info, index, module-index: none, path: none, source-path: none, source: none) = {
   let title = package-title(info)
 
   package-setup(title)
-  let symbol-ctx = symbol-context(info, none, bundle: true, path: path)
+  let symbol-ctx = symbol-context(info, index, bundle: true, path: path)
   let module-entry = info.modules.at(module-index)
   let module-info = module-entry.at(2)
 
@@ -35,16 +84,18 @@
           #raw(source, lang: "typ", block: true)
         ])
       ])
+      #source-token-data-script(symbol-ctx, source-path)
     ])
   ]
 }
 
-#let package-source-document(info, module-index: none, path: none, source-path: none, source: none) = {
+#let package-source-document(info, index, module-index: none, path: none, source-path: none, source: none) = {
   let title = package-title(info) + " - Source: " + str(source-path)
 
   document(path, title: title)[
     #package-source-page(
       info,
+      index,
       module-index: module-index,
       path: path,
       source-path: source-path,

--- a/typ/packages/tinymist-index/lib.typ
+++ b/typ/packages/tinymist-index/lib.typ
@@ -47,6 +47,23 @@
   }
 }
 
+/// Queries source tokens for a module source page.
+/// - symbol-ctx (dictionary): The package-doc symbol context.
+/// - source-path (str): The module source path.
+#let index-source-tokens(symbol-ctx, source-path) = {
+  let db = symbol-ctx.at("index", default: none)
+  if db == none or source-path == none {
+    return ()
+  }
+
+  let result = query(db, "source_tokens", str(source-path))
+  if result == none {
+    ()
+  } else {
+    result
+  }
+}
+
 #let index-symbol-kind-matches(index-kind, info-kind) = {
   if index-kind == info-kind {
     return true


### PR DESCRIPTION
- Allow `tinymist package docs` to accept Typst package specs like `@preview/touying:0.6.0` as input.
- Expose SCIP-backed `source_tokens` queries through `tinymist-index` and the Typst index helper package.
- Enrich package docs source pages with indexed hover popups and definition links while preserving soft-wrapped source layout.
- Keep source line numbers aligned with soft-wrapped lines and avoid deriving parameter source links from formatted hover signatures.
