### PR TITLE
fix(package-docs): avoid eager package preload

### DIFF
--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -118,8 +118,6 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
         .expect("package manifest must be in a package");
     let entry_point = package_entrypoint_id(toml_id, &manifest.package.entrypoint);
 
-    ctx.preload_package(entry_point);
-
     let PackageDefInfo { root, module_uses } = module_docs(ctx, entry_point)?;
 
     crate::log_debug_ct!("module_uses: {module_uses:#?}");

--- a/crates/tinymist-query/src/package.rs
+++ b/crates/tinymist-query/src/package.rs
@@ -141,7 +141,7 @@ pub fn check_package(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<()
 
     let entry_point = package_entrypoint_id(toml_id, &manifest.package.entrypoint);
 
-    ctx.shared_().preload_package(entry_point);
+    ctx.preload_package(entry_point);
     Ok(())
 }
 


### PR DESCRIPTION
Move package preloading out of packageDocs and keep explicit package checks responsible for preload. This avoids doing eager preload while generating package documentation and keeps checkPackage behavior explicit.