### PR TITLE
perf(package-docs): cache source span lookups

### DIFF
--- a/crates/tinymist-cli/src/cmd/query.rs
+++ b/crates/tinymist-cli/src/cmd/query.rs
@@ -154,55 +154,29 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
 
     match cmds {
         QueryCommands::Lsif(args) => {
-            let _scope = typst_timing::TimingScope::new("query.lsif");
             let res = snap.run_within_package(&info, move |a| {
-                let knowledge = {
-                    let _scope = typst_timing::TimingScope::new("query.lsif.knowledge");
-                    tinymist_query::index::knowledge(a)
-                        .map_err(map_string_err("failed to generate index"))?
-                };
-                let encoded = {
-                    let _scope = typst_timing::TimingScope::new("query.lsif.encode");
-                    knowledge.bind(a.shared()).to_string()
-                };
+                let knowledge = tinymist_query::index::knowledge(a)
+                    .map_err(map_string_err("failed to generate index"))?;
+                let encoded = knowledge.bind(a.shared()).to_string();
                 Ok(encoded)
             })?;
 
             write_output(Path::new(&args.output), res, "failed to write lsif output")?;
         }
         QueryCommands::Scip(args) => {
-            let _scope = typst_timing::TimingScope::new("query.scip");
             let (bytes, summary) = snap.run_within_package(&info, |a| {
-                let docs = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.package_docs");
-                    tinymist_query::docs::package_docs(a, &info)
-                        .map_err(map_string_err("failed to generate docs"))?
-                };
-                let public_api = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.public_api");
-                    docs.scip_public_api()
-                };
-                let knowledge = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.knowledge");
-                    tinymist_query::index::knowledge(a)
-                        .map_err(map_string_err("failed to generate index"))?
-                };
-                let index = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.to_index");
-                    knowledge
-                        .bind(a.shared())
-                        .to_scip_index_with_public_api(&public_api)?
-                };
-                let summary = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.summary");
-                    ScipIndexSummary::from_index(&info, &index, &public_api)
-                };
-                let bytes = {
-                    let _scope = typst_timing::TimingScope::new("query.scip.serialize");
-                    index
-                        .write_to_bytes()
-                        .context_ut("failed to serialize SCIP index")?
-                };
+                let docs = tinymist_query::docs::package_docs(a, &info)
+                    .map_err(map_string_err("failed to generate docs"))?;
+                let public_api = docs.scip_public_api();
+                let knowledge = tinymist_query::index::knowledge(a)
+                    .map_err(map_string_err("failed to generate index"))?;
+                let index = knowledge
+                    .bind(a.shared())
+                    .to_scip_index_with_public_api(&public_api)?;
+                let summary = ScipIndexSummary::from_index(&info, &index, &public_api);
+                let bytes = index
+                    .write_to_bytes()
+                    .context_ut("failed to serialize SCIP index")?;
                 Ok((bytes, summary))
             })?;
 
