### PR TITLE
fix(preview): improve ng canvas layout and zoom

### DIFF
--- a/tools/typst-preview-frontend-ng/src/app.ts
+++ b/tools/typst-preview-frontend-ng/src/app.ts
@@ -70,7 +70,9 @@ class PreviewApp {
     });
 
     this.vscode?.postMessage?.({ type: "started" });
-    window.addEventListener("resize", () => this.pageHost.scheduleViewportSnapshot());
+    window.addEventListener("resize", () =>
+      this.pageHost.scheduleViewportSnapshot({ applyLayouts: true }),
+    );
     this.elements.viewport.addEventListener(
       "scroll",
       () => this.pageHost.scheduleViewportSnapshot(),

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -32,6 +32,25 @@ interface PageLayoutMetrics {
   availableHeight: number;
 }
 
+interface PageLayoutRecord {
+  index: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  scale: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+interface ZoomAnchor {
+  pageIndex: number;
+  pageX: number;
+  pageY: number;
+  viewportX: number;
+  viewportY: number;
+}
+
 /** Owns preview page DOM and controls, handling render-worker page requests and routed preview protocol messages. */
 export class PageHost {
   private readonly elements: PreviewElements;
@@ -115,13 +134,10 @@ export class PageHost {
       return;
     }
 
-    const rect = this.elements.viewport.getBoundingClientRect();
-    const anchorX = this.elements.viewport.scrollLeft + event.clientX - rect.left;
-    const anchorY = this.elements.viewport.scrollTop + event.clientY - rect.top;
     const metrics = this.readPageLayoutMetrics();
+    const anchor = this.zoomAnchorFromEvent(event, metrics, this.collectPageLayouts());
     this.applyAllPageLayouts(metrics);
-    const ratio = this.zoomRatio / previousZoom;
-    this.elements.viewport.scrollBy(anchorX * (ratio - 1), anchorY * (ratio - 1));
+    this.restoreZoomAnchor(anchor, metrics, this.collectPageLayouts());
     this.scheduleViewportSnapshot();
   }
 
@@ -207,8 +223,8 @@ export class PageHost {
     );
   }
 
-  collectPageLayouts() {
-    const layouts = [];
+  collectPageLayouts(): PageLayoutRecord[] {
+    const layouts: PageLayoutRecord[] = [];
     let top = 0;
     let visibleCount = 0;
     const gap = this.pageGap();
@@ -223,14 +239,19 @@ export class PageHost {
         if (visibleCount > 0) {
           top += gap;
         }
+        const width = record.cssWidth;
         const height = record.cssHeight;
+        const scaleX = width / Math.max(record.width, 1);
+        const scaleY = height / Math.max(record.height, 1);
         layouts.push({
           index: record.index,
           top,
           bottom: top + height,
-          width: record.cssWidth,
+          width,
           height,
-          scale: height / Math.max(record.height, 1),
+          scale: scaleY,
+          scaleX,
+          scaleY,
         });
         top += height;
         visibleCount += 1;
@@ -738,6 +759,89 @@ export class PageHost {
 
   private pageGap() {
     return this.contentPreview ? 5 : 10;
+  }
+
+  private zoomAnchorFromEvent(
+    event: WheelEvent,
+    metrics: PageLayoutMetrics,
+    layouts: PageLayoutRecord[],
+  ): ZoomAnchor | undefined {
+    const viewportRect = this.elements.viewport.getBoundingClientRect();
+    const viewportX = event.clientX - viewportRect.left;
+    const viewportY = event.clientY - viewportRect.top;
+    const contentX = this.elements.viewport.scrollLeft + viewportX;
+    const contentY = this.elements.viewport.scrollTop + viewportY;
+    const layout =
+      this.findPageLayoutAt(layouts, contentY) || this.nearestPageLayout(layouts, contentY);
+    if (!layout) {
+      return undefined;
+    }
+
+    const record = this.pageRecords.get(layout.index);
+    if (!record) {
+      return undefined;
+    }
+
+    const pageLeft = this.pageLeft(record, metrics);
+    return {
+      pageIndex: layout.index,
+      pageX: clamp((contentX - pageLeft) / Math.max(layout.scaleX, 1e-6), 0, record.width),
+      pageY: clamp((contentY - layout.top) / Math.max(layout.scaleY, 1e-6), 0, record.height),
+      viewportX,
+      viewportY,
+    };
+  }
+
+  private restoreZoomAnchor(
+    anchor: ZoomAnchor | undefined,
+    metrics: PageLayoutMetrics,
+    layouts: PageLayoutRecord[],
+  ) {
+    if (!anchor) {
+      return;
+    }
+
+    const record = this.pageRecords.get(anchor.pageIndex);
+    const layout = layouts.find((candidate) => candidate.index === anchor.pageIndex);
+    if (!record || !layout) {
+      return;
+    }
+
+    const pageLeft = this.pageLeft(record, metrics);
+    this.elements.viewport.scrollTo({
+      left: pageLeft + anchor.pageX * layout.scaleX - anchor.viewportX,
+      top: layout.top + anchor.pageY * layout.scaleY - anchor.viewportY,
+      behavior: "auto",
+    });
+  }
+
+  private findPageLayoutAt(layouts: PageLayoutRecord[], contentY: number) {
+    return layouts.find((layout) => contentY >= layout.top && contentY <= layout.bottom);
+  }
+
+  private nearestPageLayout(layouts: PageLayoutRecord[], contentY: number) {
+    let nearest: PageLayoutRecord | undefined;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    for (const layout of layouts) {
+      const distance =
+        contentY < layout.top
+          ? layout.top - contentY
+          : contentY > layout.bottom
+            ? contentY - layout.bottom
+            : 0;
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearest = layout;
+      }
+    }
+    return nearest;
+  }
+
+  private pageLeft(record: PageRecord, metrics: PageLayoutMetrics) {
+    if (this.contentPreview) {
+      return 0;
+    }
+    return (metrics.availableWidth - record.cssWidth) / 2;
   }
 
   private handleJumpMessage(text: string) {

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -211,12 +211,14 @@ export class PageHost {
         }
         const rect = record.container.getBoundingClientRect();
         const top = rect.top - viewportRect.top + scrollTop;
+        const width = rect.width;
         const height = rect.height;
         return [
           {
             index,
             top,
             bottom: top + height,
+            width,
             height,
             scale: height / Math.max(record.height, 1),
           },

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -27,6 +27,11 @@ interface PageHostOptions {
   postWorker: (message: unknown, transfer?: Transferable[]) => void;
 }
 
+interface PageLayoutMetrics {
+  availableWidth: number;
+  availableHeight: number;
+}
+
 /** Owns preview page DOM and controls, handling render-worker page requests and routed preview protocol messages. */
 export class PageHost {
   private readonly elements: PreviewElements;
@@ -113,7 +118,8 @@ export class PageHost {
     const rect = this.elements.viewport.getBoundingClientRect();
     const anchorX = this.elements.viewport.scrollLeft + event.clientX - rect.left;
     const anchorY = this.elements.viewport.scrollTop + event.clientY - rect.top;
-    this.applyAllPageLayouts();
+    const metrics = this.readPageLayoutMetrics();
+    this.applyAllPageLayouts(metrics);
     const ratio = this.zoomRatio / previousZoom;
     this.elements.viewport.scrollBy(anchorX * (ratio - 1), anchorY * (ratio - 1));
     this.scheduleViewportSnapshot();
@@ -123,7 +129,7 @@ export class PageHost {
     this.previewMode = mode;
     this.elements.root.classList.toggle("mode-slide", mode === "Slide");
     this.elements.root.classList.toggle("mode-doc", mode === "Doc");
-    this.applyAllPageLayouts();
+    this.applyAllPageLayouts(this.readPageLayoutMetrics());
   }
 
   setContentPreview(enabled: boolean) {
@@ -149,6 +155,7 @@ export class PageHost {
     }
 
     const livePages = new Set<number>();
+    const metrics = this.readPageLayoutMetrics();
     const transferred: Array<{
       index: number;
       canvas: OffscreenCanvas;
@@ -170,7 +177,7 @@ export class PageHost {
         this.insertPage(record, page.index);
       }
 
-      this.applyPageLayout(record, page);
+      this.applyPageLayout(record, page, metrics);
       if (!record.transferred) {
         record.canvas.width = widthPx;
         record.canvas.height = heightPx;
@@ -201,37 +208,46 @@ export class PageHost {
   }
 
   collectPageLayouts() {
-    const viewportRect = this.elements.viewport.getBoundingClientRect();
-    const scrollTop = this.elements.viewport.scrollTop;
-    return [...this.pageRecords.entries()]
-      .sort(([a], [b]) => a - b)
-      .flatMap(([index, record]) => {
-        if (record.container.hidden) {
-          return [];
+    const layouts = [];
+    let top = 0;
+    let visibleCount = 0;
+    const gap = this.pageGap();
+
+    for (const page of this.lastPages) {
+      const record = this.pageRecords.get(page.index);
+      if (!record) {
+        continue;
+      }
+
+      if (!record.container.hidden) {
+        if (visibleCount > 0) {
+          top += gap;
         }
-        const rect = record.container.getBoundingClientRect();
-        const top = rect.top - viewportRect.top + scrollTop;
-        const width = rect.width;
-        const height = rect.height;
-        return [
-          {
-            index,
-            top,
-            bottom: top + height,
-            width,
-            height,
-            scale: height / Math.max(record.height, 1),
-          },
-        ];
-      });
+        const height = record.cssHeight;
+        layouts.push({
+          index: record.index,
+          top,
+          bottom: top + height,
+          width: record.cssWidth,
+          height,
+          scale: height / Math.max(record.height, 1),
+        });
+        top += height;
+        visibleCount += 1;
+        continue;
+      }
+    }
+
+    return layouts;
   }
 
-  readViewportSnapshot(): ViewportSnapshot {
+  readViewportSnapshot(metrics = this.readPageLayoutMetrics()): ViewportSnapshot {
     const viewport = this.elements.viewport;
-    const rect = viewport.getBoundingClientRect();
+    const width = metrics.availableWidth;
+    const height = metrics.availableHeight;
     return {
-      width: viewport.clientWidth,
-      height: viewport.clientHeight,
+      width,
+      height,
       scrollLeft: viewport.scrollLeft,
       scrollTop: viewport.scrollTop,
       devicePixelRatio: window.devicePixelRatio || 1,
@@ -240,28 +256,31 @@ export class PageHost {
         innerHeight: window.innerHeight,
       },
       boundingRect: {
-        x: rect.x,
-        y: rect.y,
-        width: rect.width,
-        height: rect.height,
-        top: rect.top,
-        right: rect.right,
-        bottom: rect.bottom,
-        left: rect.left,
+        x: 0,
+        y: 0,
+        width,
+        height,
+        top: 0,
+        right: width,
+        bottom: height,
+        left: 0,
       },
     };
   }
 
-  scheduleViewportSnapshot() {
+  scheduleViewportSnapshot(options: { applyLayouts?: boolean } = {}) {
     if (this.lastViewportTimer) {
       clearTimeout(this.lastViewportTimer);
     }
     this.lastViewportTimer = window.setTimeout(() => {
       this.lastViewportTimer = 0;
-      this.applyAllPageLayouts();
+      const metrics = this.readPageLayoutMetrics();
+      if (options.applyLayouts) {
+        this.applyAllPageLayouts(metrics);
+      }
       this.postWorker({
         type: "viewport",
-        viewport: this.readViewportSnapshot(),
+        viewport: this.readViewportSnapshot(metrics),
         layouts: this.collectPageLayouts(),
       });
     }, 50);
@@ -415,6 +434,8 @@ export class PageHost {
       transferred: false,
       width: page.width,
       height: page.height,
+      cssWidth: widthPx,
+      cssHeight: heightPx,
       pixelPerPt: page.pixelPerPt,
     };
     this.installPageInteractionHandlers(record);
@@ -681,15 +702,17 @@ export class PageHost {
     this.elements.pages.append(record.container);
   }
 
-  private applyPageLayout(record: PageRecord, page: PageSpec) {
+  private applyPageLayout(record: PageRecord, page: PageSpec, metrics: PageLayoutMetrics) {
     record.width = page.width;
     record.height = page.height;
     record.pixelPerPt = page.pixelPerPt;
     record.container.hidden =
       this.previewMode === "Slide" && page.index !== this.currentSlidePage - 1;
-    const scale = this.computePageScale(page);
+    const scale = this.computePageScale(page, metrics);
     const cssWidth = Math.ceil(page.width * scale);
     const cssHeight = Math.ceil(page.height * scale);
+    record.cssWidth = cssWidth;
+    record.cssHeight = cssHeight;
     record.container.style.width = `${cssWidth}px`;
     record.container.style.height = `${cssHeight}px`;
     record.shell.style.width = `${cssWidth}px`;
@@ -697,15 +720,24 @@ export class PageHost {
     record.shell.dataset.appliedScale = String(scale);
   }
 
-  private computePageScale(page: PageSpec): number {
-    const availableWidth = Math.max(1, this.elements.viewport.clientWidth);
-    const availableHeight = Math.max(1, this.elements.viewport.clientHeight);
-    const fitWidth = availableWidth / page.width;
+  private computePageScale(page: PageSpec, metrics: PageLayoutMetrics): number {
+    const fitWidth = metrics.availableWidth / page.width;
     const baseScale =
       this.previewMode === "Slide"
-        ? Math.max(0.1, Math.min(fitWidth, availableHeight / page.height))
+        ? Math.max(0.1, Math.min(fitWidth, metrics.availableHeight / page.height))
         : Math.max(0.1, fitWidth);
     return baseScale * this.zoomRatio;
+  }
+
+  private readPageLayoutMetrics(): PageLayoutMetrics {
+    return {
+      availableWidth: Math.max(1, this.elements.viewport.clientWidth),
+      availableHeight: Math.max(1, this.elements.viewport.clientHeight),
+    };
+  }
+
+  private pageGap() {
+    return this.contentPreview ? 5 : 10;
   }
 
   private handleJumpMessage(text: string) {
@@ -798,15 +830,12 @@ export class PageHost {
       this.elements.viewport.scrollTop + this.elements.viewport.clientHeight / 2;
     let bestPage = 1;
     let bestDistance = Number.POSITIVE_INFINITY;
-    for (const [index, record] of this.pageRecords) {
-      if (record.container.hidden) {
-        continue;
-      }
-      const center = record.container.offsetTop + record.container.offsetHeight / 2;
+    for (const layout of this.collectPageLayouts()) {
+      const center = (layout.top + layout.bottom) / 2;
       const distance = Math.abs(center - viewportCenter);
       if (distance < bestDistance) {
         bestDistance = distance;
-        bestPage = index + 1;
+        bestPage = layout.index + 1;
       }
     }
     return bestPage;
@@ -817,7 +846,7 @@ export class PageHost {
       return;
     }
     this.currentSlidePage = clamp(Math.trunc(page), 1, this.pageCount);
-    this.applyAllPageLayouts();
+    this.applyAllPageLayouts(this.readPageLayoutMetrics());
     this.renderCursor();
     this.elements.viewport.scrollTo({ top: 0, left: 0, behavior: "auto" });
     this.scheduleViewportSnapshot();
@@ -828,11 +857,11 @@ export class PageHost {
     this.currentSlidePage = clamp(this.currentSlidePage, 1, Math.max(1, this.pageCount));
   }
 
-  private applyAllPageLayouts() {
+  private applyAllPageLayouts(metrics = this.readPageLayoutMetrics()) {
     for (const page of this.lastPages) {
       const record = this.pageRecords.get(page.index);
       if (record) {
-        this.applyPageLayout(record, page);
+        this.applyPageLayout(record, page, metrics);
       }
     }
     this.renderCursor();

--- a/tools/typst-preview-frontend-ng/src/types.ts
+++ b/tools/typst-preview-frontend-ng/src/types.ts
@@ -31,6 +31,8 @@ export interface PageRecord {
   transferred: boolean;
   width: number;
   height: number;
+  cssWidth: number;
+  cssHeight: number;
   pixelPerPt: number;
 }
 

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -17,7 +17,8 @@ import type {
   WorkerPost,
 } from "./types";
 
-const pixelPerPt = 3;
+const minPixelPerPt = 0.5;
+const maxPixelPerPt = 4;
 
 /** Owns Typst rendering in the worker, handling document frames, canvas acknowledgements, and viewport updates. */
 export class WorkerRenderer {
@@ -34,6 +35,7 @@ export class WorkerRenderer {
   private readonly pageCanvases = new Map<number, CanvasEntry>();
   private readonly pageCacheKeys = new Map<number, string>();
   private readonly pageLatestCacheKeys = new Map<number, string>();
+  private readonly pagePixelPerPt = new Map<number, number>();
   private readonly pageInteractionCacheKeys = new Map<number, string>();
   private readonly pendingCanvasAcks = new Map<number, PendingCanvasAck>();
   private latestPageLayouts: PageLayout[] = [];
@@ -139,6 +141,7 @@ export class WorkerRenderer {
     this.pageCanvases.clear();
     this.pageCacheKeys.clear();
     this.pageLatestCacheKeys.clear();
+    this.pagePixelPerPt.clear();
     this.pageInteractionCacheKeys.clear();
     this.latestPageLayouts = [];
     for (const ack of this.pendingCanvasAcks.values()) {
@@ -180,6 +183,26 @@ export class WorkerRenderer {
       kind: typeof bound.kind === "string" ? bound.kind : "bound",
       rect: bound.rect,
     };
+  }
+
+  private computePagePixelPerPt(index: number, width: number, height: number) {
+    const devicePixelRatio = clamp(this.config.viewport?.devicePixelRatio || 1, 1, 4);
+    const layout = this.latestPageLayouts.find((candidate) => candidate.index === index);
+    if (layout?.width && layout.width > 0) {
+      return clampPixelPerPt((layout.width * devicePixelRatio) / Math.max(width, 1));
+    }
+
+    const viewport = this.config.viewport || {};
+    const viewportWidth = Math.max(1, viewport.width || viewport.window?.innerWidth || width);
+    const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || height);
+    const fitWidth = viewportWidth / Math.max(width, 1);
+    const fitHeight = viewportHeight / Math.max(height, 1);
+    const scale =
+      this.config.previewMode === "Slide"
+        ? Math.max(0.1, Math.min(fitWidth, fitHeight))
+        : Math.max(0.1, fitWidth);
+    const cssWidth = Math.ceil(width * scale);
+    return clampPixelPerPt((cssWidth * devicePixelRatio) / Math.max(width, 1));
   }
 
   private async initializeRenderer(wasmUrl: string): Promise<RenderSession> {
@@ -241,12 +264,16 @@ export class WorkerRenderer {
       this.initializedDocument = true;
     }
     session.manipulateData({ action: "merge", data: payload });
-    const pages = session.retrievePagesInfo().map((page, index) => ({
-      index,
-      width: page.width,
-      height: page.height,
-      pixelPerPt,
-    }));
+    const pages = session.retrievePagesInfo().map((page, index) => {
+      const pixelPerPt = this.computePagePixelPerPt(index, page.width, page.height);
+      this.pagePixelPerPt.set(index, pixelPerPt);
+      return {
+        index,
+        width: page.width,
+        height: page.height,
+        pixelPerPt,
+      };
+    });
     const nextGeneration = ++this.generation;
     const canvasAck = await this.ensureCanvases(nextGeneration, pages);
     if (canvasAck?.layouts) {
@@ -334,6 +361,7 @@ export class WorkerRenderer {
         this.pageCanvases.delete(index);
         this.pageCacheKeys.delete(index);
         this.pageLatestCacheKeys.delete(index);
+        this.pagePixelPerPt.delete(index);
         this.pageInteractionCacheKeys.delete(index);
       }
     }
@@ -550,4 +578,12 @@ function distanceToViewport(
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function clampPixelPerPt(value: number) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return minPixelPerPt;
+  }
+  const bucketed = Math.ceil((value - 1e-3) * 4) / 4;
+  return clamp(bucketed, minPixelPerPt, maxPixelPerPt);
 }

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -105,6 +105,21 @@ export class WorkerRenderer {
     x: number;
     y: number;
   }) {
+    this.renderQueue = this.renderQueue
+      .then(() => this.hitBoundExclusive(request))
+      .catch((error) => {
+        this.postError(error);
+      });
+    await this.renderQueue;
+  }
+
+  private async hitBoundExclusive(request: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+  }) {
     try {
       if (request.generation !== this.generation) {
         return;

--- a/tools/typst-preview-frontend-ng/src/worker/types.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/types.ts
@@ -20,6 +20,7 @@ export interface PageLayout {
   index: number;
   top: number;
   bottom: number;
+  width: number;
   height: number;
   scale: number;
 }
@@ -44,6 +45,7 @@ export interface PendingCanvasAck {
 export interface WorkerConfig {
   rendererWasmUrl?: string;
   viewport?: any;
+  previewMode?: string;
   isContentPreview?: boolean;
 }
 


### PR DESCRIPTION
- Adapt NG canvas backing resolution to page layout and device scale.
- Track viewport metrics for render layout snapshots.
- Preserve the scroll anchor while wheel-zooming.