### PR TITLE
fix(query): avoid recursive type blowups in hover and signature docs

### DIFF
--- a/crates/tinymist-analysis/src/docs/def.rs
+++ b/crates/tinymist-analysis/src/docs/def.rs
@@ -449,3 +449,10 @@ pub fn format_ty(ty: Option<&Ty>) -> TypeRepr {
 
     Some((short, long, value))
 }
+
+/// Formats the type when only the short display form is needed.
+pub fn format_ty_short(ty: Option<&Ty>) -> TypeRepr {
+    let ty = ty?;
+    let short = ty.repr().unwrap_or_else(|| "any".into());
+    Some((short.clone(), short.clone(), short))
+}

--- a/crates/tinymist-analysis/src/ty/def.rs
+++ b/crates/tinymist-analysis/src/ty/def.rs
@@ -1604,6 +1604,8 @@ impl FlowVarKind {
 pub(super) struct TypeCanoStore {
     /// Maps a type to its canonical form.
     pub cano_cache: FxHashMap<(Ty, bool), Ty>,
+    /// Memoizes sub-type transforms within one simplify call.
+    pub transform_cache: FxHashMap<(Ty, bool), Ty>,
     /// Maps a local type to its canonical form.
     pub cano_local_cache: FxHashMap<(DeclExpr, bool), Ty>,
     /// The negative bounds of a type variable.

--- a/crates/tinymist-analysis/src/ty/simplify.rs
+++ b/crates/tinymist-analysis/src/ty/simplify.rs
@@ -21,6 +21,7 @@ impl TypeInfo {
         let mut cache = self.cano_cache.lock();
         let cache = &mut *cache;
 
+        cache.transform_cache.clear();
         cache.cano_local_cache.clear();
         cache.positives.clear();
         cache.negatives.clear();
@@ -29,6 +30,7 @@ impl TypeInfo {
             principal,
             vars: &self.vars,
             cano_cache: &mut cache.cano_cache,
+            transform_cache: &mut cache.transform_cache,
             cano_local_cache: &mut cache.cano_local_cache,
 
             positives: &mut cache.positives,
@@ -46,6 +48,7 @@ struct TypeSimplifier<'a, 'b> {
     vars: &'a FxHashMap<DeclExpr, TypeVarBounds>,
 
     cano_cache: &'b mut FxHashMap<(Ty, bool), Ty>,
+    transform_cache: &'b mut FxHashMap<(Ty, bool), Ty>,
     cano_local_cache: &'b mut FxHashMap<(DeclExpr, bool), Ty>,
     negatives: &'b mut FxHashSet<DeclExpr>,
     positives: &'b mut FxHashSet<DeclExpr>,
@@ -59,8 +62,9 @@ impl TypeSimplifier<'_, '_> {
         }
 
         self.analyze(&ty, true);
-
-        self.transform(&ty, true)
+        let cano = self.transform(&ty, true);
+        self.cano_cache.insert((ty, principal), cano.clone());
+        cano
     }
 
     /// Analyzes the given type.
@@ -168,7 +172,11 @@ impl TypeSimplifier<'_, '_> {
 
     /// Transforms the given type.
     fn transform(&mut self, ty: &Ty, pol: bool) -> Ty {
-        match ty {
+        if let Some(cano) = self.transform_cache.get(&(ty.clone(), pol)) {
+            return cano.clone();
+        }
+
+        let cano = match ty {
             Ty::Let(bounds) => self.transform_let(bounds.lbs.iter(), bounds.ubs.iter(), None, pol),
             Ty::Var(var) => {
                 if let Some(cano) = self
@@ -252,7 +260,10 @@ impl TypeSimplifier<'_, '_> {
             Ty::Any => Ty::Any,
             Ty::Boolean(truthiness) => Ty::Boolean(*truthiness),
             Ty::Builtin(ty) => Ty::Builtin(ty.clone()),
-        }
+        };
+
+        self.transform_cache.insert((ty.clone(), pol), cano.clone());
+        cano
     }
 
     /// Transforms the given sequence of types.
@@ -322,6 +333,7 @@ impl TypeSimplifier<'_, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::syntax::Decl;
 
     /// See https://github.com/typst/typst/issues/6285
     #[test]
@@ -347,5 +359,87 @@ mod tests {
         res.extend(vec![ch("c"), val(Value::None), ch("a")]);
 
         test_sort_ty(res);
+    }
+
+    fn var(name: &str) -> TypeVarBounds {
+        TypeVarBounds::new(
+            TypeVar {
+                name: name.into(),
+                def: Decl::lit(name).into(),
+            },
+            DynTypeBounds::default(),
+        )
+    }
+
+    fn recursive_fun(root: &Interned<TypeVar>, depth: usize) -> Ty {
+        let mut body = Ty::Var(root.clone());
+        for _ in 0..depth {
+            body = Ty::Func(SigTy::unary(Ty::Any, body));
+        }
+        body
+    }
+
+    #[test]
+    fn test_recursive_cycle_union_is_not_aligned_like_simple_sub() {
+        let mut info = TypeInfo::default();
+
+        let one = var("one");
+        let two = var("two");
+
+        let one_ty = one.as_type();
+        let two_ty = two.as_type();
+
+        info.vars.insert(one.var.def.clone(), one.clone());
+        info.vars.insert(two.var.def.clone(), two.clone());
+
+        info.vars
+            .get(&one.var.def)
+            .unwrap()
+            .bounds
+            .bounds()
+            .write()
+            .lbs
+            .insert_mut(recursive_fun(&one.var, 1));
+        info.vars
+            .get(&two.var.def)
+            .unwrap()
+            .bounds
+            .bounds()
+            .write()
+            .lbs
+            .insert_mut(recursive_fun(&two.var, 2));
+
+        let merged = Ty::from_types([one_ty, two_ty].into_iter());
+        let simplified = info.simplify(merged, true);
+        assert_eq!(
+            format!("{simplified:?}"),
+            "((Any) => Any | (Any) => (Any) => Any)"
+        );
+    }
+
+    #[test]
+    fn test_simplify_populates_top_level_cache() {
+        let mut info = TypeInfo::default();
+        let one = var("one");
+        let one_ty = one.as_type();
+        info.vars.insert(one.var.def.clone(), one.clone());
+        info.vars
+            .get(&one.var.def)
+            .unwrap()
+            .bounds
+            .bounds()
+            .write()
+            .lbs
+            .insert_mut(recursive_fun(&one.var, 1));
+
+        let _ = info.simplify(one_ty.clone(), true);
+        let first_cache_len = info.cano_cache.lock().cano_cache.len();
+        let _ = info.simplify(one_ty, true);
+        let second_cache_len = info.cano_cache.lock().cano_cache.len();
+        assert!(
+            first_cache_len > 0,
+            "simplify should memoize the top-level result"
+        );
+        assert_eq!(first_cache_len, second_cache_len);
     }
 }

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -1,19 +1,24 @@
 //! Analysis of function signatures.
 
+use std::cell::RefCell;
+
 use itertools::Either;
 use tinymist_analysis::{ArgInfo, ArgsInfo, PartialSignature, func_signature};
 use tinymist_derive::BindTyCtx;
+use tinymist_std::hash::FxHashSet;
 
 use super::{Definition, SharedContext, prelude::*};
 use crate::analysis::PostTypeChecker;
-use crate::docs::{DocText, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
-use crate::syntax::classify_def_loosely;
+use crate::docs::{DocText, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs, sanitize_doc_ty};
+use crate::syntax::{DeclExpr, classify_def_loosely};
 use crate::ty::{
-    BoundChecker, DocSource, DynTypeBounds, ParamAttrs, ParamTy, SigWithTy, TyCtx, TypeInfo,
-    TypeVar,
+    BoundChecker, DocSource, DynTypeBounds, ParamAttrs, ParamTy, SigTy, SigWithTy, TyCtx, TyCtxMut,
+    TypeInfo, TypeVar,
 };
 
 pub use tinymist_analysis::{PrimarySignature, Signature};
+
+const SIG_OF_TYPE_BOUNDS_BUDGET: usize = 128;
 
 /// The language object that the signature is being analyzed for.
 #[derive(Debug, Clone)]
@@ -96,9 +101,13 @@ pub(crate) fn sig_of_type(
     let type_var = srcs.into_iter().next()?;
     match type_var {
         DocSource::Var(v) => {
-            let mut ty_ctx = PostTypeChecker::new(ctx.clone(), type_info);
+            let mut ty_ctx =
+                SignatureTypeContext::new(PostTypeChecker::new(ctx.clone(), type_info));
             let sig_ty = Ty::Func(ty.sig_repr(true, &mut ty_ctx)?);
-            let sig_ty = type_info.simplify(sig_ty, false);
+            if ty_ctx.exhausted() {
+                return None;
+            }
+            let sig_ty = sanitize_signature_type(sig_ty);
             let Ty::Func(sig_ty) = sig_ty else {
                 static WARN_ONCE: std::sync::Once = std::sync::Once::new();
                 WARN_ONCE.call_once(|| {
@@ -109,6 +118,7 @@ pub(crate) fn sig_of_type(
             };
 
             // todo: this will affect inlay hint: _var_with
+            ty_ctx.reset_bounds_guard();
             let (var_with, docstring) = match type_info.var_docs.get(&v.def).map(|x| x.as_ref()) {
                 Some(UntypedDefDocs::Function(sig)) => (vec![], Either::Left(sig.as_ref())),
                 Some(UntypedDefDocs::Variable(docs)) => find_alias_stack(&mut ty_ctx, &v, docs)?,
@@ -200,6 +210,117 @@ pub(crate) fn sig_of_type(
     }
 }
 
+fn sanitize_signature_type(ty: Ty) -> Ty {
+    match ty {
+        Ty::Func(sig) => {
+            let mut sig = sig.as_ref().clone();
+            sig.inputs = sig
+                .inputs
+                .iter()
+                .map(sanitize_doc_ty)
+                .collect::<Vec<_>>()
+                .into();
+            sig.body = sig.body.as_ref().map(sanitize_doc_ty);
+            Ty::Func(sig.into())
+        }
+        ty => sanitize_doc_ty(&ty),
+    }
+}
+
+/// A type context for docs/signature rendering.
+///
+/// It intentionally bounds global variable expansion: recursive package-level
+/// types should degrade to incomplete docs, not dominate hover or SCIP output.
+struct SignatureTypeContext<'a> {
+    inner: PostTypeChecker<'a>,
+    bounds: RefCell<SignatureBoundsGuard>,
+}
+
+impl<'a> SignatureTypeContext<'a> {
+    fn new(inner: PostTypeChecker<'a>) -> Self {
+        Self {
+            inner,
+            bounds: RefCell::new(SignatureBoundsGuard {
+                remaining: SIG_OF_TYPE_BOUNDS_BUDGET,
+                visited: FxHashSet::default(),
+                exhausted: false,
+            }),
+        }
+    }
+
+    fn exhausted(&self) -> bool {
+        self.bounds.borrow().exhausted
+    }
+
+    fn reset_bounds_guard(&self) {
+        *self.bounds.borrow_mut() = SignatureBoundsGuard {
+            remaining: SIG_OF_TYPE_BOUNDS_BUDGET,
+            visited: FxHashSet::default(),
+            exhausted: false,
+        };
+    }
+}
+
+struct SignatureBoundsGuard {
+    remaining: usize,
+    visited: FxHashSet<(DeclExpr, bool)>,
+    exhausted: bool,
+}
+
+impl TyCtx for SignatureTypeContext<'_> {
+    fn global_bounds(&self, var: &Interned<TypeVar>, pol: bool) -> Option<DynTypeBounds> {
+        let mut bounds = self.bounds.borrow_mut();
+        if bounds.exhausted {
+            return None;
+        }
+
+        if !bounds.visited.insert((var.def.clone(), pol)) {
+            return None;
+        }
+
+        if bounds.remaining == 0 {
+            bounds.exhausted = true;
+            return None;
+        }
+        bounds.remaining -= 1;
+        drop(bounds);
+
+        self.inner.global_bounds(var, pol)
+    }
+
+    fn local_bind_of(&self, var: &Interned<TypeVar>) -> Option<Ty> {
+        self.inner.local_bind_of(var)
+    }
+}
+
+impl TyCtxMut for SignatureTypeContext<'_> {
+    type Snap = <TypeInfo as TyCtxMut>::Snap;
+
+    fn start_scope(&mut self) -> Self::Snap {
+        self.inner.start_scope()
+    }
+
+    fn end_scope(&mut self, snap: Self::Snap) {
+        self.inner.end_scope(snap)
+    }
+
+    fn bind_local(&mut self, var: &Interned<TypeVar>, ty: Ty) {
+        self.inner.bind_local(var, ty);
+    }
+
+    fn type_of_func(&mut self, func: &Func) -> Option<Interned<SigTy>> {
+        self.inner.type_of_func(func)
+    }
+
+    fn type_of_value(&mut self, val: &Value) -> Ty {
+        self.inner.type_of_value(val)
+    }
+
+    fn check_module_item(&mut self, module: TypstFileId, key: &StrRef) -> Option<Ty> {
+        self.inner.check_module_item(module, key)
+    }
+}
+
 fn wind_stack(var_with: Vec<WithElem>, sig: Signature) -> Signature {
     if var_with.is_empty() {
         return sig;
@@ -241,7 +362,7 @@ fn wind_stack(var_with: Vec<WithElem>, sig: Signature) -> Signature {
 type WithElem<'a> = (&'a UntypedVarDocs, Option<Interned<SigWithTy>>);
 
 fn find_alias_stack<'a>(
-    ctx: &'a mut PostTypeChecker,
+    ctx: &'a mut SignatureTypeContext,
     var: &Interned<TypeVar>,
     docs: &'a UntypedVarDocs,
 ) -> Option<(Vec<WithElem<'a>>, Either<&'a UntypedSignatureDocs, Func>)> {
@@ -252,6 +373,9 @@ fn find_alias_stack<'a>(
         checking_with: true,
     };
     Ty::Var(var.clone()).bounds(true, &mut checker);
+    if checker.ctx.exhausted() {
+        return None;
+    }
 
     checker.res.map(|res| (checker.stack, res))
 }
@@ -259,7 +383,7 @@ fn find_alias_stack<'a>(
 #[derive(BindTyCtx)]
 #[bind(ctx)]
 struct AliasStackChecker<'a, 'b> {
-    ctx: &'a mut PostTypeChecker<'b>,
+    ctx: &'a mut SignatureTypeContext<'b>,
     stack: Vec<WithElem<'a>>,
     res: Option<Either<&'a UntypedSignatureDocs, Func>>,
     checking_with: bool,
@@ -277,13 +401,14 @@ impl BoundChecker for AliasStackChecker<'_, '_> {
             return;
         }
 
-        let docs = self.ctx.info.var_docs.get(&u.def).map(|x| x.as_ref());
+        let docs: Option<&UntypedDefDocs> =
+            self.ctx.inner.info.var_docs.get(&u.def).map(|x| x.as_ref());
 
         crate::log_debug_ct!("collecting var {u:?} {pol:?} => {docs:?}");
         // todo: bind builtin functions
         match docs {
             Some(UntypedDefDocs::Function(sig)) => {
-                self.res = Some(Either::Left(sig));
+                self.res = Some(Either::Left(sig.as_ref()));
             }
             Some(UntypedDefDocs::Variable(docs)) => {
                 self.checking_with = true;

--- a/crates/tinymist-query/src/analysis/signature.rs
+++ b/crates/tinymist-query/src/analysis/signature.rs
@@ -9,7 +9,7 @@ use tinymist_std::hash::FxHashSet;
 
 use super::{Definition, SharedContext, prelude::*};
 use crate::analysis::PostTypeChecker;
-use crate::docs::{DocText, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs, sanitize_doc_ty};
+use crate::docs::{DocText, UntypedDefDocs, UntypedSignatureDocs, UntypedVarDocs};
 use crate::syntax::{DeclExpr, classify_def_loosely};
 use crate::ty::{
     BoundChecker, DocSource, DynTypeBounds, ParamAttrs, ParamTy, SigTy, SigWithTy, TyCtx, TyCtxMut,
@@ -17,8 +17,6 @@ use crate::ty::{
 };
 
 pub use tinymist_analysis::{PrimarySignature, Signature};
-
-const SIG_OF_TYPE_BOUNDS_BUDGET: usize = 128;
 
 /// The language object that the signature is being analyzed for.
 #[derive(Debug, Clone)]
@@ -104,10 +102,7 @@ pub(crate) fn sig_of_type(
             let mut ty_ctx =
                 SignatureTypeContext::new(PostTypeChecker::new(ctx.clone(), type_info));
             let sig_ty = Ty::Func(ty.sig_repr(true, &mut ty_ctx)?);
-            if ty_ctx.exhausted() {
-                return None;
-            }
-            let sig_ty = sanitize_signature_type(sig_ty);
+            let sig_ty = type_info.simplify(sig_ty, false);
             let Ty::Func(sig_ty) = sig_ty else {
                 static WARN_ONCE: std::sync::Once = std::sync::Once::new();
                 WARN_ONCE.call_once(|| {
@@ -118,7 +113,7 @@ pub(crate) fn sig_of_type(
             };
 
             // todo: this will affect inlay hint: _var_with
-            ty_ctx.reset_bounds_guard();
+            ty_ctx.reset_cycle_guard();
             let (var_with, docstring) = match type_info.var_docs.get(&v.def).map(|x| x.as_ref()) {
                 Some(UntypedDefDocs::Function(sig)) => (vec![], Either::Left(sig.as_ref())),
                 Some(UntypedDefDocs::Variable(docs)) => find_alias_stack(&mut ty_ctx, &v, docs)?,
@@ -210,80 +205,31 @@ pub(crate) fn sig_of_type(
     }
 }
 
-fn sanitize_signature_type(ty: Ty) -> Ty {
-    match ty {
-        Ty::Func(sig) => {
-            let mut sig = sig.as_ref().clone();
-            sig.inputs = sig
-                .inputs
-                .iter()
-                .map(sanitize_doc_ty)
-                .collect::<Vec<_>>()
-                .into();
-            sig.body = sig.body.as_ref().map(sanitize_doc_ty);
-            Ty::Func(sig.into())
-        }
-        ty => sanitize_doc_ty(&ty),
-    }
-}
-
-/// A type context for docs/signature rendering.
-///
-/// It intentionally bounds global variable expansion: recursive package-level
-/// types should degrade to incomplete docs, not dominate hover or SCIP output.
+/// A type context for signature rendering that memoizes `(TypeVar, polarity)`
+/// visits within a single traversal so recursive bounds are only expanded once.
 struct SignatureTypeContext<'a> {
     inner: PostTypeChecker<'a>,
-    bounds: RefCell<SignatureBoundsGuard>,
+    visited: RefCell<FxHashSet<(DeclExpr, bool)>>,
 }
 
 impl<'a> SignatureTypeContext<'a> {
     fn new(inner: PostTypeChecker<'a>) -> Self {
         Self {
             inner,
-            bounds: RefCell::new(SignatureBoundsGuard {
-                remaining: SIG_OF_TYPE_BOUNDS_BUDGET,
-                visited: FxHashSet::default(),
-                exhausted: false,
-            }),
+            visited: RefCell::new(FxHashSet::default()),
         }
     }
 
-    fn exhausted(&self) -> bool {
-        self.bounds.borrow().exhausted
+    fn reset_cycle_guard(&self) {
+        self.visited.borrow_mut().clear();
     }
-
-    fn reset_bounds_guard(&self) {
-        *self.bounds.borrow_mut() = SignatureBoundsGuard {
-            remaining: SIG_OF_TYPE_BOUNDS_BUDGET,
-            visited: FxHashSet::default(),
-            exhausted: false,
-        };
-    }
-}
-
-struct SignatureBoundsGuard {
-    remaining: usize,
-    visited: FxHashSet<(DeclExpr, bool)>,
-    exhausted: bool,
 }
 
 impl TyCtx for SignatureTypeContext<'_> {
     fn global_bounds(&self, var: &Interned<TypeVar>, pol: bool) -> Option<DynTypeBounds> {
-        let mut bounds = self.bounds.borrow_mut();
-        if bounds.exhausted {
+        if !self.visited.borrow_mut().insert((var.def.clone(), pol)) {
             return None;
         }
-
-        if !bounds.visited.insert((var.def.clone(), pol)) {
-            return None;
-        }
-
-        if bounds.remaining == 0 {
-            bounds.exhausted = true;
-            return None;
-        }
-        bounds.remaining -= 1;
-        drop(bounds);
 
         self.inner.global_bounds(var, pol)
     }
@@ -373,9 +319,6 @@ fn find_alias_stack<'a>(
         checking_with: true,
     };
     Ty::Var(var.clone()).bounds(true, &mut checker);
-    if checker.ctx.exhausted() {
-        return None;
-    }
 
     checker.res.map(|res| (checker.stack, res))
 }
@@ -401,14 +344,13 @@ impl BoundChecker for AliasStackChecker<'_, '_> {
             return;
         }
 
-        let docs: Option<&UntypedDefDocs> =
-            self.ctx.inner.info.var_docs.get(&u.def).map(|x| x.as_ref());
+        let docs = self.ctx.inner.info.var_docs.get(&u.def).map(|x| x.as_ref());
 
         crate::log_debug_ct!("collecting var {u:?} {pol:?} => {docs:?}");
         // todo: bind builtin functions
         match docs {
             Some(UntypedDefDocs::Function(sig)) => {
-                self.res = Some(Either::Left(sig.as_ref()));
+                self.res = Some(Either::Left(sig));
             }
             Some(UntypedDefDocs::Variable(docs)) => {
                 self.checking_with = true;

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -6,7 +6,7 @@ use tinymist_analysis::docs::tidy::remove_list_annotations;
 use tinymist_analysis::docs::{
     DocText, DocTextResolver, ParamDocs, SignatureDocs, VarDocs, format_ty,
 };
-use tinymist_analysis::ty::DocSource;
+use tinymist_analysis::ty::{DocSource, Ty};
 use typst::syntax::Span;
 
 use crate::LocalContext;
@@ -27,9 +27,10 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     // todo people can easily forget to simplify the type which is not good. we
     // might find a way to ensure them at compile time.
     //
-    // Must be simplified before formatting, to expand type aliases.
-    let simplified_ty = type_info.simplify(ty, false);
-    let return_ty = format_ty(Some(&simplified_ty));
+    // Avoid canonicalizing here: recursive package types can make hover/docs
+    // formatting dominate SCIP generation.
+    let display_ty = sanitize_doc_ty(&ty);
+    let return_ty = format_ty(Some(&display_ty));
     match doc_source {
         DocSource::Var(var) => {
             let docs = type_info
@@ -51,6 +52,25 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
             }
         }),
         _ => None,
+    }
+}
+
+pub(crate) fn sanitize_doc_ty(ty: &Ty) -> Ty {
+    match ty {
+        Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => ty.clone(),
+        Ty::Array(elem) => Ty::Array(sanitize_doc_ty(elem).into()),
+        Ty::Tuple(elems) if elems.len() <= 4 => {
+            Ty::Tuple(elems.iter().map(sanitize_doc_ty).collect::<Vec<_>>().into())
+        }
+        Ty::Union(types) if types.len() <= 4 => {
+            let types = types
+                .iter()
+                .map(sanitize_doc_ty)
+                .filter(|ty| !matches!(ty, Ty::Any))
+                .collect::<Vec<_>>();
+            Ty::from_types(types.into_iter())
+        }
+        _ => Ty::Any,
     }
 }
 

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -4,9 +4,9 @@ use ecow::EcoString;
 use tinymist_analysis::Signature;
 use tinymist_analysis::docs::tidy::remove_list_annotations;
 use tinymist_analysis::docs::{
-    DocText, DocTextResolver, ParamDocs, SignatureDocs, VarDocs, format_ty,
+    DocText, DocTextResolver, ParamDocs, SignatureDocs, VarDocs, format_ty_short,
 };
-use tinymist_analysis::ty::{DocSource, Ty};
+use tinymist_analysis::ty::DocSource;
 use typst::syntax::Span;
 
 use crate::LocalContext;
@@ -27,10 +27,9 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     // todo people can easily forget to simplify the type which is not good. we
     // might find a way to ensure them at compile time.
     //
-    // Avoid canonicalizing here: recursive package types can make hover/docs
-    // formatting dominate SCIP generation.
-    let display_ty = sanitize_doc_ty(&ty);
-    let return_ty = format_ty(Some(&display_ty));
+    // Must be simplified before formatting, to expand type aliases.
+    let simplified_ty = type_info.simplify(ty, false);
+    let return_ty = format_ty_short(Some(&simplified_ty));
     match doc_source {
         DocSource::Var(var) => {
             let docs = type_info
@@ -52,25 +51,6 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
             }
         }),
         _ => None,
-    }
-}
-
-pub(crate) fn sanitize_doc_ty(ty: &Ty) -> Ty {
-    match ty {
-        Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => ty.clone(),
-        Ty::Array(elem) => Ty::Array(sanitize_doc_ty(elem).into()),
-        Ty::Tuple(elems) if elems.len() <= 4 => {
-            Ty::Tuple(elems.iter().map(sanitize_doc_ty).collect::<Vec<_>>().into())
-        }
-        Ty::Union(types) if types.len() <= 4 => {
-            let types = types
-                .iter()
-                .map(sanitize_doc_ty)
-                .filter(|ty| !matches!(ty, Ty::Any))
-                .collect::<Vec<_>>();
-            Ty::from_types(types.into_iter())
-        }
-        _ => Ty::Any,
     }
 }
 
@@ -100,7 +80,7 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
         .collect::<std::collections::BTreeMap<_, _>>();
     let rest = rest_in.map(|(param, ty)| ParamDocs::new(ctx, param, ty));
 
-    let ret_ty = format_ty(ret_in);
+    let ret_ty = format_ty_short(ret_in);
 
     let docs = sig
         .primary()

--- a/crates/tinymist-query/src/fixtures/hover/kleene_known_nonempty.typ
+++ b/crates/tinymist-query/src/fixtures/hover/kleene_known_nonempty.typ
@@ -1,0 +1,171 @@
+/// path: typst.toml
+[package]
+name = "fixture-anonly-minstack-noapply"
+version = "0.1.0"
+entrypoint = "src/analyze.typ"
+
+-----
+/// path: src/stackframe.typ
+#let pause(fun) = (..args) => (..env) => cont => (fun: fun, args: args)
+#let tailcall(fun) = (..args) => (fun: fun, args: args)
+
+-----
+/// path: src/match.typ
+#import "stackframe.typ"
+
+#let commit() = (subparse, input) => (ok: true, backtrack: false, next: none, rest: input)
+#let eof() = (subparse, input) => (ok: true, backtrack: true, next: none, rest: input)
+#let regex(arg: auto) = (subparse, input) => (ok: true, backtrack: true, val: input, next: none, rest: input)
+#let seq(pats: auto, array: true) = (subparse, input) => stackframe.pause(subparse)(pats.at(0, default: ()), input)()(ans => ans)
+#let str(arg: auto) = (subparse, input) => (ok: true, backtrack: true, val: arg, next: none, rest: input)
+#let iter(pat: auto) = (subparse, input) => stackframe.pause(subparse)(pat, input)()(ans => ans)
+#let star(pat: auto) = (subparse, input) => stackframe.pause(subparse)(pat, input)()(ans => ans)
+#let fork(pats: auto) = (subparse, input) => stackframe.pause(subparse)(pats.at(0, default: ()), input)()(ans => ans)
+#let maybe(pat: auto) = (subparse, input) => (ok: true, backtrack: true, val: (), next: none, rest: input)
+#let try(pat: auto) = (subparse, input) => stackframe.pause(subparse)(pat, input)()(ans => (: ..ans, backtrack: true))
+#let peek(pat: auto) = (subparse, input) => (ok: true, backtrack: true, next: none, rest: input)
+#let neg(pat: auto) = (subparse, input) => (ok: true, backtrack: true, next: none, rest: input)
+#let error(msg: auto, pat: auto) = (subparse, input) => (ok: false, backtrack: true, msg: msg, next: none, rest: input)
+#let hint(len: auto, mapping: auto) = (subparse, input) => stackframe.tailcall(subparse)(mapping.at("__", default: ()), input)
+
+-----
+/// path: src/analyze.typ
+#import "match.typ"
+
+#let reachable(grammar) = {
+  let explore(pat) = {
+    if "lab" in pat {
+      (pat.lab,)
+    } else if "pat" in pat {
+      explore(pat.pat)
+    } else if "pats" in pat {
+      for sub in pat.pats { explore(sub) }
+    } else {
+      ()
+    }
+  }
+  let reach = (:)
+  for (id, rule) in grammar {
+    reach.insert(id, explore(rule.pat).dedup())
+  }
+  reach
+}
+
+#let reachable-closure(grammar, start) = {
+  let _ = reachable(grammar)
+  start
+}
+
+#let inv-reachable-closure(grammar, start) = {
+  let _ = reachable(grammar)
+  start
+}
+
+#let check-closed(grammar) = (
+  undef: (),
+  dangling: (),
+  dangerous: inv-reachable-closure(grammar, ()),
+)
+
+#let check-empty(grammar) = {
+  let _and(l, r) = if l == false or r == false { false } else if l == true { r } else if r == true { l } else { none }
+  let _or(l, r) = if l == true or r == true { true } else if l == false { r } else if r == false { l } else { none }
+  let /* ident after */ known-nonempty(pat, known) = {
+    if pat == () {
+      none
+    } else if "lab" in pat {
+      known.at(pat.lab, default: none)
+    } else if pat.call == match.regex {
+      true
+    } else if pat.call in (match.star, match.commit, match.maybe, match.peek, match.neg, match.eof) {
+      false
+    } else if pat.call == match.str {
+      pat.arg != ""
+    } else if pat.call == match.fork {
+      let ans = true
+      for sub in pat.pats { ans = _and(ans, known-nonempty(sub, known)) }
+      ans
+    } else if pat.call == match.hint {
+      let ans = true
+      for (_, sub) in pat.mapping { ans = _and(ans, known-nonempty(sub, known)) }
+      ans
+    } else if pat.call == match.seq {
+      let ans = false
+      for sub in pat.pats { ans = _or(ans, known-nonempty(sub, known)) }
+      ans
+    } else if pat.call in (match.error,) {
+      true
+    } else if pat.call in (match.iter, match.try) {
+      known-nonempty(pat.pat, known)
+    } else {
+      panic(pat)
+    }
+  }
+  let emps = (:)
+  for (id, rule) in grammar {
+    if emps.at(id, default: none) == none {
+      emps.insert(id, known-nonempty(rule.pat, emps))
+    }
+  }
+  emps
+}
+
+#let check-leftrec(grammar, nonempty) = {
+  let next-left(pat) = {
+    if pat == () {
+      ((), true)
+    } else if "lab" in pat {
+      ((pat.lab,), nonempty.at(pat.lab, default: none) != true)
+    } else if pat.call == match.regex {
+      ((), false)
+    } else if pat.call == match.str {
+      ((), pat.arg == "")
+    } else if pat.call == match.fork {
+      let ans = ()
+      let after = true
+      for sub in pat.pats {
+        let (also, go-on) = next-left(sub)
+        ans += also
+        after = after or go-on
+      }
+      (ans, after)
+    } else if pat.call == match.hint {
+      let ans = ()
+      let after = true
+      for (_, sub) in pat.mapping {
+        let (also, go-on) = next-left(sub)
+        ans += also
+        after = after or go-on
+      }
+      (ans, after)
+    } else if pat.call == match.seq {
+      let ans = ()
+      for sub in pat.pats {
+        let (also, go-on) = next-left(sub)
+        ans += also
+        if not go-on { return (ans, false) }
+      }
+      (ans, true)
+    } else if pat.call in (match.commit,) {
+      ((), true)
+    } else if pat.call in (match.maybe, match.peek, match.neg, match.star) {
+      let (ans, _) = next-left(pat.pat)
+      (ans, true)
+    } else if pat.call in (match.eof,) {
+      ((), false)
+    } else if pat.call in (match.iter, match.try, match.error) {
+      next-left(pat.pat)
+    } else {
+      panic(pat)
+    }
+  }
+  let cycles = ()
+  for (id, rule) in grammar {
+    let (nl, _) = next-left(rule.pat)
+    if nl != () { cycles.push((id, ..nl)) }
+  }
+  (
+    cycles: cycles,
+    dangerous: inv-reachable-closure(grammar, cycles.flatten()),
+  )
+}

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@kleene_known_nonempty.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@kleene_known_nonempty.typ.snap
@@ -1,0 +1,35 @@
+---
+source: crates/tinymist-query/src/hover.rs
+expression: content
+input_file: crates/tinymist-query/src/fixtures/hover/kleene_known_nonempty.typ
+---
+Range: 40:24:40:38
+
+```typc
+let known-nonempty(
+  pat: any | dictionary,
+  known: any,
+) = any;
+```
+
+
+======
+
+
+
+
+# Positional Parameters
+
+## pat
+
+```typc
+type: any | dictionary
+```
+
+
+
+## known (positional)
+
+```typc
+type: 
+```

--- a/crates/tinymist-query/src/fixtures/type_check/recursive_slow.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/recursive_slow.typ
@@ -1,0 +1,4 @@
+#let l = (a) => (b) => l
+#let r = (a) => (b) => (c) => r
+#let merged = if true { l } else { r }
+#let use = merged(1)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_slow.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_slow.typ.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/recursive_slow.typ
+---
+"l" = (Any) => (Any) => Any
+"" = (Any) => (Any) => Any
+"a" = Any
+"" = (Any) => Any
+"b" = Any
+"r" = (Any) => (Any) => (Any) => Any
+"" = (Any) => (Any) => (Any) => Any
+"a" = Any
+"" = (Any) => (Any) => Any
+"b" = Any
+"" = (Any) => Any
+"c" = Any
+"merged" = IfTy { cond: true, then: (Any) => (Any) => Any, else_: (Any) => (Any) => (Any) => Any }
+"use" = Any
+=====
+5..6 -> @l
+9..24 -> @
+10..11 -> @a
+16..24 -> @
+17..18 -> @b
+30..31 -> @r
+34..56 -> @
+35..36 -> @a
+41..56 -> @
+42..43 -> @b
+48..56 -> @
+49..50 -> @c
+62..68 -> @merged
+81..82 -> @l
+92..93 -> @r
+101..104 -> @use
+107..113 -> @merged
+107..116 -> Any


### PR DESCRIPTION
- Cache top-level and subtree type simplification results so recursive canonicalization is reused instead of recomputed.
- Guard repeated `(TypeVar, polarity)` expansion while rendering signature docs.
- Render hover/docs return types with short forms when the full recursive expansion is not surfaced.
- Add recursive fixtures and tests for the original hover slowdown and the reduced explanatory case.