### PR TITLE
feat(preview): add ng preview interactions

### DIFF
--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -896,10 +896,7 @@ function rewritePreviewAssetRoot(previewer: ResolvedPreviewer, webview: vscode.W
   const resourceRoot =
     previewer.localResourceRoots[0] ?? vscode.Uri.file(path.dirname(previewer.htmlUri.fsPath));
   const webviewAssetRoot = `${webview.asWebviewUri(resourceRoot).toString()}/typst-webview-assets`;
-  return previewer.html.replace(
-    /(?:\.\/|\/)typst-webview-assets/g,
-    webviewAssetRoot,
-  );
+  return previewer.html.replace(/(?:\.\/|\/)typst-webview-assets/g, webviewAssetRoot);
 }
 
 // todo: useful content security policy but we don't set

--- a/tools/typst-preview-frontend-ng/renderer-worker.ts
+++ b/tools/typst-preview-frontend-ng/renderer-worker.ts
@@ -74,6 +74,15 @@ self.addEventListener("message", (event) => {
         ),
       );
       break;
+    case "hit-bound":
+      void renderer.hitBound({
+        requestId: message.requestId,
+        generation: message.generation,
+        pageIndex: message.pageIndex,
+        x: message.x,
+        y: message.y,
+      });
+      break;
     case "dispose":
       socket.dispose();
       renderer.dispose();