@@ -225,24 +199,16 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
             }
         }
         QueryCommands::PackageDocs(args) => {
-            let _scope = typst_timing::TimingScope::new("query.package_docs");
             let res = snap.run_within_package(&info, |a| {
-                let doc = {
-                    let _scope = typst_timing::TimingScope::new("query.package_docs.render");
-                    tinymist_query::docs::package_docs(a, &info)
-                        .map_err(map_string_err("failed to generate docs"))?
-                };
-                {
-                    let _scope = typst_timing::TimingScope::new("query.package_docs.markdown");
-                    tinymist_query::docs::package_docs_md(&doc)
-                        .map_err(map_string_err("failed to generate docs"))
-                }
+                let doc = tinymist_query::docs::package_docs(a, &info)
+                    .map_err(map_string_err("failed to generate docs"))?;
+                tinymist_query::docs::package_docs_md(&doc)
+                    .map_err(map_string_err("failed to generate docs"))
             })?;
 
             write_output(Path::new(&args.output), res, "failed to write package docs")?;
         }
         QueryCommands::CheckPackage(_args) => {
-            let _scope = typst_timing::TimingScope::new("query.check_package");
             snap.run_within_package(&info, |a| {
                 tinymist_query::package::check_package(a, &info)
                     .map_err(map_string_err("failed to check package"))

--- a/crates/tinymist-cli/src/cmd/query.rs
+++ b/crates/tinymist-cli/src/cmd/query.rs
@@ -135,7 +135,6 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
     let verse = compile.resolve()?;
     let snap = verse.computation();
     let snap = analysis.clone().query_snapshot(snap, None);
-
     let (id, path) = match &cmds {
         QueryCommands::Lsif(args) => (&args.id, &args.path),
         QueryCommands::Scip(args) => (&args.id, &args.path),
@@ -155,28 +154,55 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
 
     match cmds {
         QueryCommands::Lsif(args) => {
+            let _scope = typst_timing::TimingScope::new("query.lsif");
             let res = snap.run_within_package(&info, move |a| {
-                let knowledge = tinymist_query::index::knowledge(a)
-                    .map_err(map_string_err("failed to generate index"))?;
-                Ok(knowledge.bind(a.shared()).to_string())
+                let knowledge = {
+                    let _scope = typst_timing::TimingScope::new("query.lsif.knowledge");
+                    tinymist_query::index::knowledge(a)
+                        .map_err(map_string_err("failed to generate index"))?
+                };
+                let encoded = {
+                    let _scope = typst_timing::TimingScope::new("query.lsif.encode");
+                    knowledge.bind(a.shared()).to_string()
+                };
+                Ok(encoded)
             })?;
 
             write_output(Path::new(&args.output), res, "failed to write lsif output")?;
         }
         QueryCommands::Scip(args) => {
+            let _scope = typst_timing::TimingScope::new("query.scip");
             let (bytes, summary) = snap.run_within_package(&info, |a| {
-                let docs = tinymist_query::docs::package_docs(a, &info)
-                    .map_err(map_string_err("failed to generate docs"))?;
-                let public_api = docs.scip_public_api();
-                let knowledge = tinymist_query::index::knowledge(a)
-                    .map_err(map_string_err("failed to generate index"))?;
-                let index = knowledge
-                    .bind(a.shared())
-                    .to_scip_index_with_public_api(&public_api)?;
-                let summary = ScipIndexSummary::from_index(&info, &index, &public_api);
-                let bytes = index
-                    .write_to_bytes()
-                    .context_ut("failed to serialize SCIP index")?;
+                let docs = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.package_docs");
+                    tinymist_query::docs::package_docs(a, &info)
+                        .map_err(map_string_err("failed to generate docs"))?
+                };
+                let public_api = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.public_api");
+                    docs.scip_public_api()
+                };
+                let knowledge = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.knowledge");
+                    tinymist_query::index::knowledge(a)
+                        .map_err(map_string_err("failed to generate index"))?
+                };
+                let index = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.to_index");
+                    knowledge
+                        .bind(a.shared())
+                        .to_scip_index_with_public_api(&public_api)?
+                };
+                let summary = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.summary");
+                    ScipIndexSummary::from_index(&info, &index, &public_api)
+                };
+                let bytes = {
+                    let _scope = typst_timing::TimingScope::new("query.scip.serialize");
+                    index
+                        .write_to_bytes()
+                        .context_ut("failed to serialize SCIP index")?
+                };
                 Ok((bytes, summary))
             })?;
 
@@ -199,16 +225,24 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
             }
         }
         QueryCommands::PackageDocs(args) => {
+            let _scope = typst_timing::TimingScope::new("query.package_docs");
             let res = snap.run_within_package(&info, |a| {
-                let doc = tinymist_query::docs::package_docs(a, &info)
-                    .map_err(map_string_err("failed to generate docs"))?;
-                tinymist_query::docs::package_docs_md(&doc)
-                    .map_err(map_string_err("failed to generate docs"))
+                let doc = {
+                    let _scope = typst_timing::TimingScope::new("query.package_docs.render");
+                    tinymist_query::docs::package_docs(a, &info)
+                        .map_err(map_string_err("failed to generate docs"))?
+                };
+                {
+                    let _scope = typst_timing::TimingScope::new("query.package_docs.markdown");
+                    tinymist_query::docs::package_docs_md(&doc)
+                        .map_err(map_string_err("failed to generate docs"))
+                }
             })?;
 
             write_output(Path::new(&args.output), res, "failed to write package docs")?;
         }
         QueryCommands::CheckPackage(_args) => {
+            let _scope = typst_timing::TimingScope::new("query.check_package");
             snap.run_within_package(&info, |a| {
                 tinymist_query::package::check_package(a, &info)
                     .map_err(map_string_err("failed to check package"))

--- a/crates/tinymist-cli/src/cmd/query.rs
+++ b/crates/tinymist-cli/src/cmd/query.rs
@@ -135,6 +135,7 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
     let verse = compile.resolve()?;
     let snap = verse.computation();
     let snap = analysis.clone().query_snapshot(snap, None);
+
     let (id, path) = match &cmds {
         QueryCommands::Lsif(args) => (&args.id, &args.path),
         QueryCommands::Scip(args) => (&args.id, &args.path),
@@ -157,8 +158,7 @@ pub fn query_main(mut cmds: QueryCommands) -> Result<()> {
             let res = snap.run_within_package(&info, move |a| {
                 let knowledge = tinymist_query::index::knowledge(a)
                     .map_err(map_string_err("failed to generate index"))?;
-                let encoded = knowledge.bind(a.shared()).to_string();
-                Ok(encoded)
+                Ok(knowledge.bind(a.shared()).to_string())
             })?;
 
             write_output(Path::new(&args.output), res, "failed to write lsif output")?;

--- a/crates/tinymist-query/src/analysis/completion/type.rs
+++ b/crates/tinymist-query/src/analysis/completion/type.rs
@@ -98,10 +98,9 @@ impl TypeCompletionWorker<'_, '_, '_, '_> {
                 let docs = if docs.is_some() {
                     docs
                 } else {
-                    resolved_docs = param
-                        .docs
-                        .as_ref()
-                        .map(|docs| crate::docs::resolve_doc_text(self.base.worker.ctx, docs));
+                    resolved_docs = param.docs.as_ref().map(|docs| {
+                        crate::docs::resolve_doc_text(self.base.worker.ctx.shared(), docs)
+                    });
                     resolved_docs.as_deref()
                 };
                 if param.attrs.positional {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -535,11 +535,11 @@ impl LocalContext {
         match def.decl.kind() {
             DefKind::Function => {
                 let sig = self.sig_of_def(def.clone())?;
-                let docs = crate::docs::sig_docs(self, &sig)?;
+                let docs = crate::docs::sig_docs(self.shared(), &sig)?;
                 Some(DefDocs::Function(Box::new(docs)))
             }
             DefKind::Struct | DefKind::Constant | DefKind::Variable => {
-                let docs = crate::docs::var_docs(self, def.decl.span())?;
+                let docs = crate::docs::var_docs(self.shared(), def.decl.span())?;
                 Some(DefDocs::Variable(docs))
             }
             DefKind::Module => {
@@ -1037,11 +1037,11 @@ impl SharedContext {
         match def.decl.kind() {
             DefKind::Function => {
                 let sig = self.sig_of_def(def.clone())?;
-                let docs = crate::docs::sig_docs_shared(self, &sig)?;
+                let docs = crate::docs::sig_docs(self, &sig)?;
                 Some(DefDocs::Function(Box::new(docs)))
             }
             DefKind::Struct | DefKind::Constant | DefKind::Variable => {
-                let docs = crate::docs::var_docs_shared(self, def.decl.span())?;
+                let docs = crate::docs::var_docs(self, def.decl.span())?;
                 Some(DefDocs::Variable(docs))
             }
             DefKind::Module => {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::ops::DerefMut;
 use std::sync::OnceLock;
@@ -8,6 +9,7 @@ use comemo::{Track, Tracked};
 use ecow::EcoString;
 use lsp_types::Url;
 use parking_lot::Mutex;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 use tinymist_analysis::docs::DocString;
 use tinymist_analysis::stats::{AllocStats, QueryStatReportEntry};
@@ -446,6 +448,13 @@ impl LocalContext {
         self.shared_().preload_package(entry_point);
     }
 
+    pub(crate) fn preload_expr_stages<I>(&self, files: I)
+    where
+        I: IntoIterator<Item = TypstFileId>,
+    {
+        self.shared_().preload_expr_stages(files);
+    }
+
     pub(crate) fn with_vm<T>(&self, f: impl FnOnce(&mut typst_shim::eval::Vm) -> T) -> T {
         crate::upstream::with_vm((self.world() as &dyn World).track(), f)
     }
@@ -541,6 +550,39 @@ impl LocalContext {
             }
             DefKind::Reference => None,
         }
+    }
+}
+
+/// A concurrent per-request cache for expensive shared computations.
+#[derive(Clone)]
+pub struct SharedQueryCache<K, V> {
+    slots: Arc<FxDashMap<K, Arc<OnceLock<V>>>>,
+}
+
+impl<K, V> Default for SharedQueryCache<K, V>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        Self {
+            slots: Arc::new(FxDashMap::default()),
+        }
+    }
+}
+
+impl<K, V> SharedQueryCache<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    /// Gets a cached value for `key`, initializing it once if absent.
+    pub fn get_or_init(&self, key: K, init: impl FnOnce() -> V) -> V {
+        let slot = self
+            .slots
+            .entry(key)
+            .or_insert_with(|| Arc::new(OnceLock::new()))
+            .clone();
+        slot.get_or_init(init).clone()
     }
 }
 
@@ -893,15 +935,6 @@ impl SharedContext {
         definition(self, source, syntax)
     }
 
-    /// Gets the definition from a declaration.
-    pub(crate) fn def_of_decl(&self, decl: &Interned<Decl>) -> Option<Definition> {
-        match decl.as_ref() {
-            Decl::Func(..) => Some(Definition::new(decl.clone(), None)),
-            Decl::Module(..) => None,
-            _ => None,
-        }
-    }
-
     /// Gets the definition from static analysis.
     ///
     /// Passing a `doc` (compiled result) can help resolve dynamic things, e.g.
@@ -998,6 +1031,27 @@ impl SharedContext {
         crate::log_debug_ct!("check definition func {def:?}");
         let source = def.decl.file_id().and_then(|id| self.source_by_id(id).ok());
         analyze_signature(self, SignatureTarget::Def(source, def))
+    }
+
+    pub(crate) fn def_docs(self: &Arc<Self>, def: &Definition) -> Option<DefDocs> {
+        match def.decl.kind() {
+            DefKind::Function => {
+                let sig = self.sig_of_def(def.clone())?;
+                let docs = crate::docs::sig_docs_shared(self, &sig)?;
+                Some(DefDocs::Function(Box::new(docs)))
+            }
+            DefKind::Struct | DefKind::Constant | DefKind::Variable => {
+                let docs = crate::docs::var_docs_shared(self, def.decl.span())?;
+                Some(DefDocs::Variable(docs))
+            }
+            DefKind::Module => {
+                let ei = self.expr_stage_by_id(def.decl.file_id()?)?;
+                Some(DefDocs::Module(TidyModuleDocs {
+                    docs: ei.module_docstring.docs.clone().unwrap_or_default(),
+                }))
+            }
+            DefKind::Reference => None,
+        }
     }
 
     pub(crate) fn sig_of_type(self: &Arc<Self>, ti: &TypeInfo, ty: Ty) -> Option<Signature> {
@@ -1152,6 +1206,20 @@ impl SharedContext {
         //     this.type_check(&source);
         //     // crate::log_debug_ct!("prefetch type check end {fid:?}");
         // });
+    }
+
+    pub(crate) fn preload_expr_stages<I>(self: Arc<Self>, files: I)
+    where
+        I: IntoIterator<Item = TypstFileId>,
+    {
+        let files: Vec<_> = files.into_iter().collect();
+        files.par_iter().for_each(|fid| {
+            crate::log_debug_ct!("preload expr_stage {fid:?}");
+            let Some(source) = self.source_by_id(*fid).ok() else {
+                return;
+            };
+            self.expr_stage(&source);
+        });
     }
 
     pub(crate) fn preload_package(self: Arc<Self>, entry_point: TypstFileId) {

--- a/crates/tinymist-query/src/analysis/global.rs
+++ b/crates/tinymist-query/src/analysis/global.rs
@@ -469,7 +469,7 @@ impl LocalContext {
     }
 
     pub(crate) fn cached_tokens(&mut self, source: &Source) -> (SemanticTokens, Option<String>) {
-        let tokens = crate::analysis::semantic_tokens::get_semantic_tokens(self, source);
+        let tokens = crate::analysis::semantic_tokens::get_semantic_tokens(self.shared(), source);
 
         let result_id = self.tokens.as_ref().map(|t| {
             let id = t.next.revision;

--- a/crates/tinymist-query/src/analysis/semantic_tokens.rs
+++ b/crates/tinymist-query/src/analysis/semantic_tokens.rs
@@ -18,6 +18,7 @@ use typst::syntax::{LinkedNode, Source, SyntaxKind, ast};
 use crate::{
     LocalContext, LspPosition, PositionEncoding,
     adt::revision::{RevisionLock, RevisionManager, RevisionManagerLike, RevisionSlot},
+    analysis::SharedContext,
     syntax::{Expr, ExprInfo},
     ty::Ty,
 };
@@ -28,11 +29,38 @@ pub type SemanticTokens = Arc<Vec<SemanticToken>>;
 /// Get the semantic tokens for a source.
 #[typst_macros::time(span = source.root().span())]
 pub(crate) fn get_semantic_tokens(ctx: &mut LocalContext, source: &Source) -> SemanticTokens {
-    let mut tokenizer = Tokenizer::new(
-        source.clone(),
+    get_semantic_tokens_inner(
+        source,
         ctx.expr_stage(source),
         ctx.analysis.allow_multiline_token,
         ctx.analysis.position_encoding,
+    )
+}
+
+#[typst_macros::time(span = source.root().span())]
+pub(crate) fn get_semantic_tokens_shared(
+    ctx: &Arc<SharedContext>,
+    source: &Source,
+) -> SemanticTokens {
+    get_semantic_tokens_inner(
+        source,
+        ctx.expr_stage(source),
+        ctx.analysis.allow_multiline_token,
+        ctx.analysis.position_encoding,
+    )
+}
+
+fn get_semantic_tokens_inner(
+    source: &Source,
+    expr_stage: ExprInfo,
+    allow_multiline_token: bool,
+    position_encoding: PositionEncoding,
+) -> SemanticTokens {
+    let mut tokenizer = Tokenizer::new(
+        source.clone(),
+        expr_stage,
+        allow_multiline_token,
+        position_encoding,
     );
     tokenizer.tokenize_tree(&LinkedNode::new(source.root()), ModifierSet::empty());
     SemanticTokens::new(tokenizer.output)

--- a/crates/tinymist-query/src/analysis/semantic_tokens.rs
+++ b/crates/tinymist-query/src/analysis/semantic_tokens.rs
@@ -16,7 +16,7 @@ use tinymist_std::ImmutPath;
 use typst::syntax::{LinkedNode, Source, SyntaxKind, ast};
 
 use crate::{
-    LocalContext, LspPosition, PositionEncoding,
+    LspPosition, PositionEncoding,
     adt::revision::{RevisionLock, RevisionManager, RevisionManagerLike, RevisionSlot},
     analysis::SharedContext,
     syntax::{Expr, ExprInfo},
@@ -28,39 +28,12 @@ pub type SemanticTokens = Arc<Vec<SemanticToken>>;
 
 /// Get the semantic tokens for a source.
 #[typst_macros::time(span = source.root().span())]
-pub(crate) fn get_semantic_tokens(ctx: &mut LocalContext, source: &Source) -> SemanticTokens {
-    get_semantic_tokens_inner(
-        source,
-        ctx.expr_stage(source),
-        ctx.analysis.allow_multiline_token,
-        ctx.analysis.position_encoding,
-    )
-}
-
-#[typst_macros::time(span = source.root().span())]
-pub(crate) fn get_semantic_tokens_shared(
-    ctx: &Arc<SharedContext>,
-    source: &Source,
-) -> SemanticTokens {
-    get_semantic_tokens_inner(
-        source,
-        ctx.expr_stage(source),
-        ctx.analysis.allow_multiline_token,
-        ctx.analysis.position_encoding,
-    )
-}
-
-fn get_semantic_tokens_inner(
-    source: &Source,
-    expr_stage: ExprInfo,
-    allow_multiline_token: bool,
-    position_encoding: PositionEncoding,
-) -> SemanticTokens {
+pub(crate) fn get_semantic_tokens(ctx: &Arc<SharedContext>, source: &Source) -> SemanticTokens {
     let mut tokenizer = Tokenizer::new(
         source.clone(),
-        expr_stage,
-        allow_multiline_token,
-        position_encoding,
+        ctx.expr_stage(source),
+        ctx.analysis.allow_multiline_token,
+        ctx.analysis.position_encoding,
     );
     tokenizer.tokenize_tree(&LinkedNode::new(source.root()), ModifierSet::empty());
     SemanticTokens::new(tokenizer.output)

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -9,18 +9,9 @@ use tinymist_analysis::docs::{
 use tinymist_analysis::ty::DocSource;
 use typst::syntax::Span;
 
-use crate::LocalContext;
 use crate::analysis::SharedContext;
 
-pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
-    var_docs_shared(ctx.shared(), pos)
-}
-
-pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<SignatureDocs> {
-    sig_docs_shared(ctx.shared(), sig)
-}
-
-pub(crate) fn var_docs_shared(ctx: &Arc<SharedContext>, pos: Span) -> Option<VarDocs> {
+pub(crate) fn var_docs(ctx: &Arc<SharedContext>, pos: Span) -> Option<VarDocs> {
     let source = ctx.source_by_id(pos.id()?).ok()?;
     let type_info = ctx.type_check(&source);
     let ty = type_info.type_of_span(pos)?;
@@ -62,9 +53,9 @@ pub(crate) fn var_docs_shared(ctx: &Arc<SharedContext>, pos: Span) -> Option<Var
     }
 }
 
-pub(crate) fn sig_docs_shared(ctx: &Arc<SharedContext>, sig: &Signature) -> Option<SignatureDocs> {
+pub(crate) fn sig_docs(ctx: &Arc<SharedContext>, sig: &Signature) -> Option<SignatureDocs> {
     let type_sig = sig.type_sig().clone();
-    let mut resolver = SharedDocTextResolver(ctx.as_ref());
+    let mut resolver = ctx.as_ref();
 
     let pos_in = sig
         .primary()
@@ -95,7 +86,7 @@ pub(crate) fn sig_docs_shared(ctx: &Arc<SharedContext>, sig: &Signature) -> Opti
         .primary()
         .docs
         .as_ref()
-        .map(|docs| resolve_doc_text_shared(ctx, docs))
+        .map(|docs| resolve_doc_text(ctx, docs))
         .unwrap_or_default();
 
     Some(SignatureDocs {
@@ -108,26 +99,14 @@ pub(crate) fn sig_docs_shared(ctx: &Arc<SharedContext>, sig: &Signature) -> Opti
     })
 }
 
-pub(crate) fn resolve_doc_text(ctx: &mut LocalContext, docs: &DocText) -> EcoString {
-    resolve_doc_text_shared(ctx.shared().as_ref(), docs)
-}
-
-pub(crate) fn resolve_doc_text_shared(ctx: &SharedContext, docs: &DocText) -> EcoString {
+pub(crate) fn resolve_doc_text(ctx: &SharedContext, docs: &DocText) -> EcoString {
     docs.get_or_init(|raw| convert_official_doc(ctx, raw.clone()))
         .clone()
 }
 
-impl DocTextResolver for LocalContext {
+impl DocTextResolver for &SharedContext {
     fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString {
         resolve_doc_text(self, docs)
-    }
-}
-
-struct SharedDocTextResolver<'a>(&'a SharedContext);
-
-impl DocTextResolver for SharedDocTextResolver<'_> {
-    fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString {
-        resolve_doc_text_shared(self.0, docs)
     }
 }
 

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -25,11 +25,17 @@ pub(crate) fn var_docs_shared(ctx: &Arc<SharedContext>, pos: Span) -> Option<Var
     let type_info = ctx.type_check(&source);
     let ty = type_info.type_of_span(pos)?;
 
+    // todo multiple sources
+    // Must use raw result as type aliases contain the source information.
     let mut srcs = ty.sources();
     srcs.sort();
     log::debug!("check variable docs of ty: {ty:?} => {srcs:?}");
     let doc_source = srcs.into_iter().next()?;
 
+    // todo people can easily forget to simplify the type which is not good. we
+    // might find a way to ensure them at compile time.
+    //
+    // Must be simplified before formatting, to expand type aliases.
     let simplified_ty = type_info.simplify(ty, false);
     let return_ty = format_ty_short(Some(&simplified_ty));
     match doc_source {

--- a/crates/tinymist-query/src/docs/def.rs
+++ b/crates/tinymist-query/src/docs/def.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use ecow::EcoString;
 use tinymist_analysis::Signature;
@@ -13,21 +13,23 @@ use crate::LocalContext;
 use crate::analysis::SharedContext;
 
 pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
+    var_docs_shared(ctx.shared(), pos)
+}
+
+pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<SignatureDocs> {
+    sig_docs_shared(ctx.shared(), sig)
+}
+
+pub(crate) fn var_docs_shared(ctx: &Arc<SharedContext>, pos: Span) -> Option<VarDocs> {
     let source = ctx.source_by_id(pos.id()?).ok()?;
     let type_info = ctx.type_check(&source);
     let ty = type_info.type_of_span(pos)?;
 
-    // todo multiple sources
-    // Must use raw result as type aliases contain the source information.
     let mut srcs = ty.sources();
     srcs.sort();
     log::debug!("check variable docs of ty: {ty:?} => {srcs:?}");
     let doc_source = srcs.into_iter().next()?;
 
-    // todo people can easily forget to simplify the type which is not good. we
-    // might find a way to ensure them at compile time.
-    //
-    // Must be simplified before formatting, to expand type aliases.
     let simplified_ty = type_info.simplify(ty, false);
     let return_ty = format_ty_short(Some(&simplified_ty));
     match doc_source {
@@ -35,7 +37,7 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
             let docs = type_info
                 .var_docs
                 .get(&var.def)
-                .map(|docs| docs.docs().clone());
+                .map(|docstring| docstring.docs().clone());
             Some(VarDocs {
                 docs: docs.unwrap_or_default(),
                 return_ty,
@@ -43,7 +45,7 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
             })
         }
         DocSource::Ins(ins) => ins.syntax.as_ref().map(|src| {
-            let docs = convert_typst_docs(ctx, src.doc.as_ref().into());
+            let docs = convert_typst_docs_shared(ctx, src.doc.as_ref().into());
             VarDocs {
                 docs,
                 return_ty,
@@ -54,8 +56,9 @@ pub(crate) fn var_docs(ctx: &mut LocalContext, pos: Span) -> Option<VarDocs> {
     }
 }
 
-pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<SignatureDocs> {
+pub(crate) fn sig_docs_shared(ctx: &Arc<SharedContext>, sig: &Signature) -> Option<SignatureDocs> {
     let type_sig = sig.type_sig().clone();
+    let mut resolver = SharedDocTextResolver(ctx.as_ref());
 
     let pos_in = sig
         .primary()
@@ -73,12 +76,12 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
     let ret_in = type_sig.body.as_ref();
 
     let pos = pos_in
-        .map(|(param, ty)| ParamDocs::new(ctx, param, ty))
+        .map(|(param, ty)| ParamDocs::new(&mut resolver, param, ty))
         .collect::<Vec<_>>();
     let named = named_in
-        .map(|(param, ty)| (param.name.clone(), ParamDocs::new(ctx, param, ty)))
+        .map(|(param, ty)| (param.name.clone(), ParamDocs::new(&mut resolver, param, ty)))
         .collect::<std::collections::BTreeMap<_, _>>();
-    let rest = rest_in.map(|(param, ty)| ParamDocs::new(ctx, param, ty));
+    let rest = rest_in.map(|(param, ty)| ParamDocs::new(&mut resolver, param, ty));
 
     let ret_ty = format_ty_short(ret_in);
 
@@ -86,7 +89,7 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
         .primary()
         .docs
         .as_ref()
-        .map(|docs| resolve_doc_text(ctx, docs))
+        .map(|docs| resolve_doc_text_shared(ctx, docs))
         .unwrap_or_default();
 
     Some(SignatureDocs {
@@ -100,14 +103,25 @@ pub(crate) fn sig_docs(ctx: &mut LocalContext, sig: &Signature) -> Option<Signat
 }
 
 pub(crate) fn resolve_doc_text(ctx: &mut LocalContext, docs: &DocText) -> EcoString {
-    let shared = ctx.shared();
-    docs.get_or_init(|raw| convert_official_doc(shared, raw.clone()))
+    resolve_doc_text_shared(ctx.shared().as_ref(), docs)
+}
+
+pub(crate) fn resolve_doc_text_shared(ctx: &SharedContext, docs: &DocText) -> EcoString {
+    docs.get_or_init(|raw| convert_official_doc(ctx, raw.clone()))
         .clone()
 }
 
 impl DocTextResolver for LocalContext {
     fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString {
         resolve_doc_text(self, docs)
+    }
+}
+
+struct SharedDocTextResolver<'a>(&'a SharedContext);
+
+impl DocTextResolver for SharedDocTextResolver<'_> {
+    fn resolve_doc_text(&mut self, docs: &DocText) -> EcoString {
+        resolve_doc_text_shared(self.0, docs)
     }
 }
 
@@ -129,14 +143,13 @@ fn convert_official_doc(ctx: &SharedContext, docs: EcoString) -> EcoString {
     }
 }
 
-pub(crate) fn convert_typst_docs(ctx: &mut LocalContext, docs: EcoString) -> EcoString {
+pub(crate) fn convert_typst_docs_shared(ctx: &SharedContext, docs: EcoString) -> EcoString {
     if docs.trim().is_empty() {
         return docs;
     }
 
-    let shared = ctx.shared_();
     let docs_text = DocText::plain(docs.clone());
-    match crate::docs::convert_docs(&shared, &docs_text, None) {
+    match crate::docs::convert_docs(ctx, &docs_text, None) {
         Ok(converted) => {
             let converted = remove_list_annotations(&converted);
             ctx.remove_html(converted.trim().into())

--- a/crates/tinymist-query/src/docs/module.rs
+++ b/crates/tinymist-query/src/docs/module.rs
@@ -1,10 +1,12 @@
 //! Module documentation.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ecow::{EcoString, EcoVec, eco_vec};
 use itertools::Itertools;
 use lsp_types::Position;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use typst::diag::StrResult;
 use typst::syntax::FileId;
@@ -14,6 +16,7 @@ use typst_shim::syntax::RootedPathExt;
 
 use crate::LocalContext;
 use crate::adt::interner::Interned;
+use crate::analysis::{Definition, SharedQueryCache};
 use crate::docs::file_id_repr;
 use crate::package::{PackageInfo, get_manifest_id, package_entrypoint_id};
 use crate::syntax::{Decl, DefKind, Expr, ExprInfo};
@@ -33,6 +36,7 @@ pub fn package_module_docs(ctx: &mut LocalContext, pkg: &PackageInfo) -> StrResu
 pub fn module_docs(ctx: &mut LocalContext, entry_point: FileId) -> StrResult<PackageDefInfo> {
     let mut aliases = HashMap::new();
     let mut extras = vec![];
+    let shared = ctx.shared().clone();
 
     let mut scan_ctx = ScanDefCtx {
         ctx,
@@ -46,7 +50,12 @@ pub fn module_docs(ctx: &mut LocalContext, entry_point: FileId) -> StrResult<Pac
         .ctx
         .expr_stage_by_id(entry_point)
         .ok_or("entry point not found")?;
-    let mut defs = scan_ctx.defs(eco_vec![], ei);
+    let docs_cache = SharedQueryCache::<Definition, Option<DefDocs>>::default();
+    let mut defs = enrich_def_docs_parallel(
+        shared.clone(),
+        docs_cache.clone(),
+        scan_ctx.defs(eco_vec![], ei),
+    );
 
     let module_uses = aliases
         .into_iter()
@@ -58,12 +67,53 @@ pub fn module_docs(ctx: &mut LocalContext, entry_point: FileId) -> StrResult<Pac
 
     crate::log_debug_ct!("module_uses: {module_uses:#?}",);
 
-    defs.children.extend(extras);
+    defs.children.extend(
+        extras
+            .into_par_iter()
+            .map(|extra| enrich_def_docs_parallel(shared.clone(), docs_cache.clone(), extra))
+            .collect::<Vec<_>>(),
+    );
 
     Ok(PackageDefInfo {
         root: defs,
         module_uses,
     })
+}
+
+fn enrich_def_docs_parallel(
+    shared: Arc<crate::analysis::SharedContext>,
+    docs_cache: SharedQueryCache<Definition, Option<DefDocs>>,
+    mut head: DefInfo,
+) -> DefInfo {
+    head.children = head
+        .children
+        .into_par_iter()
+        .map(|child| enrich_def_docs_parallel(shared.clone(), docs_cache.clone(), child))
+        .collect();
+
+    let def_docs = head
+        .decl
+        .as_ref()
+        .and_then(definition_for_docs)
+        .and_then(|definition| {
+            docs_cache.get_or_init(definition.clone(), || shared.def_docs(&definition))
+        });
+    head.docs = def_docs.as_ref().map(|docs| docs.docs().clone());
+    head.parsed_docs = def_docs;
+
+    if head.is_external {
+        head.oneliner = head.docs.as_ref().map(|docs| oneliner(docs).to_owned());
+        head.docs = None;
+    }
+
+    head
+}
+
+fn definition_for_docs(decl: &Interned<Decl>) -> Option<Definition> {
+    match decl.as_ref() {
+        Decl::Func(..) => Some(Definition::new(decl.clone().into(), None)),
+        _ => None,
+    }
 }
 
 /// Information about a definition.
@@ -194,9 +244,6 @@ impl ScanDefCtx<'_> {
         decl: &Interned<Decl>,
         expr: Option<&Expr>,
     ) -> DefInfo {
-        let def = self.ctx.def_of_decl(decl);
-        let def_docs = def.and_then(|def| self.ctx.def_docs(&def));
-        let docs = def_docs.as_ref().map(|docs| docs.docs().clone());
         let children = match decl.as_ref() {
             Decl::Module(..) => decl.file_id().and_then(|fid| {
                 // only generate docs for the same package
@@ -237,8 +284,8 @@ impl ScanDefCtx<'_> {
             name: key.to_string().into(),
             kind: decl.kind(),
             constant: expr.map(|expr| expr.repr()),
-            docs,
-            parsed_docs: def_docs,
+            docs: None,
+            parsed_docs: None,
             decl: Some(decl.clone()),
             children: children.unwrap_or_default(),
             symbol: None,
@@ -256,8 +303,6 @@ impl ScanDefCtx<'_> {
             && span != *mod_fid
         {
             head.is_external = true;
-            head.oneliner = head.docs.map(|docs| oneliner(&docs).to_owned());
-            head.docs = None;
         }
 
         // Insert module that is not exported

--- a/crates/tinymist-query/src/docs/module.rs
+++ b/crates/tinymist-query/src/docs/module.rs
@@ -111,7 +111,7 @@ fn enrich_def_docs_parallel(
 
 fn definition_for_docs(decl: &Interned<Decl>) -> Option<Definition> {
     match decl.as_ref() {
-        Decl::Func(..) => Some(Definition::new(decl.clone().into(), None)),
+        Decl::Func(..) => Some(Definition::new(decl.clone(), None)),
         _ => None,
     }
 }

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -1,5 +1,6 @@
 use core::fmt::Write;
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use ecow::{EcoString, EcoVec};
@@ -10,7 +11,7 @@ use tinymist_std::path::unix_slash;
 use tinymist_world::package::PackageSpec;
 use typst::diag::{StrResult, eco_format};
 use typst::syntax::package::PackageManifest;
-use typst::syntax::{FileId, Span, VirtualRoot};
+use typst::syntax::{FileId, Source, Span, SyntaxNode, VirtualRoot};
 use typst_shim::syntax::{RootedPathExt, source_range};
 
 use crate::LocalContext;
@@ -106,6 +107,67 @@ impl BundleSection {
     }
 }
 
+#[derive(Default)]
+struct PackageDocSpanIndex {
+    by_file: HashMap<FileId, SourceSpanIndex>,
+}
+
+struct SourceSpanIndex {
+    source: Source,
+    ranges: HashMap<Span, Range<usize>>,
+}
+
+impl PackageDocSpanIndex {
+    fn source(&mut self, ctx: &LocalContext, fid: FileId) -> Option<Source> {
+        Some(self.entry(ctx, fid)?.source.clone())
+    }
+
+    fn source_range(&mut self, ctx: &LocalContext, span: Span) -> Option<(Source, Range<usize>)> {
+        let fid = span.id()?;
+        let entry = self.entry(ctx, fid)?;
+        let range = entry
+            .ranges
+            .get(&span)
+            .cloned()
+            .or_else(|| source_range(&entry.source, span))?;
+        Some((entry.source.clone(), range))
+    }
+
+    fn entry(&mut self, ctx: &LocalContext, fid: FileId) -> Option<&SourceSpanIndex> {
+        if !self.by_file.contains_key(&fid) {
+            let source = ctx.source_by_id(fid).ok()?;
+            self.by_file.insert(fid, SourceSpanIndex::new(source));
+        }
+
+        self.by_file.get(&fid)
+    }
+}
+
+impl SourceSpanIndex {
+    fn new(source: Source) -> Self {
+        let mut ranges = HashMap::new();
+        collect_source_spans(source.root(), 0, &mut ranges);
+        Self { source, ranges }
+    }
+}
+
+fn collect_source_spans(
+    node: &SyntaxNode,
+    offset: usize,
+    ranges: &mut HashMap<Span, Range<usize>>,
+) {
+    let span = node.span();
+    if span.id().is_some() {
+        ranges.entry(span).or_insert(offset..offset + node.len());
+    }
+
+    let mut child_offset = offset;
+    for child in node.children() {
+        collect_source_spans(child, child_offset, ranges);
+        child_offset += child.len();
+    }
+}
+
 /// Generate full documents in markdown format
 pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<PackageDoc> {
     log::info!("generate_md_docs {spec:?}");
@@ -151,12 +213,13 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
     };
 
     let mut modules = vec![];
+    let mut span_index = PackageDocSpanIndex::default();
 
     while !modules_to_generate.is_empty() {
         for (parent_ident, mut def) in std::mem::take(&mut modules_to_generate) {
             // parent_ident, symbols
 
-            set_scip_symbol(ctx, &mut def);
+            set_scip_symbol(ctx, &mut span_index, &mut def);
             let module_val = def.decl.as_ref().unwrap();
             let fid = module_val.file_id();
             let aka = fid.map(&mut akas).unwrap_or_default();
@@ -175,24 +238,23 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
                 parent_ident: parent_ident.clone(),
                 aka,
                 path: fid.map(|fid| fid.vpath().get_without_slash().to_owned().into()),
-                source: fid.and_then(|fid| ctx.source_by_id(fid).ok().map(|src| src.text().into())),
+                source: fid
+                    .and_then(|fid| span_index.source(ctx, fid).map(|src| src.text().into())),
             };
 
             for child in def.children.iter_mut() {
-                set_scip_symbol(ctx, child);
+                set_scip_symbol(ctx, &mut span_index, child);
                 let span = child.decl.as_ref().map(|decl| decl.span());
                 let fid_range = span.and_then(|v| {
-                    v.id().and_then(|fid| {
-                        let allocated = file_ids.insert_full(fid).0;
-                        let src = ctx.source_by_id(fid).ok()?;
-                        let rng = source_range(&src, v)?;
-                        let start = ctx.to_lsp_range(rng.clone(), &src).start;
-                        child.source = Some(SourceQuery {
-                            file: allocated,
-                            position: start,
-                        });
-                        Some((allocated, rng.start, rng.end))
-                    })
+                    let fid = v.id()?;
+                    let allocated = file_ids.insert_full(fid).0;
+                    let (src, rng) = span_index.source_range(ctx, v)?;
+                    let start = ctx.to_lsp_range(rng.clone(), &src).start;
+                    child.source = Some(SourceQuery {
+                        file: allocated,
+                        position: start,
+                    });
+                    Some((allocated, rng.start, rng.end))
                 });
                 let child_fid = child.decl.as_ref().and_then(|decl| decl.file_id());
                 let child_fid = child_fid.or_else(|| span.and_then(Span::id)).or(fid);
@@ -349,12 +411,24 @@ fn is_public_api_symbol(def: &crate::docs::DefInfo) -> bool {
     !def.name.as_ref().starts_with('_')
 }
 
-fn set_scip_symbol(ctx: &LocalContext, def: &mut crate::docs::DefInfo) {
+fn set_scip_symbol(
+    ctx: &LocalContext,
+    span_index: &mut PackageDocSpanIndex,
+    def: &mut crate::docs::DefInfo,
+) {
     let Some(decl) = def.decl.as_ref() else {
         return;
     };
     let definition = Definition::new(decl.clone(), None);
-    def.symbol = crate::index::scip::scip_symbol(ctx.shared(), &definition).ok();
+    let disambiguator = span_index
+        .source_range(ctx, decl.span())
+        .map(|(source, range)| {
+            let start = ctx.to_lsp_range(range, &source).start;
+            format!("L{}_C{}", start.line, start.character)
+        })
+        .unwrap_or_else(|| format!("{:x}", decl.span().into_raw()));
+    def.symbol =
+        crate::index::scip::scip_symbol_with_disambiguator(&definition, disambiguator).ok();
 }
 
 /// Generate full documents in markdown format

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -147,9 +147,9 @@ impl PackageDocSpanIndex {
     }
 
     fn entry(&mut self, ctx: &LocalContext, fid: FileId) -> Option<&SourceSpanIndex> {
-        if !self.by_file.contains_key(&fid) {
+        if let std::collections::hash_map::Entry::Vacant(entry) = self.by_file.entry(fid) {
             let source = ctx.source_by_id(fid).ok()?;
-            self.by_file.insert(fid, SourceSpanIndex::new(source));
+            entry.insert(SourceSpanIndex::new(source));
         }
 
         self.by_file.get(&fid)

--- a/crates/tinymist-query/src/docs/package.rs
+++ b/crates/tinymist-query/src/docs/package.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use ecow::{EcoString, EcoVec};
 use indexmap::IndexSet;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use tinymist_analysis::docs::tidy::remove_list_annotations;
 use tinymist_std::path::unix_slash;
@@ -118,6 +119,18 @@ struct SourceSpanIndex {
 }
 
 impl PackageDocSpanIndex {
+    fn preload(ctx: &LocalContext, fids: &[FileId]) -> Self {
+        let shared = ctx.shared().clone();
+        let by_file = fids
+            .par_iter()
+            .filter_map(|fid| {
+                let source = shared.source_by_id(*fid).ok()?;
+                Some((*fid, SourceSpanIndex::new(source)))
+            })
+            .collect();
+        Self { by_file }
+    }
+
     fn source(&mut self, ctx: &LocalContext, fid: FileId) -> Option<Source> {
         Some(self.entry(ctx, fid)?.source.clone())
     }
@@ -180,6 +193,10 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
         .expect("package manifest must be in a package");
     let entry_point = package_entrypoint_id(toml_id, &manifest.package.entrypoint);
 
+    let depended: Vec<_> = ctx.depended_source_files().into_iter().collect();
+    ctx.preload_expr_stages(depended.iter().copied());
+    let mut span_index = PackageDocSpanIndex::preload(ctx, &depended);
+
     let PackageDefInfo { root, module_uses } = module_docs(ctx, entry_point)?;
 
     crate::log_debug_ct!("module_uses: {module_uses:#?}");
@@ -213,7 +230,6 @@ pub fn package_docs(ctx: &mut LocalContext, spec: &PackageInfo) -> StrResult<Pac
     };
 
     let mut modules = vec![];
-    let mut span_index = PackageDocSpanIndex::default();
 
     while !modules_to_generate.is_empty() {
         for (parent_ident, mut def) in std::mem::take(&mut modules_to_generate) {

--- a/crates/tinymist-query/src/hover.rs
+++ b/crates/tinymist-query/src/hover.rs
@@ -28,10 +28,18 @@ pub struct HoverRequest {
     pub position: LspPosition,
 }
 
-pub(crate) fn hover_from_definition(
-    ctx: &mut LocalContext,
+pub(crate) fn hover_from_definition_shared(
+    ctx: &Arc<crate::analysis::SharedContext>,
     def: &Definition,
     range: Option<LspRange>,
+) -> Option<Hover> {
+    hover_from_docs(def, range, ctx.def_docs(def))
+}
+
+fn hover_from_docs(
+    def: &Definition,
+    range: Option<LspRange>,
+    sym_docs: Option<DefDocs>,
 ) -> Option<Hover> {
     let mut contents = vec![];
 
@@ -49,8 +57,6 @@ pub(crate) fn hover_from_definition(
             contents.push(format!("Bibliography: `{}`", def.name()));
         }
         _ => {
-            let sym_docs = ctx.def_docs(def);
-
             if matches!(
                 def.decl.kind(),
                 DefKind::Function | DefKind::Variable | DefKind::Constant

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -8,13 +8,12 @@
 use core::fmt;
 use std::sync::Arc;
 
-use crate::analysis::{SemanticTokens, SharedContext, SharedQueryCache};
+use crate::analysis::{SemanticTokens, SharedContext};
 use crate::index::protocol::ResultSet;
 use crate::prelude::Definition;
 use crate::{LocalContext, path_to_url};
 use ecow::EcoString;
 use lsp_types::{Hover, Url};
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tinymist_analysis::docs::DefDocs;
 use tinymist_analysis::syntax::classify_syntax;
 use tinymist_std::error::WithContextUntyped;
@@ -334,14 +333,16 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
         }
     }
 
-    let shared = ctx.shared().clone();
-    let hovers = SharedQueryCache::<Definition, Option<Hover>>::default();
-    let def_docs = SharedQueryCache::<Definition, Option<DefDocs>>::default();
+    let mut worker = DumpWorker {
+        ctx,
+        strings: FxHashMap::default(),
+        references: FxHashMap::default(),
+        hovers: FxHashMap::default(),
+        def_docs: FxHashMap::default(),
+    };
     let files = files
-        .par_iter()
-        .map(move |fid| {
-            DumpWorker::new(shared.clone(), hovers.clone(), def_docs.clone()).file(*fid)
-        })
+        .iter()
+        .map(move |fid| worker.file(fid))
         .collect::<tinymist_std::Result<Vec<FileIndex>>>()?;
 
     Ok(Knowledge {
@@ -359,46 +360,43 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
     })
 }
 
-struct DumpWorker {
-    /// The shared context.
-    ctx: Arc<SharedContext>,
+struct DumpWorker<'a> {
+    /// The context.
+    ctx: &'a mut LocalContext,
+    /// A string interner.
+    strings: FxHashMap<EcoString, EcoString>,
     /// The references collected so far.
     references: FxHashMap<Span, ReferenceIndex>,
-    /// Shared static hover results.
-    hovers: SharedQueryCache<Definition, Option<Hover>>,
-    /// Shared typed documentation.
-    def_docs: SharedQueryCache<Definition, Option<DefDocs>>,
+    /// The static hover results collected so far.
+    hovers: FxHashMap<Definition, Option<Hover>>,
+    /// The typed documentation collected so far.
+    def_docs: FxHashMap<Definition, Option<DefDocs>>,
 }
 
-impl DumpWorker {
-    fn new(
-        ctx: Arc<SharedContext>,
-        hovers: SharedQueryCache<Definition, Option<Hover>>,
-        def_docs: SharedQueryCache<Definition, Option<DefDocs>>,
-    ) -> Self {
-        Self {
-            ctx,
-            references: FxHashMap::default(),
-            hovers,
-            def_docs,
-        }
-    }
-
-    fn file(&mut self, fid: FileId) -> tinymist_std::Result<FileIndex> {
-        let source = self.ctx.source_by_id(fid).context_ut("cannot parse")?;
-        let semantic_tokens =
-            crate::analysis::semantic_tokens::get_semantic_tokens(&self.ctx, &source);
+impl DumpWorker<'_> {
+    fn file(&mut self, fid: &FileId) -> tinymist_std::Result<FileIndex> {
+        let source = self.ctx.source_by_id(*fid).context_ut("cannot parse")?;
+        let semantic_tokens = crate::SemanticTokensFullRequest::compute(self.ctx, &source);
 
         let root = LinkedNode::new(source.root());
         self.walk(&source, &root);
         let references = std::mem::take(&mut self.references);
 
         Ok(FileIndex {
-            fid,
+            fid: *fid,
             semantic_tokens,
-            documentation: Some(EcoString::from("File documentation.")), // todo
+            documentation: Some(self.intern("File documentation.")), // todo
             references,
         })
+    }
+
+    fn intern(&mut self, s: &str) -> EcoString {
+        if let Some(v) = self.strings.get(s) {
+            return v.clone();
+        }
+        let v = EcoString::from(s);
+        self.strings.insert(v.clone(), v.clone());
+        v
     }
 
     fn walk(&mut self, source: &Source, node: &LinkedNode) {
@@ -434,13 +432,22 @@ impl DumpWorker {
     }
 
     fn hover(&mut self, definition: &Definition) -> Option<Hover> {
-        self.hovers.get_or_init(definition.clone(), || {
-            crate::hover::hover_from_definition_shared(&self.ctx, definition, None)
-        })
+        if let Some(hover) = self.hovers.get(definition) {
+            return hover.clone();
+        }
+
+        let hover = crate::hover::hover_from_definition_shared(self.ctx.shared(), definition, None);
+        self.hovers.insert(definition.clone(), hover.clone());
+        hover
     }
 
     fn def_docs(&mut self, definition: &Definition) -> Option<DefDocs> {
-        self.def_docs
-            .get_or_init(definition.clone(), || self.ctx.def_docs(definition))
+        if let Some(docs) = self.def_docs.get(definition) {
+            return docs.clone();
+        }
+
+        let docs = self.ctx.def_docs(definition);
+        self.def_docs.insert(definition.clone(), docs.clone());
+        docs
     }
 }

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -8,12 +8,13 @@
 use core::fmt;
 use std::sync::Arc;
 
-use crate::analysis::{SemanticTokens, SharedContext};
+use crate::analysis::{SemanticTokens, SharedContext, SharedQueryCache};
 use crate::index::protocol::ResultSet;
 use crate::prelude::Definition;
 use crate::{LocalContext, path_to_url};
 use ecow::EcoString;
 use lsp_types::{Hover, Url};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tinymist_analysis::docs::DefDocs;
 use tinymist_analysis::syntax::classify_syntax;
 use tinymist_std::error::WithContextUntyped;
@@ -333,16 +334,14 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
         }
     }
 
-    let mut worker = DumpWorker {
-        ctx,
-        strings: FxHashMap::default(),
-        references: FxHashMap::default(),
-        hovers: FxHashMap::default(),
-        def_docs: FxHashMap::default(),
-    };
+    let shared = ctx.shared().clone();
+    let hovers = SharedQueryCache::<Definition, Option<Hover>>::default();
+    let def_docs = SharedQueryCache::<Definition, Option<DefDocs>>::default();
     let files = files
-        .iter()
-        .map(move |fid| worker.file(fid))
+        .par_iter()
+        .map(move |fid| {
+            DumpWorker::new(shared.clone(), hovers.clone(), def_docs.clone()).file(*fid)
+        })
         .collect::<tinymist_std::Result<Vec<FileIndex>>>()?;
 
     Ok(Knowledge {
@@ -360,43 +359,46 @@ pub fn knowledge(ctx: &mut LocalContext) -> tinymist_std::Result<Knowledge> {
     })
 }
 
-struct DumpWorker<'a> {
-    /// The context.
-    ctx: &'a mut LocalContext,
-    /// A string interner.
-    strings: FxHashMap<EcoString, EcoString>,
+struct DumpWorker {
+    /// The shared context.
+    ctx: Arc<SharedContext>,
     /// The references collected so far.
     references: FxHashMap<Span, ReferenceIndex>,
-    /// The static hover results collected so far.
-    hovers: FxHashMap<Definition, Option<Hover>>,
-    /// The typed documentation collected so far.
-    def_docs: FxHashMap<Definition, Option<DefDocs>>,
+    /// Shared static hover results.
+    hovers: SharedQueryCache<Definition, Option<Hover>>,
+    /// Shared typed documentation.
+    def_docs: SharedQueryCache<Definition, Option<DefDocs>>,
 }
 
-impl DumpWorker<'_> {
-    fn file(&mut self, fid: &FileId) -> tinymist_std::Result<FileIndex> {
-        let source = self.ctx.source_by_id(*fid).context_ut("cannot parse")?;
-        let semantic_tokens = crate::SemanticTokensFullRequest::compute(self.ctx, &source);
+impl DumpWorker {
+    fn new(
+        ctx: Arc<SharedContext>,
+        hovers: SharedQueryCache<Definition, Option<Hover>>,
+        def_docs: SharedQueryCache<Definition, Option<DefDocs>>,
+    ) -> Self {
+        Self {
+            ctx,
+            references: FxHashMap::default(),
+            hovers,
+            def_docs,
+        }
+    }
+
+    fn file(&mut self, fid: FileId) -> tinymist_std::Result<FileIndex> {
+        let source = self.ctx.source_by_id(fid).context_ut("cannot parse")?;
+        let semantic_tokens =
+            crate::analysis::semantic_tokens::get_semantic_tokens_shared(&self.ctx, &source);
 
         let root = LinkedNode::new(source.root());
         self.walk(&source, &root);
         let references = std::mem::take(&mut self.references);
 
         Ok(FileIndex {
-            fid: *fid,
+            fid,
             semantic_tokens,
-            documentation: Some(self.intern("File documentation.")), // todo
+            documentation: Some(EcoString::from("File documentation.")), // todo
             references,
         })
-    }
-
-    fn intern(&mut self, s: &str) -> EcoString {
-        if let Some(v) = self.strings.get(s) {
-            return v.clone();
-        }
-        let v = EcoString::from(s);
-        self.strings.insert(v.clone(), v.clone());
-        v
     }
 
     fn walk(&mut self, source: &Source, node: &LinkedNode) {
@@ -432,22 +434,13 @@ impl DumpWorker<'_> {
     }
 
     fn hover(&mut self, definition: &Definition) -> Option<Hover> {
-        if let Some(hover) = self.hovers.get(definition) {
-            return hover.clone();
-        }
-
-        let hover = crate::hover::hover_from_definition(self.ctx, definition, None);
-        self.hovers.insert(definition.clone(), hover.clone());
-        hover
+        self.hovers.get_or_init(definition.clone(), || {
+            crate::hover::hover_from_definition_shared(&self.ctx, definition, None)
+        })
     }
 
     fn def_docs(&mut self, definition: &Definition) -> Option<DefDocs> {
-        if let Some(docs) = self.def_docs.get(definition) {
-            return docs.clone();
-        }
-
-        let docs = self.ctx.def_docs(definition);
-        self.def_docs.insert(definition.clone(), docs.clone());
-        docs
+        self.def_docs
+            .get_or_init(definition.clone(), || self.ctx.def_docs(definition))
     }
 }

--- a/crates/tinymist-query/src/index/mod.rs
+++ b/crates/tinymist-query/src/index/mod.rs
@@ -387,7 +387,7 @@ impl DumpWorker {
     fn file(&mut self, fid: FileId) -> tinymist_std::Result<FileIndex> {
         let source = self.ctx.source_by_id(fid).context_ut("cannot parse")?;
         let semantic_tokens =
-            crate::analysis::semantic_tokens::get_semantic_tokens_shared(&self.ctx, &source);
+            crate::analysis::semantic_tokens::get_semantic_tokens(&self.ctx, &source);
 
         let root = LinkedNode::new(source.root());
         self.walk(&source, &root);

--- a/crates/tinymist-query/src/index/scip.rs
+++ b/crates/tinymist-query/src/index/scip.rs
@@ -369,6 +369,14 @@ pub(crate) fn scip_symbol(
     ctx: &SharedContext,
     definition: &Definition,
 ) -> tinymist_std::Result<String> {
+    let disambiguator = definition_disambiguator(ctx, definition);
+    scip_symbol_with_disambiguator(definition, disambiguator)
+}
+
+pub(crate) fn scip_symbol_with_disambiguator(
+    definition: &Definition,
+    disambiguator: String,
+) -> tinymist_std::Result<String> {
     let mut descriptors = Vec::new();
     if let Some(fid) = definition.file_id() {
         let path = fid.vpath().get_without_slash();
@@ -386,7 +394,7 @@ pub(crate) fn scip_symbol(
     }
 
     descriptors.push(scip_descriptor(
-        &definition_disambiguator(ctx, definition),
+        &disambiguator,
         descriptor::Suffix::Meta,
         "",
     ));

--- a/crates/tinymist-query/src/semantic_tokens_full.rs
+++ b/crates/tinymist-query/src/semantic_tokens_full.rs
@@ -40,7 +40,7 @@ impl SemanticRequest for SemanticTokensFullRequest {
 impl SemanticTokensFullRequest {
     /// Computes the semantic tokens for a given source code.
     pub fn compute(ctx: &mut LocalContext, source: &Source) -> crate::analysis::SemanticTokens {
-        crate::analysis::semantic_tokens::get_semantic_tokens(ctx, source)
+        crate::analysis::semantic_tokens::get_semantic_tokens(ctx.shared(), source)
     }
 }
 

--- a/crates/tinymist-query/src/signature_help.rs
+++ b/crates/tinymist-query/src/signature_help.rs
@@ -127,7 +127,7 @@ impl SemanticRequest for SignatureHelpRequest {
 }
 
 fn markdown_docs(ctx: &mut LocalContext, docs: &crate::docs::DocText) -> Documentation {
-    let docs = crate::docs::resolve_doc_text(ctx, docs);
+    let docs = crate::docs::resolve_doc_text(ctx.shared(), docs);
     Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value: docs.into(),


### PR DESCRIPTION
- cache source span lookups once per source during package docs generation
- reuse cached ranges for package docs source queries and SCIP symbol disambiguators
- avoid repeated syntax tree walks when exporting large package docs