### PR TITLE
fix(query): skip missing preload sources

### DIFF
--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1166,7 +1166,9 @@ impl SharedContext {
         impl Preloader {
             fn work(&self, fid: TypstFileId) {
                 crate::log_debug_ct!("preload package {fid:?}");
-                let source = self.shared.source_by_id(fid).ok().unwrap();
+                let Some(source) = self.shared.source_by_id(fid).ok() else {
+                    return;
+                };
                 let exprs = self.shared.expr_stage(&source);
                 self.shared.type_check(&source);
                 exprs.imports.iter().for_each(|(fid, _)| {


### PR DESCRIPTION
Avoid panicking when package preload discovers an import whose source cannot be loaded. Missing sources are skipped so package analysis can surface the package-level error instead of aborting in the preloader.