### PR TITLE
perf(preview): improve ng scroll rendering

### DIFF
--- a/tools/typst-preview-frontend-ng/renderer-worker.ts
+++ b/tools/typst-preview-frontend-ng/renderer-worker.ts
@@ -74,6 +74,12 @@ self.addEventListener("message", (event) => {
         ),
       );
       break;
+    case "request-interactions":
+      void renderer.requestInteractions({
+        generation: message.generation,
+        pageIndices: message.pageIndices || [],
+      });
+      break;
     case "hit-bound":
       void renderer.hitBound({
         requestId: message.requestId,
@@ -81,6 +87,25 @@ self.addEventListener("message", (event) => {
         pageIndex: message.pageIndex,
         x: message.x,
         y: message.y,
+      });
+      break;
+    case "hit-text":
+      void renderer.hitText({
+        requestId: message.requestId,
+        generation: message.generation,
+        pageIndex: message.pageIndex,
+        x: message.x,
+        y: message.y,
+        rect: message.rect,
+      });
+      break;
+    case "resolve-text-rect":
+      void renderer.resolveTextRect({
+        requestId: message.requestId,
+        generation: message.generation,
+        pageIndex: message.pageIndex,
+        textId: message.textId,
+        rect: message.rect,
       });
       break;
     case "dispose":

--- a/tools/typst-preview-frontend-ng/src/app.ts
+++ b/tools/typst-preview-frontend-ng/src/app.ts
@@ -75,7 +75,7 @@ class PreviewApp {
     );
     this.elements.viewport.addEventListener(
       "scroll",
-      () => this.pageHost.scheduleViewportSnapshot(),
+      () => this.pageHost.scheduleViewportSnapshot({ scrolling: true }),
       { passive: true },
     );
     window.addEventListener("beforeunload", () => this.disposeWorker());
@@ -98,7 +98,30 @@ class PreviewApp {
         this.handleEnsurePages(message);
         break;
       case "render-complete":
+        this.pageHost.markRendered(
+          message.generation,
+          message.layer,
+          message.quality,
+          message.pageIndices || [],
+          message.fullPageIndices || [],
+        );
+        this.pageHost.updateInteractions(
+          message.generation,
+          message.interactions || [],
+          message.invalidatedInteractions || [],
+        );
+        break;
+      case "render-evicted":
+        this.pageHost.markEvicted(message.generation, message.pageIndices || []);
+        break;
+      case "interactions":
         this.pageHost.updateInteractions(message.generation, message.interactions || []);
+        break;
+      case "text-hit":
+        this.pageHost.handleTextHit(message);
+        break;
+      case "text-rect":
+        this.pageHost.handleTextRect(message);
         break;
       case "bound-hit":
         this.pageHost.handleBoundHit(message);

--- a/tools/typst-preview-frontend-ng/src/controls.ts
+++ b/tools/typst-preview-frontend-ng/src/controls.ts
@@ -5,13 +5,14 @@ export interface PageControlHost {
   readonly mode: PreviewMode;
   goToPreviousSlide(): void;
   goToNextSlide(): void;
+  setDragging(active: boolean): void;
   toggleInvertColors(): void;
   applyWheelZoom(event: WheelEvent): void;
 }
 
 export function installPageControls(elements: PreviewElements, host: PageControlHost) {
   installKeyboardShortcuts(elements, host);
-  installDragPan(elements);
+  installDragPan(elements, host);
   installWheelZoom(elements, host);
 }
 
@@ -69,22 +70,45 @@ function installKeyboardShortcuts(elements: PreviewElements, host: PageControlHo
   });
 }
 
-function installDragPan(elements: PreviewElements) {
+function installDragPan(elements: PreviewElements, host: PageControlHost) {
   let lastX = 0;
   let lastY = 0;
+  let pendingX = 0;
+  let pendingY = 0;
+  let animationFrame = 0;
   let moved = false;
+  let dragging = false;
 
-  const onMouseMove = (event: MouseEvent) => {
-    elements.viewport.scrollBy(lastX - event.clientX, lastY - event.clientY);
-    lastX = event.clientX;
-    lastY = event.clientY;
+  const flushMouseMove = () => {
+    animationFrame = 0;
+    elements.viewport.scrollBy(lastX - pendingX, lastY - pendingY);
+    lastX = pendingX;
+    lastY = pendingY;
     moved = true;
   };
 
-  const onMouseUp = () => {
+  const onMouseMove = (event: MouseEvent) => {
+    event.preventDefault();
+    pendingX = event.clientX;
+    pendingY = event.clientY;
+    if (!animationFrame) {
+      animationFrame = window.requestAnimationFrame(flushMouseMove);
+    }
+  };
+
+  const finishDrag = () => {
+    if (!dragging) {
+      return;
+    }
+    dragging = false;
+    if (animationFrame) {
+      window.cancelAnimationFrame(animationFrame);
+      flushMouseMove();
+    }
     document.removeEventListener("mousemove", onMouseMove);
-    document.removeEventListener("mouseup", onMouseUp);
-    elements.root.classList.remove("dragging");
+    document.removeEventListener("mouseup", finishDrag);
+    window.removeEventListener("blur", finishDrag);
+    host.setDragging(false);
     if (!moved) {
       document.getSelection()?.removeAllRanges();
     }
@@ -95,12 +119,17 @@ function installDragPan(elements: PreviewElements) {
       return;
     }
     event.preventDefault();
+    finishDrag();
+    dragging = true;
     lastX = event.clientX;
     lastY = event.clientY;
+    pendingX = event.clientX;
+    pendingY = event.clientY;
     moved = false;
-    elements.root.classList.add("dragging");
+    host.setDragging(true);
     document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("mouseup", finishDrag);
+    window.addEventListener("blur", finishDrag);
   });
 }
 

--- a/tools/typst-preview-frontend-ng/src/interactions.ts
+++ b/tools/typst-preview-frontend-ng/src/interactions.ts
@@ -20,6 +20,11 @@ export interface LinkInteraction {
   target: LinkTarget;
 }
 
+export interface LinkTextHighlight {
+  text: TextInteraction;
+  rect: PageRect;
+}
+
 export interface TextInteraction {
   id: number;
   rect: PageRect;
@@ -37,8 +42,11 @@ export interface PageInteractions {
   texts: TextInteraction[];
 }
 
-const interactionTagPattern =
-  /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-(?:text|link)\b[^"]*"[^>]*)>/g;
+const textHighlightEnabled = false;
+
+const interactionTagPattern = textHighlightEnabled
+  ? /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-(?:text|link)\b[^"]*"[^>]*)>/g
+  : /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-link\b[^"]*"[^>]*)>/g;
 
 /** Extracts lightweight page-space hit-test metadata from renderer semantics HTML. */
 export function parsePageInteractions(pageIndex: number, html: string): PageInteractions {
@@ -49,17 +57,22 @@ export function parsePageInteractions(pageIndex: number, html: string): PageInte
     const tagName = match[1];
     const attrs = match[2];
     const className = readAttribute(attrs, "class") || "";
-    const rect = readPageRect(attrs);
-    if (!rect) {
-      continue;
-    }
 
     if (tagName === "a" || hasClass(className, "typst-content-link")) {
+      const rect = readPageRect(attrs);
+      if (!rect) {
+        continue;
+      }
       links.push({ rect, target: parseLinkTarget(attrs) });
       continue;
     }
 
-    if (hasClass(className, "typst-content-text")) {
+    if (textHighlightEnabled && hasClass(className, "typst-content-text")) {
+      const contentStart = (match.index || 0) + match[0].length;
+      const rect = readTextRect(attrs, () => readTagContent(html, tagName, contentStart));
+      if (!rect) {
+        continue;
+      }
       const id = Number.parseInt(readAttribute(attrs, "data-text-id") || "", 10);
       if (Number.isFinite(id)) {
         texts.push({ id, rect });
@@ -86,6 +99,9 @@ export function hitTestText(
   x: number,
   y: number,
 ): TextInteraction | undefined {
+  if (!textHighlightEnabled) {
+    return undefined;
+  }
   if (!interactions) {
     return undefined;
   }
@@ -108,11 +124,21 @@ export function textRectsForLink(
   interactions: PageInteractions | undefined,
   link: LinkInteraction,
 ): PageRect[] {
+  return textHighlightsForLink(interactions, link).map((highlight) => highlight.rect);
+}
+
+export function textHighlightsForLink(
+  interactions: PageInteractions | undefined,
+  link: LinkInteraction,
+): LinkTextHighlight[] {
+  if (!textHighlightEnabled) {
+    return [];
+  }
   if (!interactions) {
     return [];
   }
 
-  const rects: PageRect[] = [];
+  const highlights: LinkTextHighlight[] = [];
   const linkRects = interactions.links
     .filter((candidate) => sameLinkTarget(candidate.target, link.target))
     .map((candidate) => visualLinkRect(candidate.rect));
@@ -121,12 +147,12 @@ export function textRectsForLink(
     for (const text of interactions.texts) {
       const clipped = intersectRects(text.rect, linkRect);
       if (clipped && isMeaningfulTextClip(text.rect, clipped)) {
-        rects.push(clipped);
+        highlights.push({ text, rect: clipped });
       }
     }
   }
 
-  return dedupeRects(rects);
+  return dedupeLinkTextHighlights(highlights);
 }
 
 function findTopmost<T extends { rect: PageRect }>(
@@ -195,6 +221,19 @@ function dedupeRects(rects: PageRect[]) {
   });
 }
 
+function dedupeLinkTextHighlights(highlights: LinkTextHighlight[]) {
+  const seen = new Set<string>();
+  return highlights.filter((highlight) => {
+    const rect = highlight.rect;
+    const key = `${highlight.text.id}:${rect.x.toFixed(3)}:${rect.y.toFixed(3)}:${rect.width.toFixed(3)}:${rect.height.toFixed(3)}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 function sameLinkTarget(a: LinkTarget, b: LinkTarget) {
   if (a.kind !== b.kind || a.href !== b.href) {
     return false;
@@ -232,6 +271,36 @@ function readPageRect(attrs: string): PageRect | undefined {
     height: readStyleCoordinate(style, "height"),
   };
   return isValidRect(fromStyle) ? fromStyle : undefined;
+}
+
+function readTextRect(attrs: string, readContent: () => string): PageRect | undefined {
+  const rect = readPageRect(attrs);
+  if (rect) {
+    return rect;
+  }
+
+  const style = readAttribute(attrs, "style");
+  if (!style) {
+    return undefined;
+  }
+
+  const x = readStyleCoordinate(style, "left");
+  const y = readStyleCoordinate(style, "top");
+  const height =
+    readStyleCoordinate(style, "line-height") ||
+    readStyleCoordinate(style, "font-size") ||
+    readPixelStyleCoordinate(style, "font-size");
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(height) || height <= 0) {
+    return undefined;
+  }
+
+  const scaleX = readScaleX(style) ?? 1;
+  const width = estimateHtmlTextWidth(readContent(), height, scaleX);
+  if (!Number.isFinite(width) || width <= 0) {
+    return undefined;
+  }
+
+  return { x, y, width, height };
 }
 
 function isValidRect(rect: {
@@ -312,7 +381,122 @@ function readStyleCoordinate(style: string, property: string): number | undefine
   return Number.isFinite(value) ? value : undefined;
 }
 
+function readPixelStyleCoordinate(style: string, property: string): number | undefined {
+  const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = style.match(new RegExp(`${escapedProperty}\\s*:\\s*([0-9.]+)px`, "i"));
+  if (!match) {
+    return undefined;
+  }
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function readScaleX(style: string): number | undefined {
+  const match = style.match(/transform\s*:\s*scaleX\(([^)]+)\)/i);
+  if (!match) {
+    return undefined;
+  }
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+let cachedFontMetric: { semi: number; full: number; emoji: number } | undefined;
+
+function estimateHtmlTextWidth(html: string, fontSize: number, scaleX: number) {
+  const metric = (cachedFontMetric ??= measureBrowserMonospaceMetric());
+  let units = 0;
+  for (let index = 0; index < html.length; index += 1) {
+    const char = html[index];
+    if (char === "<") {
+      const end = html.indexOf(">", index + 1);
+      if (end < 0) {
+        break;
+      }
+      index = end;
+      continue;
+    }
+    if (char === "&") {
+      const end = html.indexOf(";", index + 1);
+      if (end >= 0) {
+        index = end;
+      }
+      units += metric.semi;
+      continue;
+    }
+
+    const codePoint = html.codePointAt(index) || 0;
+    if (codePoint > 0xffff) {
+      index += 1;
+    }
+    if (isZeroWidthCodePoint(codePoint)) {
+      continue;
+    }
+    units += isEmojiCodePoint(codePoint)
+      ? metric.emoji
+      : isFullWidthCodePoint(codePoint)
+        ? metric.full
+        : metric.semi;
+  }
+  return units * fontSize * scaleX;
+}
+
+function measureBrowserMonospaceMetric() {
+  try {
+    const canvas = new OffscreenCanvas(0, 0);
+    const context = canvas.getContext("2d");
+    if (context) {
+      context.font = "128px monospace";
+      return {
+        semi: context.measureText("A").width / 128,
+        full: context.measureText("\u55b5").width / 128,
+        emoji: context.measureText(String.fromCodePoint(0x1f984)).width / 128,
+      };
+    }
+  } catch (_error) {}
+  return { semi: 0.6, full: 1, emoji: 1 };
+}
+
+function isZeroWidthCodePoint(codePoint: number) {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    codePoint === 0x200b ||
+    codePoint === 0x200c ||
+    codePoint === 0x200d ||
+    codePoint === 0xfe0e ||
+    codePoint === 0xfe0f
+  );
+}
+
+function isEmojiCodePoint(codePoint: number) {
+  return codePoint > 0xffff;
+}
+
+function isFullWidthCodePoint(codePoint: number) {
+  return (
+    (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+  );
+}
+
 function decodeHtmlAttribute(value: string) {
+  return decodeHtmlText(value);
+}
+
+function readTagContent(html: string, tagName: string, contentStart: number) {
+  const close = html.indexOf(`</${tagName}>`, contentStart);
+  return close < 0 ? "" : html.slice(contentStart, close);
+}
+
+function decodeHtmlText(value: string) {
   return value
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")

--- a/tools/typst-preview-frontend-ng/src/interactions.ts
+++ b/tools/typst-preview-frontend-ng/src/interactions.ts
@@ -68,8 +68,7 @@ export function parsePageInteractions(pageIndex: number, html: string): PageInte
     }
 
     if (textHighlightEnabled && hasClass(className, "typst-content-text")) {
-      const contentStart = (match.index || 0) + match[0].length;
-      const rect = readTextRect(attrs, () => readTagContent(html, tagName, contentStart));
+      const rect = readPageRect(attrs);
       if (!rect) {
         continue;
       }
@@ -209,18 +208,6 @@ function isMeaningfulTextClip(text: PageRect, clipped: PageRect) {
   return clipped.width >= 0.25 && clipped.height / Math.max(text.height, 1) >= 0.45;
 }
 
-function dedupeRects(rects: PageRect[]) {
-  const seen = new Set<string>();
-  return rects.filter((rect) => {
-    const key = `${rect.x.toFixed(3)}:${rect.y.toFixed(3)}:${rect.width.toFixed(3)}:${rect.height.toFixed(3)}`;
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-}
-
 function dedupeLinkTextHighlights(highlights: LinkTextHighlight[]) {
   const seen = new Set<string>();
   return highlights.filter((highlight) => {
@@ -271,36 +258,6 @@ function readPageRect(attrs: string): PageRect | undefined {
     height: readStyleCoordinate(style, "height"),
   };
   return isValidRect(fromStyle) ? fromStyle : undefined;
-}
-
-function readTextRect(attrs: string, readContent: () => string): PageRect | undefined {
-  const rect = readPageRect(attrs);
-  if (rect) {
-    return rect;
-  }
-
-  const style = readAttribute(attrs, "style");
-  if (!style) {
-    return undefined;
-  }
-
-  const x = readStyleCoordinate(style, "left");
-  const y = readStyleCoordinate(style, "top");
-  const height =
-    readStyleCoordinate(style, "line-height") ||
-    readStyleCoordinate(style, "font-size") ||
-    readPixelStyleCoordinate(style, "font-size");
-  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(height) || height <= 0) {
-    return undefined;
-  }
-
-  const scaleX = readScaleX(style) ?? 1;
-  const width = estimateHtmlTextWidth(readContent(), height, scaleX);
-  if (!Number.isFinite(width) || width <= 0) {
-    return undefined;
-  }
-
-  return { x, y, width, height };
 }
 
 function isValidRect(rect: {
@@ -381,119 +338,8 @@ function readStyleCoordinate(style: string, property: string): number | undefine
   return Number.isFinite(value) ? value : undefined;
 }
 
-function readPixelStyleCoordinate(style: string, property: string): number | undefined {
-  const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = style.match(new RegExp(`${escapedProperty}\\s*:\\s*([0-9.]+)px`, "i"));
-  if (!match) {
-    return undefined;
-  }
-  const value = Number.parseFloat(match[1]);
-  return Number.isFinite(value) ? value : undefined;
-}
-
-function readScaleX(style: string): number | undefined {
-  const match = style.match(/transform\s*:\s*scaleX\(([^)]+)\)/i);
-  if (!match) {
-    return undefined;
-  }
-  const value = Number.parseFloat(match[1]);
-  return Number.isFinite(value) ? value : undefined;
-}
-
-let cachedFontMetric: { semi: number; full: number; emoji: number } | undefined;
-
-function estimateHtmlTextWidth(html: string, fontSize: number, scaleX: number) {
-  const metric = (cachedFontMetric ??= measureBrowserMonospaceMetric());
-  let units = 0;
-  for (let index = 0; index < html.length; index += 1) {
-    const char = html[index];
-    if (char === "<") {
-      const end = html.indexOf(">", index + 1);
-      if (end < 0) {
-        break;
-      }
-      index = end;
-      continue;
-    }
-    if (char === "&") {
-      const end = html.indexOf(";", index + 1);
-      if (end >= 0) {
-        index = end;
-      }
-      units += metric.semi;
-      continue;
-    }
-
-    const codePoint = html.codePointAt(index) || 0;
-    if (codePoint > 0xffff) {
-      index += 1;
-    }
-    if (isZeroWidthCodePoint(codePoint)) {
-      continue;
-    }
-    units += isEmojiCodePoint(codePoint)
-      ? metric.emoji
-      : isFullWidthCodePoint(codePoint)
-        ? metric.full
-        : metric.semi;
-  }
-  return units * fontSize * scaleX;
-}
-
-function measureBrowserMonospaceMetric() {
-  try {
-    const canvas = new OffscreenCanvas(0, 0);
-    const context = canvas.getContext("2d");
-    if (context) {
-      context.font = "128px monospace";
-      return {
-        semi: context.measureText("A").width / 128,
-        full: context.measureText("\u55b5").width / 128,
-        emoji: context.measureText(String.fromCodePoint(0x1f984)).width / 128,
-      };
-    }
-  } catch (_error) {}
-  return { semi: 0.6, full: 1, emoji: 1 };
-}
-
-function isZeroWidthCodePoint(codePoint: number) {
-  return (
-    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
-    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
-    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
-    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
-    codePoint === 0x200b ||
-    codePoint === 0x200c ||
-    codePoint === 0x200d ||
-    codePoint === 0xfe0e ||
-    codePoint === 0xfe0f
-  );
-}
-
-function isEmojiCodePoint(codePoint: number) {
-  return codePoint > 0xffff;
-}
-
-function isFullWidthCodePoint(codePoint: number) {
-  return (
-    (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
-    (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
-    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
-    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
-    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
-    (codePoint >= 0xffe0 && codePoint <= 0xffe6)
-  );
-}
-
 function decodeHtmlAttribute(value: string) {
   return decodeHtmlText(value);
-}
-
-function readTagContent(html: string, tagName: string, contentStart: number) {
-  const close = html.indexOf(`</${tagName}>`, contentStart);
-  return close < 0 ? "" : html.slice(contentStart, close);
 }
 
 function decodeHtmlText(value: string) {

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -263,7 +263,13 @@ export class PageHost {
         record.fullHeightPx = heightPx;
         const offscreen = record.canvas.transferControlToOffscreen();
         record.transferred = true;
-        transferred.push({ index: page.index, layer: "full", canvas: offscreen, widthPx, heightPx });
+        transferred.push({
+          index: page.index,
+          layer: "full",
+          canvas: offscreen,
+          widthPx,
+          heightPx,
+        });
       }
     }
 
@@ -379,21 +385,26 @@ export class PageHost {
     if (this.lastViewportTimer) {
       clearTimeout(this.lastViewportTimer);
     }
-    this.lastViewportTimer = window.setTimeout(() => {
-      this.lastViewportTimer = 0;
-      this.postViewportSnapshot({
-        applyLayouts: options.applyLayouts,
-        requestInteractions: !this.dragging,
-      });
-    }, options.scrolling ? 0 : 16);
+    this.lastViewportTimer = window.setTimeout(
+      () => {
+        this.lastViewportTimer = 0;
+        this.postViewportSnapshot({
+          applyLayouts: options.applyLayouts,
+          requestInteractions: !this.dragging,
+        });
+      },
+      options.scrolling ? 0 : 16,
+    );
   }
 
-  private postViewportSnapshot(options: {
-    applyLayouts?: boolean;
-    force?: boolean;
-    requestInteractions?: boolean;
-    renderDuringDrag?: boolean;
-  } = {}) {
+  private postViewportSnapshot(
+    options: {
+      applyLayouts?: boolean;
+      force?: boolean;
+      requestInteractions?: boolean;
+      renderDuringDrag?: boolean;
+    } = {},
+  ) {
     const metrics = this.readPageLayoutMetrics();
     if (options.applyLayouts) {
       this.applyAllPageLayouts(metrics);
@@ -621,10 +632,7 @@ export class PageHost {
       return;
     }
 
-    if (
-      message.hit &&
-      this.textHitContains(pending.text, message.rect, message.x, message.y)
-    ) {
+    if (message.hit && this.textHitContains(pending.text, message.rect, message.x, message.y)) {
       this.showTextHover(record, pending.text, message.rect);
       return;
     }
@@ -955,7 +963,9 @@ export class PageHost {
 
     const textRects = textHighlightsForLink(record.interactions, link).map((highlight) => {
       this.requestTextVisualRect(record, highlight.text);
-      const visualRect = this.textHoverRects.get(this.textHoverKey(record.index, highlight.text.id));
+      const visualRect = this.textHoverRects.get(
+        this.textHoverKey(record.index, highlight.text.id),
+      );
       return visualRect ? alignTextClipToVisualRect(highlight.rect, visualRect) : highlight.rect;
     });
     this.renderInteractionHighlights(record, textRects, "link");
@@ -1137,7 +1147,12 @@ export class PageHost {
     return `${this.interactionGeneration}:${pageIndex}:${textId}`;
   }
 
-  private textHitContains(text: TextInteraction, hitRect: PageRect | undefined, x: number, y: number) {
+  private textHitContains(
+    text: TextInteraction,
+    hitRect: PageRect | undefined,
+    x: number,
+    y: number,
+  ) {
     return rectContainsPage(textHoverRect(text, hitRect), x, y);
   }
 

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -3,7 +3,7 @@ import { installPageControls } from "./controls";
 import {
   hitTestLink,
   hitTestText,
-  textRectsForLink,
+  textHighlightsForLink,
   type BoundInteraction,
   type LinkInteraction,
   type PageInteractions,
@@ -60,7 +60,11 @@ export class PageHost {
   private currentSlidePage = 1;
   private pageCount = 0;
   private zoomRatio = 1;
+  private dragging = false;
+  private scrolling = false;
+  private lastViewportPostKey = "";
   private lastViewportTimer = 0;
+  private scrollIdleTimer = 0;
   private lastPages: PageSpec[] = [];
   private pendingCursor: PreviewPosition | undefined;
   private outlineData: any;
@@ -81,7 +85,27 @@ export class PageHost {
       }
     | undefined;
   private activeHoverKey = "";
-  private nextBoundRequestId = 0;
+  private activeTextHover:
+    | {
+        generation: number;
+        pageIndex: number;
+        rect: PageRect;
+      }
+    | undefined;
+  private readonly textHoverRects = new Map<string, PageRect>();
+  private readonly pendingTextRectRequests = new Set<string>();
+  private readonly pendingInteractionRequests = new Set<number>();
+  private nextHitRequestId = 0;
+  private pendingTextHover:
+    | {
+        requestId: number;
+        generation: number;
+        pageIndex: number;
+        x: number;
+        y: number;
+        text: TextInteraction;
+      }
+    | undefined;
   private pendingBoundHover:
     | {
         requestId: number;
@@ -120,6 +144,31 @@ export class PageHost {
 
   toggleInvertColors() {
     this.elements.root.classList.toggle("invert-colors");
+  }
+
+  setDragging(active: boolean) {
+    if (this.dragging === active) {
+      return;
+    }
+    this.dragging = active;
+    this.elements.root.classList.toggle("dragging", active);
+    if (active) {
+      this.activeHoverKey = "";
+      this.activeTextHover = undefined;
+      this.pendingTextHover = undefined;
+      this.pendingBoundHover = undefined;
+    } else {
+      this.scrolling = false;
+      if (this.scrollIdleTimer) {
+        window.clearTimeout(this.scrollIdleTimer);
+        this.scrollIdleTimer = 0;
+      }
+    }
+    this.postViewportSnapshot({
+      requestInteractions: !active,
+      renderDuringDrag: !active,
+      force: true,
+    });
   }
 
   applyWheelZoom(event: WheelEvent) {
@@ -168,12 +217,25 @@ export class PageHost {
     this.updatePageCount(pages.length);
     if (this.interactionGeneration !== generation) {
       this.interactionGeneration = generation;
+      this.textHoverRects.clear();
+      this.pendingTextRectRequests.clear();
+      this.pendingInteractionRequests.clear();
+      this.activeTextHover = undefined;
+      this.pendingTextHover = undefined;
+      this.pendingBoundHover = undefined;
+      for (const record of this.pageRecords.values()) {
+        record.interactions = undefined;
+        this.renderLinkAnchors(record);
+        record.container.classList.remove("canvas-ready");
+        record.container.classList.remove("full-ready");
+      }
     }
 
     const livePages = new Set<number>();
     const metrics = this.readPageLayoutMetrics();
     const transferred: Array<{
       index: number;
+      layer: "preview" | "full";
       canvas: OffscreenCanvas;
       widthPx: number;
       heightPx: number;
@@ -183,7 +245,7 @@ export class PageHost {
       livePages.add(page.index);
       const widthPx = Math.max(1, Math.ceil(page.width * page.pixelPerPt));
       const heightPx = Math.max(1, Math.ceil(page.height * page.pixelPerPt));
-      const key = `${page.width.toFixed(3)}:${page.height.toFixed(3)}:${page.pixelPerPt}`;
+      const key = [page.width.toFixed(3), page.height.toFixed(3), page.pixelPerPt].join(":");
       let record = this.pageRecords.get(page.index);
 
       if (!record || record.key !== key) {
@@ -195,11 +257,13 @@ export class PageHost {
 
       this.applyPageLayout(record, page, metrics);
       if (!record.transferred) {
-        record.canvas.width = widthPx;
-        record.canvas.height = heightPx;
+        record.canvas.width = 1;
+        record.canvas.height = 1;
+        record.fullWidthPx = widthPx;
+        record.fullHeightPx = heightPx;
         const offscreen = record.canvas.transferControlToOffscreen();
         record.transferred = true;
-        transferred.push({ index: page.index, canvas: offscreen, widthPx, heightPx });
+        transferred.push({ index: page.index, layer: "full", canvas: offscreen, widthPx, heightPx });
       }
     }
 
@@ -272,6 +336,8 @@ export class PageHost {
       scrollLeft: viewport.scrollLeft,
       scrollTop: viewport.scrollTop,
       devicePixelRatio: window.devicePixelRatio || 1,
+      dragging: this.dragging,
+      scrolling: this.scrolling,
       window: {
         innerWidth: window.innerWidth,
         innerHeight: window.innerHeight,
@@ -289,22 +355,80 @@ export class PageHost {
     };
   }
 
-  scheduleViewportSnapshot(options: { applyLayouts?: boolean } = {}) {
+  scheduleViewportSnapshot(options: { applyLayouts?: boolean; scrolling?: boolean } = {}) {
+    if (options.scrolling) {
+      this.scrolling = true;
+      if (this.scrollIdleTimer) {
+        window.clearTimeout(this.scrollIdleTimer);
+      }
+      this.scrollIdleTimer = window.setTimeout(() => {
+        this.scrollIdleTimer = 0;
+        this.scrolling = false;
+        this.postViewportSnapshot({ requestInteractions: !this.dragging, force: true });
+      }, 120);
+      if (this.lastViewportTimer) {
+        clearTimeout(this.lastViewportTimer);
+        this.lastViewportTimer = 0;
+      }
+      this.postViewportSnapshot({
+        applyLayouts: options.applyLayouts,
+        requestInteractions: false,
+      });
+      return;
+    }
     if (this.lastViewportTimer) {
       clearTimeout(this.lastViewportTimer);
     }
     this.lastViewportTimer = window.setTimeout(() => {
       this.lastViewportTimer = 0;
-      const metrics = this.readPageLayoutMetrics();
-      if (options.applyLayouts) {
-        this.applyAllPageLayouts(metrics);
-      }
-      this.postWorker({
-        type: "viewport",
-        viewport: this.readViewportSnapshot(metrics),
-        layouts: this.collectPageLayouts(),
+      this.postViewportSnapshot({
+        applyLayouts: options.applyLayouts,
+        requestInteractions: !this.dragging,
       });
-    }, 50);
+    }, options.scrolling ? 0 : 16);
+  }
+
+  private postViewportSnapshot(options: {
+    applyLayouts?: boolean;
+    force?: boolean;
+    requestInteractions?: boolean;
+    renderDuringDrag?: boolean;
+  } = {}) {
+    const metrics = this.readPageLayoutMetrics();
+    if (options.applyLayouts) {
+      this.applyAllPageLayouts(metrics);
+    }
+    const layouts = this.collectPageLayouts();
+    const viewport = this.readViewportSnapshot(metrics);
+    if (options.renderDuringDrag !== undefined) {
+      viewport.renderDuringDrag = options.renderDuringDrag;
+    }
+    const key = this.viewportPostKey(viewport);
+    if (!options.force && key === this.lastViewportPostKey) {
+      return;
+    }
+    this.lastViewportPostKey = key;
+    this.postWorker({
+      type: "viewport",
+      viewport,
+      layouts,
+    });
+    if (options.requestInteractions ?? !this.dragging) {
+      this.requestViewportInteractions(layouts);
+    }
+  }
+
+  private viewportPostKey(viewport: ViewportSnapshot) {
+    return [
+      viewport.width,
+      viewport.height,
+      viewport.scrollLeft,
+      viewport.scrollTop,
+      viewport.devicePixelRatio,
+      viewport.dragging ? 1 : 0,
+      viewport.scrolling ? 1 : 0,
+      viewport.renderDuringDrag === false ? 0 : 1,
+    ].join(":");
   }
 
   handlePreviewProtocolMessage(kind: string, text: string) {
@@ -332,11 +456,24 @@ export class PageHost {
     }
   }
 
-  updateInteractions(generation: number, interactions: PageInteractions[]) {
+  updateInteractions(
+    generation: number,
+    interactions: PageInteractions[],
+    invalidatedPageIndices: number[] = [],
+  ) {
     if (generation !== this.interactionGeneration) {
       return;
     }
     let refreshHover = false;
+    for (const pageIndex of invalidatedPageIndices) {
+      const record = this.pageRecords.get(pageIndex);
+      if (record) {
+        record.interactions = undefined;
+        this.renderLinkAnchors(record);
+        refreshHover ||= this.lastPointer?.pageIndex === record.index;
+      }
+      this.pendingInteractionRequests.delete(pageIndex);
+    }
     for (const pageInteractions of interactions) {
       const record = this.pageRecords.get(pageInteractions.pageIndex);
       if (record) {
@@ -344,9 +481,68 @@ export class PageHost {
         this.renderLinkAnchors(record);
         refreshHover ||= this.lastPointer?.pageIndex === record.index;
       }
+      this.pendingInteractionRequests.delete(pageInteractions.pageIndex);
     }
     if (refreshHover) {
       this.activeHoverKey = "";
+      this.restoreInteractionHover();
+    }
+  }
+
+  markRendered(
+    generation: number,
+    layer: "full" | undefined,
+    quality: "preview" | "full" | undefined,
+    pageIndices: number[],
+    fullPageIndices: number[] = [],
+  ) {
+    if (generation !== this.interactionGeneration) {
+      return;
+    }
+    if (layer !== "full") {
+      return;
+    }
+
+    for (const pageIndex of pageIndices) {
+      const record = this.pageRecords.get(pageIndex);
+      if (!record) {
+        continue;
+      }
+      record.container.classList.add("canvas-ready");
+    }
+
+    if (quality !== "full") {
+      return;
+    }
+
+    for (const pageIndex of fullPageIndices) {
+      const record = this.pageRecords.get(pageIndex);
+      if (record) {
+        record.container.classList.add("full-ready");
+      }
+    }
+  }
+
+  markEvicted(generation: number, pageIndices: number[]) {
+    if (generation !== this.interactionGeneration) {
+      return;
+    }
+    let refreshHover = false;
+    for (const pageIndex of pageIndices) {
+      const record = this.pageRecords.get(pageIndex);
+      if (!record) {
+        continue;
+      }
+      record.container.classList.remove("canvas-ready");
+      record.container.classList.remove("full-ready");
+      record.interactions = undefined;
+      this.renderLinkAnchors(record);
+      this.pendingInteractionRequests.delete(pageIndex);
+      refreshHover ||= this.lastPointer?.pageIndex === pageIndex;
+    }
+    if (refreshHover) {
+      this.activeHoverKey = "";
+      this.activeTextHover = undefined;
       this.restoreInteractionHover();
     }
   }
@@ -392,17 +588,91 @@ export class PageHost {
     this.showBoundHover(record, message.bound);
   }
 
+  handleTextHit(message: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    hit: boolean;
+    rect?: PageRect;
+  }) {
+    const pending = this.pendingTextHover;
+    if (
+      !pending ||
+      pending.requestId !== message.requestId ||
+      pending.generation !== message.generation ||
+      pending.pageIndex !== message.pageIndex ||
+      this.interactionGeneration !== message.generation
+    ) {
+      return;
+    }
+
+    if (
+      !this.lastPointer ||
+      this.lastPointer.pageIndex !== message.pageIndex ||
+      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
+    ) {
+      return;
+    }
+
+    const record = this.pageRecords.get(message.pageIndex);
+    if (!record) {
+      return;
+    }
+
+    if (
+      message.hit &&
+      this.textHitContains(pending.text, message.rect, message.x, message.y)
+    ) {
+      this.showTextHover(record, pending.text, message.rect);
+      return;
+    }
+
+    this.clearInteractionHighlight(record);
+    this.activeHoverKey = "";
+    this.requestBoundHover(record, { x: message.x, y: message.y });
+  }
+
+  handleTextRect(message: {
+    generation: number;
+    pageIndex: number;
+    textId: number;
+    rect?: PageRect;
+  }) {
+    if (message.generation !== this.interactionGeneration) {
+      return;
+    }
+
+    const key = this.textHoverKey(message.pageIndex, message.textId);
+    this.pendingTextRectRequests.delete(key);
+    if (message.rect) {
+      this.textHoverRects.set(key, message.rect);
+    }
+
+    if (this.lastPointer?.pageIndex === message.pageIndex) {
+      this.activeHoverKey = "";
+      this.restoreInteractionHover();
+    }
+  }
+
   clearPages() {
     for (const record of this.pageRecords.values()) {
       record.container.remove();
     }
     this.pageRecords.clear();
     this.lastPages = [];
+    this.lastViewportPostKey = "";
     this.pendingCursor = undefined;
     this.interactionGeneration = 0;
     this.pointerDown = undefined;
     this.lastPointer = undefined;
     this.activeHoverKey = "";
+    this.activeTextHover = undefined;
+    this.textHoverRects.clear();
+    this.pendingTextRectRequests.clear();
+    this.pendingInteractionRequests.clear();
+    this.pendingTextHover = undefined;
     this.pendingBoundHover = undefined;
     this.updatePageCount(0);
   }
@@ -424,8 +694,9 @@ export class PageHost {
     shell.dataset.pageHeight = page.height.toFixed(3);
 
     const canvas = document.createElement("canvas");
-    canvas.width = widthPx;
-    canvas.height = heightPx;
+    canvas.className = "typst-full-canvas";
+    canvas.width = 1;
+    canvas.height = 1;
 
     const interactionLayer = document.createElement("div");
     interactionLayer.className = "typst-interaction-layer";
@@ -439,7 +710,7 @@ export class PageHost {
     const jumpMarker = document.createElement("div");
     jumpMarker.className = "typst-jump-marker";
 
-    shell.appendChild(canvas);
+    shell.append(canvas);
     container.append(shell, linkLayer, interactionLayer, cursor, jumpMarker);
 
     const record = {
@@ -455,6 +726,8 @@ export class PageHost {
       transferred: false,
       width: page.width,
       height: page.height,
+      fullWidthPx: widthPx,
+      fullHeightPx: heightPx,
       cssWidth: widthPx,
       cssHeight: heightPx,
       pixelPerPt: page.pixelPerPt,
@@ -493,6 +766,15 @@ export class PageHost {
   }
 
   private handlePagePointerMove(record: PageRecord, event: MouseEvent) {
+    if (this.isDragging()) {
+      if (this.activeHoverKey || record.interactionLayer.childElementCount > 0) {
+        this.clearInteractionHighlight(record);
+        this.activeHoverKey = "";
+      }
+      this.lastPointer = undefined;
+      return;
+    }
+
     const point = this.pagePointFromEvent(record, event);
     if (!point) {
       this.clearInteractionHighlight(record);
@@ -507,6 +789,7 @@ export class PageHost {
 
   private updateInteractionHover(record: PageRecord, point: { x: number; y: number }) {
     if (!record.interactions) {
+      this.requestPageInteractions([record.index]);
       this.clearInteractionHighlight(record);
       this.activeHoverKey = "";
       return;
@@ -518,9 +801,20 @@ export class PageHost {
       return;
     }
 
+    if (this.activeTextHoverContains(record, point)) {
+      record.container.style.cursor = "text";
+      return;
+    }
+
+    const cachedText = this.cachedTextHoverAt(record, point);
+    if (cachedText) {
+      this.showTextHoverRect(record, cachedText.text, cachedText.rect);
+      return;
+    }
+
     const text = hitTestText(record.interactions, point.x, point.y);
     if (text) {
-      this.showTextHover(record, text);
+      this.requestTextHover(record, text, point);
       return;
     }
 
@@ -538,6 +832,55 @@ export class PageHost {
     this.updateInteractionHover(record, this.lastPointer);
   }
 
+  private requestViewportInteractions(layouts: PageLayoutRecord[]) {
+    if (this.interactionGeneration <= 0) {
+      return;
+    }
+    if (this.isDragging()) {
+      return;
+    }
+
+    const viewportTop = this.elements.viewport.scrollTop;
+    const viewportBottom = viewportTop + this.elements.viewport.clientHeight;
+    const pageIndices = layouts
+      .filter((layout) => layout.bottom >= viewportTop && layout.top <= viewportBottom)
+      .map((layout) => layout.index);
+    this.requestPageInteractions(pageIndices);
+  }
+
+  private requestPageInteractions(pageIndices: number[]) {
+    const missing: number[] = [];
+    const seen = new Set<number>();
+    for (const pageIndex of pageIndices) {
+      if (seen.has(pageIndex) || this.pendingInteractionRequests.has(pageIndex)) {
+        continue;
+      }
+      seen.add(pageIndex);
+
+      const record = this.pageRecords.get(pageIndex);
+      if (!record || record.interactions) {
+        continue;
+      }
+
+      this.pendingInteractionRequests.add(pageIndex);
+      missing.push(pageIndex);
+    }
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    this.postWorker({
+      type: "request-interactions",
+      generation: this.interactionGeneration,
+      pageIndices: missing,
+    });
+  }
+
+  private isDragging() {
+    return this.dragging;
+  }
+
   private handlePageClick(record: PageRecord, event: MouseEvent) {
     if (this.isDragClick(record, event)) {
       return;
@@ -548,6 +891,10 @@ export class PageHost {
       return;
     }
     this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
+
+    if (!record.interactions) {
+      this.requestPageInteractions([record.index]);
+    }
 
     const link = hitTestLink(record.interactions, point.x, point.y);
     if (link?.target.kind === "internal" && link.target.position) {
@@ -603,20 +950,84 @@ export class PageHost {
       return;
     }
     this.activeHoverKey = key;
+    this.activeTextHover = undefined;
     record.container.style.cursor = "pointer";
 
-    const textRects = textRectsForLink(record.interactions, link);
+    const textRects = textHighlightsForLink(record.interactions, link).map((highlight) => {
+      this.requestTextVisualRect(record, highlight.text);
+      const visualRect = this.textHoverRects.get(this.textHoverKey(record.index, highlight.text.id));
+      return visualRect ? alignTextClipToVisualRect(highlight.rect, visualRect) : highlight.rect;
+    });
     this.renderInteractionHighlights(record, textRects, "link");
   }
 
-  private showTextHover(record: PageRecord, text: TextInteraction) {
-    const key = `text:${record.index}:${text.id}`;
+  private showTextHover(record: PageRecord, text: TextInteraction, hitRect?: PageRect) {
+    const visualRect = textHoverRect(text, hitRect);
+    this.textHoverRects.set(this.textHoverKey(record.index, text.id), visualRect);
+    this.showTextHoverRect(record, text, visualRect);
+  }
+
+  private showTextHoverRect(record: PageRecord, text: TextInteraction, visualRect: PageRect) {
+    const key = `text:${record.index}:${text.id}:${visualRect.x}:${visualRect.y}:${visualRect.width}:${visualRect.height}`;
     if (this.activeHoverKey === key) {
       return;
     }
     this.activeHoverKey = key;
+    this.activeTextHover = {
+      generation: this.interactionGeneration,
+      pageIndex: record.index,
+      rect: visualRect,
+    };
     record.container.style.cursor = "text";
-    this.renderInteractionHighlights(record, [text.rect], "text");
+    this.renderInteractionHighlights(record, [visualRect], "text");
+  }
+
+  private requestTextHover(
+    record: PageRecord,
+    text: TextInteraction,
+    point: { x: number; y: number },
+  ) {
+    const key = `text-query:${record.index}:${text.id}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+
+    const request = {
+      requestId: ++this.nextHitRequestId,
+      generation: this.interactionGeneration,
+      pageIndex: record.index,
+      x: point.x,
+      y: point.y,
+      text,
+    };
+    this.activeHoverKey = key;
+    this.pendingTextHover = request;
+    record.container.style.cursor = "";
+    this.postWorker({
+      type: "hit-text",
+      requestId: request.requestId,
+      generation: request.generation,
+      pageIndex: request.pageIndex,
+      x: request.x,
+      y: request.y,
+      rect: text.rect,
+    });
+  }
+
+  private requestTextVisualRect(record: PageRecord, text: TextInteraction) {
+    const key = this.textHoverKey(record.index, text.id);
+    if (this.textHoverRects.has(key) || this.pendingTextRectRequests.has(key)) {
+      return;
+    }
+    this.pendingTextRectRequests.add(key);
+    this.postWorker({
+      type: "resolve-text-rect",
+      requestId: ++this.nextHitRequestId,
+      generation: this.interactionGeneration,
+      pageIndex: record.index,
+      textId: text.id,
+      rect: text.rect,
+    });
   }
 
   private showBoundHover(record: PageRecord, bound: BoundInteraction) {
@@ -625,6 +1036,7 @@ export class PageHost {
       return;
     }
     this.activeHoverKey = key;
+    this.activeTextHover = undefined;
     record.container.style.cursor = "";
     this.renderInteractionHighlights(record, [bound.rect], "bound");
   }
@@ -636,7 +1048,7 @@ export class PageHost {
     }
 
     const request = {
-      requestId: ++this.nextBoundRequestId,
+      requestId: ++this.nextHitRequestId,
       generation: this.interactionGeneration,
       pageIndex: record.index,
       x: point.x,
@@ -694,7 +1106,39 @@ export class PageHost {
 
   private clearInteractionHighlight(record: PageRecord) {
     record.container.style.cursor = "";
+    this.activeTextHover = undefined;
     record.interactionLayer.replaceChildren();
+  }
+
+  private activeTextHoverContains(record: PageRecord, point: { x: number; y: number }) {
+    return (
+      this.activeTextHover?.generation === this.interactionGeneration &&
+      this.activeTextHover.pageIndex === record.index &&
+      rectContainsPage(this.activeTextHover.rect, point.x, point.y)
+    );
+  }
+
+  private cachedTextHoverAt(record: PageRecord, point: { x: number; y: number }) {
+    const texts = record.interactions?.texts;
+    if (!texts) {
+      return undefined;
+    }
+    for (let index = texts.length - 1; index >= 0; index -= 1) {
+      const text = texts[index];
+      const rect = this.textHoverRects.get(this.textHoverKey(record.index, text.id));
+      if (rect && rectContainsPage(rect, point.x, point.y)) {
+        return { text, rect };
+      }
+    }
+    return undefined;
+  }
+
+  private textHoverKey(pageIndex: number, textId: number) {
+    return `${this.interactionGeneration}:${pageIndex}:${textId}`;
+  }
+
+  private textHitContains(text: TextInteraction, hitRect: PageRect | undefined, x: number, y: number) {
+    return rectContainsPage(textHoverRect(text, hitRect), x, y);
   }
 
   private applyRectStyle(record: PageRecord, element: HTMLElement, rect: PageRect) {
@@ -739,6 +1183,16 @@ export class PageHost {
     record.shell.style.width = `${cssWidth}px`;
     record.shell.style.height = `${cssHeight}px`;
     record.shell.dataset.appliedScale = String(scale);
+    this.alignCanvasBackingStore(record, page);
+  }
+
+  private alignCanvasBackingStore(record: PageRecord, page: PageSpec) {
+    const drawnWidthPx = page.width * page.pixelPerPt;
+    const drawnHeightPx = page.height * page.pixelPerPt;
+    const widthScale = record.fullWidthPx / Math.max(drawnWidthPx, 1);
+    const heightScale = record.fullHeightPx / Math.max(drawnHeightPx, 1);
+    record.canvas.style.width = `${widthScale * 100}%`;
+    record.canvas.style.height = `${heightScale * 100}%`;
   }
 
   private computePageScale(page: PageSpec, metrics: PageLayoutMetrics): number {
@@ -1037,6 +1491,23 @@ function determineInvertColor() {
     (cls.contains("vscode-dark") || cls.contains("vscode-high-contrast")) &&
     !cls.contains("vscode-light")
   );
+}
+
+function textHoverRect(text: TextInteraction, hitRect: PageRect | undefined) {
+  return hitRect || text.rect;
+}
+
+function rectContainsPage(rect: PageRect, x: number, y: number) {
+  return x >= rect.x && y >= rect.y && x <= rect.x + rect.width && y <= rect.y + rect.height;
+}
+
+function alignTextClipToVisualRect(clippedRect: PageRect, visualRect: PageRect): PageRect {
+  return {
+    x: clippedRect.x,
+    y: visualRect.y,
+    width: clippedRect.width,
+    height: visualRect.height,
+  };
 }
 
 const zoomFactors = [

--- a/tools/typst-preview-frontend-ng/src/types.ts
+++ b/tools/typst-preview-frontend-ng/src/types.ts
@@ -31,6 +31,8 @@ export interface PageRecord {
   transferred: boolean;
   width: number;
   height: number;
+  fullWidthPx: number;
+  fullHeightPx: number;
   cssWidth: number;
   cssHeight: number;
   pixelPerPt: number;
@@ -54,6 +56,9 @@ export interface ViewportSnapshot {
   scrollLeft: number;
   scrollTop: number;
   devicePixelRatio: number;
+  dragging?: boolean;
+  scrolling?: boolean;
+  renderDuringDrag?: boolean;
   window: {
     innerWidth: number;
     innerHeight: number;

--- a/tools/typst-preview-frontend-ng/src/worker/canvas-store.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/canvas-store.ts
@@ -1,0 +1,208 @@
+import type { CanvasEntry, CanvasLayer, PageRenderSpec } from "./types";
+import { commitPixelRect } from "./render-utils";
+
+/** Owns worker-side canvas entries, render cache keys, scratch buffers, and LRU eviction. */
+export class CanvasStore {
+  private readonly entries = new Map<number, CanvasEntry>();
+  private readonly lru = new Map<number, true>();
+  private readonly renderCacheKeys = new Map<number, string>();
+  private readonly latestCacheKeys = new Map<number, string>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  get(pageIndex: number) {
+    return this.entries.get(pageIndex);
+  }
+
+  indices() {
+    return this.entries.keys();
+  }
+
+  setCanvas(pageIndex: number, canvas: OffscreenCanvas, widthPx: number, heightPx: number) {
+    this.entries.set(pageIndex, {
+      canvas,
+      widthPx,
+      heightPx,
+    });
+    this.renderCacheKeys.delete(pageIndex);
+  }
+
+  deletePage(pageIndex: number) {
+    this.entries.delete(pageIndex);
+    this.lru.delete(pageIndex);
+    this.renderCacheKeys.delete(pageIndex);
+    this.latestCacheKeys.delete(pageIndex);
+  }
+
+  clear() {
+    this.entries.clear();
+    this.lru.clear();
+    this.renderCacheKeys.clear();
+    this.latestCacheKeys.clear();
+  }
+
+  getRenderCacheKey(pageIndex: number) {
+    return this.renderCacheKeys.get(pageIndex);
+  }
+
+  setRenderCacheKey(pageIndex: number, cacheKey: string) {
+    this.renderCacheKeys.set(pageIndex, cacheKey);
+  }
+
+  deleteRenderCacheKey(pageIndex: number) {
+    this.renderCacheKeys.delete(pageIndex);
+  }
+
+  getLatestCacheKey(pageIndex: number) {
+    return this.latestCacheKeys.get(pageIndex);
+  }
+
+  setLatestCacheKey(pageIndex: number, cacheKey: string) {
+    this.latestCacheKeys.set(pageIndex, cacheKey);
+  }
+
+  touch(pageIndex: number) {
+    this.lru.delete(pageIndex);
+    this.lru.set(pageIndex, true);
+  }
+
+  resizeEntry(entry: CanvasEntry, pageIndex: number, widthPx: number, heightPx: number) {
+    let resized = false;
+    if (entry.canvas.width !== widthPx) {
+      entry.canvas.width = widthPx;
+      entry.hasContent = false;
+      this.renderCacheKeys.delete(pageIndex);
+      resized = true;
+    }
+    if (entry.canvas.height !== heightPx) {
+      entry.canvas.height = heightPx;
+      entry.hasContent = false;
+      this.renderCacheKeys.delete(pageIndex);
+      resized = true;
+    }
+    entry.widthPx = widthPx;
+    entry.heightPx = heightPx;
+    return resized;
+  }
+
+  ensureContext(entry: CanvasEntry, pageIndex: number) {
+    const context =
+      entry.context ||
+      entry.canvas.getContext("2d", {
+        alpha: false,
+        desynchronized: true,
+      });
+    if (!context) {
+      throw new Error(`cannot create 2d context for page ${pageIndex}`);
+    }
+    entry.context = context;
+    return context;
+  }
+
+  ensureScratchContext(entry: CanvasEntry, pageIndex: number, layer: CanvasLayer) {
+    if (!entry.scratch) {
+      entry.scratch = new OffscreenCanvas(entry.widthPx, entry.heightPx);
+    }
+    if (entry.scratch.width !== entry.widthPx) {
+      entry.scratch.width = entry.widthPx;
+    }
+    if (entry.scratch.height !== entry.heightPx) {
+      entry.scratch.height = entry.heightPx;
+    }
+
+    const context =
+      entry.scratchContext ||
+      entry.scratch.getContext("2d", {
+        alpha: false,
+        desynchronized: true,
+      });
+    if (!context) {
+      throw new Error(`cannot create ${layer} scratch context for page ${pageIndex}`);
+    }
+    entry.scratchContext = context;
+    return context;
+  }
+
+  releaseScratch(entry: CanvasEntry) {
+    if (!entry.scratch) {
+      return;
+    }
+    if (entry.scratch.width !== 1) {
+      entry.scratch.width = 1;
+    }
+    if (entry.scratch.height !== 1) {
+      entry.scratch.height = 1;
+    }
+    entry.scratchContext = undefined;
+  }
+
+  initializeTargetCanvas(target: OffscreenCanvasRenderingContext2D, entry: CanvasEntry) {
+    target.setTransform(1, 0, 0, 1, 0, 0);
+    target.fillStyle = "#ffffff";
+    target.fillRect(0, 0, entry.widthPx, entry.heightPx);
+  }
+
+  commitScratchToTarget(
+    entry: CanvasEntry,
+    target: OffscreenCanvasRenderingContext2D,
+    scratch: OffscreenCanvasRenderingContext2D,
+    page: PageRenderSpec,
+    pixelPerPt: number,
+  ) {
+    target.setTransform(1, 0, 0, 1, 0, 0);
+    const rect = commitPixelRect(page, pixelPerPt, entry.widthPx, entry.heightPx);
+    if (!rect) {
+      return;
+    }
+    target.clearRect(rect.x, rect.y, rect.width, rect.height);
+    target.drawImage(
+      scratch.canvas,
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+    );
+  }
+
+  enforceLimit(protectedPages: Set<number>) {
+    if (this.lru.size <= this.maxEntries) {
+      return [];
+    }
+
+    const evicted: number[] = [];
+    while (this.lru.size > this.maxEntries) {
+      const candidate = [...this.lru.keys()].find((pageIndex) => !protectedPages.has(pageIndex));
+      if (candidate === undefined) {
+        break;
+      }
+
+      const entry = this.entries.get(candidate);
+      if (entry) {
+        this.evictEntry(entry);
+      }
+      this.lru.delete(candidate);
+      this.renderCacheKeys.delete(candidate);
+      this.latestCacheKeys.delete(candidate);
+      evicted.push(candidate);
+    }
+    return evicted;
+  }
+
+  private evictEntry(entry: CanvasEntry) {
+    entry.canvas.width = 1;
+    entry.canvas.height = 1;
+    entry.widthPx = 1;
+    entry.heightPx = 1;
+    entry.hasContent = false;
+    entry.quality = undefined;
+    entry.renderedGeneration = undefined;
+    entry.renderedPixelPerPt = undefined;
+    entry.renderedWindowKey = undefined;
+    entry.context = undefined;
+    this.releaseScratch(entry);
+  }
+}

--- a/tools/typst-preview-frontend-ng/src/worker/interaction-store.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/interaction-store.ts
@@ -1,0 +1,55 @@
+import type { RenderSession } from "@myriaddreamin/typst.ts/dist/esm/renderer.mjs";
+import { parsePageInteractions, type PageInteractions } from "../interactions";
+
+/** Caches per-page interaction metadata rendered from typst.ts semantic output. */
+export class InteractionStore {
+  private readonly cacheKeys = new Map<number, string>();
+  private readonly interactions = new Map<number, PageInteractions>();
+
+  clear() {
+    this.cacheKeys.clear();
+    this.interactions.clear();
+  }
+
+  deletePage(pageIndex: number) {
+    this.cacheKeys.delete(pageIndex);
+    this.interactions.delete(pageIndex);
+  }
+
+  invalidateIfCacheKeyChanged(pageIndex: number, cacheKey: string) {
+    if (this.cacheKeys.get(pageIndex) === cacheKey) {
+      return undefined;
+    }
+
+    const hadInteractions = this.cacheKeys.has(pageIndex) || this.interactions.has(pageIndex);
+    this.deletePage(pageIndex);
+    return hadInteractions;
+  }
+
+  async renderPage(
+    session: RenderSession,
+    pageIndex: number,
+    pixelPerPt: number,
+    cacheKey?: string,
+  ) {
+    const cached = this.interactions.get(pageIndex);
+    if (cacheKey && cached && this.cacheKeys.get(pageIndex) === cacheKey) {
+      return cached;
+    }
+
+    const metadata = await session.renderCanvas({
+      pageOffset: pageIndex,
+      pixelPerPt,
+      dataSelection: {
+        body: false,
+        semantics: true,
+      },
+    } as any);
+    const interactions = parsePageInteractions(pageIndex, metadata.htmlSemantics?.[0] || "");
+    if (cacheKey) {
+      this.cacheKeys.set(pageIndex, cacheKey);
+    }
+    this.interactions.set(pageIndex, interactions);
+    return interactions;
+  }
+}

--- a/tools/typst-preview-frontend-ng/src/worker/render-utils.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/render-utils.ts
@@ -1,0 +1,177 @@
+import type { PageLayout, PageRenderSpec, PageSpec } from "./types";
+
+const minPixelPerPt = 0.5;
+const maxPixelPerPt = 4;
+const interactivePixelPerPtScale = 0.65;
+const minInteractivePixelPerPt = 0.7;
+const maxInteractivePixelPerPt = 1.25;
+
+export function yieldToEventLoop(): Promise<void> {
+  const scheduler = (globalThis as any).scheduler;
+  if (typeof scheduler?.yield === "function") {
+    return scheduler.yield();
+  }
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function clampPixelPerPt(value: number) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return minPixelPerPt;
+  }
+  const bucketed = Math.ceil((value - 1e-3) * 4) / 4;
+  return clamp(bucketed, minPixelPerPt, maxPixelPerPt);
+}
+
+export function computeInteractivePixelPerPt(value: number) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return minInteractivePixelPerPt;
+  }
+  return clamp(
+    value * interactivePixelPerPtScale,
+    minInteractivePixelPerPt,
+    maxInteractivePixelPerPt,
+  );
+}
+
+export function isFullPageRender(page: PageRenderSpec) {
+  const window = page.window;
+  if (!window) {
+    return true;
+  }
+  return (
+    window.lo.x <= 0 && window.lo.y <= 0 && window.hi.x >= page.width && window.hi.y >= page.height
+  );
+}
+
+export function commitPixelRect(
+  page: PageRenderSpec,
+  pixelPerPt: number,
+  widthPx: number,
+  heightPx: number,
+) {
+  if (!page.window) {
+    return { x: 0, y: 0, width: widthPx, height: heightPx };
+  }
+
+  const x = Math.trunc(clamp(Math.floor(page.window.lo.x * pixelPerPt), 0, widthPx));
+  const y = Math.trunc(clamp(Math.floor(page.window.lo.y * pixelPerPt), 0, heightPx));
+  const right = Math.trunc(clamp(Math.ceil(page.window.hi.x * pixelPerPt), 0, widthPx));
+  const bottom = Math.trunc(clamp(Math.ceil(page.window.hi.y * pixelPerPt), 0, heightPx));
+  if (right <= x || bottom <= y) {
+    return undefined;
+  }
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+export function renderWindowKey(page: PageRenderSpec) {
+  if (!page.window) {
+    return "full";
+  }
+  const { lo, hi } = page.window;
+  return `${lo.x}:${lo.y}:${hi.x}:${hi.y}`;
+}
+
+export function pageDistanceToViewport(page: PageRenderSpec, layouts: PageLayout[], viewport: any) {
+  const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
+  const viewportTop = Math.max(0, viewport.scrollTop || 0);
+  const viewportBottom = viewportTop + viewportHeight;
+  const viewportCenter = (viewportTop + viewportBottom) / 2;
+  const layout = layouts.find((candidate) => candidate.index === page.index);
+  if (!layout) {
+    return page.index * 1_000_000;
+  }
+  if (page.window) {
+    const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
+    const top = layout.top + page.window.lo.y * scale;
+    const bottom = layout.top + page.window.hi.y * scale;
+    return distanceToRange(top, bottom, viewportCenter, viewportTop, viewportBottom);
+  }
+  return distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom);
+}
+
+export function selectStagePagesAt(
+  pages: PageSpec[],
+  layouts: PageLayout[],
+  viewport: any,
+  screens: number,
+  viewportTop: number,
+  options: { windowed?: boolean } = {},
+): PageRenderSpec[] {
+  if (!Number.isFinite(screens)) {
+    return pages.map((page) => ({ ...page }));
+  }
+
+  const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
+  const viewportBottom = viewportTop + viewportHeight;
+  const sideScreens = Math.max(0, (screens - 1) / 2);
+  const rangeTop = Math.max(0, viewportTop - viewportHeight * sideScreens);
+  const rangeBottom = viewportBottom + viewportHeight * sideScreens;
+  const viewportCenter = (viewportTop + viewportBottom) / 2;
+  const layoutMap = new Map(layouts.map((layout) => [layout.index, layout]));
+
+  return pages
+    .flatMap((page) => {
+      const layout = layoutMap.get(page.index);
+      if (!layout || layout.bottom < rangeTop || layout.top > rangeBottom) {
+        return [];
+      }
+
+      const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
+      if (options.windowed === false) {
+        return [
+          {
+            ...page,
+            distance: distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom),
+          },
+        ];
+      }
+
+      const loY = clamp((rangeTop - layout.top) / scale, 0, page.height);
+      const hiY = clamp((rangeBottom - layout.top) / scale, 0, page.height);
+      if (hiY <= loY) {
+        return [];
+      }
+
+      return [
+        {
+          ...page,
+          window: {
+            lo: { x: -1, y: Math.max(0, loY - 1) },
+            hi: { x: page.width + 1, y: Math.min(page.height, hiY + 1) },
+          },
+          distance: distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom),
+        },
+      ];
+    })
+    .sort((a, b) => a.distance - b.distance || a.index - b.index)
+    .map(({ distance: _distance, ...page }) => page);
+}
+
+function distanceToViewport(
+  layout: PageLayout,
+  viewportCenter: number,
+  viewportTop: number,
+  viewportBottom: number,
+) {
+  return distanceToRange(layout.top, layout.bottom, viewportCenter, viewportTop, viewportBottom);
+}
+
+function distanceToRange(
+  top: number,
+  bottom: number,
+  viewportCenter: number,
+  viewportTop: number,
+  viewportBottom: number,
+) {
+  if (top <= viewportBottom && bottom >= viewportTop) {
+    return Math.abs((top + bottom) / 2 - viewportCenter) * 0.001;
+  }
+  if (bottom < viewportTop) {
+    return viewportTop - bottom;
+  }
+  return top - viewportBottom;
+}

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -4,36 +4,38 @@ import {
   type TypstRenderer,
 } from "@myriaddreamin/typst.ts/dist/esm/renderer.mjs";
 import * as rendererWrapper from "@myriaddreamin/typst-ts-renderer";
+import { type BoundInteraction, type PageInteractions, type PageRect } from "../interactions";
+import { CanvasStore } from "./canvas-store";
+import { InteractionStore } from "./interaction-store";
 import {
-  parsePageInteractions,
-  type BoundInteraction,
-  type PageInteractions,
-  type PageRect,
-} from "../interactions";
+  clamp,
+  clampPixelPerPt,
+  computeInteractivePixelPerPt,
+  isFullPageRender,
+  pageDistanceToViewport,
+  renderWindowKey,
+  selectStagePagesAt,
+  yieldToEventLoop,
+} from "./render-utils";
+import { hitRenderedTextBox, resolveRenderedTextRect } from "./text-hit";
 import type {
   CanvasAck,
-  CanvasEntry,
+  CanvasLayer,
   PageLayout,
   PageRenderSpec,
   PageRenderResult,
   PageSpec,
   PendingCanvasAck,
+  RenderQuality,
   WorkerConfig,
   WorkerPost,
 } from "./types";
 
-const minPixelPerPt = 0.5;
-const maxPixelPerPt = 4;
 const visibleRenderScreens = 1;
 const scrollRenderScreens = 1;
 const prefetchRenderScreens = 5;
 const idlePrefetchDelayMs = 120;
 const maxCanvasBufferPages = 18;
-const interactivePixelPerPtScale = 0.65;
-const minInteractivePixelPerPt = 0.7;
-const maxInteractivePixelPerPt = 1.25;
-type CanvasLayer = "full";
-type RenderQuality = "preview" | "full";
 
 interface RenderAndPostOptions {
   session: RenderSession;
@@ -86,13 +88,9 @@ export class WorkerRenderer {
   private viewportRenderQueued = false;
   private idlePrefetchTimer = 0;
   private latestPages: PageSpec[] = [];
-  private readonly pageCanvases = new Map<number, CanvasEntry>();
-  private readonly pageCanvasLru = new Map<number, true>();
-  private readonly pageCacheKeys = new Map<number, string>();
-  private readonly pageLatestCacheKeys = new Map<number, string>();
+  private readonly canvasStore = new CanvasStore(maxCanvasBufferPages);
+  private readonly interactionStore = new InteractionStore();
   private readonly pagePixelPerPt = new Map<number, number>();
-  private readonly pageInteractionCacheKeys = new Map<number, string>();
-  private readonly pageInteractions = new Map<number, PageInteractions>();
   private readonly pendingCanvasAcks = new Map<number, PendingCanvasAck>();
   private latestPageLayouts: PageLayout[] = [];
 
@@ -162,10 +160,7 @@ export class WorkerRenderer {
   private async renderViewportUpdate(frameVersion: number) {
     const handledViewportVersion = this.viewportVersion;
     try {
-      if (
-        this.isRenderInterrupted(frameVersion) ||
-        this.latestPages.length === 0
-      ) {
+      if (this.isRenderInterrupted(frameVersion) || this.latestPages.length === 0) {
         return;
       }
 
@@ -338,13 +333,7 @@ export class WorkerRenderer {
     ack?: CanvasAck,
   ) {
     for (const page of canvases) {
-      const layer = page.layer || "full";
-      this.pageCanvases.set(page.index, {
-        canvas: page.canvas,
-        widthPx: page.widthPx,
-        heightPx: page.heightPx,
-      });
-      this.pageCacheKeys.delete(page.index);
+      this.canvasStore.setCanvas(page.index, page.canvas, page.widthPx, page.heightPx);
     }
     this.resolveCanvasAck(generation, ack);
   }
@@ -368,10 +357,7 @@ export class WorkerRenderer {
     await this.renderQueue;
   }
 
-  async requestInteractions(request: {
-    generation: number;
-    pageIndices: number[];
-  }) {
+  async requestInteractions(request: { generation: number; pageIndices: number[] }) {
     const viewportVersion = this.viewportVersion;
     this.renderQueue = this.renderQueue
       .then(() => this.requestInteractionsExclusive({ ...request, viewportVersion }))
@@ -408,7 +394,13 @@ export class WorkerRenderer {
       return;
     }
 
-    const result = this.hitRenderedTextBox(request.pageIndex, request.x, request.y, request.rect);
+    const result = hitRenderedTextBox(
+      this.canvasStore.get(request.pageIndex),
+      this.pagePixelPerPt.get(request.pageIndex),
+      request.x,
+      request.y,
+      request.rect,
+    );
     if (request.generation !== this.generation) {
       return;
     }
@@ -437,7 +429,11 @@ export class WorkerRenderer {
         return;
       }
 
-      const rect = this.resolveRenderedTextRect(request.pageIndex, request.rect);
+      const rect = resolveRenderedTextRect(
+        this.canvasStore.get(request.pageIndex),
+        this.pagePixelPerPt.get(request.pageIndex),
+        request.rect,
+      );
       if (request.generation !== this.generation) {
         return;
       }
@@ -491,274 +487,6 @@ export class WorkerRenderer {
     }
   }
 
-  private hitRenderedTextBox(pageIndex: number, x: number, y: number, rect?: PageRect) {
-    const entry = this.pageCanvases.get(pageIndex);
-    const context = entry?.context;
-    const pixelPerPt = this.pagePixelPerPt.get(pageIndex);
-    if (!entry || !context || !pixelPerPt) {
-      return { hit: false };
-    }
-
-    const px = Math.floor(x * pixelPerPt);
-    const py = Math.floor(y * pixelPerPt);
-    if (rect && usesTextRunBounds(rect)) {
-      const textRect = this.textRunInkBounds(context, entry, pixelPerPt, rect, py);
-      return textRect ? { hit: true, rect: textRect } : { hit: false };
-    }
-
-    const start = this.nearestInkPixel(context, entry, px, py, pixelPerPt, rect);
-    if (!start) {
-      return { hit: false };
-    }
-
-    return {
-      hit: true,
-      rect: this.connectedInkBounds(context, entry, start.x, start.y, pixelPerPt),
-    };
-  }
-
-  private resolveRenderedTextRect(pageIndex: number, rect: PageRect) {
-    const entry = this.pageCanvases.get(pageIndex);
-    const context = entry?.context;
-    const pixelPerPt = this.pagePixelPerPt.get(pageIndex);
-    if (!entry || !context || !pixelPerPt) {
-      return undefined;
-    }
-    return this.textRunInkBounds(context, entry, pixelPerPt, rect);
-  }
-
-  private textRunInkBounds(
-    context: OffscreenCanvasRenderingContext2D,
-    entry: CanvasEntry,
-    pixelPerPt: number,
-    rect: PageRect,
-    preferredY?: number,
-  ) {
-    const rectLeft = Math.floor(rect.x * pixelPerPt);
-    const rectTop = rect.y * pixelPerPt;
-    const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt) - 1;
-    const rectBottom = (rect.y + rect.height) * pixelPerPt;
-    const rectHeight = Math.max(1, rectBottom - rectTop);
-    const yPad = Math.trunc(clamp(rectHeight * 1.6, 4, 48));
-    const left = Math.trunc(clamp(rectLeft, 0, Math.max(0, entry.widthPx - 1)));
-    const right = Math.trunc(clamp(rectRight, 0, Math.max(0, entry.widthPx - 1)));
-    const top = Math.trunc(clamp(Math.floor(rectTop) - yPad, 0, Math.max(0, entry.heightPx - 1)));
-    const bottom = Math.trunc(
-      clamp(Math.ceil(rectBottom) + yPad, 0, Math.max(0, entry.heightPx - 1)),
-    );
-    const width = right - left + 1;
-    const height = bottom - top + 1;
-    if (width <= 0 || height <= 0) {
-      return undefined;
-    }
-
-    const pixels = context.getImageData(left, top, width, height).data;
-    const rowClusters = this.textInkRowClusters(pixels, width, height, top);
-    const cluster = chooseTextRowCluster(rowClusters, rectTop, rectBottom, preferredY);
-    if (!cluster) {
-      return undefined;
-    }
-
-    let minX = Number.POSITIVE_INFINITY;
-    let maxX = Number.NEGATIVE_INFINITY;
-    let minY = Number.POSITIVE_INFINITY;
-    let maxY = Number.NEGATIVE_INFINITY;
-    for (let y = cluster.top; y <= cluster.bottom; y += 1) {
-      const row = y - top;
-      for (let x = 0; x < width; x += 1) {
-        const index = row * width + x;
-        if (!pixelHasVisibleInk(pixels, index * 4)) {
-          continue;
-        }
-        const px = left + x;
-        minX = Math.min(minX, px);
-        maxX = Math.max(maxX, px);
-        minY = Math.min(minY, y);
-        maxY = Math.max(maxY, y);
-      }
-    }
-
-    if (!Number.isFinite(minX)) {
-      return undefined;
-    }
-
-    return {
-      x: minX / pixelPerPt,
-      y: minY / pixelPerPt,
-      width: (maxX - minX + 1) / pixelPerPt,
-      height: (maxY - minY + 1) / pixelPerPt,
-    };
-  }
-
-  private textInkRowClusters(
-    pixels: Uint8ClampedArray,
-    width: number,
-    height: number,
-    top: number,
-  ) {
-    const clusters: Array<{ top: number; bottom: number; ink: number }> = [];
-    for (let y = 0; y < height; y += 1) {
-      let rowInk = 0;
-      for (let x = 0; x < width; x += 1) {
-        const index = y * width + x;
-        if (pixelHasVisibleInk(pixels, index * 4)) {
-          rowInk += 1;
-        }
-      }
-      if (rowInk === 0) {
-        continue;
-      }
-      const pageY = top + y;
-      const last = clusters[clusters.length - 1];
-      if (!last || pageY > last.bottom + 1) {
-        clusters.push({ top: pageY, bottom: pageY, ink: rowInk });
-        continue;
-      }
-      last.bottom = pageY;
-      last.ink += rowInk;
-    }
-    return clusters;
-  }
-
-  private nearestInkPixel(
-    context: OffscreenCanvasRenderingContext2D,
-    entry: CanvasEntry,
-    px: number,
-    py: number,
-    pixelPerPt: number,
-    rect?: PageRect,
-  ) {
-    let left: number;
-    let top: number;
-    let right: number;
-    let bottom: number;
-
-    if (rect) {
-      const rectLeft = Math.floor(rect.x * pixelPerPt);
-      const rectTop = Math.floor(rect.y * pixelPerPt);
-      const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt);
-      const rectBottom = Math.ceil((rect.y + rect.height) * pixelPerPt);
-      const pad = Math.trunc(
-        clamp(Math.max(rectRight - rectLeft, rectBottom - rectTop) * 2, 16, 96),
-      );
-      left = Math.trunc(clamp(rectLeft - pad, 0, Math.max(0, entry.widthPx - 1)));
-      top = Math.trunc(clamp(rectTop - pad, 0, Math.max(0, entry.heightPx - 1)));
-      right = Math.trunc(clamp(rectRight + pad, 0, Math.max(0, entry.widthPx - 1)));
-      bottom = Math.trunc(clamp(rectBottom + pad, 0, Math.max(0, entry.heightPx - 1)));
-    } else {
-      const radius = 48;
-      left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
-      top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
-      right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
-      bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
-    }
-
-    const width = right - left + 1;
-    const height = bottom - top + 1;
-    if (width <= 0 || height <= 0) {
-      return undefined;
-    }
-
-    const pixels = context.getImageData(left, top, width, height).data;
-    let bestIndex = -1;
-    let bestDistance = Number.POSITIVE_INFINITY;
-    for (let index = 0; index < width * height; index += 1) {
-      if (!pixelHasStrongInk(pixels, index * 4)) {
-        continue;
-      }
-      const x = left + (index % width);
-      const y = top + Math.floor(index / width);
-      const distance = (x - px) ** 2 + (y - py) ** 2;
-      if (distance < bestDistance) {
-        bestDistance = distance;
-        bestIndex = index;
-      }
-    }
-
-    if (bestIndex < 0) {
-      return undefined;
-    }
-
-    return {
-      x: left + (bestIndex % width),
-      y: top + Math.floor(bestIndex / width),
-    };
-  }
-
-  private connectedInkBounds(
-    context: OffscreenCanvasRenderingContext2D,
-    entry: CanvasEntry,
-    px: number,
-    py: number,
-    pixelPerPt: number,
-  ) {
-    const radius = 80;
-    const left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
-    const top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
-    const right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
-    const bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
-    const width = right - left + 1;
-    const height = bottom - top + 1;
-    const pixels = context.getImageData(left, top, width, height).data;
-    const startX = px - left;
-    const startY = py - top;
-    const start = startY * width + startX;
-    const visited = new Uint8Array(width * height);
-    const stack = [start];
-    let minX = startX;
-    let maxX = startX;
-    let minY = startY;
-    let maxY = startY;
-    let visitedInk = 0;
-
-    while (stack.length > 0 && visitedInk < 16_384) {
-      const index = stack.pop()!;
-      if (visited[index]) {
-        continue;
-      }
-      visited[index] = 1;
-      if (!pixelHasVisibleInk(pixels, index * 4)) {
-        continue;
-      }
-
-      visitedInk += 1;
-      const x = index % width;
-      const y = Math.floor(index / width);
-      minX = Math.min(minX, x);
-      maxX = Math.max(maxX, x);
-      minY = Math.min(minY, y);
-      maxY = Math.max(maxY, y);
-
-      for (let dy = -1; dy <= 1; dy += 1) {
-        for (let dx = -1; dx <= 1; dx += 1) {
-          if (dx === 0 && dy === 0) {
-            continue;
-          }
-          const nx = x + dx;
-          const ny = y + dy;
-          if (nx < 0 || ny < 0 || nx >= width || ny >= height) {
-            continue;
-          }
-          const next = ny * width + nx;
-          if (!visited[next]) {
-            stack.push(next);
-          }
-        }
-      }
-    }
-
-    const rectLeft = Math.max(0, left + minX);
-    const rectTop = Math.max(0, top + minY);
-    const rectRight = Math.min(entry.widthPx - 1, left + maxX);
-    const rectBottom = Math.min(entry.heightPx - 1, top + maxY);
-    return {
-      x: rectLeft / pixelPerPt,
-      y: rectTop / pixelPerPt,
-      width: (rectRight - rectLeft + 1) / pixelPerPt,
-      height: (rectBottom - rectTop + 1) / pixelPerPt,
-    };
-  }
-
   resetDocumentState() {
     this.initializedDocument = false;
     this.generation = 0;
@@ -767,13 +495,9 @@ export class WorkerRenderer {
     this.viewportRenderQueued = false;
     this.clearIdlePrefetchTimer();
     this.latestPages = [];
-    this.pageCanvases.clear();
-    this.pageCanvasLru.clear();
-    this.pageCacheKeys.clear();
-    this.pageLatestCacheKeys.clear();
+    this.canvasStore.clear();
+    this.interactionStore.clear();
     this.pagePixelPerPt.clear();
-    this.pageInteractionCacheKeys.clear();
-    this.pageInteractions.clear();
     this.latestPageLayouts = [];
     for (const ack of this.pendingCanvasAcks.values()) {
       clearTimeout(ack.timeout);
@@ -853,7 +577,14 @@ export class WorkerRenderer {
         continue;
       }
 
-      interactions.push(await this.renderPageInteractions(session, pageIndex, pixelPerPt));
+      interactions.push(
+        await this.interactionStore.renderPage(
+          session,
+          pageIndex,
+          pixelPerPt,
+          this.interactionCacheKey(pageIndex),
+        ),
+      );
     }
 
     if (
@@ -946,9 +677,10 @@ export class WorkerRenderer {
 
     if (kind === "new" || !this.initializedDocument) {
       session.reset();
-      this.pageCacheKeys.clear();
-      this.pageInteractionCacheKeys.clear();
-      this.pageInteractions.clear();
+      for (const index of this.canvasStore.indices()) {
+        this.canvasStore.deleteRenderCacheKey(index);
+      }
+      this.interactionStore.clear();
       this.initializedDocument = true;
     }
     session.manipulateData({ action: "merge", data: payload });
@@ -1084,15 +816,11 @@ export class WorkerRenderer {
 
   private ensureCanvases(nextGeneration: number, pages: PageSpec[]): Promise<CanvasAck | null> {
     const livePages = new Set(pages.map((page) => page.index));
-    for (const index of this.pageCanvases.keys()) {
+    for (const index of this.canvasStore.indices()) {
       if (!livePages.has(index)) {
-        this.pageCanvases.delete(index);
-        this.pageCanvasLru.delete(index);
-        this.pageCacheKeys.delete(index);
-        this.pageLatestCacheKeys.delete(index);
+        this.canvasStore.deletePage(index);
         this.pagePixelPerPt.delete(index);
-        this.pageInteractionCacheKeys.delete(index);
-        this.pageInteractions.delete(index);
+        this.interactionStore.deletePage(index);
       }
     }
 
@@ -1139,7 +867,7 @@ export class WorkerRenderer {
         break;
       }
 
-      const entry = this.pageCanvases.get(page.index);
+      const entry = this.canvasStore.get(page.index);
       if (!entry) {
         throw new Error(`missing ${options.layer} offscreen canvas for page ${page.index}`);
       }
@@ -1157,7 +885,7 @@ export class WorkerRenderer {
         entry.renderedPixelPerPt === pixelPerPt &&
         (entry.renderedWindowKey === "full" || entry.renderedWindowKey === windowKey)
       ) {
-        this.touchCanvasLru(page.index);
+        this.canvasStore.touch(page.index);
         pushResult({
           pageIndex: page.index,
           quality: entry.quality,
@@ -1175,51 +903,27 @@ export class WorkerRenderer {
             entry.renderedPixelPerPt === pixelPerPt &&
             entry.renderedWindowKey === windowKey))
       ) {
-        this.touchCanvasLru(page.index);
+        this.canvasStore.touch(page.index);
         pushResult({ pageIndex: page.index, quality: entry.quality });
         continue;
       }
 
       const widthPx = Math.max(1, Math.ceil(page.width * pixelPerPt));
       const heightPx = Math.max(1, Math.ceil(page.height * pixelPerPt));
-      let resized = false;
-      if (entry.canvas.width !== widthPx) {
-        entry.canvas.width = widthPx;
-        entry.hasContent = false;
-        this.pageCacheKeys.delete(page.index);
-        resized = true;
-      }
-      if (entry.canvas.height !== heightPx) {
-        entry.canvas.height = heightPx;
-        entry.hasContent = false;
-        this.pageCacheKeys.delete(page.index);
-        resized = true;
-      }
-      entry.widthPx = widthPx;
-      entry.heightPx = heightPx;
-
-      const context =
-        entry.context ||
-        entry.canvas.getContext("2d", {
-          alpha: false,
-          desynchronized: true,
-        });
-      if (!context) {
-        throw new Error(`cannot create 2d context for page ${page.index}`);
-      }
-      entry.context = context;
+      const resized = this.canvasStore.resizeEntry(entry, page.index, widthPx, heightPx);
+      const context = this.canvasStore.ensureContext(entry, page.index);
       const fullPageRender = isFullPageRender(page);
       const fullPageResult = options.quality === "full" && fullPageRender;
       if (!fullPageRender && (resized || !entry.hasContent)) {
-        this.initializeTargetCanvas(context, entry);
+        this.canvasStore.initializeTargetCanvas(context, entry);
       }
       const cacheKey =
         options.useCacheKey && fullPageRender && entry.hasContent && entry.quality === "full"
-          ? this.pageCacheKeys.get(page.index)
+          ? this.canvasStore.getRenderCacheKey(page.index)
           : undefined;
       const renderContext = fullPageRender
         ? context
-        : this.ensureScratchContext(entry, page.index, options.layer);
+        : this.canvasStore.ensureScratchContext(entry, page.index, options.layer);
 
       const renderOptions = {
         canvas: renderContext,
@@ -1235,7 +939,7 @@ export class WorkerRenderer {
       const result = await session.renderCanvas(renderOptions);
       if (this.isRenderInterrupted(options.frameVersion)) {
         if (!fullPageRender) {
-          this.releaseScratch(entry);
+          this.canvasStore.releaseScratch(entry);
         }
         break;
       }
@@ -1245,7 +949,7 @@ export class WorkerRenderer {
       if (!cacheHit && fullPageRender) {
         entry.hasContent = true;
       } else if (!cacheHit) {
-        this.commitScratchToTarget(entry, context, renderContext, page, pixelPerPt);
+        this.canvasStore.commitScratchToTarget(entry, context, renderContext, page, pixelPerPt);
         entry.hasContent = true;
       }
       entry.quality = options.quality;
@@ -1253,17 +957,22 @@ export class WorkerRenderer {
       entry.renderedPixelPerPt = pixelPerPt;
       entry.renderedWindowKey = windowKey;
       if (!fullPageRender) {
-        this.releaseScratch(entry);
+        this.canvasStore.releaseScratch(entry);
       }
       if (entry.hasContent) {
-        this.touchCanvasLru(page.index);
+        this.canvasStore.touch(page.index);
       }
 
       if (options.quality === "full" && result.cacheKey) {
-        this.pageLatestCacheKeys.set(page.index, result.cacheKey);
+        this.canvasStore.setLatestCacheKey(page.index, result.cacheKey);
       }
-      if (options.quality === "full" && options.updateCacheKey && fullPageRender && result.cacheKey) {
-        this.pageCacheKeys.set(page.index, result.cacheKey);
+      if (
+        options.quality === "full" &&
+        options.updateCacheKey &&
+        fullPageRender &&
+        result.cacheKey
+      ) {
+        this.canvasStore.setRenderCacheKey(page.index, result.cacheKey);
       }
 
       if (stopAfterCommit) {
@@ -1273,17 +982,18 @@ export class WorkerRenderer {
           pageIndex: page.index,
           quality: options.quality,
           fullPage: fullPageResult,
-          interactions: await this.renderPageInteractions(session, page.index, pixelPerPt),
+          interactions: await this.interactionStore.renderPage(
+            session,
+            page.index,
+            pixelPerPt,
+            this.interactionCacheKey(page.index),
+          ),
         });
-      } else if (
-        options.quality === "full" &&
-        result.cacheKey &&
-        this.pageInteractionCacheKeys.get(page.index) !== result.cacheKey
-      ) {
-        const hadInteractions =
-          this.pageInteractionCacheKeys.has(page.index) || this.pageInteractions.has(page.index);
-        this.pageInteractionCacheKeys.delete(page.index);
-        this.pageInteractions.delete(page.index);
+      } else if (options.quality === "full" && result.cacheKey) {
+        const hadInteractions = this.interactionStore.invalidateIfCacheKeyChanged(
+          page.index,
+          result.cacheKey,
+        );
         pushResult(
           hadInteractions
             ? {
@@ -1310,38 +1020,15 @@ export class WorkerRenderer {
     return results;
   }
 
-  private touchCanvasLru(pageIndex: number) {
-    this.pageCanvasLru.delete(pageIndex);
-    this.pageCanvasLru.set(pageIndex, true);
-  }
-
   private enforceCanvasBuffer(generation: number) {
-    if (this.pageCanvasLru.size <= maxCanvasBufferPages) {
-      return;
-    }
-
     const protectedPages = new Set(
       this.selectStagePages(this.latestPages, prefetchRenderScreens, { windowed: false }).map(
         (page) => page.index,
       ),
     );
-    const evicted: number[] = [];
-    while (this.pageCanvasLru.size > maxCanvasBufferPages) {
-      const candidate = [...this.pageCanvasLru.keys()].find((pageIndex) => !protectedPages.has(pageIndex));
-      if (candidate === undefined) {
-        break;
-      }
-
-      const entry = this.pageCanvases.get(candidate);
-      if (entry) {
-        this.evictCanvasEntry(entry);
-      }
-      this.pageCanvasLru.delete(candidate);
-      this.pageCacheKeys.delete(candidate);
-      this.pageLatestCacheKeys.delete(candidate);
-      this.pageInteractionCacheKeys.delete(candidate);
-      this.pageInteractions.delete(candidate);
-      evicted.push(candidate);
+    const evicted = this.canvasStore.enforceLimit(protectedPages);
+    for (const pageIndex of evicted) {
+      this.interactionStore.deletePage(pageIndex);
     }
 
     if (evicted.length > 0) {
@@ -1353,20 +1040,6 @@ export class WorkerRenderer {
     }
   }
 
-  private evictCanvasEntry(entry: CanvasEntry) {
-    entry.canvas.width = 1;
-    entry.canvas.height = 1;
-    entry.widthPx = 1;
-    entry.heightPx = 1;
-    entry.hasContent = false;
-    entry.quality = undefined;
-    entry.renderedGeneration = undefined;
-    entry.renderedPixelPerPt = undefined;
-    entry.renderedWindowKey = undefined;
-    entry.context = undefined;
-    this.releaseScratch(entry);
-  }
-
   private takeNextViewportPage(pages: PageRenderSpec[]) {
     if (pages.length === 0) {
       return undefined;
@@ -1375,7 +1048,11 @@ export class WorkerRenderer {
     let bestIndex = 0;
     let bestDistance = Number.POSITIVE_INFINITY;
     for (let index = 0; index < pages.length; index += 1) {
-      const distance = this.pageDistanceToCurrentViewport(pages[index]);
+      const distance = pageDistanceToViewport(
+        pages[index],
+        this.latestPageLayouts,
+        this.config.viewport || {},
+      );
       if (distance < bestDistance) {
         bestDistance = distance;
         bestIndex = index;
@@ -1385,122 +1062,10 @@ export class WorkerRenderer {
     return pages.splice(bestIndex, 1)[0];
   }
 
-  private ensureScratchContext(entry: CanvasEntry, pageIndex: number, layer: CanvasLayer) {
-    if (!entry.scratch) {
-      entry.scratch = new OffscreenCanvas(entry.widthPx, entry.heightPx);
-    }
-    if (entry.scratch.width !== entry.widthPx) {
-      entry.scratch.width = entry.widthPx;
-    }
-    if (entry.scratch.height !== entry.heightPx) {
-      entry.scratch.height = entry.heightPx;
-    }
-
-    const context =
-      entry.scratchContext ||
-      entry.scratch.getContext("2d", {
-        alpha: false,
-        desynchronized: true,
-      });
-    if (!context) {
-      throw new Error(`cannot create ${layer} scratch context for page ${pageIndex}`);
-    }
-    entry.scratchContext = context;
-    return context;
-  }
-
-  private releaseScratch(entry: CanvasEntry) {
-    if (!entry.scratch) {
-      return;
-    }
-    if (entry.scratch.width !== 1) {
-      entry.scratch.width = 1;
-    }
-    if (entry.scratch.height !== 1) {
-      entry.scratch.height = 1;
-    }
-    entry.scratchContext = undefined;
-  }
-
-  private initializeTargetCanvas(
-    target: OffscreenCanvasRenderingContext2D,
-    entry: CanvasEntry,
-  ) {
-    target.setTransform(1, 0, 0, 1, 0, 0);
-    target.fillStyle = "#ffffff";
-    target.fillRect(0, 0, entry.widthPx, entry.heightPx);
-  }
-
-  private commitScratchToTarget(
-    entry: CanvasEntry,
-    target: OffscreenCanvasRenderingContext2D,
-    scratch: OffscreenCanvasRenderingContext2D,
-    page: PageRenderSpec,
-    pixelPerPt: number,
-  ) {
-    target.setTransform(1, 0, 0, 1, 0, 0);
-    const rect = commitPixelRect(page, pixelPerPt, entry.widthPx, entry.heightPx);
-    if (!rect) {
-      return;
-    }
-    target.clearRect(rect.x, rect.y, rect.width, rect.height);
-    target.drawImage(
-      scratch.canvas,
-      rect.x,
-      rect.y,
-      rect.width,
-      rect.height,
-      rect.x,
-      rect.y,
-      rect.width,
-      rect.height,
+  private interactionCacheKey(pageIndex: number) {
+    return (
+      this.canvasStore.getLatestCacheKey(pageIndex) || this.canvasStore.getRenderCacheKey(pageIndex)
     );
-  }
-
-  private pageDistanceToCurrentViewport(page: PageRenderSpec) {
-    const viewport = this.config.viewport || {};
-    const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
-    const viewportTop = Math.max(0, viewport.scrollTop || 0);
-    const viewportBottom = viewportTop + viewportHeight;
-    const viewportCenter = (viewportTop + viewportBottom) / 2;
-    const layout = this.latestPageLayouts.find((candidate) => candidate.index === page.index);
-    if (!layout) {
-      return page.index * 1_000_000;
-    }
-    if (page.window) {
-      const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
-      const top = layout.top + page.window.lo.y * scale;
-      const bottom = layout.top + page.window.hi.y * scale;
-      return distanceToRange(top, bottom, viewportCenter, viewportTop, viewportBottom);
-    }
-    return distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom);
-  }
-
-  private async renderPageInteractions(
-    session: RenderSession,
-    pageIndex: number,
-    pixelPerPt: number,
-  ) {
-    const cacheKey = this.pageLatestCacheKeys.get(pageIndex) || this.pageCacheKeys.get(pageIndex);
-    const cached = this.pageInteractions.get(pageIndex);
-    if (cacheKey && cached && this.pageInteractionCacheKeys.get(pageIndex) === cacheKey) {
-      return cached;
-    }
-
-    const metadata = await session.renderCanvas({
-      pageOffset: pageIndex,
-      pixelPerPt,
-      dataSelection: {
-        body: false,
-        semantics: true,
-      },
-    } as any);
-    const interactions = parsePageInteractions(pageIndex, metadata.htmlSemantics?.[0] || "");
-    if (cacheKey) {
-      this.pageInteractionCacheKeys.set(pageIndex, cacheKey);
-    }
-    this.pageInteractions.set(pageIndex, interactions);
-    return interactions;
   }
 
   private selectStagePages(
@@ -1510,64 +1075,14 @@ export class WorkerRenderer {
   ): PageRenderSpec[] {
     const viewport = this.config.viewport || {};
     const viewportTop = Math.max(0, viewport.scrollTop || 0);
-    return this.selectStagePagesAt(pages, screens, viewportTop, options);
-  }
-
-  private selectStagePagesAt(
-    pages: PageSpec[],
-    screens: number,
-    viewportTop: number,
-    options: { windowed?: boolean } = {},
-  ): PageRenderSpec[] {
-    if (!Number.isFinite(screens)) {
-      return pages.map((page) => ({ ...page }));
-    }
-
-    const viewport = this.config.viewport || {};
-    const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
-    const viewportBottom = viewportTop + viewportHeight;
-    const sideScreens = Math.max(0, (screens - 1) / 2);
-    const rangeTop = Math.max(0, viewportTop - viewportHeight * sideScreens);
-    const rangeBottom = viewportBottom + viewportHeight * sideScreens;
-    const viewportCenter = (viewportTop + viewportBottom) / 2;
-    const layouts = new Map(this.latestPageLayouts.map((layout) => [layout.index, layout]));
-
-    return pages
-      .flatMap((page) => {
-        const layout = layouts.get(page.index);
-        if (!layout || layout.bottom < rangeTop || layout.top > rangeBottom) {
-          return [];
-        }
-
-        const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
-        if (options.windowed === false) {
-          return [
-            {
-              ...page,
-              distance: distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom),
-            },
-          ];
-        }
-
-        const loY = clamp((rangeTop - layout.top) / scale, 0, page.height);
-        const hiY = clamp((rangeBottom - layout.top) / scale, 0, page.height);
-        if (hiY <= loY) {
-          return [];
-        }
-
-        return [
-          {
-            ...page,
-            window: {
-              lo: { x: -1, y: Math.max(0, loY - 1) },
-              hi: { x: page.width + 1, y: Math.min(page.height, hiY + 1) },
-            },
-            distance: distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom),
-          },
-        ];
-      })
-      .sort((a, b) => a.distance - b.distance || a.index - b.index)
-      .map(({ distance: _distance, ...page }) => page);
+    return selectStagePagesAt(
+      pages,
+      this.latestPageLayouts,
+      viewport,
+      screens,
+      viewportTop,
+      options,
+    );
   }
 
   private isRenderInterrupted(frameVersion: number) {
@@ -1633,141 +1148,4 @@ export class WorkerRenderer {
       stack: error instanceof Error ? error.stack : undefined,
     });
   }
-}
-
-function yieldToEventLoop(): Promise<void> {
-  const scheduler = (globalThis as any).scheduler;
-  if (typeof scheduler?.yield === "function") {
-    return scheduler.yield();
-  }
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-function distanceToViewport(
-  layout: PageLayout,
-  viewportCenter: number,
-  viewportTop: number,
-  viewportBottom: number,
-) {
-  return distanceToRange(layout.top, layout.bottom, viewportCenter, viewportTop, viewportBottom);
-}
-
-function distanceToRange(
-  top: number,
-  bottom: number,
-  viewportCenter: number,
-  viewportTop: number,
-  viewportBottom: number,
-) {
-  if (top <= viewportBottom && bottom >= viewportTop) {
-    return Math.abs((top + bottom) / 2 - viewportCenter) * 0.001;
-  }
-  if (bottom < viewportTop) {
-    return viewportTop - bottom;
-  }
-  return top - viewportBottom;
-}
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, value));
-}
-
-function isFullPageRender(page: PageRenderSpec) {
-  const window = page.window;
-  if (!window) {
-    return true;
-  }
-  return (
-    window.lo.x <= 0 &&
-    window.lo.y <= 0 &&
-    window.hi.x >= page.width &&
-    window.hi.y >= page.height
-  );
-}
-
-function commitPixelRect(
-  page: PageRenderSpec,
-  pixelPerPt: number,
-  widthPx: number,
-  heightPx: number,
-) {
-  if (!page.window) {
-    return { x: 0, y: 0, width: widthPx, height: heightPx };
-  }
-
-  const x = Math.trunc(clamp(Math.floor(page.window.lo.x * pixelPerPt), 0, widthPx));
-  const y = Math.trunc(clamp(Math.floor(page.window.lo.y * pixelPerPt), 0, heightPx));
-  const right = Math.trunc(clamp(Math.ceil(page.window.hi.x * pixelPerPt), 0, widthPx));
-  const bottom = Math.trunc(clamp(Math.ceil(page.window.hi.y * pixelPerPt), 0, heightPx));
-  if (right <= x || bottom <= y) {
-    return undefined;
-  }
-  return { x, y, width: right - x, height: bottom - y };
-}
-
-function renderWindowKey(page: PageRenderSpec) {
-  if (!page.window) {
-    return "full";
-  }
-  const { lo, hi } = page.window;
-  return `${lo.x}:${lo.y}:${hi.x}:${hi.y}`;
-}
-
-function usesTextRunBounds(rect: PageRect) {
-  return rect.width > rect.height * 3;
-}
-
-function chooseTextRowCluster(
-  clusters: Array<{ top: number; bottom: number; ink: number }>,
-  rectTop: number,
-  rectBottom: number,
-  preferredY?: number,
-) {
-  let best: { top: number; bottom: number; ink: number } | undefined;
-  let bestScore = Number.NEGATIVE_INFINITY;
-  const rectCenter = (rectTop + rectBottom) / 2;
-  for (const cluster of clusters) {
-    const overlap = Math.min(cluster.bottom + 1, rectBottom) - Math.max(cluster.top, rectTop);
-    const clusterCenter = (cluster.top + cluster.bottom + 1) / 2;
-    const distance = Math.abs(clusterCenter - (preferredY ?? rectCenter));
-    const score = Math.max(0, overlap) * 10_000 + cluster.ink - distance;
-    if (score > bestScore) {
-      bestScore = score;
-      best = cluster;
-    }
-  }
-  return best;
-}
-
-function pixelDistanceFromWhite(pixels: Uint8ClampedArray, offset: number) {
-  return (
-    Math.abs(255 - pixels[offset]) +
-    Math.abs(255 - pixels[offset + 1]) +
-    Math.abs(255 - pixels[offset + 2])
-  );
-}
-
-function pixelHasStrongInk(pixels: Uint8ClampedArray, offset: number) {
-  const alpha = pixels[offset + 3];
-  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 48;
-}
-
-function pixelHasVisibleInk(pixels: Uint8ClampedArray, offset: number) {
-  const alpha = pixels[offset + 3];
-  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 12;
-}
-
-function clampPixelPerPt(value: number) {
-  if (!Number.isFinite(value) || value <= 0) {
-    return minPixelPerPt;
-  }
-  const bucketed = Math.ceil((value - 1e-3) * 4) / 4;
-  return clamp(bucketed, minPixelPerPt, maxPixelPerPt);
-}
-
-function computeInteractivePixelPerPt(value: number) {
-  if (!Number.isFinite(value) || value <= 0) {
-    return minInteractivePixelPerPt;
-  }
-  return clamp(value * interactivePixelPerPtScale, minInteractivePixelPerPt, maxInteractivePixelPerPt);
 }

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -4,7 +4,12 @@ import {
   type TypstRenderer,
 } from "@myriaddreamin/typst.ts/dist/esm/renderer.mjs";
 import * as rendererWrapper from "@myriaddreamin/typst-ts-renderer";
-import { parsePageInteractions, type BoundInteraction } from "../interactions";
+import {
+  parsePageInteractions,
+  type BoundInteraction,
+  type PageInteractions,
+  type PageRect,
+} from "../interactions";
 import type {
   CanvasAck,
   CanvasEntry,
@@ -19,6 +24,51 @@ import type {
 
 const minPixelPerPt = 0.5;
 const maxPixelPerPt = 4;
+const visibleRenderScreens = 1;
+const scrollRenderScreens = 1;
+const prefetchRenderScreens = 5;
+const idlePrefetchDelayMs = 120;
+const maxCanvasBufferPages = 18;
+const interactivePixelPerPtScale = 0.65;
+const minInteractivePixelPerPt = 0.7;
+const maxInteractivePixelPerPt = 1.25;
+type CanvasLayer = "full";
+type RenderQuality = "preview" | "full";
+
+interface RenderAndPostOptions {
+  session: RenderSession;
+  pages: PageRenderSpec[];
+  generation: number;
+  kind: string;
+  frameBytes: number;
+  phase: string;
+  layer: CanvasLayer;
+  quality: RenderQuality;
+  useCacheKey: boolean;
+  updateCacheKey: boolean;
+  collectInteractions: boolean;
+  prioritizeViewport: boolean;
+  cancelOnViewportChange: boolean;
+  pauseWhenDragging: boolean;
+  viewportVersion: number;
+  frameVersion: number;
+  flushResults?: boolean;
+}
+
+interface RenderPagesOptions {
+  useCacheKey: boolean;
+  updateCacheKey: boolean;
+  collectInteractions: boolean;
+  prioritizeViewport: boolean;
+  cancelOnViewportChange: boolean;
+  pauseWhenDragging: boolean;
+  viewportVersion: number;
+  frameVersion: number;
+  layer: CanvasLayer;
+  quality: RenderQuality;
+  generation: number;
+  onResult?: (result: PageRenderResult) => void;
+}
 
 /** Owns Typst rendering in the worker, handling document frames, canvas acknowledgements, and viewport updates. */
 export class WorkerRenderer {
@@ -32,11 +82,17 @@ export class WorkerRenderer {
   private rendererWasmUrl = "";
   private sessionReady: Promise<RenderSession> | undefined;
   private renderQueue = Promise.resolve();
+  private viewportVersion = 0;
+  private viewportRenderQueued = false;
+  private idlePrefetchTimer = 0;
+  private latestPages: PageSpec[] = [];
   private readonly pageCanvases = new Map<number, CanvasEntry>();
+  private readonly pageCanvasLru = new Map<number, true>();
   private readonly pageCacheKeys = new Map<number, string>();
   private readonly pageLatestCacheKeys = new Map<number, string>();
   private readonly pagePixelPerPt = new Map<number, number>();
   private readonly pageInteractionCacheKeys = new Map<number, string>();
+  private readonly pageInteractions = new Map<number, PageInteractions>();
   private readonly pendingCanvasAcks = new Map<number, PendingCanvasAck>();
   private latestPageLayouts: PageLayout[] = [];
 
@@ -49,9 +105,14 @@ export class WorkerRenderer {
   }
 
   setViewport(viewport: any, layouts?: PageLayout[]) {
+    this.clearIdlePrefetchTimer();
     this.config = { ...this.config, viewport };
     if (layouts) {
       this.latestPageLayouts = layouts;
+    }
+    this.viewportVersion += 1;
+    if (!this.isViewportDragging() || this.isViewportScrolling()) {
+      this.scheduleViewportRender();
     }
   }
 
@@ -79,17 +140,211 @@ export class WorkerRenderer {
     await this.renderQueue;
   }
 
+  private scheduleViewportRender() {
+    if (
+      this.disposed ||
+      this.viewportRenderQueued ||
+      this.generation <= 0 ||
+      this.latestPages.length === 0
+    ) {
+      return;
+    }
+
+    this.viewportRenderQueued = true;
+    const frameVersion = this.documentVersion;
+    this.renderQueue = this.renderQueue
+      .then(() => this.renderViewportUpdate(frameVersion))
+      .catch((error) => {
+        this.postError(error);
+      });
+  }
+
+  private async renderViewportUpdate(frameVersion: number) {
+    const handledViewportVersion = this.viewportVersion;
+    try {
+      if (
+        this.isRenderInterrupted(frameVersion) ||
+        this.latestPages.length === 0
+      ) {
+        return;
+      }
+
+      const session = await this.ensureSessionReady();
+      if (this.isRenderInterrupted(frameVersion)) {
+        return;
+      }
+
+      if (this.isViewportDragging() && !this.isViewportScrolling()) {
+        return;
+      }
+
+      if (this.isViewportScrolling()) {
+        await this.renderScrollVisiblePage(session, frameVersion, handledViewportVersion);
+      } else {
+        await this.renderProgressiveStages({
+          session,
+          pages: this.latestPages,
+          generation: this.generation,
+          kind: "viewport",
+          frameBytes: 0,
+          frameVersion,
+          viewportVersion: handledViewportVersion,
+        });
+        this.scheduleIdlePrefetch(frameVersion, this.generation, handledViewportVersion);
+      }
+    } finally {
+      this.viewportRenderQueued = false;
+      if (
+        !this.disposed &&
+        (!this.isViewportDragging() || this.isViewportScrolling()) &&
+        this.viewportVersion !== handledViewportVersion
+      ) {
+        this.scheduleViewportRender();
+      }
+    }
+  }
+
+  private async renderScrollVisiblePage(
+    session: RenderSession,
+    frameVersion: number,
+    viewportVersion: number,
+  ) {
+    if (this.latestPages.length === 0 || this.isRenderInterrupted(frameVersion)) {
+      return;
+    }
+
+    await this.renderAndPostComplete({
+      session,
+      pages: this.selectStagePages(this.latestPages, scrollRenderScreens, { windowed: true }),
+      generation: this.generation,
+      kind: "scroll",
+      frameBytes: 0,
+      phase: "scroll-visible",
+      layer: "full",
+      quality: "full",
+      useCacheKey: true,
+      updateCacheKey: true,
+      collectInteractions: false,
+      prioritizeViewport: false,
+      cancelOnViewportChange: true,
+      pauseWhenDragging: false,
+      viewportVersion,
+      frameVersion,
+      flushResults: true,
+    });
+  }
+
+  private scheduleIdlePrefetch(frameVersion: number, generation: number, viewportVersion: number) {
+    this.clearIdlePrefetchTimer();
+    if (
+      this.disposed ||
+      this.isViewportInteractive() ||
+      this.latestPages.length === 0 ||
+      generation !== this.generation ||
+      frameVersion !== this.documentVersion ||
+      viewportVersion !== this.viewportVersion
+    ) {
+      return;
+    }
+
+    this.idlePrefetchTimer = setTimeout(() => {
+      this.idlePrefetchTimer = 0;
+      if (
+        this.disposed ||
+        this.isViewportInteractive() ||
+        generation !== this.generation ||
+        frameVersion !== this.documentVersion ||
+        viewportVersion !== this.viewportVersion
+      ) {
+        return;
+      }
+
+      this.renderQueue = this.renderQueue
+        .then(() => this.renderIdlePrefetch(frameVersion, generation, viewportVersion))
+        .catch((error) => {
+          this.postError(error);
+        });
+    }, idlePrefetchDelayMs) as unknown as number;
+  }
+
+  private clearIdlePrefetchTimer() {
+    if (!this.idlePrefetchTimer) {
+      return;
+    }
+    clearTimeout(this.idlePrefetchTimer);
+    this.idlePrefetchTimer = 0;
+  }
+
+  private async renderIdlePrefetch(
+    frameVersion: number,
+    generation: number,
+    viewportVersion: number,
+  ) {
+    if (
+      this.shouldStopRender({
+        frameVersion,
+        viewportVersion,
+        cancelOnViewportChange: true,
+        pauseWhenDragging: true,
+      }) ||
+      generation !== this.generation ||
+      this.latestPages.length === 0
+    ) {
+      return;
+    }
+
+    const session = await this.ensureSessionReady();
+    if (
+      this.shouldStopRender({
+        frameVersion,
+        viewportVersion,
+        cancelOnViewportChange: true,
+        pauseWhenDragging: true,
+      }) ||
+      generation !== this.generation
+    ) {
+      return;
+    }
+
+    await this.renderAndPostComplete({
+      session,
+      pages: this.selectStagePages(this.latestPages, prefetchRenderScreens, { windowed: false }),
+      generation,
+      kind: "prefetch",
+      frameBytes: 0,
+      phase: "prefetch",
+      layer: "full",
+      quality: "full",
+      useCacheKey: true,
+      updateCacheKey: true,
+      collectInteractions: false,
+      prioritizeViewport: true,
+      cancelOnViewportChange: true,
+      pauseWhenDragging: true,
+      viewportVersion,
+      frameVersion,
+    });
+  }
+
   acceptCanvases(
     generation: number,
-    canvases: Array<{ index: number; canvas: OffscreenCanvas; widthPx: number; heightPx: number }>,
+    canvases: Array<{
+      index: number;
+      layer?: CanvasLayer;
+      canvas: OffscreenCanvas;
+      widthPx: number;
+      heightPx: number;
+    }>,
     ack?: CanvasAck,
   ) {
     for (const page of canvases) {
+      const layer = page.layer || "full";
       this.pageCanvases.set(page.index, {
         canvas: page.canvas,
         widthPx: page.widthPx,
         heightPx: page.heightPx,
       });
+      this.pageCacheKeys.delete(page.index);
     }
     this.resolveCanvasAck(generation, ack);
   }
@@ -111,6 +366,93 @@ export class WorkerRenderer {
         this.postError(error);
       });
     await this.renderQueue;
+  }
+
+  async requestInteractions(request: {
+    generation: number;
+    pageIndices: number[];
+  }) {
+    const viewportVersion = this.viewportVersion;
+    this.renderQueue = this.renderQueue
+      .then(() => this.requestInteractionsExclusive({ ...request, viewportVersion }))
+      .catch((error) => {
+        this.postError(error);
+      });
+    await this.renderQueue;
+  }
+
+  hitText(request: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    rect?: PageRect;
+  }) {
+    try {
+      this.hitTextExclusive(request);
+    } catch (error) {
+      this.postError(error);
+    }
+  }
+
+  private hitTextExclusive(request: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    rect?: PageRect;
+  }) {
+    if (request.generation !== this.generation) {
+      return;
+    }
+
+    const result = this.hitRenderedTextBox(request.pageIndex, request.x, request.y, request.rect);
+    if (request.generation !== this.generation) {
+      return;
+    }
+
+    this.post({
+      type: "text-hit",
+      requestId: request.requestId,
+      generation: request.generation,
+      pageIndex: request.pageIndex,
+      x: request.x,
+      y: request.y,
+      hit: result.hit,
+      rect: result.rect,
+    });
+  }
+
+  resolveTextRect(request: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    textId: number;
+    rect: PageRect;
+  }) {
+    try {
+      if (request.generation !== this.generation) {
+        return;
+      }
+
+      const rect = this.resolveRenderedTextRect(request.pageIndex, request.rect);
+      if (request.generation !== this.generation) {
+        return;
+      }
+
+      this.post({
+        type: "text-rect",
+        requestId: request.requestId,
+        generation: request.generation,
+        pageIndex: request.pageIndex,
+        textId: request.textId,
+        rect,
+      });
+    } catch (error) {
+      this.postError(error);
+    }
   }
 
   private async hitBoundExclusive(request: {
@@ -149,15 +491,289 @@ export class WorkerRenderer {
     }
   }
 
+  private hitRenderedTextBox(pageIndex: number, x: number, y: number, rect?: PageRect) {
+    const entry = this.pageCanvases.get(pageIndex);
+    const context = entry?.context;
+    const pixelPerPt = this.pagePixelPerPt.get(pageIndex);
+    if (!entry || !context || !pixelPerPt) {
+      return { hit: false };
+    }
+
+    const px = Math.floor(x * pixelPerPt);
+    const py = Math.floor(y * pixelPerPt);
+    if (rect && usesTextRunBounds(rect)) {
+      const textRect = this.textRunInkBounds(context, entry, pixelPerPt, rect, py);
+      return textRect ? { hit: true, rect: textRect } : { hit: false };
+    }
+
+    const start = this.nearestInkPixel(context, entry, px, py, pixelPerPt, rect);
+    if (!start) {
+      return { hit: false };
+    }
+
+    return {
+      hit: true,
+      rect: this.connectedInkBounds(context, entry, start.x, start.y, pixelPerPt),
+    };
+  }
+
+  private resolveRenderedTextRect(pageIndex: number, rect: PageRect) {
+    const entry = this.pageCanvases.get(pageIndex);
+    const context = entry?.context;
+    const pixelPerPt = this.pagePixelPerPt.get(pageIndex);
+    if (!entry || !context || !pixelPerPt) {
+      return undefined;
+    }
+    return this.textRunInkBounds(context, entry, pixelPerPt, rect);
+  }
+
+  private textRunInkBounds(
+    context: OffscreenCanvasRenderingContext2D,
+    entry: CanvasEntry,
+    pixelPerPt: number,
+    rect: PageRect,
+    preferredY?: number,
+  ) {
+    const rectLeft = Math.floor(rect.x * pixelPerPt);
+    const rectTop = rect.y * pixelPerPt;
+    const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt) - 1;
+    const rectBottom = (rect.y + rect.height) * pixelPerPt;
+    const rectHeight = Math.max(1, rectBottom - rectTop);
+    const yPad = Math.trunc(clamp(rectHeight * 1.6, 4, 48));
+    const left = Math.trunc(clamp(rectLeft, 0, Math.max(0, entry.widthPx - 1)));
+    const right = Math.trunc(clamp(rectRight, 0, Math.max(0, entry.widthPx - 1)));
+    const top = Math.trunc(clamp(Math.floor(rectTop) - yPad, 0, Math.max(0, entry.heightPx - 1)));
+    const bottom = Math.trunc(
+      clamp(Math.ceil(rectBottom) + yPad, 0, Math.max(0, entry.heightPx - 1)),
+    );
+    const width = right - left + 1;
+    const height = bottom - top + 1;
+    if (width <= 0 || height <= 0) {
+      return undefined;
+    }
+
+    const pixels = context.getImageData(left, top, width, height).data;
+    const rowClusters = this.textInkRowClusters(pixels, width, height, top);
+    const cluster = chooseTextRowCluster(rowClusters, rectTop, rectBottom, preferredY);
+    if (!cluster) {
+      return undefined;
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (let y = cluster.top; y <= cluster.bottom; y += 1) {
+      const row = y - top;
+      for (let x = 0; x < width; x += 1) {
+        const index = row * width + x;
+        if (!pixelHasVisibleInk(pixels, index * 4)) {
+          continue;
+        }
+        const px = left + x;
+        minX = Math.min(minX, px);
+        maxX = Math.max(maxX, px);
+        minY = Math.min(minY, y);
+        maxY = Math.max(maxY, y);
+      }
+    }
+
+    if (!Number.isFinite(minX)) {
+      return undefined;
+    }
+
+    return {
+      x: minX / pixelPerPt,
+      y: minY / pixelPerPt,
+      width: (maxX - minX + 1) / pixelPerPt,
+      height: (maxY - minY + 1) / pixelPerPt,
+    };
+  }
+
+  private textInkRowClusters(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number,
+    top: number,
+  ) {
+    const clusters: Array<{ top: number; bottom: number; ink: number }> = [];
+    for (let y = 0; y < height; y += 1) {
+      let rowInk = 0;
+      for (let x = 0; x < width; x += 1) {
+        const index = y * width + x;
+        if (pixelHasVisibleInk(pixels, index * 4)) {
+          rowInk += 1;
+        }
+      }
+      if (rowInk === 0) {
+        continue;
+      }
+      const pageY = top + y;
+      const last = clusters[clusters.length - 1];
+      if (!last || pageY > last.bottom + 1) {
+        clusters.push({ top: pageY, bottom: pageY, ink: rowInk });
+        continue;
+      }
+      last.bottom = pageY;
+      last.ink += rowInk;
+    }
+    return clusters;
+  }
+
+  private nearestInkPixel(
+    context: OffscreenCanvasRenderingContext2D,
+    entry: CanvasEntry,
+    px: number,
+    py: number,
+    pixelPerPt: number,
+    rect?: PageRect,
+  ) {
+    let left: number;
+    let top: number;
+    let right: number;
+    let bottom: number;
+
+    if (rect) {
+      const rectLeft = Math.floor(rect.x * pixelPerPt);
+      const rectTop = Math.floor(rect.y * pixelPerPt);
+      const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt);
+      const rectBottom = Math.ceil((rect.y + rect.height) * pixelPerPt);
+      const pad = Math.trunc(
+        clamp(Math.max(rectRight - rectLeft, rectBottom - rectTop) * 2, 16, 96),
+      );
+      left = Math.trunc(clamp(rectLeft - pad, 0, Math.max(0, entry.widthPx - 1)));
+      top = Math.trunc(clamp(rectTop - pad, 0, Math.max(0, entry.heightPx - 1)));
+      right = Math.trunc(clamp(rectRight + pad, 0, Math.max(0, entry.widthPx - 1)));
+      bottom = Math.trunc(clamp(rectBottom + pad, 0, Math.max(0, entry.heightPx - 1)));
+    } else {
+      const radius = 48;
+      left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
+      top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
+      right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
+      bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
+    }
+
+    const width = right - left + 1;
+    const height = bottom - top + 1;
+    if (width <= 0 || height <= 0) {
+      return undefined;
+    }
+
+    const pixels = context.getImageData(left, top, width, height).data;
+    let bestIndex = -1;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let index = 0; index < width * height; index += 1) {
+      if (!pixelHasStrongInk(pixels, index * 4)) {
+        continue;
+      }
+      const x = left + (index % width);
+      const y = top + Math.floor(index / width);
+      const distance = (x - px) ** 2 + (y - py) ** 2;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = index;
+      }
+    }
+
+    if (bestIndex < 0) {
+      return undefined;
+    }
+
+    return {
+      x: left + (bestIndex % width),
+      y: top + Math.floor(bestIndex / width),
+    };
+  }
+
+  private connectedInkBounds(
+    context: OffscreenCanvasRenderingContext2D,
+    entry: CanvasEntry,
+    px: number,
+    py: number,
+    pixelPerPt: number,
+  ) {
+    const radius = 80;
+    const left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
+    const top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
+    const right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
+    const bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
+    const width = right - left + 1;
+    const height = bottom - top + 1;
+    const pixels = context.getImageData(left, top, width, height).data;
+    const startX = px - left;
+    const startY = py - top;
+    const start = startY * width + startX;
+    const visited = new Uint8Array(width * height);
+    const stack = [start];
+    let minX = startX;
+    let maxX = startX;
+    let minY = startY;
+    let maxY = startY;
+    let visitedInk = 0;
+
+    while (stack.length > 0 && visitedInk < 16_384) {
+      const index = stack.pop()!;
+      if (visited[index]) {
+        continue;
+      }
+      visited[index] = 1;
+      if (!pixelHasVisibleInk(pixels, index * 4)) {
+        continue;
+      }
+
+      visitedInk += 1;
+      const x = index % width;
+      const y = Math.floor(index / width);
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
+
+      for (let dy = -1; dy <= 1; dy += 1) {
+        for (let dx = -1; dx <= 1; dx += 1) {
+          if (dx === 0 && dy === 0) {
+            continue;
+          }
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) {
+            continue;
+          }
+          const next = ny * width + nx;
+          if (!visited[next]) {
+            stack.push(next);
+          }
+        }
+      }
+    }
+
+    const rectLeft = Math.max(0, left + minX);
+    const rectTop = Math.max(0, top + minY);
+    const rectRight = Math.min(entry.widthPx - 1, left + maxX);
+    const rectBottom = Math.min(entry.heightPx - 1, top + maxY);
+    return {
+      x: rectLeft / pixelPerPt,
+      y: rectTop / pixelPerPt,
+      width: (rectRight - rectLeft + 1) / pixelPerPt,
+      height: (rectBottom - rectTop + 1) / pixelPerPt,
+    };
+  }
+
   resetDocumentState() {
     this.initializedDocument = false;
     this.generation = 0;
     this.documentVersion += 1;
+    this.viewportVersion += 1;
+    this.viewportRenderQueued = false;
+    this.clearIdlePrefetchTimer();
+    this.latestPages = [];
     this.pageCanvases.clear();
+    this.pageCanvasLru.clear();
     this.pageCacheKeys.clear();
     this.pageLatestCacheKeys.clear();
     this.pagePixelPerPt.clear();
     this.pageInteractionCacheKeys.clear();
+    this.pageInteractions.clear();
     this.latestPageLayouts = [];
     for (const ack of this.pendingCanvasAcks.values()) {
       clearTimeout(ack.timeout);
@@ -198,6 +814,62 @@ export class WorkerRenderer {
       kind: typeof bound.kind === "string" ? bound.kind : "bound",
       rect: bound.rect,
     };
+  }
+
+  private async requestInteractionsExclusive(request: {
+    generation: number;
+    pageIndices: number[];
+    viewportVersion: number;
+  }) {
+    if (
+      request.generation !== this.generation ||
+      request.viewportVersion !== this.viewportVersion ||
+      this.isViewportInteractive()
+    ) {
+      return;
+    }
+
+    const session = await this.ensureSessionReady();
+    if (
+      request.generation !== this.generation ||
+      request.viewportVersion !== this.viewportVersion ||
+      this.isViewportInteractive()
+    ) {
+      return;
+    }
+
+    const interactions: PageInteractions[] = [];
+    for (const pageIndex of request.pageIndices) {
+      if (
+        request.generation !== this.generation ||
+        request.viewportVersion !== this.viewportVersion ||
+        this.isViewportInteractive()
+      ) {
+        return;
+      }
+
+      const pixelPerPt = this.pagePixelPerPt.get(pageIndex);
+      if (!pixelPerPt) {
+        continue;
+      }
+
+      interactions.push(await this.renderPageInteractions(session, pageIndex, pixelPerPt));
+    }
+
+    if (
+      request.generation !== this.generation ||
+      request.viewportVersion !== this.viewportVersion ||
+      this.isViewportInteractive() ||
+      interactions.length === 0
+    ) {
+      return;
+    }
+
+    this.post({
+      type: "interactions",
+      generation: request.generation,
+      interactions,
+    });
   }
 
   private computePagePixelPerPt(index: number, width: number, height: number) {
@@ -276,6 +948,7 @@ export class WorkerRenderer {
       session.reset();
       this.pageCacheKeys.clear();
       this.pageInteractionCacheKeys.clear();
+      this.pageInteractions.clear();
       this.initializedDocument = true;
     }
     session.manipulateData({ action: "merge", data: payload });
@@ -289,6 +962,7 @@ export class WorkerRenderer {
         pixelPerPt,
       };
     });
+    this.latestPages = pages;
     const nextGeneration = ++this.generation;
     const canvasAck = await this.ensureCanvases(nextGeneration, pages);
     if (canvasAck?.layouts) {
@@ -301,7 +975,9 @@ export class WorkerRenderer {
       kind,
       frameBytes,
       frameVersion,
+      viewportVersion: this.viewportVersion,
     });
+    this.scheduleIdlePrefetch(frameVersion, nextGeneration, this.viewportVersion);
   }
 
   private async renderProgressiveStages(options: {
@@ -311,11 +987,21 @@ export class WorkerRenderer {
     kind: string;
     frameBytes: number;
     frameVersion: number;
+    viewportVersion: number;
   }) {
     const stages = [
-      { phase: "near-3", screens: 3, useCacheKey: true, updateCacheKey: false },
-      { phase: "near-27", screens: 27, useCacheKey: true, updateCacheKey: false },
-      { phase: "all", screens: Number.POSITIVE_INFINITY, useCacheKey: true, updateCacheKey: true },
+      {
+        phase: "visible",
+        layer: "full" as const,
+        quality: "full" as const,
+        screens: visibleRenderScreens,
+        useCacheKey: true,
+        updateCacheKey: true,
+        collectInteractions: true,
+        prioritizeViewport: true,
+        cancelOnViewportChange: true,
+        pauseWhenDragging: true,
+      },
     ];
 
     for (const stage of stages) {
@@ -325,47 +1011,74 @@ export class WorkerRenderer {
 
       await this.renderAndPostComplete({
         ...options,
-        pages: this.selectStagePages(options.pages, stage.screens),
+        pages: this.selectStagePages(options.pages, stage.screens, { windowed: false }),
         phase: stage.phase,
+        layer: stage.layer,
+        quality: stage.quality,
         useCacheKey: stage.useCacheKey,
         updateCacheKey: stage.updateCacheKey,
+        collectInteractions: stage.collectInteractions,
+        prioritizeViewport: stage.prioritizeViewport,
+        cancelOnViewportChange: stage.cancelOnViewportChange,
+        pauseWhenDragging: stage.pauseWhenDragging,
+        viewportVersion: options.viewportVersion,
       });
     }
   }
 
-  private async renderAndPostComplete(options: {
-    session: RenderSession;
-    pages: PageRenderSpec[];
-    generation: number;
-    kind: string;
-    frameBytes: number;
-    phase: string;
-    useCacheKey: boolean;
-    updateCacheKey: boolean;
-    frameVersion: number;
-  }) {
-    if (this.isRenderInterrupted(options.frameVersion)) {
+  private async renderAndPostComplete(options: RenderAndPostOptions) {
+    if (this.shouldStopRender(options)) {
       return;
     }
 
     const results = await this.renderPages(options.session, options.pages, {
       useCacheKey: options.useCacheKey,
       updateCacheKey: options.updateCacheKey,
+      collectInteractions: options.collectInteractions,
+      prioritizeViewport: options.prioritizeViewport,
+      cancelOnViewportChange: options.cancelOnViewportChange,
+      pauseWhenDragging: options.pauseWhenDragging,
+      viewportVersion: options.viewportVersion,
       frameVersion: options.frameVersion,
+      layer: options.layer,
+      quality: options.quality,
+      generation: options.generation,
+      onResult: options.flushResults
+        ? (result) => this.postRenderComplete(options, [result])
+        : undefined,
     });
     if (this.isRenderInterrupted(options.frameVersion)) {
       return;
     }
+    if (results.length === 0 && this.shouldStopRender(options)) {
+      return;
+    }
+    this.enforceCanvasBuffer(options.generation);
 
+    if (options.flushResults) {
+      return;
+    }
+
+    this.postRenderComplete(options, results);
+  }
+
+  private postRenderComplete(options: RenderAndPostOptions, results: PageRenderResult[]) {
     this.post({
       type: "render-complete",
       generation: options.generation,
       kind: options.kind,
       frameBytes: options.frameBytes,
       phase: options.phase,
+      layer: options.layer,
+      quality: options.quality,
       pageCount: options.pages.length,
       renderedPages: results.length,
+      pageIndices: results.map((result) => result.pageIndex),
+      fullPageIndices: results
+        .filter((result) => result.fullPage)
+        .map((result) => result.pageIndex),
       interactions: results.flatMap((result) => result.interactions || []),
+      invalidatedInteractions: results.flatMap((result) => result.invalidatedInteractions || []),
     });
   }
 
@@ -374,10 +1087,12 @@ export class WorkerRenderer {
     for (const index of this.pageCanvases.keys()) {
       if (!livePages.has(index)) {
         this.pageCanvases.delete(index);
+        this.pageCanvasLru.delete(index);
         this.pageCacheKeys.delete(index);
         this.pageLatestCacheKeys.delete(index);
         this.pagePixelPerPt.delete(index);
         this.pageInteractionCacheKeys.delete(index);
+        this.pageInteractions.delete(index);
       }
     }
 
@@ -405,28 +1120,83 @@ export class WorkerRenderer {
   private async renderPages(
     session: RenderSession,
     pages: PageRenderSpec[],
-    options: { useCacheKey: boolean; updateCacheKey: boolean; frameVersion: number },
+    options: RenderPagesOptions,
   ) {
     const results: PageRenderResult[] = [];
+    const pushResult = (result: PageRenderResult) => {
+      results.push(result);
+      options.onResult?.(result);
+    };
     let batchRendered = 0;
-    for (const page of pages) {
-      if (this.isRenderInterrupted(options.frameVersion)) {
+    const pendingPages = options.prioritizeViewport ? [...pages] : undefined;
+    for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+      if (this.shouldStopRender(options)) {
+        break;
+      }
+
+      const page = pendingPages ? this.takeNextViewportPage(pendingPages) : pages[pageIndex];
+      if (!page) {
         break;
       }
 
       const entry = this.pageCanvases.get(page.index);
       if (!entry) {
-        throw new Error(`missing offscreen canvas for page ${page.index}`);
+        throw new Error(`missing ${options.layer} offscreen canvas for page ${page.index}`);
       }
 
-      const widthPx = Math.max(1, Math.ceil(page.width * page.pixelPerPt));
-      const heightPx = Math.max(1, Math.ceil(page.height * page.pixelPerPt));
+      const pixelPerPt =
+        options.quality === "preview"
+          ? computeInteractivePixelPerPt(page.pixelPerPt)
+          : page.pixelPerPt;
+      const windowKey = renderWindowKey(page);
+      if (
+        options.quality === "full" &&
+        entry.hasContent &&
+        entry.quality === "full" &&
+        entry.renderedGeneration === options.generation &&
+        entry.renderedPixelPerPt === pixelPerPt &&
+        (entry.renderedWindowKey === "full" || entry.renderedWindowKey === windowKey)
+      ) {
+        this.touchCanvasLru(page.index);
+        pushResult({
+          pageIndex: page.index,
+          quality: entry.quality,
+          fullPage: entry.renderedWindowKey === "full",
+        });
+        continue;
+      }
+
+      if (
+        options.quality === "preview" &&
+        entry.hasContent &&
+        entry.renderedGeneration === options.generation &&
+        (entry.quality === "full" ||
+          (entry.quality === "preview" &&
+            entry.renderedPixelPerPt === pixelPerPt &&
+            entry.renderedWindowKey === windowKey))
+      ) {
+        this.touchCanvasLru(page.index);
+        pushResult({ pageIndex: page.index, quality: entry.quality });
+        continue;
+      }
+
+      const widthPx = Math.max(1, Math.ceil(page.width * pixelPerPt));
+      const heightPx = Math.max(1, Math.ceil(page.height * pixelPerPt));
+      let resized = false;
       if (entry.canvas.width !== widthPx) {
         entry.canvas.width = widthPx;
+        entry.hasContent = false;
+        this.pageCacheKeys.delete(page.index);
+        resized = true;
       }
       if (entry.canvas.height !== heightPx) {
         entry.canvas.height = heightPx;
+        entry.hasContent = false;
+        this.pageCacheKeys.delete(page.index);
+        resized = true;
       }
+      entry.widthPx = widthPx;
+      entry.heightPx = heightPx;
 
       const context =
         entry.context ||
@@ -438,41 +1208,94 @@ export class WorkerRenderer {
         throw new Error(`cannot create 2d context for page ${page.index}`);
       }
       entry.context = context;
+      const fullPageRender = isFullPageRender(page);
+      const fullPageResult = options.quality === "full" && fullPageRender;
+      if (!fullPageRender && (resized || !entry.hasContent)) {
+        this.initializeTargetCanvas(context, entry);
+      }
+      const cacheKey =
+        options.useCacheKey && fullPageRender && entry.hasContent && entry.quality === "full"
+          ? this.pageCacheKeys.get(page.index)
+          : undefined;
+      const renderContext = fullPageRender
+        ? context
+        : this.ensureScratchContext(entry, page.index, options.layer);
 
       const renderOptions = {
-        canvas: context,
+        canvas: renderContext,
         pageOffset: page.index,
         backgroundColor: "#ffffff",
-        pixelPerPt: page.pixelPerPt,
+        pixelPerPt,
         window: page.window,
-        cacheKey: options.useCacheKey ? this.pageCacheKeys.get(page.index) : undefined,
+        cacheKey,
         dataSelection: {
           body: true,
         },
       } as any;
       const result = await session.renderCanvas(renderOptions);
-      if (result.cacheKey) {
+      if (this.isRenderInterrupted(options.frameVersion)) {
+        if (!fullPageRender) {
+          this.releaseScratch(entry);
+        }
+        break;
+      }
+      const stopAfterCommit = this.shouldStopRender(options);
+
+      const cacheHit = !!cacheKey && result.cacheKey === cacheKey;
+      if (!cacheHit && fullPageRender) {
+        entry.hasContent = true;
+      } else if (!cacheHit) {
+        this.commitScratchToTarget(entry, context, renderContext, page, pixelPerPt);
+        entry.hasContent = true;
+      }
+      entry.quality = options.quality;
+      entry.renderedGeneration = options.generation;
+      entry.renderedPixelPerPt = pixelPerPt;
+      entry.renderedWindowKey = windowKey;
+      if (!fullPageRender) {
+        this.releaseScratch(entry);
+      }
+      if (entry.hasContent) {
+        this.touchCanvasLru(page.index);
+      }
+
+      if (options.quality === "full" && result.cacheKey) {
         this.pageLatestCacheKeys.set(page.index, result.cacheKey);
       }
-      if (options.updateCacheKey && result.cacheKey) {
+      if (options.quality === "full" && options.updateCacheKey && fullPageRender && result.cacheKey) {
         this.pageCacheKeys.set(page.index, result.cacheKey);
       }
 
-      if (result.cacheKey && this.pageInteractionCacheKeys.get(page.index) !== result.cacheKey) {
-        const metadata = await session.renderCanvas({
-          pageOffset: page.index,
-          pixelPerPt: page.pixelPerPt,
-          dataSelection: {
-            body: false,
-            semantics: true,
-          },
-        } as any);
-        this.pageInteractionCacheKeys.set(page.index, result.cacheKey);
-        results.push({
-          interactions: parsePageInteractions(page.index, metadata.htmlSemantics?.[0] || ""),
+      if (stopAfterCommit) {
+        pushResult({ pageIndex: page.index, quality: options.quality, fullPage: fullPageResult });
+      } else if (options.quality === "full" && options.collectInteractions) {
+        pushResult({
+          pageIndex: page.index,
+          quality: options.quality,
+          fullPage: fullPageResult,
+          interactions: await this.renderPageInteractions(session, page.index, pixelPerPt),
         });
+      } else if (
+        options.quality === "full" &&
+        result.cacheKey &&
+        this.pageInteractionCacheKeys.get(page.index) !== result.cacheKey
+      ) {
+        const hadInteractions =
+          this.pageInteractionCacheKeys.has(page.index) || this.pageInteractions.has(page.index);
+        this.pageInteractionCacheKeys.delete(page.index);
+        this.pageInteractions.delete(page.index);
+        pushResult(
+          hadInteractions
+            ? {
+                pageIndex: page.index,
+                quality: options.quality,
+                fullPage: fullPageResult,
+                invalidatedInteractions: [page.index],
+              }
+            : { pageIndex: page.index, quality: options.quality, fullPage: fullPageResult },
+        );
       } else {
-        results.push({});
+        pushResult({ pageIndex: page.index, quality: options.quality, fullPage: fullPageResult });
       }
 
       batchRendered += 1;
@@ -480,18 +1303,228 @@ export class WorkerRenderer {
         batchRendered = 0;
         await yieldToEventLoop();
       }
+      if (stopAfterCommit) {
+        break;
+      }
     }
     return results;
   }
 
-  private selectStagePages(pages: PageSpec[], screens: number): PageRenderSpec[] {
+  private touchCanvasLru(pageIndex: number) {
+    this.pageCanvasLru.delete(pageIndex);
+    this.pageCanvasLru.set(pageIndex, true);
+  }
+
+  private enforceCanvasBuffer(generation: number) {
+    if (this.pageCanvasLru.size <= maxCanvasBufferPages) {
+      return;
+    }
+
+    const protectedPages = new Set(
+      this.selectStagePages(this.latestPages, prefetchRenderScreens, { windowed: false }).map(
+        (page) => page.index,
+      ),
+    );
+    const evicted: number[] = [];
+    while (this.pageCanvasLru.size > maxCanvasBufferPages) {
+      const candidate = [...this.pageCanvasLru.keys()].find((pageIndex) => !protectedPages.has(pageIndex));
+      if (candidate === undefined) {
+        break;
+      }
+
+      const entry = this.pageCanvases.get(candidate);
+      if (entry) {
+        this.evictCanvasEntry(entry);
+      }
+      this.pageCanvasLru.delete(candidate);
+      this.pageCacheKeys.delete(candidate);
+      this.pageLatestCacheKeys.delete(candidate);
+      this.pageInteractionCacheKeys.delete(candidate);
+      this.pageInteractions.delete(candidate);
+      evicted.push(candidate);
+    }
+
+    if (evicted.length > 0) {
+      this.post({
+        type: "render-evicted",
+        generation,
+        pageIndices: evicted,
+      });
+    }
+  }
+
+  private evictCanvasEntry(entry: CanvasEntry) {
+    entry.canvas.width = 1;
+    entry.canvas.height = 1;
+    entry.widthPx = 1;
+    entry.heightPx = 1;
+    entry.hasContent = false;
+    entry.quality = undefined;
+    entry.renderedGeneration = undefined;
+    entry.renderedPixelPerPt = undefined;
+    entry.renderedWindowKey = undefined;
+    entry.context = undefined;
+    this.releaseScratch(entry);
+  }
+
+  private takeNextViewportPage(pages: PageRenderSpec[]) {
+    if (pages.length === 0) {
+      return undefined;
+    }
+
+    let bestIndex = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let index = 0; index < pages.length; index += 1) {
+      const distance = this.pageDistanceToCurrentViewport(pages[index]);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = index;
+      }
+    }
+
+    return pages.splice(bestIndex, 1)[0];
+  }
+
+  private ensureScratchContext(entry: CanvasEntry, pageIndex: number, layer: CanvasLayer) {
+    if (!entry.scratch) {
+      entry.scratch = new OffscreenCanvas(entry.widthPx, entry.heightPx);
+    }
+    if (entry.scratch.width !== entry.widthPx) {
+      entry.scratch.width = entry.widthPx;
+    }
+    if (entry.scratch.height !== entry.heightPx) {
+      entry.scratch.height = entry.heightPx;
+    }
+
+    const context =
+      entry.scratchContext ||
+      entry.scratch.getContext("2d", {
+        alpha: false,
+        desynchronized: true,
+      });
+    if (!context) {
+      throw new Error(`cannot create ${layer} scratch context for page ${pageIndex}`);
+    }
+    entry.scratchContext = context;
+    return context;
+  }
+
+  private releaseScratch(entry: CanvasEntry) {
+    if (!entry.scratch) {
+      return;
+    }
+    if (entry.scratch.width !== 1) {
+      entry.scratch.width = 1;
+    }
+    if (entry.scratch.height !== 1) {
+      entry.scratch.height = 1;
+    }
+    entry.scratchContext = undefined;
+  }
+
+  private initializeTargetCanvas(
+    target: OffscreenCanvasRenderingContext2D,
+    entry: CanvasEntry,
+  ) {
+    target.setTransform(1, 0, 0, 1, 0, 0);
+    target.fillStyle = "#ffffff";
+    target.fillRect(0, 0, entry.widthPx, entry.heightPx);
+  }
+
+  private commitScratchToTarget(
+    entry: CanvasEntry,
+    target: OffscreenCanvasRenderingContext2D,
+    scratch: OffscreenCanvasRenderingContext2D,
+    page: PageRenderSpec,
+    pixelPerPt: number,
+  ) {
+    target.setTransform(1, 0, 0, 1, 0, 0);
+    const rect = commitPixelRect(page, pixelPerPt, entry.widthPx, entry.heightPx);
+    if (!rect) {
+      return;
+    }
+    target.clearRect(rect.x, rect.y, rect.width, rect.height);
+    target.drawImage(
+      scratch.canvas,
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+    );
+  }
+
+  private pageDistanceToCurrentViewport(page: PageRenderSpec) {
+    const viewport = this.config.viewport || {};
+    const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
+    const viewportTop = Math.max(0, viewport.scrollTop || 0);
+    const viewportBottom = viewportTop + viewportHeight;
+    const viewportCenter = (viewportTop + viewportBottom) / 2;
+    const layout = this.latestPageLayouts.find((candidate) => candidate.index === page.index);
+    if (!layout) {
+      return page.index * 1_000_000;
+    }
+    if (page.window) {
+      const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
+      const top = layout.top + page.window.lo.y * scale;
+      const bottom = layout.top + page.window.hi.y * scale;
+      return distanceToRange(top, bottom, viewportCenter, viewportTop, viewportBottom);
+    }
+    return distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom);
+  }
+
+  private async renderPageInteractions(
+    session: RenderSession,
+    pageIndex: number,
+    pixelPerPt: number,
+  ) {
+    const cacheKey = this.pageLatestCacheKeys.get(pageIndex) || this.pageCacheKeys.get(pageIndex);
+    const cached = this.pageInteractions.get(pageIndex);
+    if (cacheKey && cached && this.pageInteractionCacheKeys.get(pageIndex) === cacheKey) {
+      return cached;
+    }
+
+    const metadata = await session.renderCanvas({
+      pageOffset: pageIndex,
+      pixelPerPt,
+      dataSelection: {
+        body: false,
+        semantics: true,
+      },
+    } as any);
+    const interactions = parsePageInteractions(pageIndex, metadata.htmlSemantics?.[0] || "");
+    if (cacheKey) {
+      this.pageInteractionCacheKeys.set(pageIndex, cacheKey);
+    }
+    this.pageInteractions.set(pageIndex, interactions);
+    return interactions;
+  }
+
+  private selectStagePages(
+    pages: PageSpec[],
+    screens: number,
+    options: { windowed?: boolean } = {},
+  ): PageRenderSpec[] {
+    const viewport = this.config.viewport || {};
+    const viewportTop = Math.max(0, viewport.scrollTop || 0);
+    return this.selectStagePagesAt(pages, screens, viewportTop, options);
+  }
+
+  private selectStagePagesAt(
+    pages: PageSpec[],
+    screens: number,
+    viewportTop: number,
+    options: { windowed?: boolean } = {},
+  ): PageRenderSpec[] {
     if (!Number.isFinite(screens)) {
       return pages.map((page) => ({ ...page }));
     }
 
     const viewport = this.config.viewport || {};
     const viewportHeight = Math.max(1, viewport.height || viewport.window?.innerHeight || 1);
-    const viewportTop = Math.max(0, viewport.scrollTop || 0);
     const viewportBottom = viewportTop + viewportHeight;
     const sideScreens = Math.max(0, (screens - 1) / 2);
     const rangeTop = Math.max(0, viewportTop - viewportHeight * sideScreens);
@@ -507,6 +1540,15 @@ export class WorkerRenderer {
         }
 
         const scale = layout.scale || layout.height / Math.max(page.height, 1) || 1;
+        if (options.windowed === false) {
+          return [
+            {
+              ...page,
+              distance: distanceToViewport(layout, viewportCenter, viewportTop, viewportBottom),
+            },
+          ];
+        }
+
         const loY = clamp((rangeTop - layout.top) / scale, 0, page.height);
         const hiY = clamp((rangeBottom - layout.top) / scale, 0, page.height);
         if (hiY <= loY) {
@@ -530,6 +1572,31 @@ export class WorkerRenderer {
 
   private isRenderInterrupted(frameVersion: number) {
     return this.disposed || frameVersion !== this.documentVersion;
+  }
+
+  private shouldStopRender(options: {
+    frameVersion: number;
+    cancelOnViewportChange?: boolean;
+    pauseWhenDragging?: boolean;
+    viewportVersion?: number;
+  }) {
+    return (
+      this.isRenderInterrupted(options.frameVersion) ||
+      (!!options.pauseWhenDragging && this.isViewportInteractive()) ||
+      (!!options.cancelOnViewportChange && options.viewportVersion !== this.viewportVersion)
+    );
+  }
+
+  private isViewportDragging() {
+    return !!this.config.viewport?.dragging;
+  }
+
+  private isViewportScrolling() {
+    return !!this.config.viewport?.scrolling;
+  }
+
+  private isViewportInteractive() {
+    return this.isViewportDragging() || this.isViewportScrolling();
   }
 
   private resolveCanvasAck(generation: number, canvasAck?: CanvasAck) {
@@ -582,17 +1649,112 @@ function distanceToViewport(
   viewportTop: number,
   viewportBottom: number,
 ) {
-  if (layout.top <= viewportBottom && layout.bottom >= viewportTop) {
-    return Math.abs((layout.top + layout.bottom) / 2 - viewportCenter) * 0.001;
+  return distanceToRange(layout.top, layout.bottom, viewportCenter, viewportTop, viewportBottom);
+}
+
+function distanceToRange(
+  top: number,
+  bottom: number,
+  viewportCenter: number,
+  viewportTop: number,
+  viewportBottom: number,
+) {
+  if (top <= viewportBottom && bottom >= viewportTop) {
+    return Math.abs((top + bottom) / 2 - viewportCenter) * 0.001;
   }
-  if (layout.bottom < viewportTop) {
-    return viewportTop - layout.bottom;
+  if (bottom < viewportTop) {
+    return viewportTop - bottom;
   }
-  return layout.top - viewportBottom;
+  return top - viewportBottom;
 }
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function isFullPageRender(page: PageRenderSpec) {
+  const window = page.window;
+  if (!window) {
+    return true;
+  }
+  return (
+    window.lo.x <= 0 &&
+    window.lo.y <= 0 &&
+    window.hi.x >= page.width &&
+    window.hi.y >= page.height
+  );
+}
+
+function commitPixelRect(
+  page: PageRenderSpec,
+  pixelPerPt: number,
+  widthPx: number,
+  heightPx: number,
+) {
+  if (!page.window) {
+    return { x: 0, y: 0, width: widthPx, height: heightPx };
+  }
+
+  const x = Math.trunc(clamp(Math.floor(page.window.lo.x * pixelPerPt), 0, widthPx));
+  const y = Math.trunc(clamp(Math.floor(page.window.lo.y * pixelPerPt), 0, heightPx));
+  const right = Math.trunc(clamp(Math.ceil(page.window.hi.x * pixelPerPt), 0, widthPx));
+  const bottom = Math.trunc(clamp(Math.ceil(page.window.hi.y * pixelPerPt), 0, heightPx));
+  if (right <= x || bottom <= y) {
+    return undefined;
+  }
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function renderWindowKey(page: PageRenderSpec) {
+  if (!page.window) {
+    return "full";
+  }
+  const { lo, hi } = page.window;
+  return `${lo.x}:${lo.y}:${hi.x}:${hi.y}`;
+}
+
+function usesTextRunBounds(rect: PageRect) {
+  return rect.width > rect.height * 3;
+}
+
+function chooseTextRowCluster(
+  clusters: Array<{ top: number; bottom: number; ink: number }>,
+  rectTop: number,
+  rectBottom: number,
+  preferredY?: number,
+) {
+  let best: { top: number; bottom: number; ink: number } | undefined;
+  let bestScore = Number.NEGATIVE_INFINITY;
+  const rectCenter = (rectTop + rectBottom) / 2;
+  for (const cluster of clusters) {
+    const overlap = Math.min(cluster.bottom + 1, rectBottom) - Math.max(cluster.top, rectTop);
+    const clusterCenter = (cluster.top + cluster.bottom + 1) / 2;
+    const distance = Math.abs(clusterCenter - (preferredY ?? rectCenter));
+    const score = Math.max(0, overlap) * 10_000 + cluster.ink - distance;
+    if (score > bestScore) {
+      bestScore = score;
+      best = cluster;
+    }
+  }
+  return best;
+}
+
+function pixelDistanceFromWhite(pixels: Uint8ClampedArray, offset: number) {
+  return (
+    Math.abs(255 - pixels[offset]) +
+    Math.abs(255 - pixels[offset + 1]) +
+    Math.abs(255 - pixels[offset + 2])
+  );
+}
+
+function pixelHasStrongInk(pixels: Uint8ClampedArray, offset: number) {
+  const alpha = pixels[offset + 3];
+  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 48;
+}
+
+function pixelHasVisibleInk(pixels: Uint8ClampedArray, offset: number) {
+  const alpha = pixels[offset + 3];
+  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 12;
 }
 
 function clampPixelPerPt(value: number) {
@@ -601,4 +1763,11 @@ function clampPixelPerPt(value: number) {
   }
   const bucketed = Math.ceil((value - 1e-3) * 4) / 4;
   return clamp(bucketed, minPixelPerPt, maxPixelPerPt);
+}
+
+function computeInteractivePixelPerPt(value: number) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return minInteractivePixelPerPt;
+  }
+  return clamp(value * interactivePixelPerPtScale, minInteractivePixelPerPt, maxInteractivePixelPerPt);
 }

--- a/tools/typst-preview-frontend-ng/src/worker/rendering.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/rendering.ts
@@ -176,7 +176,7 @@ export class WorkerRenderer {
       if (this.isViewportScrolling()) {
         await this.renderScrollVisiblePage(session, frameVersion, handledViewportVersion);
       } else {
-        await this.renderProgressiveStages({
+        await this.renderVisiblePages({
           session,
           pages: this.latestPages,
           generation: this.generation,
@@ -700,7 +700,7 @@ export class WorkerRenderer {
     if (canvasAck?.layouts) {
       this.latestPageLayouts = canvasAck.layouts;
     }
-    await this.renderProgressiveStages({
+    await this.renderVisiblePages({
       session,
       pages,
       generation: nextGeneration,
@@ -712,7 +712,7 @@ export class WorkerRenderer {
     this.scheduleIdlePrefetch(frameVersion, nextGeneration, this.viewportVersion);
   }
 
-  private async renderProgressiveStages(options: {
+  private async renderVisiblePages(options: {
     session: RenderSession;
     pages: PageSpec[];
     generation: number;
@@ -721,41 +721,24 @@ export class WorkerRenderer {
     frameVersion: number;
     viewportVersion: number;
   }) {
-    const stages = [
-      {
-        phase: "visible",
-        layer: "full" as const,
-        quality: "full" as const,
-        screens: visibleRenderScreens,
-        useCacheKey: true,
-        updateCacheKey: true,
-        collectInteractions: true,
-        prioritizeViewport: true,
-        cancelOnViewportChange: true,
-        pauseWhenDragging: true,
-      },
-    ];
-
-    for (const stage of stages) {
-      if (this.isRenderInterrupted(options.frameVersion)) {
-        return;
-      }
-
-      await this.renderAndPostComplete({
-        ...options,
-        pages: this.selectStagePages(options.pages, stage.screens, { windowed: false }),
-        phase: stage.phase,
-        layer: stage.layer,
-        quality: stage.quality,
-        useCacheKey: stage.useCacheKey,
-        updateCacheKey: stage.updateCacheKey,
-        collectInteractions: stage.collectInteractions,
-        prioritizeViewport: stage.prioritizeViewport,
-        cancelOnViewportChange: stage.cancelOnViewportChange,
-        pauseWhenDragging: stage.pauseWhenDragging,
-        viewportVersion: options.viewportVersion,
-      });
+    if (this.isRenderInterrupted(options.frameVersion)) {
+      return;
     }
+
+    await this.renderAndPostComplete({
+      ...options,
+      pages: this.selectStagePages(options.pages, visibleRenderScreens, { windowed: false }),
+      phase: "visible",
+      layer: "full",
+      quality: "full",
+      useCacheKey: true,
+      updateCacheKey: true,
+      collectInteractions: true,
+      prioritizeViewport: true,
+      cancelOnViewportChange: true,
+      pauseWhenDragging: true,
+      viewportVersion: options.viewportVersion,
+    });
   }
 
   private async renderAndPostComplete(options: RenderAndPostOptions) {

--- a/tools/typst-preview-frontend-ng/src/worker/text-hit.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/text-hit.ts
@@ -1,0 +1,319 @@
+import type { PageRect } from "../interactions";
+import type { CanvasEntry } from "./types";
+import { clamp } from "./render-utils";
+
+export interface TextHitResult {
+  hit: boolean;
+  rect?: PageRect;
+}
+
+export function hitRenderedTextBox(
+  entry: CanvasEntry | undefined,
+  pixelPerPt: number | undefined,
+  x: number,
+  y: number,
+  rect?: PageRect,
+): TextHitResult {
+  const context = entry?.context;
+  if (!entry || !context || !pixelPerPt) {
+    return { hit: false };
+  }
+
+  const px = Math.floor(x * pixelPerPt);
+  const py = Math.floor(y * pixelPerPt);
+  if (rect && usesTextRunBounds(rect)) {
+    const textRect = textRunInkBounds(context, entry, pixelPerPt, rect, py);
+    return textRect ? { hit: true, rect: textRect } : { hit: false };
+  }
+
+  const start = nearestInkPixel(context, entry, px, py, pixelPerPt, rect);
+  if (!start) {
+    return { hit: false };
+  }
+
+  return {
+    hit: true,
+    rect: connectedInkBounds(context, entry, start.x, start.y, pixelPerPt),
+  };
+}
+
+export function resolveRenderedTextRect(
+  entry: CanvasEntry | undefined,
+  pixelPerPt: number | undefined,
+  rect: PageRect,
+) {
+  const context = entry?.context;
+  if (!entry || !context || !pixelPerPt) {
+    return undefined;
+  }
+  return textRunInkBounds(context, entry, pixelPerPt, rect);
+}
+
+function textRunInkBounds(
+  context: OffscreenCanvasRenderingContext2D,
+  entry: CanvasEntry,
+  pixelPerPt: number,
+  rect: PageRect,
+  preferredY?: number,
+) {
+  const rectLeft = Math.floor(rect.x * pixelPerPt);
+  const rectTop = rect.y * pixelPerPt;
+  const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt) - 1;
+  const rectBottom = (rect.y + rect.height) * pixelPerPt;
+  const rectHeight = Math.max(1, rectBottom - rectTop);
+  const yPad = Math.trunc(clamp(rectHeight * 1.6, 4, 48));
+  const left = Math.trunc(clamp(rectLeft, 0, Math.max(0, entry.widthPx - 1)));
+  const right = Math.trunc(clamp(rectRight, 0, Math.max(0, entry.widthPx - 1)));
+  const top = Math.trunc(clamp(Math.floor(rectTop) - yPad, 0, Math.max(0, entry.heightPx - 1)));
+  const bottom = Math.trunc(
+    clamp(Math.ceil(rectBottom) + yPad, 0, Math.max(0, entry.heightPx - 1)),
+  );
+  const width = right - left + 1;
+  const height = bottom - top + 1;
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+
+  const pixels = context.getImageData(left, top, width, height).data;
+  const rowClusters = textInkRowClusters(pixels, width, height, top);
+  const cluster = chooseTextRowCluster(rowClusters, rectTop, rectBottom, preferredY);
+  if (!cluster) {
+    return undefined;
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (let y = cluster.top; y <= cluster.bottom; y += 1) {
+    const row = y - top;
+    for (let x = 0; x < width; x += 1) {
+      const index = row * width + x;
+      if (!pixelHasVisibleInk(pixels, index * 4)) {
+        continue;
+      }
+      const px = left + x;
+      minX = Math.min(minX, px);
+      maxX = Math.max(maxX, px);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (!Number.isFinite(minX)) {
+    return undefined;
+  }
+
+  return {
+    x: minX / pixelPerPt,
+    y: minY / pixelPerPt,
+    width: (maxX - minX + 1) / pixelPerPt,
+    height: (maxY - minY + 1) / pixelPerPt,
+  };
+}
+
+function textInkRowClusters(pixels: Uint8ClampedArray, width: number, height: number, top: number) {
+  const clusters: Array<{ top: number; bottom: number; ink: number }> = [];
+  for (let y = 0; y < height; y += 1) {
+    let rowInk = 0;
+    for (let x = 0; x < width; x += 1) {
+      const index = y * width + x;
+      if (pixelHasVisibleInk(pixels, index * 4)) {
+        rowInk += 1;
+      }
+    }
+    if (rowInk === 0) {
+      continue;
+    }
+    const pageY = top + y;
+    const last = clusters[clusters.length - 1];
+    if (!last || pageY > last.bottom + 1) {
+      clusters.push({ top: pageY, bottom: pageY, ink: rowInk });
+      continue;
+    }
+    last.bottom = pageY;
+    last.ink += rowInk;
+  }
+  return clusters;
+}
+
+function nearestInkPixel(
+  context: OffscreenCanvasRenderingContext2D,
+  entry: CanvasEntry,
+  px: number,
+  py: number,
+  pixelPerPt: number,
+  rect?: PageRect,
+) {
+  let left: number;
+  let top: number;
+  let right: number;
+  let bottom: number;
+
+  if (rect) {
+    const rectLeft = Math.floor(rect.x * pixelPerPt);
+    const rectTop = Math.floor(rect.y * pixelPerPt);
+    const rectRight = Math.ceil((rect.x + rect.width) * pixelPerPt);
+    const rectBottom = Math.ceil((rect.y + rect.height) * pixelPerPt);
+    const pad = Math.trunc(clamp(Math.max(rectRight - rectLeft, rectBottom - rectTop) * 2, 16, 96));
+    left = Math.trunc(clamp(rectLeft - pad, 0, Math.max(0, entry.widthPx - 1)));
+    top = Math.trunc(clamp(rectTop - pad, 0, Math.max(0, entry.heightPx - 1)));
+    right = Math.trunc(clamp(rectRight + pad, 0, Math.max(0, entry.widthPx - 1)));
+    bottom = Math.trunc(clamp(rectBottom + pad, 0, Math.max(0, entry.heightPx - 1)));
+  } else {
+    const radius = 48;
+    left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
+    top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
+    right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
+    bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
+  }
+
+  const width = right - left + 1;
+  const height = bottom - top + 1;
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+
+  const pixels = context.getImageData(left, top, width, height).data;
+  let bestIndex = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < width * height; index += 1) {
+    if (!pixelHasStrongInk(pixels, index * 4)) {
+      continue;
+    }
+    const x = left + (index % width);
+    const y = top + Math.floor(index / width);
+    const distance = (x - px) ** 2 + (y - py) ** 2;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+
+  if (bestIndex < 0) {
+    return undefined;
+  }
+
+  return {
+    x: left + (bestIndex % width),
+    y: top + Math.floor(bestIndex / width),
+  };
+}
+
+function connectedInkBounds(
+  context: OffscreenCanvasRenderingContext2D,
+  entry: CanvasEntry,
+  px: number,
+  py: number,
+  pixelPerPt: number,
+) {
+  const radius = 80;
+  const left = Math.trunc(clamp(px - radius, 0, Math.max(0, entry.widthPx - 1)));
+  const top = Math.trunc(clamp(py - radius, 0, Math.max(0, entry.heightPx - 1)));
+  const right = Math.trunc(clamp(px + radius, 0, Math.max(0, entry.widthPx - 1)));
+  const bottom = Math.trunc(clamp(py + radius, 0, Math.max(0, entry.heightPx - 1)));
+  const width = right - left + 1;
+  const height = bottom - top + 1;
+  const pixels = context.getImageData(left, top, width, height).data;
+  const startX = px - left;
+  const startY = py - top;
+  const start = startY * width + startX;
+  const visited = new Uint8Array(width * height);
+  const stack = [start];
+  let minX = startX;
+  let maxX = startX;
+  let minY = startY;
+  let maxY = startY;
+  let visitedInk = 0;
+
+  while (stack.length > 0 && visitedInk < 16_384) {
+    const index = stack.pop()!;
+    if (visited[index]) {
+      continue;
+    }
+    visited[index] = 1;
+    if (!pixelHasVisibleInk(pixels, index * 4)) {
+      continue;
+    }
+
+    visitedInk += 1;
+    const x = index % width;
+    const y = Math.floor(index / width);
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+
+    for (let dy = -1; dy <= 1; dy += 1) {
+      for (let dx = -1; dx <= 1; dx += 1) {
+        if (dx === 0 && dy === 0) {
+          continue;
+        }
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx < 0 || ny < 0 || nx >= width || ny >= height) {
+          continue;
+        }
+        const next = ny * width + nx;
+        if (!visited[next]) {
+          stack.push(next);
+        }
+      }
+    }
+  }
+
+  const rectLeft = Math.max(0, left + minX);
+  const rectTop = Math.max(0, top + minY);
+  const rectRight = Math.min(entry.widthPx - 1, left + maxX);
+  const rectBottom = Math.min(entry.heightPx - 1, top + maxY);
+  return {
+    x: rectLeft / pixelPerPt,
+    y: rectTop / pixelPerPt,
+    width: (rectRight - rectLeft + 1) / pixelPerPt,
+    height: (rectBottom - rectTop + 1) / pixelPerPt,
+  };
+}
+
+function usesTextRunBounds(rect: PageRect) {
+  return rect.width > rect.height * 3;
+}
+
+function chooseTextRowCluster(
+  clusters: Array<{ top: number; bottom: number; ink: number }>,
+  rectTop: number,
+  rectBottom: number,
+  preferredY?: number,
+) {
+  let best: { top: number; bottom: number; ink: number } | undefined;
+  let bestScore = Number.NEGATIVE_INFINITY;
+  const rectCenter = (rectTop + rectBottom) / 2;
+  for (const cluster of clusters) {
+    const overlap = Math.min(cluster.bottom + 1, rectBottom) - Math.max(cluster.top, rectTop);
+    const clusterCenter = (cluster.top + cluster.bottom + 1) / 2;
+    const distance = Math.abs(clusterCenter - (preferredY ?? rectCenter));
+    const score = Math.max(0, overlap) * 10_000 + cluster.ink - distance;
+    if (score > bestScore) {
+      bestScore = score;
+      best = cluster;
+    }
+  }
+  return best;
+}
+
+function pixelDistanceFromWhite(pixels: Uint8ClampedArray, offset: number) {
+  return (
+    Math.abs(255 - pixels[offset]) +
+    Math.abs(255 - pixels[offset + 1]) +
+    Math.abs(255 - pixels[offset + 2])
+  );
+}
+
+function pixelHasStrongInk(pixels: Uint8ClampedArray, offset: number) {
+  const alpha = pixels[offset + 3];
+  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 48;
+}
+
+function pixelHasVisibleInk(pixels: Uint8ClampedArray, offset: number) {
+  const alpha = pixels[offset + 3];
+  return alpha > 0 && pixelDistanceFromWhite(pixels, offset) > 12;
+}

--- a/tools/typst-preview-frontend-ng/src/worker/types.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/types.ts
@@ -25,6 +25,9 @@ export interface PageLayout {
   scale: number;
 }
 
+export type CanvasLayer = "full";
+export type RenderQuality = "preview" | "full";
+
 export interface CanvasEntry {
   canvas: OffscreenCanvas;
   context?: OffscreenCanvasRenderingContext2D;
@@ -33,7 +36,7 @@ export interface CanvasEntry {
   widthPx: number;
   heightPx: number;
   hasContent?: boolean;
-  quality?: "preview" | "full";
+  quality?: RenderQuality;
   renderedGeneration?: number;
   renderedPixelPerPt?: number;
   renderedWindowKey?: string;
@@ -60,7 +63,7 @@ export type WorkerPost = (message: unknown) => void;
 
 export interface PageRenderResult {
   pageIndex: number;
-  quality?: "preview" | "full";
+  quality?: RenderQuality;
   fullPage?: boolean;
   interactions?: PageInteractions;
   invalidatedInteractions?: number[];

--- a/tools/typst-preview-frontend-ng/src/worker/types.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/types.ts
@@ -28,8 +28,15 @@ export interface PageLayout {
 export interface CanvasEntry {
   canvas: OffscreenCanvas;
   context?: OffscreenCanvasRenderingContext2D;
+  scratch?: OffscreenCanvas;
+  scratchContext?: OffscreenCanvasRenderingContext2D;
   widthPx: number;
   heightPx: number;
+  hasContent?: boolean;
+  quality?: "preview" | "full";
+  renderedGeneration?: number;
+  renderedPixelPerPt?: number;
+  renderedWindowKey?: string;
 }
 
 export interface CanvasAck {
@@ -52,5 +59,9 @@ export interface WorkerConfig {
 export type WorkerPost = (message: unknown) => void;
 
 export interface PageRenderResult {
+  pageIndex: number;
+  quality?: "preview" | "full";
+  fullPage?: boolean;
   interactions?: PageInteractions;
+  invalidatedInteractions?: number[];
 }

--- a/tools/typst-preview-frontend-ng/styles/pages.css
+++ b/tools/typst-preview-frontend-ng/styles/pages.css
@@ -45,9 +45,16 @@
 }
 
 .typst-page-canvas canvas {
+  position: absolute;
+  inset: 0;
   display: block;
   width: 100%;
   height: 100%;
+  opacity: 0;
+}
+
+.typst-page.canvas-ready .typst-full-canvas {
+  opacity: 1;
 }
 
 .dragging .typst-page {


### PR DESCRIPTION
- Prioritize visible-page rendering during scroll and drag interactions.
- Add idle full-quality prefetch with bounded canvas buffers.
- Defer interaction collection while the viewport is moving.