--- a/tools/typst-preview-frontend-ng/src/app.ts
+++ b/tools/typst-preview-frontend-ng/src/app.ts
@@ -96,6 +96,10 @@ class PreviewApp {
         this.handleEnsurePages(message);
         break;
       case "render-complete":
+        this.pageHost.updateInteractions(message.generation, message.interactions || []);
+        break;
+      case "bound-hit":
+        this.pageHost.handleBoundHit(message);
         break;
       case "error":
         console.error("[typst-preview-ng]", message.message, message);

--- a/tools/typst-preview-frontend-ng/src/interactions.ts
+++ b/tools/typst-preview-frontend-ng/src/interactions.ts
@@ -1,0 +1,322 @@
+export interface PageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface LinkTarget {
+  kind: "external" | "internal" | "unknown";
+  href: string;
+  position?: {
+    page: number;
+    x: number;
+    y: number;
+  };
+}
+
+export interface LinkInteraction {
+  rect: PageRect;
+  target: LinkTarget;
+}
+
+export interface TextInteraction {
+  id: number;
+  rect: PageRect;
+}
+
+export interface BoundInteraction {
+  id: number;
+  kind: string;
+  rect: PageRect;
+}
+
+export interface PageInteractions {
+  pageIndex: number;
+  links: LinkInteraction[];
+  texts: TextInteraction[];
+}
+
+const interactionTagPattern =
+  /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-(?:text|link)\b[^"]*"[^>]*)>/g;
+
+/** Extracts lightweight page-space hit-test metadata from renderer semantics HTML. */
+export function parsePageInteractions(pageIndex: number, html: string): PageInteractions {
+  const links: LinkInteraction[] = [];
+  const texts: TextInteraction[] = [];
+
+  for (const match of html.matchAll(interactionTagPattern)) {
+    const tagName = match[1];
+    const attrs = match[2];
+    const className = readAttribute(attrs, "class") || "";
+    const rect = readPageRect(attrs);
+    if (!rect) {
+      continue;
+    }
+
+    if (tagName === "a" || hasClass(className, "typst-content-link")) {
+      links.push({ rect, target: parseLinkTarget(attrs) });
+      continue;
+    }
+
+    if (hasClass(className, "typst-content-text")) {
+      const id = Number.parseInt(readAttribute(attrs, "data-text-id") || "", 10);
+      if (Number.isFinite(id)) {
+        texts.push({ id, rect });
+      }
+    }
+  }
+
+  return { pageIndex, links, texts };
+}
+
+export function hitTestLink(
+  interactions: PageInteractions | undefined,
+  x: number,
+  y: number,
+): LinkInteraction | undefined {
+  if (!interactions) {
+    return undefined;
+  }
+  return findTopmost(interactions.links, x, y);
+}
+
+export function hitTestText(
+  interactions: PageInteractions | undefined,
+  x: number,
+  y: number,
+): TextInteraction | undefined {
+  if (!interactions) {
+    return undefined;
+  }
+  return findTopmost(interactions.texts, x, y);
+}
+
+export function intersectingTextRects(
+  interactions: PageInteractions | undefined,
+  rect: PageRect,
+): PageRect[] {
+  if (!interactions) {
+    return [];
+  }
+  return interactions.texts
+    .filter((text) => rectsIntersect(text.rect, rect))
+    .map((text) => text.rect);
+}
+
+export function textRectsForLink(
+  interactions: PageInteractions | undefined,
+  link: LinkInteraction,
+): PageRect[] {
+  if (!interactions) {
+    return [];
+  }
+
+  const rects: PageRect[] = [];
+  const linkRects = interactions.links
+    .filter((candidate) => sameLinkTarget(candidate.target, link.target))
+    .map((candidate) => visualLinkRect(candidate.rect));
+
+  for (const linkRect of linkRects) {
+    for (const text of interactions.texts) {
+      const clipped = intersectRects(text.rect, linkRect);
+      if (clipped && isMeaningfulTextClip(text.rect, clipped)) {
+        rects.push(clipped);
+      }
+    }
+  }
+
+  return dedupeRects(rects);
+}
+
+function findTopmost<T extends { rect: PageRect }>(
+  items: T[],
+  x: number,
+  y: number,
+): T | undefined {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    if (rectContains(items[i].rect, x, y)) {
+      return items[i];
+    }
+  }
+  return undefined;
+}
+
+function rectContains(rect: PageRect, x: number, y: number) {
+  return x >= rect.x && y >= rect.y && x <= rect.x + rect.width && y <= rect.y + rect.height;
+}
+
+function rectsIntersect(a: PageRect, b: PageRect) {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function intersectRects(a: PageRect, b: PageRect): PageRect | undefined {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.width, b.x + b.width);
+  const bottom = Math.min(a.y + a.height, b.y + b.height);
+  if (right <= x || bottom <= y) {
+    return undefined;
+  }
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function visualLinkRect(rect: PageRect): PageRect {
+  return insetRect(rect, Math.min(1, rect.width * 0.1), Math.min(2, rect.height * 0.2)) || rect;
+}
+
+function insetRect(rect: PageRect, xInset: number, yInset: number): PageRect | undefined {
+  const width = rect.width - xInset * 2;
+  const height = rect.height - yInset * 2;
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+  return {
+    x: rect.x + xInset,
+    y: rect.y + yInset,
+    width,
+    height,
+  };
+}
+
+function isMeaningfulTextClip(text: PageRect, clipped: PageRect) {
+  return clipped.width >= 0.25 && clipped.height / Math.max(text.height, 1) >= 0.45;
+}
+
+function dedupeRects(rects: PageRect[]) {
+  const seen = new Set<string>();
+  return rects.filter((rect) => {
+    const key = `${rect.x.toFixed(3)}:${rect.y.toFixed(3)}:${rect.width.toFixed(3)}:${rect.height.toFixed(3)}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function sameLinkTarget(a: LinkTarget, b: LinkTarget) {
+  if (a.kind !== b.kind || a.href !== b.href) {
+    return false;
+  }
+  if (a.kind !== "internal") {
+    return true;
+  }
+  return (
+    a.position?.page === b.position?.page &&
+    a.position?.x === b.position?.x &&
+    a.position?.y === b.position?.y
+  );
+}
+
+function readPageRect(attrs: string): PageRect | undefined {
+  const fromData = {
+    x: readNumberAttribute(attrs, "data-typst-x"),
+    y: readNumberAttribute(attrs, "data-typst-y"),
+    width: readNumberAttribute(attrs, "data-typst-width"),
+    height: readNumberAttribute(attrs, "data-typst-height"),
+  };
+  if (isValidRect(fromData)) {
+    return fromData;
+  }
+
+  const style = readAttribute(attrs, "style");
+  if (!style) {
+    return undefined;
+  }
+
+  const fromStyle = {
+    x: readStyleCoordinate(style, "left"),
+    y: readStyleCoordinate(style, "top"),
+    width: readStyleCoordinate(style, "width"),
+    height: readStyleCoordinate(style, "height"),
+  };
+  return isValidRect(fromStyle) ? fromStyle : undefined;
+}
+
+function isValidRect(rect: {
+  x: number | undefined;
+  y: number | undefined;
+  width: number | undefined;
+  height: number | undefined;
+}): rect is PageRect {
+  return (
+    Number.isFinite(rect.x) &&
+    Number.isFinite(rect.y) &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    rect.width > 0 &&
+    rect.height > 0
+  );
+}
+
+function parseLinkTarget(attrs: string): LinkTarget {
+  const onclick = readAttribute(attrs, "onclick");
+  const internal = onclick?.match(
+    /handleTypstLocation\(this,\s*([0-9]+),\s*([^,\s]+),\s*([^)]+)\)/,
+  );
+  if (internal) {
+    return {
+      kind: "internal",
+      href: "#",
+      position: {
+        page: Number.parseInt(internal[1], 10),
+        x: Number.parseFloat(internal[2]),
+        y: Number.parseFloat(internal[3]),
+      },
+    };
+  }
+
+  const href = readAttribute(attrs, "href") || "";
+  if (isSupportedExternalHref(href)) {
+    return { kind: "external", href };
+  }
+  return { kind: "unknown", href };
+}
+
+function isSupportedExternalHref(href: string) {
+  return /^(https?:\/\/|mailto:)/i.test(href);
+}
+
+function readNumberAttribute(attrs: string, name: string): number | undefined {
+  const value = readAttribute(attrs, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  const number = Number.parseFloat(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function readAttribute(attrs: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = attrs.match(new RegExp(`\\b${escapedName}="([^"]*)"`, "i"));
+  return match ? decodeHtmlAttribute(match[1]) : undefined;
+}
+
+function hasClass(className: string, name: string) {
+  return className.split(/\s+/).includes(name);
+}
+
+function readStyleCoordinate(style: string, property: string): number | undefined {
+  const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = style.match(
+    new RegExp(
+      `${escapedProperty}\\s*:\\s*calc\\(var\\(--data-text-(?:width|height)\\) \\* ([^)]+)\\)`,
+      "i",
+    ),
+  );
+  if (!match) {
+    return undefined;
+  }
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function decodeHtmlAttribute(value: string) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -1,5 +1,15 @@
 import type { PreviewElements } from "./dom";
 import { installPageControls } from "./controls";
+import {
+  hitTestLink,
+  hitTestText,
+  textRectsForLink,
+  type BoundInteraction,
+  type LinkInteraction,
+  type PageInteractions,
+  type PageRect,
+  type TextInteraction,
+} from "./interactions";
 import { parseInvertColorStrategy, parsePreviewPositions } from "./protocol";
 import type {
   InvertColorStrategy,
@@ -31,6 +41,32 @@ export class PageHost {
   private pendingCursor: PreviewPosition | undefined;
   private outlineData: any;
   private autoInvertDecision: boolean | undefined;
+  private interactionGeneration = 0;
+  private pointerDown:
+    | {
+        pageIndex: number;
+        x: number;
+        y: number;
+      }
+    | undefined;
+  private lastPointer:
+    | {
+        pageIndex: number;
+        x: number;
+        y: number;
+      }
+    | undefined;
+  private activeHoverKey = "";
+  private nextBoundRequestId = 0;
+  private pendingBoundHover:
+    | {
+        requestId: number;
+        generation: number;
+        pageIndex: number;
+        x: number;
+        y: number;
+      }
+    | undefined;
   private readonly pageRecords = new Map<number, PageRecord>();
 
   constructor({ elements, postWorker }: PageHostOptions) {
@@ -108,6 +144,9 @@ export class PageHost {
 
     this.lastPages = pages;
     this.updatePageCount(pages.length);
+    if (this.interactionGeneration !== generation) {
+      this.interactionGeneration = generation;
+    }
 
     const livePages = new Set<number>();
     const transferred: Array<{
@@ -143,6 +182,10 @@ export class PageHost {
 
     for (const [index, record] of this.pageRecords) {
       if (!livePages.has(index)) {
+        if (this.lastPointer?.pageIndex === index) {
+          this.lastPointer = undefined;
+          this.activeHoverKey = "";
+        }
         record.container.remove();
         this.pageRecords.delete(index);
       }
@@ -247,6 +290,66 @@ export class PageHost {
     }
   }
 
+  updateInteractions(generation: number, interactions: PageInteractions[]) {
+    if (generation !== this.interactionGeneration) {
+      return;
+    }
+    let refreshHover = false;
+    for (const pageInteractions of interactions) {
+      const record = this.pageRecords.get(pageInteractions.pageIndex);
+      if (record) {
+        record.interactions = pageInteractions;
+        this.renderLinkAnchors(record);
+        refreshHover ||= this.lastPointer?.pageIndex === record.index;
+      }
+    }
+    if (refreshHover) {
+      this.activeHoverKey = "";
+      this.restoreInteractionHover();
+    }
+  }
+
+  handleBoundHit(message: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    bound?: BoundInteraction;
+  }) {
+    const pending = this.pendingBoundHover;
+    if (
+      !pending ||
+      pending.requestId !== message.requestId ||
+      pending.generation !== message.generation ||
+      pending.pageIndex !== message.pageIndex ||
+      this.interactionGeneration !== message.generation
+    ) {
+      return;
+    }
+
+    if (
+      !this.lastPointer ||
+      this.lastPointer.pageIndex !== message.pageIndex ||
+      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
+    ) {
+      return;
+    }
+
+    const record = this.pageRecords.get(message.pageIndex);
+    if (!record) {
+      return;
+    }
+
+    if (!message.bound) {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      return;
+    }
+
+    this.showBoundHover(record, message.bound);
+  }
+
   clearPages() {
     for (const record of this.pageRecords.values()) {
       record.container.remove();
@@ -254,6 +357,11 @@ export class PageHost {
     this.pageRecords.clear();
     this.lastPages = [];
     this.pendingCursor = undefined;
+    this.interactionGeneration = 0;
+    this.pointerDown = undefined;
+    this.lastPointer = undefined;
+    this.activeHoverKey = "";
+    this.pendingBoundHover = undefined;
     this.updatePageCount(0);
   }
 
@@ -277,26 +385,29 @@ export class PageHost {
     canvas.width = widthPx;
     canvas.height = heightPx;
 
+    const interactionLayer = document.createElement("div");
+    interactionLayer.className = "typst-interaction-layer";
+
+    const linkLayer = document.createElement("div");
+    linkLayer.className = "typst-link-layer";
+
     const cursor = document.createElement("div");
     cursor.className = "typst-cursor";
 
     const jumpMarker = document.createElement("div");
     jumpMarker.className = "typst-jump-marker";
 
-    container.addEventListener("click", () => {
-      if (this.contentPreview) {
-        this.postWorker({ type: "send", text: `outline-sync,${page.index + 1}` });
-      }
-    });
-
     shell.appendChild(canvas);
-    container.append(shell, cursor, jumpMarker);
+    container.append(shell, linkLayer, interactionLayer, cursor, jumpMarker);
 
-    return {
+    const record = {
+      index: page.index,
       key,
       container,
       shell,
       canvas,
+      linkLayer,
+      interactionLayer,
       cursor,
       jumpMarker,
       transferred: false,
@@ -304,6 +415,253 @@ export class PageHost {
       height: page.height,
       pixelPerPt: page.pixelPerPt,
     };
+    this.installPageInteractionHandlers(record);
+    return record;
+  }
+
+  private installPageInteractionHandlers(record: PageRecord) {
+    record.container.addEventListener("mousedown", (event) => {
+      if (event.button !== 0) {
+        return;
+      }
+      this.pointerDown = {
+        pageIndex: record.index,
+        x: event.clientX,
+        y: event.clientY,
+      };
+    });
+
+    record.container.addEventListener("mousemove", (event) => {
+      this.handlePagePointerMove(record, event);
+    });
+
+    record.container.addEventListener("mouseleave", () => {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      if (this.lastPointer?.pageIndex === record.index) {
+        this.lastPointer = undefined;
+      }
+    });
+
+    record.container.addEventListener("click", (event) => {
+      this.handlePageClick(record, event);
+    });
+  }
+
+  private handlePagePointerMove(record: PageRecord, event: MouseEvent) {
+    const point = this.pagePointFromEvent(record, event);
+    if (!point) {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      this.lastPointer = undefined;
+      return;
+    }
+
+    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
+    this.updateInteractionHover(record, point);
+  }
+
+  private updateInteractionHover(record: PageRecord, point: { x: number; y: number }) {
+    if (!record.interactions) {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      return;
+    }
+
+    const link = hitTestLink(record.interactions, point.x, point.y);
+    if (link) {
+      this.showLinkHover(record, link);
+      return;
+    }
+
+    const text = hitTestText(record.interactions, point.x, point.y);
+    if (text) {
+      this.showTextHover(record, text);
+      return;
+    }
+
+    this.requestBoundHover(record, point);
+  }
+
+  private restoreInteractionHover() {
+    if (!this.lastPointer) {
+      return;
+    }
+    const record = this.pageRecords.get(this.lastPointer.pageIndex);
+    if (!record) {
+      return;
+    }
+    this.updateInteractionHover(record, this.lastPointer);
+  }
+
+  private handlePageClick(record: PageRecord, event: MouseEvent) {
+    if (this.isDragClick(record, event)) {
+      return;
+    }
+
+    const point = this.pagePointFromEvent(record, event);
+    if (!point) {
+      return;
+    }
+    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
+
+    const link = hitTestLink(record.interactions, point.x, point.y);
+    if (link?.target.kind === "internal" && link.target.position) {
+      event.preventDefault();
+      this.scrollToTypstLocation(link.target.position);
+      return;
+    }
+
+    if (this.contentPreview) {
+      this.postWorker({ type: "send", text: `outline-sync,${record.index + 1}` });
+      return;
+    }
+
+    this.postWorker({
+      type: "send",
+      text: `src-point ${JSON.stringify({
+        page_no: record.index + 1,
+        x: point.x,
+        y: point.y,
+      })}`,
+    });
+  }
+
+  private pagePointFromEvent(
+    record: PageRecord,
+    event: MouseEvent,
+  ): { x: number; y: number } | undefined {
+    const rect = record.shell.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return undefined;
+    }
+
+    return {
+      x: clamp(((event.clientX - rect.left) / rect.width) * record.width, 0, record.width),
+      y: clamp(((event.clientY - rect.top) / rect.height) * record.height, 0, record.height),
+    };
+  }
+
+  private isDragClick(record: PageRecord, event: MouseEvent) {
+    const start = this.pointerDown;
+    this.pointerDown = undefined;
+    if (!start || start.pageIndex !== record.index) {
+      return false;
+    }
+
+    const distance = Math.hypot(event.clientX - start.x, event.clientY - start.y);
+    return distance > 4;
+  }
+
+  private showLinkHover(record: PageRecord, link: LinkInteraction) {
+    const key = `link:${record.index}:${link.target.kind}:${link.target.href}:${link.rect.x}:${link.rect.y}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    record.container.style.cursor = "pointer";
+
+    const textRects = textRectsForLink(record.interactions, link);
+    this.renderInteractionHighlights(record, textRects, "link");
+  }
+
+  private showTextHover(record: PageRecord, text: TextInteraction) {
+    const key = `text:${record.index}:${text.id}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    record.container.style.cursor = "text";
+    this.renderInteractionHighlights(record, [text.rect], "text");
+  }
+
+  private showBoundHover(record: PageRecord, bound: BoundInteraction) {
+    const key = `bound:${record.index}:${bound.kind}:${bound.rect.x}:${bound.rect.y}:${bound.rect.width}:${bound.rect.height}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    record.container.style.cursor = "";
+    this.renderInteractionHighlights(record, [bound.rect], "bound");
+  }
+
+  private requestBoundHover(record: PageRecord, point: { x: number; y: number }) {
+    const key = `bound-query:${record.index}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+
+    const request = {
+      requestId: ++this.nextBoundRequestId,
+      generation: this.interactionGeneration,
+      pageIndex: record.index,
+      x: point.x,
+      y: point.y,
+    };
+    this.activeHoverKey = key;
+    this.pendingBoundHover = request;
+    record.container.style.cursor = "";
+    this.postWorker({
+      type: "hit-bound",
+      ...request,
+    });
+  }
+
+  private renderLinkAnchors(record: PageRecord) {
+    const interactions = record.interactions;
+    if (!interactions) {
+      record.linkLayer.replaceChildren();
+      return;
+    }
+
+    const anchors = interactions.links.flatMap((link) => {
+      if (link.target.kind !== "external") {
+        return [];
+      }
+
+      const anchor = document.createElement("a");
+      anchor.href = link.target.href;
+      anchor.target = "_blank";
+      anchor.rel = "noopener noreferrer";
+      anchor.title = link.target.href;
+      anchor.setAttribute("aria-label", link.target.href);
+      anchor.addEventListener("click", (event) => event.stopPropagation());
+      this.applyRectStyle(record, anchor, link.rect);
+      return [anchor];
+    });
+
+    record.linkLayer.replaceChildren(...anchors);
+  }
+
+  private renderInteractionHighlights(
+    record: PageRecord,
+    rects: PageRect[],
+    kind: "link" | "text" | "bound",
+  ) {
+    record.interactionLayer.replaceChildren(
+      ...rects.slice(0, 64).map((rect) => {
+        const highlight = document.createElement("div");
+        highlight.className = `typst-interaction-highlight ${kind}`;
+        this.applyRectStyle(record, highlight, rect);
+        return highlight;
+      }),
+    );
+  }
+
+  private clearInteractionHighlight(record: PageRecord) {
+    record.container.style.cursor = "";
+    record.interactionLayer.replaceChildren();
+  }
+
+  private applyRectStyle(record: PageRecord, element: HTMLElement, rect: PageRect) {
+    const x = clamp(rect.x / Math.max(record.width, 1), 0, 1);
+    const y = clamp(rect.y / Math.max(record.height, 1), 0, 1);
+    const right = clamp((rect.x + rect.width) / Math.max(record.width, 1), 0, 1);
+    const bottom = clamp((rect.y + rect.height) / Math.max(record.height, 1), 0, 1);
+    element.style.left = `${x * 100}%`;
+    element.style.top = `${y * 100}%`;
+    element.style.width = `${Math.max(0, right - x) * 100}%`;
+    element.style.height = `${Math.max(0, bottom - y) * 100}%`;
   }
 
   private insertPage(record: PageRecord, index: number) {

--- a/tools/typst-preview-frontend-ng/src/types.ts
+++ b/tools/typst-preview-frontend-ng/src/types.ts
@@ -1,3 +1,5 @@
+import type { PageInteractions } from "./interactions";
+
 export type PreviewMode = "Doc" | "Slide";
 export type InvertColorStrategy = "never" | "auto" | "always";
 export type InvertColorStrategyMap = Partial<Record<"rest" | "image", InvertColorStrategy>>;
@@ -16,12 +18,16 @@ export interface PageSpec {
 }
 
 export interface PageRecord {
+  index: number;
   key: string;
   container: HTMLDivElement;
   shell: HTMLDivElement;
   canvas: HTMLCanvasElement;
+  linkLayer: HTMLDivElement;
+  interactionLayer: HTMLDivElement;
   cursor: HTMLDivElement;
   jumpMarker: HTMLDivElement;
+  interactions?: PageInteractions;
   transferred: boolean;
   width: number;
   height: number;

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -163,7 +163,7 @@ export class WorkerRenderer {
   ): BoundInteraction | undefined {
     const hitCanvasPageBound = (session as any).hitCanvasPageBound;
     if (typeof hitCanvasPageBound !== "function") {
-      throw new Error("typst.ts renderer does not provide canvas bound hit testing");
+      return undefined;
     }
 
     const bound = hitCanvasPageBound.call(session, {

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -4,11 +4,13 @@ import {
   type TypstRenderer,
 } from "@myriaddreamin/typst.ts/dist/esm/renderer.mjs";
 import * as rendererWrapper from "@myriaddreamin/typst-ts-renderer";
+import { parsePageInteractions, type BoundInteraction } from "../interactions";
 import type {
   CanvasAck,
   CanvasEntry,
   PageLayout,
   PageRenderSpec,
+  PageRenderResult,
   PageSpec,
   PendingCanvasAck,
   WorkerConfig,
@@ -31,6 +33,8 @@ export class WorkerRenderer {
   private renderQueue = Promise.resolve();
   private readonly pageCanvases = new Map<number, CanvasEntry>();
   private readonly pageCacheKeys = new Map<number, string>();
+  private readonly pageLatestCacheKeys = new Map<number, string>();
+  private readonly pageInteractionCacheKeys = new Map<number, string>();
   private readonly pendingCanvasAcks = new Map<number, PendingCanvasAck>();
   private latestPageLayouts: PageLayout[] = [];
 
@@ -92,12 +96,50 @@ export class WorkerRenderer {
     this.rejectCanvasAck(generation, error);
   }
 
+  async hitBound(request: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+  }) {
+    try {
+      if (request.generation !== this.generation) {
+        return;
+      }
+
+      const session = await this.ensureSessionReady();
+      if (request.generation !== this.generation) {
+        return;
+      }
+
+      const bound = this.hitCanvasBound(session, request.pageIndex, request.x, request.y);
+      if (request.generation !== this.generation) {
+        return;
+      }
+
+      this.post({
+        type: "bound-hit",
+        requestId: request.requestId,
+        generation: request.generation,
+        pageIndex: request.pageIndex,
+        x: request.x,
+        y: request.y,
+        bound,
+      });
+    } catch (error) {
+      this.postError(error);
+    }
+  }
+
   resetDocumentState() {
     this.initializedDocument = false;
     this.generation = 0;
     this.documentVersion += 1;
     this.pageCanvases.clear();
     this.pageCacheKeys.clear();
+    this.pageLatestCacheKeys.clear();
+    this.pageInteractionCacheKeys.clear();
     this.latestPageLayouts = [];
     for (const ack of this.pendingCanvasAcks.values()) {
       clearTimeout(ack.timeout);
@@ -111,6 +153,33 @@ export class WorkerRenderer {
     this.resetDocumentState();
     this.releaseSession?.();
     this.sessionReady = undefined;
+  }
+
+  private hitCanvasBound(
+    session: RenderSession,
+    pageIndex: number,
+    x: number,
+    y: number,
+  ): BoundInteraction | undefined {
+    const hitCanvasPageBound = (session as any).hitCanvasPageBound;
+    if (typeof hitCanvasPageBound !== "function") {
+      throw new Error("typst.ts renderer does not provide canvas bound hit testing");
+    }
+
+    const bound = hitCanvasPageBound.call(session, {
+      pageOffset: pageIndex,
+      x,
+      y,
+    });
+    if (!bound?.rect) {
+      return undefined;
+    }
+
+    return {
+      id: 0,
+      kind: typeof bound.kind === "string" ? bound.kind : "bound",
+      rect: bound.rect,
+    };
   }
 
   private async initializeRenderer(wasmUrl: string): Promise<RenderSession> {
@@ -168,6 +237,7 @@ export class WorkerRenderer {
     if (kind === "new" || !this.initializedDocument) {
       session.reset();
       this.pageCacheKeys.clear();
+      this.pageInteractionCacheKeys.clear();
       this.initializedDocument = true;
     }
     session.manipulateData({ action: "merge", data: payload });
@@ -253,6 +323,7 @@ export class WorkerRenderer {
       phase: options.phase,
       pageCount: options.pages.length,
       renderedPages: results.length,
+      interactions: results.flatMap((result) => result.interactions || []),
     });
   }
 
@@ -262,6 +333,8 @@ export class WorkerRenderer {
       if (!livePages.has(index)) {
         this.pageCanvases.delete(index);
         this.pageCacheKeys.delete(index);
+        this.pageLatestCacheKeys.delete(index);
+        this.pageInteractionCacheKeys.delete(index);
       }
     }
 
@@ -291,7 +364,7 @@ export class WorkerRenderer {
     pages: PageRenderSpec[],
     options: { useCacheKey: boolean; updateCacheKey: boolean; frameVersion: number },
   ) {
-    const results = [];
+    const results: PageRenderResult[] = [];
     let batchRendered = 0;
     for (const page of pages) {
       if (this.isRenderInterrupted(options.frameVersion)) {
@@ -335,10 +408,29 @@ export class WorkerRenderer {
         },
       } as any;
       const result = await session.renderCanvas(renderOptions);
+      if (result.cacheKey) {
+        this.pageLatestCacheKeys.set(page.index, result.cacheKey);
+      }
       if (options.updateCacheKey && result.cacheKey) {
         this.pageCacheKeys.set(page.index, result.cacheKey);
       }
-      results.push(result);
+
+      if (result.cacheKey && this.pageInteractionCacheKeys.get(page.index) !== result.cacheKey) {
+        const metadata = await session.renderCanvas({
+          pageOffset: page.index,
+          pixelPerPt: page.pixelPerPt,
+          dataSelection: {
+            body: false,
+            semantics: true,
+          },
+        } as any);
+        this.pageInteractionCacheKeys.set(page.index, result.cacheKey);
+        results.push({
+          interactions: parsePageInteractions(page.index, metadata.htmlSemantics?.[0] || ""),
+        });
+      } else {
+        results.push({});
+      }
 
       batchRendered += 1;
       if (batchRendered >= 8) {

--- a/tools/typst-preview-frontend-ng/src/worker/types.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/types.ts
@@ -1,3 +1,5 @@
+import type { PageInteractions } from "../interactions";
+
 export interface PageSpec {
   index: number;
   width: number;
@@ -46,3 +48,7 @@ export interface WorkerConfig {
 }
 
 export type WorkerPost = (message: unknown) => void;
+
+export interface PageRenderResult {
+  interactions?: PageInteractions;
+}

--- a/tools/typst-preview-frontend-ng/styles/pages.css
+++ b/tools/typst-preview-frontend-ng/styles/pages.css
@@ -50,6 +50,46 @@
   height: 100%;
 }
 
+.dragging .typst-page {
+  cursor: grabbing !important;
+}
+
+.typst-link-layer,
+.typst-interaction-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.typst-link-layer a {
+  position: absolute;
+  display: block;
+  pointer-events: auto;
+  color: inherit;
+  text-decoration: none;
+}
+
+.typst-interaction-highlight {
+  position: absolute;
+  box-sizing: border-box;
+  pointer-events: none;
+  border-radius: 1px;
+}
+
+.typst-interaction-highlight.link {
+  background: #66bab7;
+  mix-blend-mode: lighten;
+}
+
+.typst-interaction-highlight.text {
+  background: #f75c2f;
+  mix-blend-mode: lighten;
+}
+
+.typst-interaction-highlight.bound {
+  box-shadow: inset 0 0 0 1px #66bab7;
+}
+
 .invert-colors .typst-page-canvas {
   filter: invert(0.933333) hue-rotate(180deg);
 }


### PR DESCRIPTION
- Add NG preview link and bound interaction handling.
- Route interaction requests through the preview worker.
- Keep text hover parsing available for follow-up tuning.