### PR TITLE
dev(preview-frontend): split page host helpers

### DIFF
--- a/tools/typst-preview-frontend-ng/src/interactions.ts
+++ b/tools/typst-preview-frontend-ng/src/interactions.ts
@@ -1,3 +1,6 @@
+import type { PageLayout, PageRecord } from "./types";
+import { clamp } from "./utils";
+
 export interface PageRect {
   x: number;
   y: number;
@@ -41,6 +44,34 @@ export interface PageInteractions {
   links: LinkInteraction[];
   texts: TextInteraction[];
 }
+
+interface PagePoint {
+  x: number;
+  y: number;
+}
+
+interface PagePointer extends PagePoint {
+  pageIndex: number;
+}
+
+interface ActiveTextHover {
+  generation: number;
+  pageIndex: number;
+  rect: PageRect;
+}
+
+interface PendingTextHover extends PagePointer {
+  requestId: number;
+  generation: number;
+  text: TextInteraction;
+}
+
+interface PendingBoundHover extends PagePointer {
+  requestId: number;
+  generation: number;
+}
+
+type InteractionHighlightKind = "link" | "text" | "bound";
 
 const textHighlightEnabled = false;
 
@@ -154,6 +185,706 @@ export function textHighlightsForLink(
   return dedupeLinkTextHighlights(highlights);
 }
 
+function pagePointFromEvent(record: PageRecord, event: MouseEvent): PagePoint | undefined {
+  const rect = record.shell.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) {
+    return undefined;
+  }
+
+  return {
+    x: clamp(((event.clientX - rect.left) / rect.width) * record.width, 0, record.width),
+    y: clamp(((event.clientY - rect.top) / rect.height) * record.height, 0, record.height),
+  };
+}
+
+function isDragClick(
+  record: PageRecord,
+  pointerDown: PagePointer | undefined,
+  event: MouseEvent,
+) {
+  if (!pointerDown || pointerDown.pageIndex !== record.index) {
+    return false;
+  }
+
+  const distance = Math.hypot(event.clientX - pointerDown.x, event.clientY - pointerDown.y);
+  return distance > 4;
+}
+
+function textVisualRectKey(generation: number, pageIndex: number, textId: number) {
+  return `${generation}:${pageIndex}:${textId}`;
+}
+
+function textHoverRect(text: TextInteraction, hitRect: PageRect | undefined) {
+  return hitRect || text.rect;
+}
+
+function rectContainsPage(rect: PageRect, x: number, y: number) {
+  return x >= rect.x && y >= rect.y && x <= rect.x + rect.width && y <= rect.y + rect.height;
+}
+
+function alignTextClipToVisualRect(clippedRect: PageRect, visualRect: PageRect): PageRect {
+  return {
+    x: clippedRect.x,
+    y: visualRect.y,
+    width: clippedRect.width,
+    height: visualRect.height,
+  };
+}
+
+function renderLinkAnchors(record: PageRecord) {
+  const interactions = record.interactions;
+  if (!interactions) {
+    record.linkLayer.replaceChildren();
+    return;
+  }
+
+  const anchors = interactions.links.flatMap((link) => {
+    if (link.target.kind !== "external") {
+      return [];
+    }
+
+    const anchor = document.createElement("a");
+    anchor.href = link.target.href;
+    anchor.target = "_blank";
+    anchor.rel = "noopener noreferrer";
+    anchor.title = link.target.href;
+    anchor.setAttribute("aria-label", link.target.href);
+    anchor.addEventListener("click", (event) => event.stopPropagation());
+    applyPageRectStyle(record, anchor, link.rect);
+    return [anchor];
+  });
+
+  record.linkLayer.replaceChildren(...anchors);
+}
+
+function renderInteractionHighlights(
+  record: PageRecord,
+  rects: PageRect[],
+  kind: InteractionHighlightKind,
+) {
+  record.interactionLayer.replaceChildren(
+    ...rects.slice(0, 64).map((rect) => {
+      const highlight = document.createElement("div");
+      highlight.className = `typst-interaction-highlight ${kind}`;
+      applyPageRectStyle(record, highlight, rect);
+      return highlight;
+    }),
+  );
+}
+
+function clearInteractionLayer(record: PageRecord) {
+  record.container.style.cursor = "";
+  record.interactionLayer.replaceChildren();
+}
+
+type LinkPosition = NonNullable<LinkTarget["position"]>;
+
+export interface PageInteractionControllerOptions {
+  postWorker: (message: unknown) => void;
+  getRecord: (pageIndex: number) => PageRecord | undefined;
+  getRecords: () => Iterable<PageRecord>;
+  getViewport: () => HTMLElement;
+  isDragging: () => boolean;
+  isContentPreview: () => boolean;
+  scrollToTypstLocation: (position: LinkPosition) => void;
+}
+
+export class PageInteractionController {
+  private generation = 0;
+  private pointerDown: PagePointer | undefined;
+  private lastPointer: PagePointer | undefined;
+  private activeHoverKey = "";
+  private activeTextHover: ActiveTextHover | undefined;
+  private readonly textHoverRects = new Map<string, PageRect>();
+  private readonly pendingTextRectRequests = new Set<string>();
+  private readonly pendingInteractionRequests = new Set<number>();
+  private nextHitRequestId = 0;
+  private pendingTextHover: PendingTextHover | undefined;
+  private pendingBoundHover: PendingBoundHover | undefined;
+
+  constructor(private readonly options: PageInteractionControllerOptions) {}
+
+  matchesGeneration(generation: number) {
+    return generation === this.generation;
+  }
+
+  handleDraggingChanged(active: boolean) {
+    if (!active) {
+      return;
+    }
+    this.activeHoverKey = "";
+    this.activeTextHover = undefined;
+    this.pendingTextHover = undefined;
+    this.pendingBoundHover = undefined;
+  }
+
+  startGeneration(generation: number) {
+    if (this.generation === generation) {
+      return false;
+    }
+
+    this.generation = generation;
+    this.textHoverRects.clear();
+    this.pendingTextRectRequests.clear();
+    this.pendingInteractionRequests.clear();
+    this.activeTextHover = undefined;
+    this.pendingTextHover = undefined;
+    this.pendingBoundHover = undefined;
+
+    for (const record of this.options.getRecords()) {
+      record.interactions = undefined;
+      renderLinkAnchors(record);
+    }
+
+    return true;
+  }
+
+  removePage(pageIndex: number) {
+    if (this.lastPointer?.pageIndex === pageIndex) {
+      this.lastPointer = undefined;
+      this.activeHoverKey = "";
+    }
+  }
+
+  resetAll() {
+    this.generation = 0;
+    this.pointerDown = undefined;
+    this.lastPointer = undefined;
+    this.activeHoverKey = "";
+    this.activeTextHover = undefined;
+    this.textHoverRects.clear();
+    this.pendingTextRectRequests.clear();
+    this.pendingInteractionRequests.clear();
+    this.pendingTextHover = undefined;
+    this.pendingBoundHover = undefined;
+  }
+
+  installPageHandlers(record: PageRecord) {
+    record.container.addEventListener("mousedown", (event) => {
+      if (event.button !== 0) {
+        return;
+      }
+      this.pointerDown = {
+        pageIndex: record.index,
+        x: event.clientX,
+        y: event.clientY,
+      };
+    });
+
+    record.container.addEventListener("mousemove", (event) => {
+      this.handlePagePointerMove(record, event);
+    });
+
+    record.container.addEventListener("mouseleave", () => {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      if (this.lastPointer?.pageIndex === record.index) {
+        this.lastPointer = undefined;
+      }
+    });
+
+    record.container.addEventListener("click", (event) => {
+      this.handlePageClick(record, event);
+    });
+  }
+
+  updateInteractions(
+    generation: number,
+    interactions: PageInteractions[],
+    invalidatedPageIndices: number[] = [],
+  ) {
+    if (!this.matchesGeneration(generation)) {
+      return;
+    }
+    let refreshHover = false;
+    for (const pageIndex of invalidatedPageIndices) {
+      const record = this.options.getRecord(pageIndex);
+      if (record) {
+        record.interactions = undefined;
+        renderLinkAnchors(record);
+        refreshHover ||= this.lastPointer?.pageIndex === record.index;
+      }
+      this.pendingInteractionRequests.delete(pageIndex);
+    }
+    for (const pageInteractions of interactions) {
+      const record = this.options.getRecord(pageInteractions.pageIndex);
+      if (record) {
+        record.interactions = pageInteractions;
+        renderLinkAnchors(record);
+        refreshHover ||= this.lastPointer?.pageIndex === record.index;
+      }
+      this.pendingInteractionRequests.delete(pageInteractions.pageIndex);
+    }
+    if (refreshHover) {
+      this.activeHoverKey = "";
+      this.restoreInteractionHover();
+    }
+  }
+
+  markEvicted(generation: number, pageIndices: number[]) {
+    if (!this.matchesGeneration(generation)) {
+      return;
+    }
+    let refreshHover = false;
+    for (const pageIndex of pageIndices) {
+      const record = this.options.getRecord(pageIndex);
+      if (!record) {
+        continue;
+      }
+      record.interactions = undefined;
+      renderLinkAnchors(record);
+      this.pendingInteractionRequests.delete(pageIndex);
+      refreshHover ||= this.lastPointer?.pageIndex === pageIndex;
+    }
+    if (refreshHover) {
+      this.activeHoverKey = "";
+      this.activeTextHover = undefined;
+      this.restoreInteractionHover();
+    }
+  }
+
+  handleBoundHit(message: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    bound?: BoundInteraction;
+  }) {
+    const pending = this.pendingBoundHover;
+    if (
+      !pending ||
+      pending.requestId !== message.requestId ||
+      pending.generation !== message.generation ||
+      pending.pageIndex !== message.pageIndex ||
+      !this.matchesGeneration(message.generation)
+    ) {
+      return;
+    }
+
+    if (
+      !this.lastPointer ||
+      this.lastPointer.pageIndex !== message.pageIndex ||
+      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
+    ) {
+      return;
+    }
+
+    const record = this.options.getRecord(message.pageIndex);
+    if (!record) {
+      return;
+    }
+
+    if (!message.bound) {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      return;
+    }
+
+    this.showBoundHover(record, message.bound);
+  }
+
+  handleTextHit(message: {
+    requestId: number;
+    generation: number;
+    pageIndex: number;
+    x: number;
+    y: number;
+    hit: boolean;
+    rect?: PageRect;
+  }) {
+    const pending = this.pendingTextHover;
+    if (
+      !pending ||
+      pending.requestId !== message.requestId ||
+      pending.generation !== message.generation ||
+      pending.pageIndex !== message.pageIndex ||
+      !this.matchesGeneration(message.generation)
+    ) {
+      return;
+    }
+
+    if (
+      !this.lastPointer ||
+      this.lastPointer.pageIndex !== message.pageIndex ||
+      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
+    ) {
+      return;
+    }
+
+    const record = this.options.getRecord(message.pageIndex);
+    if (!record) {
+      return;
+    }
+
+    if (message.hit && this.textHitContains(pending.text, message.rect, message.x, message.y)) {
+      this.showTextHover(record, pending.text, message.rect);
+      return;
+    }
+
+    this.clearInteractionHighlight(record);
+    this.activeHoverKey = "";
+    this.requestBoundHover(record, { x: message.x, y: message.y });
+  }
+
+  handleTextRect(message: {
+    generation: number;
+    pageIndex: number;
+    textId: number;
+    rect?: PageRect;
+  }) {
+    if (!this.matchesGeneration(message.generation)) {
+      return;
+    }
+
+    const key = textVisualRectKey(this.generation, message.pageIndex, message.textId);
+    this.pendingTextRectRequests.delete(key);
+    if (message.rect) {
+      this.textHoverRects.set(key, message.rect);
+    }
+
+    if (this.lastPointer?.pageIndex === message.pageIndex) {
+      this.activeHoverKey = "";
+      this.restoreInteractionHover();
+    }
+  }
+
+  requestViewportInteractions(layouts: PageLayout[]) {
+    if (this.generation <= 0) {
+      return;
+    }
+    if (this.options.isDragging()) {
+      return;
+    }
+
+    const viewport = this.options.getViewport();
+    const viewportTop = viewport.scrollTop;
+    const viewportBottom = viewportTop + viewport.clientHeight;
+    const pageIndices = layouts
+      .filter((layout) => layout.bottom >= viewportTop && layout.top <= viewportBottom)
+      .map((layout) => layout.index);
+    this.requestPageInteractions(pageIndices);
+  }
+
+  private handlePagePointerMove(record: PageRecord, event: MouseEvent) {
+    if (this.options.isDragging()) {
+      if (this.activeHoverKey || record.interactionLayer.childElementCount > 0) {
+        this.clearInteractionHighlight(record);
+        this.activeHoverKey = "";
+      }
+      this.lastPointer = undefined;
+      return;
+    }
+
+    const point = pagePointFromEvent(record, event);
+    if (!point) {
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      this.lastPointer = undefined;
+      return;
+    }
+
+    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
+    this.updateInteractionHover(record, point);
+  }
+
+  private updateInteractionHover(record: PageRecord, point: PagePoint) {
+    if (!record.interactions) {
+      this.requestPageInteractions([record.index]);
+      this.clearInteractionHighlight(record);
+      this.activeHoverKey = "";
+      return;
+    }
+
+    const link = hitTestLink(record.interactions, point.x, point.y);
+    if (link) {
+      this.showLinkHover(record, link);
+      return;
+    }
+
+    if (this.activeTextHoverContains(record, point)) {
+      record.container.style.cursor = "text";
+      return;
+    }
+
+    const cachedText = this.cachedTextHoverAt(record, point);
+    if (cachedText) {
+      this.showTextHoverRect(record, cachedText.text, cachedText.rect);
+      return;
+    }
+
+    const text = hitTestText(record.interactions, point.x, point.y);
+    if (text) {
+      this.requestTextHover(record, text, point);
+      return;
+    }
+
+    this.requestBoundHover(record, point);
+  }
+
+  private restoreInteractionHover() {
+    if (!this.lastPointer) {
+      return;
+    }
+    const record = this.options.getRecord(this.lastPointer.pageIndex);
+    if (!record) {
+      return;
+    }
+    this.updateInteractionHover(record, this.lastPointer);
+  }
+
+  private requestPageInteractions(pageIndices: number[]) {
+    const missing: number[] = [];
+    const seen = new Set<number>();
+    for (const pageIndex of pageIndices) {
+      if (seen.has(pageIndex) || this.pendingInteractionRequests.has(pageIndex)) {
+        continue;
+      }
+      seen.add(pageIndex);
+
+      const record = this.options.getRecord(pageIndex);
+      if (!record || record.interactions) {
+        continue;
+      }
+
+      this.pendingInteractionRequests.add(pageIndex);
+      missing.push(pageIndex);
+    }
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    this.options.postWorker({
+      type: "request-interactions",
+      generation: this.generation,
+      pageIndices: missing,
+    });
+  }
+
+  private handlePageClick(record: PageRecord, event: MouseEvent) {
+    const wasDragClick = isDragClick(record, this.pointerDown, event);
+    this.pointerDown = undefined;
+    if (wasDragClick) {
+      return;
+    }
+
+    const point = pagePointFromEvent(record, event);
+    if (!point) {
+      return;
+    }
+    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
+
+    if (!record.interactions) {
+      this.requestPageInteractions([record.index]);
+    }
+
+    const link = hitTestLink(record.interactions, point.x, point.y);
+    if (link?.target.kind === "internal" && link.target.position) {
+      event.preventDefault();
+      this.options.scrollToTypstLocation(link.target.position);
+      return;
+    }
+
+    if (this.options.isContentPreview()) {
+      this.options.postWorker({ type: "send", text: `outline-sync,${record.index + 1}` });
+      return;
+    }
+
+    this.options.postWorker({
+      type: "send",
+      text: `src-point ${JSON.stringify({
+        page_no: record.index + 1,
+        x: point.x,
+        y: point.y,
+      })}`,
+    });
+  }
+
+  private showLinkHover(record: PageRecord, link: LinkInteraction) {
+    const key = `link:${record.index}:${link.target.kind}:${link.target.href}:${link.rect.x}:${link.rect.y}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    this.activeTextHover = undefined;
+    record.container.style.cursor = "pointer";
+
+    const textRects = textHighlightsForLink(record.interactions, link).map((highlight) => {
+      this.requestTextVisualRect(record, highlight.text);
+      const visualRect = this.textHoverRects.get(
+        textVisualRectKey(this.generation, record.index, highlight.text.id),
+      );
+      return visualRect ? alignTextClipToVisualRect(highlight.rect, visualRect) : highlight.rect;
+    });
+    renderInteractionHighlights(record, textRects, "link");
+  }
+
+  private showTextHover(record: PageRecord, text: TextInteraction, hitRect?: PageRect) {
+    const visualRect = textHoverRect(text, hitRect);
+    this.textHoverRects.set(textVisualRectKey(this.generation, record.index, text.id), visualRect);
+    this.showTextHoverRect(record, text, visualRect);
+  }
+
+  private showTextHoverRect(record: PageRecord, text: TextInteraction, visualRect: PageRect) {
+    const key = [
+      "text",
+      record.index,
+      text.id,
+      visualRect.x,
+      visualRect.y,
+      visualRect.width,
+      visualRect.height,
+    ].join(":");
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    this.activeTextHover = {
+      generation: this.generation,
+      pageIndex: record.index,
+      rect: visualRect,
+    };
+    record.container.style.cursor = "text";
+    renderInteractionHighlights(record, [visualRect], "text");
+  }
+
+  private requestTextHover(record: PageRecord, text: TextInteraction, point: PagePoint) {
+    const key = `text-query:${record.index}:${text.id}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+
+    const request = {
+      requestId: ++this.nextHitRequestId,
+      generation: this.generation,
+      pageIndex: record.index,
+      x: point.x,
+      y: point.y,
+      text,
+    };
+    this.activeHoverKey = key;
+    this.pendingTextHover = request;
+    record.container.style.cursor = "";
+    this.options.postWorker({
+      type: "hit-text",
+      requestId: request.requestId,
+      generation: request.generation,
+      pageIndex: request.pageIndex,
+      x: request.x,
+      y: request.y,
+      rect: text.rect,
+    });
+  }
+
+  private requestTextVisualRect(record: PageRecord, text: TextInteraction) {
+    const key = textVisualRectKey(this.generation, record.index, text.id);
+    if (this.textHoverRects.has(key) || this.pendingTextRectRequests.has(key)) {
+      return;
+    }
+    this.pendingTextRectRequests.add(key);
+    this.options.postWorker({
+      type: "resolve-text-rect",
+      requestId: ++this.nextHitRequestId,
+      generation: this.generation,
+      pageIndex: record.index,
+      textId: text.id,
+      rect: text.rect,
+    });
+  }
+
+  private showBoundHover(record: PageRecord, bound: BoundInteraction) {
+    const key = [
+      "bound",
+      record.index,
+      bound.kind,
+      bound.rect.x,
+      bound.rect.y,
+      bound.rect.width,
+      bound.rect.height,
+    ].join(":");
+    if (this.activeHoverKey === key) {
+      return;
+    }
+    this.activeHoverKey = key;
+    this.activeTextHover = undefined;
+    record.container.style.cursor = "";
+    renderInteractionHighlights(record, [bound.rect], "bound");
+  }
+
+  private requestBoundHover(record: PageRecord, point: PagePoint) {
+    const key = `bound-query:${record.index}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
+    if (this.activeHoverKey === key) {
+      return;
+    }
+
+    const request = {
+      requestId: ++this.nextHitRequestId,
+      generation: this.generation,
+      pageIndex: record.index,
+      x: point.x,
+      y: point.y,
+    };
+    this.activeHoverKey = key;
+    this.pendingBoundHover = request;
+    record.container.style.cursor = "";
+    this.options.postWorker({
+      type: "hit-bound",
+      ...request,
+    });
+  }
+
+  private clearInteractionHighlight(record: PageRecord) {
+    this.activeTextHover = undefined;
+    clearInteractionLayer(record);
+  }
+
+  private activeTextHoverContains(record: PageRecord, point: PagePoint) {
+    return (
+      this.activeTextHover?.generation === this.generation &&
+      this.activeTextHover.pageIndex === record.index &&
+      rectContainsPage(this.activeTextHover.rect, point.x, point.y)
+    );
+  }
+
+  private cachedTextHoverAt(record: PageRecord, point: PagePoint) {
+    const texts = record.interactions?.texts;
+    if (!texts) {
+      return undefined;
+    }
+    for (let index = texts.length - 1; index >= 0; index -= 1) {
+      const text = texts[index];
+      const rect = this.textHoverRects.get(
+        textVisualRectKey(this.generation, record.index, text.id),
+      );
+      if (rect && rectContainsPage(rect, point.x, point.y)) {
+        return { text, rect };
+      }
+    }
+    return undefined;
+  }
+
+  private textHitContains(
+    text: TextInteraction,
+    hitRect: PageRect | undefined,
+    x: number,
+    y: number,
+  ) {
+    return rectContainsPage(textHoverRect(text, hitRect), x, y);
+  }
+}
+
+function applyPageRectStyle(record: PageRecord, element: HTMLElement, rect: PageRect) {
+  const x = clamp(rect.x / Math.max(record.width, 1), 0, 1);
+  const y = clamp(rect.y / Math.max(record.height, 1), 0, 1);
+  const right = clamp((rect.x + rect.width) / Math.max(record.width, 1), 0, 1);
+  const bottom = clamp((rect.y + rect.height) / Math.max(record.height, 1), 0, 1);
+  element.style.left = `${x * 100}%`;
+  element.style.top = `${y * 100}%`;
+  element.style.width = `${Math.max(0, right - x) * 100}%`;
+  element.style.height = `${Math.max(0, bottom - y) * 100}%`;
+}
+
 function findTopmost<T extends { rect: PageRect }>(
   items: T[],
   x: number,
@@ -212,7 +943,13 @@ function dedupeLinkTextHighlights(highlights: LinkTextHighlight[]) {
   const seen = new Set<string>();
   return highlights.filter((highlight) => {
     const rect = highlight.rect;
-    const key = `${highlight.text.id}:${rect.x.toFixed(3)}:${rect.y.toFixed(3)}:${rect.width.toFixed(3)}:${rect.height.toFixed(3)}`;
+    const key = [
+      highlight.text.id,
+      rect.x.toFixed(3),
+      rect.y.toFixed(3),
+      rect.width.toFixed(3),
+      rect.height.toFixed(3),
+    ].join(":");
     if (seen.has(key)) {
       return false;
     }

--- a/tools/typst-preview-frontend-ng/src/layout.ts
+++ b/tools/typst-preview-frontend-ng/src/layout.ts
@@ -1,0 +1,282 @@
+import type { PageLayout, PageRecord, PageSpec, PreviewMode, ViewportSnapshot } from "./types";
+import { clamp } from "./utils";
+
+export interface PageLayoutMetrics {
+  availableWidth: number;
+  availableHeight: number;
+}
+
+export interface PageLayoutRecord extends PageLayout {
+  scaleX: number;
+  scaleY: number;
+}
+
+export interface ZoomAnchor {
+  pageIndex: number;
+  pageX: number;
+  pageY: number;
+  viewportX: number;
+  viewportY: number;
+}
+
+interface PageLayoutOptions {
+  previewMode: PreviewMode;
+  currentSlidePage: number;
+  zoomRatio: number;
+}
+
+const zoomFactors = [
+  0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.3, 1.5, 1.7, 1.9, 2.1, 2.4, 2.7, 3, 3.3,
+  3.7, 4.1, 4.6, 5.1, 5.7, 6.3, 7, 7.7, 8.5, 9.4, 10,
+];
+
+export function nextZoomRatio(current: number, deltaY: number) {
+  if (deltaY < 0) {
+    return zoomFactors.find((factor) => factor > current) ?? current;
+  }
+  if (deltaY > 0) {
+    return [...zoomFactors].reverse().find((factor) => factor < current) ?? current;
+  }
+  return current;
+}
+
+export function collectPageLayouts(
+  pages: PageSpec[],
+  records: ReadonlyMap<number, PageRecord>,
+  gap: number,
+): PageLayoutRecord[] {
+  const layouts: PageLayoutRecord[] = [];
+  let top = 0;
+  let visibleCount = 0;
+
+  for (const page of pages) {
+    const record = records.get(page.index);
+    if (!record || record.container.hidden) {
+      continue;
+    }
+
+    if (visibleCount > 0) {
+      top += gap;
+    }
+    const width = record.cssWidth;
+    const height = record.cssHeight;
+    const scaleX = width / Math.max(record.width, 1);
+    const scaleY = height / Math.max(record.height, 1);
+    layouts.push({
+      index: record.index,
+      top,
+      bottom: top + height,
+      width,
+      height,
+      scale: scaleY,
+      scaleX,
+      scaleY,
+    });
+    top += height;
+    visibleCount += 1;
+  }
+
+  return layouts;
+}
+
+export function readPageLayoutMetrics(viewport: HTMLElement): PageLayoutMetrics {
+  return {
+    availableWidth: Math.max(1, viewport.clientWidth),
+    availableHeight: Math.max(1, viewport.clientHeight),
+  };
+}
+
+export function readViewportSnapshot(
+  viewport: HTMLElement,
+  metrics: PageLayoutMetrics,
+  state: { dragging: boolean; scrolling: boolean },
+): ViewportSnapshot {
+  const width = metrics.availableWidth;
+  const height = metrics.availableHeight;
+  return {
+    width,
+    height,
+    scrollLeft: viewport.scrollLeft,
+    scrollTop: viewport.scrollTop,
+    devicePixelRatio: window.devicePixelRatio || 1,
+    dragging: state.dragging,
+    scrolling: state.scrolling,
+    window: {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+    },
+    boundingRect: {
+      x: 0,
+      y: 0,
+      width,
+      height,
+      top: 0,
+      right: width,
+      bottom: height,
+      left: 0,
+    },
+  };
+}
+
+export function viewportPostKey(viewport: ViewportSnapshot) {
+  return [
+    viewport.width,
+    viewport.height,
+    viewport.scrollLeft,
+    viewport.scrollTop,
+    viewport.devicePixelRatio,
+    viewport.dragging ? 1 : 0,
+    viewport.scrolling ? 1 : 0,
+    viewport.renderDuringDrag === false ? 0 : 1,
+  ].join(":");
+}
+
+export function applyPageLayout(
+  record: PageRecord,
+  page: PageSpec,
+  metrics: PageLayoutMetrics,
+  options: PageLayoutOptions,
+) {
+  record.width = page.width;
+  record.height = page.height;
+  record.pixelPerPt = page.pixelPerPt;
+  record.container.hidden =
+    options.previewMode === "Slide" && page.index !== options.currentSlidePage - 1;
+  const scale = computePageScale(page, metrics, options.previewMode, options.zoomRatio);
+  const cssWidth = Math.ceil(page.width * scale);
+  const cssHeight = Math.ceil(page.height * scale);
+  record.cssWidth = cssWidth;
+  record.cssHeight = cssHeight;
+  record.container.style.width = `${cssWidth}px`;
+  record.container.style.height = `${cssHeight}px`;
+  record.shell.style.width = `${cssWidth}px`;
+  record.shell.style.height = `${cssHeight}px`;
+  record.shell.dataset.appliedScale = String(scale);
+  alignCanvasBackingStore(record, page);
+}
+
+export function currentViewportPage(viewport: HTMLElement, layouts: PageLayoutRecord[]): number {
+  const viewportCenter = viewport.scrollTop + viewport.clientHeight / 2;
+  let bestPage = 1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const layout of layouts) {
+    const center = (layout.top + layout.bottom) / 2;
+    const distance = Math.abs(center - viewportCenter);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestPage = layout.index + 1;
+    }
+  }
+  return bestPage;
+}
+
+export function zoomAnchorFromEvent(
+  event: WheelEvent,
+  viewport: HTMLElement,
+  records: ReadonlyMap<number, PageRecord>,
+  metrics: PageLayoutMetrics,
+  layouts: PageLayoutRecord[],
+  contentPreview: boolean,
+): ZoomAnchor | undefined {
+  const viewportRect = viewport.getBoundingClientRect();
+  const viewportX = event.clientX - viewportRect.left;
+  const viewportY = event.clientY - viewportRect.top;
+  const contentX = viewport.scrollLeft + viewportX;
+  const contentY = viewport.scrollTop + viewportY;
+  const layout = findPageLayoutAt(layouts, contentY) || nearestPageLayout(layouts, contentY);
+  if (!layout) {
+    return undefined;
+  }
+
+  const record = records.get(layout.index);
+  if (!record) {
+    return undefined;
+  }
+
+  const left = pageLeft(record, metrics, contentPreview);
+  return {
+    pageIndex: layout.index,
+    pageX: clamp((contentX - left) / Math.max(layout.scaleX, 1e-6), 0, record.width),
+    pageY: clamp((contentY - layout.top) / Math.max(layout.scaleY, 1e-6), 0, record.height),
+    viewportX,
+    viewportY,
+  };
+}
+
+export function restoreZoomAnchor(
+  anchor: ZoomAnchor | undefined,
+  viewport: HTMLElement,
+  records: ReadonlyMap<number, PageRecord>,
+  metrics: PageLayoutMetrics,
+  layouts: PageLayoutRecord[],
+  contentPreview: boolean,
+) {
+  if (!anchor) {
+    return;
+  }
+
+  const record = records.get(anchor.pageIndex);
+  const layout = layouts.find((candidate) => candidate.index === anchor.pageIndex);
+  if (!record || !layout) {
+    return;
+  }
+
+  const left = pageLeft(record, metrics, contentPreview);
+  viewport.scrollTo({
+    left: left + anchor.pageX * layout.scaleX - anchor.viewportX,
+    top: layout.top + anchor.pageY * layout.scaleY - anchor.viewportY,
+    behavior: "auto",
+  });
+}
+
+function alignCanvasBackingStore(record: PageRecord, page: PageSpec) {
+  const drawnWidthPx = page.width * page.pixelPerPt;
+  const drawnHeightPx = page.height * page.pixelPerPt;
+  const widthScale = record.fullWidthPx / Math.max(drawnWidthPx, 1);
+  const heightScale = record.fullHeightPx / Math.max(drawnHeightPx, 1);
+  record.canvas.style.width = `${widthScale * 100}%`;
+  record.canvas.style.height = `${heightScale * 100}%`;
+}
+
+function computePageScale(
+  page: PageSpec,
+  metrics: PageLayoutMetrics,
+  previewMode: PreviewMode,
+  zoomRatio: number,
+): number {
+  const fitWidth = metrics.availableWidth / page.width;
+  const baseScale =
+    previewMode === "Slide"
+      ? Math.max(0.1, Math.min(fitWidth, metrics.availableHeight / page.height))
+      : Math.max(0.1, fitWidth);
+  return baseScale * zoomRatio;
+}
+
+function pageLeft(record: PageRecord, metrics: PageLayoutMetrics, contentPreview: boolean) {
+  if (contentPreview) {
+    return 0;
+  }
+  return (metrics.availableWidth - record.cssWidth) / 2;
+}
+
+function findPageLayoutAt(layouts: PageLayoutRecord[], contentY: number) {
+  return layouts.find((layout) => contentY >= layout.top && contentY <= layout.bottom);
+}
+
+function nearestPageLayout(layouts: PageLayoutRecord[], contentY: number) {
+  let nearest: PageLayoutRecord | undefined;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const layout of layouts) {
+    const distance =
+      contentY < layout.top
+        ? layout.top - contentY
+        : contentY > layout.bottom
+          ? contentY - layout.bottom
+          : 0;
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = layout;
+    }
+  }
+  return nearest;
+}

--- a/tools/typst-preview-frontend-ng/src/navigation.ts
+++ b/tools/typst-preview-frontend-ng/src/navigation.ts
@@ -1,0 +1,66 @@
+import type { PageRecord, PreviewPosition } from "./types";
+import { clamp } from "./utils";
+
+export function parseCursorPosition(text: string): PreviewPosition | undefined {
+  const [page, x, y] = text
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number.parseFloat(value));
+  if (!Number.isFinite(page) || !Number.isFinite(x) || !Number.isFinite(y)) {
+    return undefined;
+  }
+  return { page, x, y };
+}
+
+export function scrollViewportToTypstLocation(
+  viewport: HTMLElement,
+  record: PageRecord,
+  position: PreviewPosition,
+) {
+  const xRatio = clamp(position.x / Math.max(record.width, 1), 0, 1);
+  const yRatio = clamp(position.y / Math.max(record.height, 1), 0, 1);
+  const left = record.container.offsetLeft + xRatio * record.container.offsetWidth;
+  const top = record.container.offsetTop + yRatio * record.container.offsetHeight;
+  viewport.scrollTo({
+    left: Math.max(0, left - viewport.clientWidth / 2),
+    top: Math.max(0, top - viewport.clientHeight / 2),
+    behavior: "auto",
+  });
+  return { xRatio, yRatio };
+}
+
+export function showJumpMarker(record: PageRecord, xRatio: number, yRatio: number) {
+  record.jumpMarker.style.left = `${xRatio * 100}%`;
+  record.jumpMarker.style.top = `${yRatio * 100}%`;
+  record.jumpMarker.classList.remove("visible");
+  void record.jumpMarker.offsetWidth;
+  record.jumpMarker.classList.add("visible");
+  window.setTimeout(() => record.jumpMarker.classList.remove("visible"), 900);
+}
+
+export function renderCursor(
+  records: Iterable<PageRecord>,
+  pendingCursor: PreviewPosition | undefined,
+) {
+  const recordList = Array.from(records);
+  for (const record of recordList) {
+    record.cursor.classList.remove("visible");
+  }
+  if (!pendingCursor) {
+    return;
+  }
+
+  for (const record of recordList) {
+    if (record.index !== pendingCursor.page - 1) {
+      continue;
+    }
+    record.cursor.style.left = `${
+      clamp(pendingCursor.x / Math.max(record.width, 1), 0, 1) * 100
+    }%`;
+    record.cursor.style.top = `${
+      clamp(pendingCursor.y / Math.max(record.height, 1), 0, 1) * 100
+    }%`;
+    record.cursor.classList.add("visible");
+    return;
+  }
+}

--- a/tools/typst-preview-frontend-ng/src/outline.ts
+++ b/tools/typst-preview-frontend-ng/src/outline.ts
@@ -1,0 +1,56 @@
+import type { PreviewPosition } from "./types";
+
+export function renderOutline(
+  panel: HTMLDivElement,
+  outlineData: any,
+  contentPreview: boolean,
+  scrollToTypstLocation: (position: PreviewPosition) => void,
+) {
+  const items = Array.isArray(outlineData?.items) ? outlineData.items : [];
+  panel.replaceChildren();
+  panel.classList.toggle("hidden", !contentPreview || items.length === 0);
+  if (!contentPreview || items.length === 0) {
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const item of items) {
+    fragment.appendChild(createOutlineItem(item, 1, scrollToTypstLocation));
+  }
+  panel.appendChild(fragment);
+}
+
+function createOutlineItem(
+  item: any,
+  level: number,
+  scrollToTypstLocation: (position: PreviewPosition) => void,
+): HTMLElement {
+  const container = document.createElement("div");
+  container.className = `typst-outline level-${Math.min(level, 5)}`;
+  const title = document.createElement("button");
+  title.type = "button";
+  title.className = "typst-outline-title";
+  title.textContent = String(item?.title ?? "");
+
+  const position = outlinePosition(item?.position);
+  if (position) {
+    title.addEventListener("click", () => scrollToTypstLocation(position));
+  }
+
+  container.appendChild(title);
+  for (const child of Array.isArray(item?.children) ? item.children : []) {
+    container.appendChild(createOutlineItem(child, level + 1, scrollToTypstLocation));
+  }
+  return container;
+}
+
+function outlinePosition(position: any): PreviewPosition | undefined {
+  if (!position) {
+    return undefined;
+  }
+  return {
+    page: Number(position.page_no ?? position.page ?? 1),
+    x: Number(position.x ?? 0),
+    y: Number(position.y ?? 0),
+  };
+}

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -1,19 +1,35 @@
 import type { PreviewElements } from "./dom";
 import { installPageControls } from "./controls";
 import {
-  hitTestLink,
-  hitTestText,
-  textHighlightsForLink,
+  PageInteractionController,
   type BoundInteraction,
-  type LinkInteraction,
   type PageInteractions,
   type PageRect,
-  type TextInteraction,
 } from "./interactions";
+import {
+  applyPageLayout as applyLayout,
+  collectPageLayouts as collectLayouts,
+  currentViewportPage as currentPageFromLayouts,
+  nextZoomRatio,
+  readPageLayoutMetrics as readLayoutMetrics,
+  readViewportSnapshot as buildViewportSnapshot,
+  restoreZoomAnchor,
+  viewportPostKey,
+  zoomAnchorFromEvent,
+  type PageLayoutMetrics,
+  type PageLayoutRecord,
+} from "./layout";
+import {
+  parseCursorPosition,
+  renderCursor,
+  scrollViewportToTypstLocation,
+  showJumpMarker,
+} from "./navigation";
+import { renderOutline } from "./outline";
+import { createPageRecord } from "./page-record";
 import { parseInvertColorStrategy, parsePreviewPositions } from "./protocol";
+import { InvertColorController } from "./theme";
 import type {
-  InvertColorStrategy,
-  InvertColorStrategyMap,
   PageRecord,
   PageSpec,
   PreviewMode,
@@ -27,31 +43,7 @@ interface PageHostOptions {
   postWorker: (message: unknown, transfer?: Transferable[]) => void;
 }
 
-interface PageLayoutMetrics {
-  availableWidth: number;
-  availableHeight: number;
-}
-
-interface PageLayoutRecord {
-  index: number;
-  top: number;
-  bottom: number;
-  width: number;
-  height: number;
-  scale: number;
-  scaleX: number;
-  scaleY: number;
-}
-
-interface ZoomAnchor {
-  pageIndex: number;
-  pageX: number;
-  pageY: number;
-  viewportX: number;
-  viewportY: number;
-}
-
-/** Owns preview page DOM and controls, handling render-worker page requests and routed preview protocol messages. */
+/** Owns preview page DOM, render-worker page requests, and routed preview protocol messages. */
 export class PageHost {
   private readonly elements: PreviewElements;
   private readonly postWorker: PageHostOptions["postWorker"];
@@ -68,58 +60,22 @@ export class PageHost {
   private lastPages: PageSpec[] = [];
   private pendingCursor: PreviewPosition | undefined;
   private outlineData: any;
-  private autoInvertDecision: boolean | undefined;
-  private interactionGeneration = 0;
-  private pointerDown:
-    | {
-        pageIndex: number;
-        x: number;
-        y: number;
-      }
-    | undefined;
-  private lastPointer:
-    | {
-        pageIndex: number;
-        x: number;
-        y: number;
-      }
-    | undefined;
-  private activeHoverKey = "";
-  private activeTextHover:
-    | {
-        generation: number;
-        pageIndex: number;
-        rect: PageRect;
-      }
-    | undefined;
-  private readonly textHoverRects = new Map<string, PageRect>();
-  private readonly pendingTextRectRequests = new Set<string>();
-  private readonly pendingInteractionRequests = new Set<number>();
-  private nextHitRequestId = 0;
-  private pendingTextHover:
-    | {
-        requestId: number;
-        generation: number;
-        pageIndex: number;
-        x: number;
-        y: number;
-        text: TextInteraction;
-      }
-    | undefined;
-  private pendingBoundHover:
-    | {
-        requestId: number;
-        generation: number;
-        pageIndex: number;
-        x: number;
-        y: number;
-      }
-    | undefined;
+  private readonly invertColors = new InvertColorController();
+  private readonly interactions: PageInteractionController;
   private readonly pageRecords = new Map<number, PageRecord>();
 
   constructor({ elements, postWorker }: PageHostOptions) {
     this.elements = elements;
     this.postWorker = postWorker;
+    this.interactions = new PageInteractionController({
+      postWorker,
+      getRecord: (pageIndex) => this.pageRecords.get(pageIndex),
+      getRecords: () => this.pageRecords.values(),
+      getViewport: () => this.elements.viewport,
+      isDragging: () => this.dragging,
+      isContentPreview: () => this.contentPreview,
+      scrollToTypstLocation: (position) => this.scrollToTypstLocation(position),
+    });
   }
 
   get mode() {
@@ -152,12 +108,8 @@ export class PageHost {
     }
     this.dragging = active;
     this.elements.root.classList.toggle("dragging", active);
-    if (active) {
-      this.activeHoverKey = "";
-      this.activeTextHover = undefined;
-      this.pendingTextHover = undefined;
-      this.pendingBoundHover = undefined;
-    } else {
+    this.interactions.handleDraggingChanged(active);
+    if (!active) {
       this.scrolling = false;
       if (this.scrollIdleTimer) {
         window.clearTimeout(this.scrollIdleTimer);
@@ -173,20 +125,29 @@ export class PageHost {
 
   applyWheelZoom(event: WheelEvent) {
     const previousZoom = this.zoomRatio;
-    if (event.deltaY < 0) {
-      this.zoomRatio = zoomFactors.find((factor) => factor > this.zoomRatio) ?? this.zoomRatio;
-    } else if (event.deltaY > 0) {
-      this.zoomRatio =
-        [...zoomFactors].reverse().find((factor) => factor < this.zoomRatio) ?? this.zoomRatio;
-    }
+    this.zoomRatio = nextZoomRatio(this.zoomRatio, event.deltaY);
     if (this.zoomRatio === previousZoom) {
       return;
     }
 
     const metrics = this.readPageLayoutMetrics();
-    const anchor = this.zoomAnchorFromEvent(event, metrics, this.collectPageLayouts());
+    const anchor = zoomAnchorFromEvent(
+      event,
+      this.elements.viewport,
+      this.pageRecords,
+      metrics,
+      this.collectPageLayouts(),
+      this.contentPreview,
+    );
     this.applyAllPageLayouts(metrics);
-    this.restoreZoomAnchor(anchor, metrics, this.collectPageLayouts());
+    restoreZoomAnchor(
+      anchor,
+      this.elements.viewport,
+      this.pageRecords,
+      metrics,
+      this.collectPageLayouts(),
+      this.contentPreview,
+    );
     this.scheduleViewportSnapshot();
   }
 
@@ -215,17 +176,8 @@ export class PageHost {
 
     this.lastPages = pages;
     this.updatePageCount(pages.length);
-    if (this.interactionGeneration !== generation) {
-      this.interactionGeneration = generation;
-      this.textHoverRects.clear();
-      this.pendingTextRectRequests.clear();
-      this.pendingInteractionRequests.clear();
-      this.activeTextHover = undefined;
-      this.pendingTextHover = undefined;
-      this.pendingBoundHover = undefined;
+    if (this.interactions.startGeneration(generation)) {
       for (const record of this.pageRecords.values()) {
-        record.interactions = undefined;
-        this.renderLinkAnchors(record);
         record.container.classList.remove("canvas-ready");
         record.container.classList.remove("full-ready");
       }
@@ -250,12 +202,17 @@ export class PageHost {
 
       if (!record || record.key !== key) {
         record?.container.remove();
-        record = this.createPageRecord(page, key, widthPx, heightPx);
+        record = createPageRecord(page, key, widthPx, heightPx);
+        this.interactions.installPageHandlers(record);
         this.pageRecords.set(page.index, record);
         this.insertPage(record, page.index);
       }
 
-      this.applyPageLayout(record, page, metrics);
+      applyLayout(record, page, metrics, {
+        previewMode: this.previewMode,
+        currentSlidePage: this.currentSlidePage,
+        zoomRatio: this.zoomRatio,
+      });
       if (!record.transferred) {
         record.canvas.width = 1;
         record.canvas.height = 1;
@@ -275,10 +232,7 @@ export class PageHost {
 
     for (const [index, record] of this.pageRecords) {
       if (!livePages.has(index)) {
-        if (this.lastPointer?.pageIndex === index) {
-          this.lastPointer = undefined;
-          this.activeHoverKey = "";
-        }
+        this.interactions.removePage(index);
         record.container.remove();
         this.pageRecords.delete(index);
       }
@@ -294,71 +248,14 @@ export class PageHost {
   }
 
   collectPageLayouts(): PageLayoutRecord[] {
-    const layouts: PageLayoutRecord[] = [];
-    let top = 0;
-    let visibleCount = 0;
-    const gap = this.pageGap();
-
-    for (const page of this.lastPages) {
-      const record = this.pageRecords.get(page.index);
-      if (!record) {
-        continue;
-      }
-
-      if (!record.container.hidden) {
-        if (visibleCount > 0) {
-          top += gap;
-        }
-        const width = record.cssWidth;
-        const height = record.cssHeight;
-        const scaleX = width / Math.max(record.width, 1);
-        const scaleY = height / Math.max(record.height, 1);
-        layouts.push({
-          index: record.index,
-          top,
-          bottom: top + height,
-          width,
-          height,
-          scale: scaleY,
-          scaleX,
-          scaleY,
-        });
-        top += height;
-        visibleCount += 1;
-        continue;
-      }
-    }
-
-    return layouts;
+    return collectLayouts(this.lastPages, this.pageRecords, this.pageGap());
   }
 
   readViewportSnapshot(metrics = this.readPageLayoutMetrics()): ViewportSnapshot {
-    const viewport = this.elements.viewport;
-    const width = metrics.availableWidth;
-    const height = metrics.availableHeight;
-    return {
-      width,
-      height,
-      scrollLeft: viewport.scrollLeft,
-      scrollTop: viewport.scrollTop,
-      devicePixelRatio: window.devicePixelRatio || 1,
+    return buildViewportSnapshot(this.elements.viewport, metrics, {
       dragging: this.dragging,
       scrolling: this.scrolling,
-      window: {
-        innerWidth: window.innerWidth,
-        innerHeight: window.innerHeight,
-      },
-      boundingRect: {
-        x: 0,
-        y: 0,
-        width,
-        height,
-        top: 0,
-        right: width,
-        bottom: height,
-        left: 0,
-      },
-    };
+    });
   }
 
   scheduleViewportSnapshot(options: { applyLayouts?: boolean; scrolling?: boolean } = {}) {
@@ -414,7 +311,7 @@ export class PageHost {
     if (options.renderDuringDrag !== undefined) {
       viewport.renderDuringDrag = options.renderDuringDrag;
     }
-    const key = this.viewportPostKey(viewport);
+    const key = viewportPostKey(viewport);
     if (!options.force && key === this.lastViewportPostKey) {
       return;
     }
@@ -425,21 +322,8 @@ export class PageHost {
       layouts,
     });
     if (options.requestInteractions ?? !this.dragging) {
-      this.requestViewportInteractions(layouts);
+      this.interactions.requestViewportInteractions(layouts);
     }
-  }
-
-  private viewportPostKey(viewport: ViewportSnapshot) {
-    return [
-      viewport.width,
-      viewport.height,
-      viewport.scrollLeft,
-      viewport.scrollTop,
-      viewport.devicePixelRatio,
-      viewport.dragging ? 1 : 0,
-      viewport.scrolling ? 1 : 0,
-      viewport.renderDuringDrag === false ? 0 : 1,
-    ].join(":");
   }
 
   handlePreviewProtocolMessage(kind: string, text: string) {
@@ -456,12 +340,11 @@ export class PageHost {
       case "partial-rendering":
         break;
       case "invert-colors":
-        this.ensureInvertColors(parseInvertColorStrategy(text));
+        this.invertColors.apply(this.elements.root, parseInvertColorStrategy(text));
         break;
       case "outline":
         try {
-          this.outlineData = JSON.parse(text);
-          this.renderOutline();
+          this.setOutlineData(JSON.parse(text));
         } catch (_error) {}
         break;
     }
@@ -472,32 +355,7 @@ export class PageHost {
     interactions: PageInteractions[],
     invalidatedPageIndices: number[] = [],
   ) {
-    if (generation !== this.interactionGeneration) {
-      return;
-    }
-    let refreshHover = false;
-    for (const pageIndex of invalidatedPageIndices) {
-      const record = this.pageRecords.get(pageIndex);
-      if (record) {
-        record.interactions = undefined;
-        this.renderLinkAnchors(record);
-        refreshHover ||= this.lastPointer?.pageIndex === record.index;
-      }
-      this.pendingInteractionRequests.delete(pageIndex);
-    }
-    for (const pageInteractions of interactions) {
-      const record = this.pageRecords.get(pageInteractions.pageIndex);
-      if (record) {
-        record.interactions = pageInteractions;
-        this.renderLinkAnchors(record);
-        refreshHover ||= this.lastPointer?.pageIndex === record.index;
-      }
-      this.pendingInteractionRequests.delete(pageInteractions.pageIndex);
-    }
-    if (refreshHover) {
-      this.activeHoverKey = "";
-      this.restoreInteractionHover();
-    }
+    this.interactions.updateInteractions(generation, interactions, invalidatedPageIndices);
   }
 
   markRendered(
@@ -507,7 +365,7 @@ export class PageHost {
     pageIndices: number[],
     fullPageIndices: number[] = [],
   ) {
-    if (generation !== this.interactionGeneration) {
+    if (!this.interactions.matchesGeneration(generation)) {
       return;
     }
     if (layer !== "full") {
@@ -535,10 +393,9 @@ export class PageHost {
   }
 
   markEvicted(generation: number, pageIndices: number[]) {
-    if (generation !== this.interactionGeneration) {
+    if (!this.interactions.matchesGeneration(generation)) {
       return;
     }
-    let refreshHover = false;
     for (const pageIndex of pageIndices) {
       const record = this.pageRecords.get(pageIndex);
       if (!record) {
@@ -546,16 +403,8 @@ export class PageHost {
       }
       record.container.classList.remove("canvas-ready");
       record.container.classList.remove("full-ready");
-      record.interactions = undefined;
-      this.renderLinkAnchors(record);
-      this.pendingInteractionRequests.delete(pageIndex);
-      refreshHover ||= this.lastPointer?.pageIndex === pageIndex;
     }
-    if (refreshHover) {
-      this.activeHoverKey = "";
-      this.activeTextHover = undefined;
-      this.restoreInteractionHover();
-    }
+    this.interactions.markEvicted(generation, pageIndices);
   }
 
   handleBoundHit(message: {
@@ -566,37 +415,7 @@ export class PageHost {
     y: number;
     bound?: BoundInteraction;
   }) {
-    const pending = this.pendingBoundHover;
-    if (
-      !pending ||
-      pending.requestId !== message.requestId ||
-      pending.generation !== message.generation ||
-      pending.pageIndex !== message.pageIndex ||
-      this.interactionGeneration !== message.generation
-    ) {
-      return;
-    }
-
-    if (
-      !this.lastPointer ||
-      this.lastPointer.pageIndex !== message.pageIndex ||
-      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
-    ) {
-      return;
-    }
-
-    const record = this.pageRecords.get(message.pageIndex);
-    if (!record) {
-      return;
-    }
-
-    if (!message.bound) {
-      this.clearInteractionHighlight(record);
-      this.activeHoverKey = "";
-      return;
-    }
-
-    this.showBoundHover(record, message.bound);
+    this.interactions.handleBoundHit(message);
   }
 
   handleTextHit(message: {
@@ -608,38 +427,7 @@ export class PageHost {
     hit: boolean;
     rect?: PageRect;
   }) {
-    const pending = this.pendingTextHover;
-    if (
-      !pending ||
-      pending.requestId !== message.requestId ||
-      pending.generation !== message.generation ||
-      pending.pageIndex !== message.pageIndex ||
-      this.interactionGeneration !== message.generation
-    ) {
-      return;
-    }
-
-    if (
-      !this.lastPointer ||
-      this.lastPointer.pageIndex !== message.pageIndex ||
-      Math.hypot(this.lastPointer.x - message.x, this.lastPointer.y - message.y) > 0.5
-    ) {
-      return;
-    }
-
-    const record = this.pageRecords.get(message.pageIndex);
-    if (!record) {
-      return;
-    }
-
-    if (message.hit && this.textHitContains(pending.text, message.rect, message.x, message.y)) {
-      this.showTextHover(record, pending.text, message.rect);
-      return;
-    }
-
-    this.clearInteractionHighlight(record);
-    this.activeHoverKey = "";
-    this.requestBoundHover(record, { x: message.x, y: message.y });
+    this.interactions.handleTextHit(message);
   }
 
   handleTextRect(message: {
@@ -648,20 +436,7 @@ export class PageHost {
     textId: number;
     rect?: PageRect;
   }) {
-    if (message.generation !== this.interactionGeneration) {
-      return;
-    }
-
-    const key = this.textHoverKey(message.pageIndex, message.textId);
-    this.pendingTextRectRequests.delete(key);
-    if (message.rect) {
-      this.textHoverRects.set(key, message.rect);
-    }
-
-    if (this.lastPointer?.pageIndex === message.pageIndex) {
-      this.activeHoverKey = "";
-      this.restoreInteractionHover();
-    }
+    this.interactions.handleTextRect(message);
   }
 
   clearPages() {
@@ -672,499 +447,8 @@ export class PageHost {
     this.lastPages = [];
     this.lastViewportPostKey = "";
     this.pendingCursor = undefined;
-    this.interactionGeneration = 0;
-    this.pointerDown = undefined;
-    this.lastPointer = undefined;
-    this.activeHoverKey = "";
-    this.activeTextHover = undefined;
-    this.textHoverRects.clear();
-    this.pendingTextRectRequests.clear();
-    this.pendingInteractionRequests.clear();
-    this.pendingTextHover = undefined;
-    this.pendingBoundHover = undefined;
+    this.interactions.resetAll();
     this.updatePageCount(0);
-  }
-
-  private createPageRecord(
-    page: PageSpec,
-    key: string,
-    widthPx: number,
-    heightPx: number,
-  ): PageRecord {
-    const container = document.createElement("div");
-    container.className = "typst-page canvas-mode";
-    container.dataset.pageNumber = String(page.index);
-
-    const shell = document.createElement("div");
-    shell.className = "typst-page-canvas";
-    shell.dataset.pageNumber = String(page.index);
-    shell.dataset.pageWidth = page.width.toFixed(3);
-    shell.dataset.pageHeight = page.height.toFixed(3);
-
-    const canvas = document.createElement("canvas");
-    canvas.className = "typst-full-canvas";
-    canvas.width = 1;
-    canvas.height = 1;
-
-    const interactionLayer = document.createElement("div");
-    interactionLayer.className = "typst-interaction-layer";
-
-    const linkLayer = document.createElement("div");
-    linkLayer.className = "typst-link-layer";
-
-    const cursor = document.createElement("div");
-    cursor.className = "typst-cursor";
-
-    const jumpMarker = document.createElement("div");
-    jumpMarker.className = "typst-jump-marker";
-
-    shell.append(canvas);
-    container.append(shell, linkLayer, interactionLayer, cursor, jumpMarker);
-
-    const record = {
-      index: page.index,
-      key,
-      container,
-      shell,
-      canvas,
-      linkLayer,
-      interactionLayer,
-      cursor,
-      jumpMarker,
-      transferred: false,
-      width: page.width,
-      height: page.height,
-      fullWidthPx: widthPx,
-      fullHeightPx: heightPx,
-      cssWidth: widthPx,
-      cssHeight: heightPx,
-      pixelPerPt: page.pixelPerPt,
-    };
-    this.installPageInteractionHandlers(record);
-    return record;
-  }
-
-  private installPageInteractionHandlers(record: PageRecord) {
-    record.container.addEventListener("mousedown", (event) => {
-      if (event.button !== 0) {
-        return;
-      }
-      this.pointerDown = {
-        pageIndex: record.index,
-        x: event.clientX,
-        y: event.clientY,
-      };
-    });
-
-    record.container.addEventListener("mousemove", (event) => {
-      this.handlePagePointerMove(record, event);
-    });
-
-    record.container.addEventListener("mouseleave", () => {
-      this.clearInteractionHighlight(record);
-      this.activeHoverKey = "";
-      if (this.lastPointer?.pageIndex === record.index) {
-        this.lastPointer = undefined;
-      }
-    });
-
-    record.container.addEventListener("click", (event) => {
-      this.handlePageClick(record, event);
-    });
-  }
-
-  private handlePagePointerMove(record: PageRecord, event: MouseEvent) {
-    if (this.isDragging()) {
-      if (this.activeHoverKey || record.interactionLayer.childElementCount > 0) {
-        this.clearInteractionHighlight(record);
-        this.activeHoverKey = "";
-      }
-      this.lastPointer = undefined;
-      return;
-    }
-
-    const point = this.pagePointFromEvent(record, event);
-    if (!point) {
-      this.clearInteractionHighlight(record);
-      this.activeHoverKey = "";
-      this.lastPointer = undefined;
-      return;
-    }
-
-    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
-    this.updateInteractionHover(record, point);
-  }
-
-  private updateInteractionHover(record: PageRecord, point: { x: number; y: number }) {
-    if (!record.interactions) {
-      this.requestPageInteractions([record.index]);
-      this.clearInteractionHighlight(record);
-      this.activeHoverKey = "";
-      return;
-    }
-
-    const link = hitTestLink(record.interactions, point.x, point.y);
-    if (link) {
-      this.showLinkHover(record, link);
-      return;
-    }
-
-    if (this.activeTextHoverContains(record, point)) {
-      record.container.style.cursor = "text";
-      return;
-    }
-
-    const cachedText = this.cachedTextHoverAt(record, point);
-    if (cachedText) {
-      this.showTextHoverRect(record, cachedText.text, cachedText.rect);
-      return;
-    }
-
-    const text = hitTestText(record.interactions, point.x, point.y);
-    if (text) {
-      this.requestTextHover(record, text, point);
-      return;
-    }
-
-    this.requestBoundHover(record, point);
-  }
-
-  private restoreInteractionHover() {
-    if (!this.lastPointer) {
-      return;
-    }
-    const record = this.pageRecords.get(this.lastPointer.pageIndex);
-    if (!record) {
-      return;
-    }
-    this.updateInteractionHover(record, this.lastPointer);
-  }
-
-  private requestViewportInteractions(layouts: PageLayoutRecord[]) {
-    if (this.interactionGeneration <= 0) {
-      return;
-    }
-    if (this.isDragging()) {
-      return;
-    }
-
-    const viewportTop = this.elements.viewport.scrollTop;
-    const viewportBottom = viewportTop + this.elements.viewport.clientHeight;
-    const pageIndices = layouts
-      .filter((layout) => layout.bottom >= viewportTop && layout.top <= viewportBottom)
-      .map((layout) => layout.index);
-    this.requestPageInteractions(pageIndices);
-  }
-
-  private requestPageInteractions(pageIndices: number[]) {
-    const missing: number[] = [];
-    const seen = new Set<number>();
-    for (const pageIndex of pageIndices) {
-      if (seen.has(pageIndex) || this.pendingInteractionRequests.has(pageIndex)) {
-        continue;
-      }
-      seen.add(pageIndex);
-
-      const record = this.pageRecords.get(pageIndex);
-      if (!record || record.interactions) {
-        continue;
-      }
-
-      this.pendingInteractionRequests.add(pageIndex);
-      missing.push(pageIndex);
-    }
-
-    if (missing.length === 0) {
-      return;
-    }
-
-    this.postWorker({
-      type: "request-interactions",
-      generation: this.interactionGeneration,
-      pageIndices: missing,
-    });
-  }
-
-  private isDragging() {
-    return this.dragging;
-  }
-
-  private handlePageClick(record: PageRecord, event: MouseEvent) {
-    if (this.isDragClick(record, event)) {
-      return;
-    }
-
-    const point = this.pagePointFromEvent(record, event);
-    if (!point) {
-      return;
-    }
-    this.lastPointer = { pageIndex: record.index, x: point.x, y: point.y };
-
-    if (!record.interactions) {
-      this.requestPageInteractions([record.index]);
-    }
-
-    const link = hitTestLink(record.interactions, point.x, point.y);
-    if (link?.target.kind === "internal" && link.target.position) {
-      event.preventDefault();
-      this.scrollToTypstLocation(link.target.position);
-      return;
-    }
-
-    if (this.contentPreview) {
-      this.postWorker({ type: "send", text: `outline-sync,${record.index + 1}` });
-      return;
-    }
-
-    this.postWorker({
-      type: "send",
-      text: `src-point ${JSON.stringify({
-        page_no: record.index + 1,
-        x: point.x,
-        y: point.y,
-      })}`,
-    });
-  }
-
-  private pagePointFromEvent(
-    record: PageRecord,
-    event: MouseEvent,
-  ): { x: number; y: number } | undefined {
-    const rect = record.shell.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0) {
-      return undefined;
-    }
-
-    return {
-      x: clamp(((event.clientX - rect.left) / rect.width) * record.width, 0, record.width),
-      y: clamp(((event.clientY - rect.top) / rect.height) * record.height, 0, record.height),
-    };
-  }
-
-  private isDragClick(record: PageRecord, event: MouseEvent) {
-    const start = this.pointerDown;
-    this.pointerDown = undefined;
-    if (!start || start.pageIndex !== record.index) {
-      return false;
-    }
-
-    const distance = Math.hypot(event.clientX - start.x, event.clientY - start.y);
-    return distance > 4;
-  }
-
-  private showLinkHover(record: PageRecord, link: LinkInteraction) {
-    const key = `link:${record.index}:${link.target.kind}:${link.target.href}:${link.rect.x}:${link.rect.y}`;
-    if (this.activeHoverKey === key) {
-      return;
-    }
-    this.activeHoverKey = key;
-    this.activeTextHover = undefined;
-    record.container.style.cursor = "pointer";
-
-    const textRects = textHighlightsForLink(record.interactions, link).map((highlight) => {
-      this.requestTextVisualRect(record, highlight.text);
-      const visualRect = this.textHoverRects.get(
-        this.textHoverKey(record.index, highlight.text.id),
-      );
-      return visualRect ? alignTextClipToVisualRect(highlight.rect, visualRect) : highlight.rect;
-    });
-    this.renderInteractionHighlights(record, textRects, "link");
-  }
-
-  private showTextHover(record: PageRecord, text: TextInteraction, hitRect?: PageRect) {
-    const visualRect = textHoverRect(text, hitRect);
-    this.textHoverRects.set(this.textHoverKey(record.index, text.id), visualRect);
-    this.showTextHoverRect(record, text, visualRect);
-  }
-
-  private showTextHoverRect(record: PageRecord, text: TextInteraction, visualRect: PageRect) {
-    const key = `text:${record.index}:${text.id}:${visualRect.x}:${visualRect.y}:${visualRect.width}:${visualRect.height}`;
-    if (this.activeHoverKey === key) {
-      return;
-    }
-    this.activeHoverKey = key;
-    this.activeTextHover = {
-      generation: this.interactionGeneration,
-      pageIndex: record.index,
-      rect: visualRect,
-    };
-    record.container.style.cursor = "text";
-    this.renderInteractionHighlights(record, [visualRect], "text");
-  }
-
-  private requestTextHover(
-    record: PageRecord,
-    text: TextInteraction,
-    point: { x: number; y: number },
-  ) {
-    const key = `text-query:${record.index}:${text.id}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
-    if (this.activeHoverKey === key) {
-      return;
-    }
-
-    const request = {
-      requestId: ++this.nextHitRequestId,
-      generation: this.interactionGeneration,
-      pageIndex: record.index,
-      x: point.x,
-      y: point.y,
-      text,
-    };
-    this.activeHoverKey = key;
-    this.pendingTextHover = request;
-    record.container.style.cursor = "";
-    this.postWorker({
-      type: "hit-text",
-      requestId: request.requestId,
-      generation: request.generation,
-      pageIndex: request.pageIndex,
-      x: request.x,
-      y: request.y,
-      rect: text.rect,
-    });
-  }
-
-  private requestTextVisualRect(record: PageRecord, text: TextInteraction) {
-    const key = this.textHoverKey(record.index, text.id);
-    if (this.textHoverRects.has(key) || this.pendingTextRectRequests.has(key)) {
-      return;
-    }
-    this.pendingTextRectRequests.add(key);
-    this.postWorker({
-      type: "resolve-text-rect",
-      requestId: ++this.nextHitRequestId,
-      generation: this.interactionGeneration,
-      pageIndex: record.index,
-      textId: text.id,
-      rect: text.rect,
-    });
-  }
-
-  private showBoundHover(record: PageRecord, bound: BoundInteraction) {
-    const key = `bound:${record.index}:${bound.kind}:${bound.rect.x}:${bound.rect.y}:${bound.rect.width}:${bound.rect.height}`;
-    if (this.activeHoverKey === key) {
-      return;
-    }
-    this.activeHoverKey = key;
-    this.activeTextHover = undefined;
-    record.container.style.cursor = "";
-    this.renderInteractionHighlights(record, [bound.rect], "bound");
-  }
-
-  private requestBoundHover(record: PageRecord, point: { x: number; y: number }) {
-    const key = `bound-query:${record.index}:${point.x.toFixed(1)}:${point.y.toFixed(1)}`;
-    if (this.activeHoverKey === key) {
-      return;
-    }
-
-    const request = {
-      requestId: ++this.nextHitRequestId,
-      generation: this.interactionGeneration,
-      pageIndex: record.index,
-      x: point.x,
-      y: point.y,
-    };
-    this.activeHoverKey = key;
-    this.pendingBoundHover = request;
-    record.container.style.cursor = "";
-    this.postWorker({
-      type: "hit-bound",
-      ...request,
-    });
-  }
-
-  private renderLinkAnchors(record: PageRecord) {
-    const interactions = record.interactions;
-    if (!interactions) {
-      record.linkLayer.replaceChildren();
-      return;
-    }
-
-    const anchors = interactions.links.flatMap((link) => {
-      if (link.target.kind !== "external") {
-        return [];
-      }
-
-      const anchor = document.createElement("a");
-      anchor.href = link.target.href;
-      anchor.target = "_blank";
-      anchor.rel = "noopener noreferrer";
-      anchor.title = link.target.href;
-      anchor.setAttribute("aria-label", link.target.href);
-      anchor.addEventListener("click", (event) => event.stopPropagation());
-      this.applyRectStyle(record, anchor, link.rect);
-      return [anchor];
-    });
-
-    record.linkLayer.replaceChildren(...anchors);
-  }
-
-  private renderInteractionHighlights(
-    record: PageRecord,
-    rects: PageRect[],
-    kind: "link" | "text" | "bound",
-  ) {
-    record.interactionLayer.replaceChildren(
-      ...rects.slice(0, 64).map((rect) => {
-        const highlight = document.createElement("div");
-        highlight.className = `typst-interaction-highlight ${kind}`;
-        this.applyRectStyle(record, highlight, rect);
-        return highlight;
-      }),
-    );
-  }
-
-  private clearInteractionHighlight(record: PageRecord) {
-    record.container.style.cursor = "";
-    this.activeTextHover = undefined;
-    record.interactionLayer.replaceChildren();
-  }
-
-  private activeTextHoverContains(record: PageRecord, point: { x: number; y: number }) {
-    return (
-      this.activeTextHover?.generation === this.interactionGeneration &&
-      this.activeTextHover.pageIndex === record.index &&
-      rectContainsPage(this.activeTextHover.rect, point.x, point.y)
-    );
-  }
-
-  private cachedTextHoverAt(record: PageRecord, point: { x: number; y: number }) {
-    const texts = record.interactions?.texts;
-    if (!texts) {
-      return undefined;
-    }
-    for (let index = texts.length - 1; index >= 0; index -= 1) {
-      const text = texts[index];
-      const rect = this.textHoverRects.get(this.textHoverKey(record.index, text.id));
-      if (rect && rectContainsPage(rect, point.x, point.y)) {
-        return { text, rect };
-      }
-    }
-    return undefined;
-  }
-
-  private textHoverKey(pageIndex: number, textId: number) {
-    return `${this.interactionGeneration}:${pageIndex}:${textId}`;
-  }
-
-  private textHitContains(
-    text: TextInteraction,
-    hitRect: PageRect | undefined,
-    x: number,
-    y: number,
-  ) {
-    return rectContainsPage(textHoverRect(text, hitRect), x, y);
-  }
-
-  private applyRectStyle(record: PageRecord, element: HTMLElement, rect: PageRect) {
-    const x = clamp(rect.x / Math.max(record.width, 1), 0, 1);
-    const y = clamp(rect.y / Math.max(record.height, 1), 0, 1);
-    const right = clamp((rect.x + rect.width) / Math.max(record.width, 1), 0, 1);
-    const bottom = clamp((rect.y + rect.height) / Math.max(record.height, 1), 0, 1);
-    element.style.left = `${x * 100}%`;
-    element.style.top = `${y * 100}%`;
-    element.style.width = `${Math.max(0, right - x) * 100}%`;
-    element.style.height = `${Math.max(0, bottom - y) * 100}%`;
   }
 
   private insertPage(record: PageRecord, index: number) {
@@ -1182,135 +466,12 @@ export class PageHost {
     this.elements.pages.append(record.container);
   }
 
-  private applyPageLayout(record: PageRecord, page: PageSpec, metrics: PageLayoutMetrics) {
-    record.width = page.width;
-    record.height = page.height;
-    record.pixelPerPt = page.pixelPerPt;
-    record.container.hidden =
-      this.previewMode === "Slide" && page.index !== this.currentSlidePage - 1;
-    const scale = this.computePageScale(page, metrics);
-    const cssWidth = Math.ceil(page.width * scale);
-    const cssHeight = Math.ceil(page.height * scale);
-    record.cssWidth = cssWidth;
-    record.cssHeight = cssHeight;
-    record.container.style.width = `${cssWidth}px`;
-    record.container.style.height = `${cssHeight}px`;
-    record.shell.style.width = `${cssWidth}px`;
-    record.shell.style.height = `${cssHeight}px`;
-    record.shell.dataset.appliedScale = String(scale);
-    this.alignCanvasBackingStore(record, page);
-  }
-
-  private alignCanvasBackingStore(record: PageRecord, page: PageSpec) {
-    const drawnWidthPx = page.width * page.pixelPerPt;
-    const drawnHeightPx = page.height * page.pixelPerPt;
-    const widthScale = record.fullWidthPx / Math.max(drawnWidthPx, 1);
-    const heightScale = record.fullHeightPx / Math.max(drawnHeightPx, 1);
-    record.canvas.style.width = `${widthScale * 100}%`;
-    record.canvas.style.height = `${heightScale * 100}%`;
-  }
-
-  private computePageScale(page: PageSpec, metrics: PageLayoutMetrics): number {
-    const fitWidth = metrics.availableWidth / page.width;
-    const baseScale =
-      this.previewMode === "Slide"
-        ? Math.max(0.1, Math.min(fitWidth, metrics.availableHeight / page.height))
-        : Math.max(0.1, fitWidth);
-    return baseScale * this.zoomRatio;
-  }
-
   private readPageLayoutMetrics(): PageLayoutMetrics {
-    return {
-      availableWidth: Math.max(1, this.elements.viewport.clientWidth),
-      availableHeight: Math.max(1, this.elements.viewport.clientHeight),
-    };
+    return readLayoutMetrics(this.elements.viewport);
   }
 
   private pageGap() {
     return this.contentPreview ? 5 : 10;
-  }
-
-  private zoomAnchorFromEvent(
-    event: WheelEvent,
-    metrics: PageLayoutMetrics,
-    layouts: PageLayoutRecord[],
-  ): ZoomAnchor | undefined {
-    const viewportRect = this.elements.viewport.getBoundingClientRect();
-    const viewportX = event.clientX - viewportRect.left;
-    const viewportY = event.clientY - viewportRect.top;
-    const contentX = this.elements.viewport.scrollLeft + viewportX;
-    const contentY = this.elements.viewport.scrollTop + viewportY;
-    const layout =
-      this.findPageLayoutAt(layouts, contentY) || this.nearestPageLayout(layouts, contentY);
-    if (!layout) {
-      return undefined;
-    }
-
-    const record = this.pageRecords.get(layout.index);
-    if (!record) {
-      return undefined;
-    }
-
-    const pageLeft = this.pageLeft(record, metrics);
-    return {
-      pageIndex: layout.index,
-      pageX: clamp((contentX - pageLeft) / Math.max(layout.scaleX, 1e-6), 0, record.width),
-      pageY: clamp((contentY - layout.top) / Math.max(layout.scaleY, 1e-6), 0, record.height),
-      viewportX,
-      viewportY,
-    };
-  }
-
-  private restoreZoomAnchor(
-    anchor: ZoomAnchor | undefined,
-    metrics: PageLayoutMetrics,
-    layouts: PageLayoutRecord[],
-  ) {
-    if (!anchor) {
-      return;
-    }
-
-    const record = this.pageRecords.get(anchor.pageIndex);
-    const layout = layouts.find((candidate) => candidate.index === anchor.pageIndex);
-    if (!record || !layout) {
-      return;
-    }
-
-    const pageLeft = this.pageLeft(record, metrics);
-    this.elements.viewport.scrollTo({
-      left: pageLeft + anchor.pageX * layout.scaleX - anchor.viewportX,
-      top: layout.top + anchor.pageY * layout.scaleY - anchor.viewportY,
-      behavior: "auto",
-    });
-  }
-
-  private findPageLayoutAt(layouts: PageLayoutRecord[], contentY: number) {
-    return layouts.find((layout) => contentY >= layout.top && contentY <= layout.bottom);
-  }
-
-  private nearestPageLayout(layouts: PageLayoutRecord[], contentY: number) {
-    let nearest: PageLayoutRecord | undefined;
-    let nearestDistance = Number.POSITIVE_INFINITY;
-    for (const layout of layouts) {
-      const distance =
-        contentY < layout.top
-          ? layout.top - contentY
-          : contentY > layout.bottom
-            ? contentY - layout.bottom
-            : 0;
-      if (distance < nearestDistance) {
-        nearestDistance = distance;
-        nearest = layout;
-      }
-    }
-    return nearest;
-  }
-
-  private pageLeft(record: PageRecord, metrics: PageLayoutMetrics) {
-    if (this.contentPreview) {
-      return 0;
-    }
-    return (metrics.availableWidth - record.cssWidth) / 2;
   }
 
   private handleJumpMessage(text: string) {
@@ -1320,7 +481,9 @@ export class PageHost {
     }
 
     const currentPage =
-      this.previewMode === "Slide" ? this.currentSlidePage : this.currentViewportPage();
+      this.previewMode === "Slide"
+        ? this.currentSlidePage
+        : currentPageFromLayouts(this.elements.viewport, this.collectPageLayouts());
     const target = positions.reduce((best, position) =>
       Math.abs(position.page - currentPage) <= Math.abs(best.page - currentPage) ? position : best,
     );
@@ -1333,17 +496,14 @@ export class PageHost {
   }
 
   private handleCursorMessage(text: string) {
-    const [page, x, y] = text
-      .trim()
-      .split(/\s+/)
-      .map((value) => Number.parseFloat(value));
-    if (!Number.isFinite(page) || !Number.isFinite(x) || !Number.isFinite(y)) {
+    const position = parseCursorPosition(text);
+    if (!position) {
       return;
     }
 
-    this.pendingCursor = { page, x, y };
+    this.pendingCursor = position;
     if (this.previewMode === "Slide") {
-      this.setCurrentSlidePage(page);
+      this.setCurrentSlidePage(position.page);
     }
     this.renderCursor();
   }
@@ -1354,64 +514,17 @@ export class PageHost {
       return;
     }
 
-    const xRatio = clamp(position.x / Math.max(record.width, 1), 0, 1);
-    const yRatio = clamp(position.y / Math.max(record.height, 1), 0, 1);
-    const left = record.container.offsetLeft + xRatio * record.container.offsetWidth;
-    const top = record.container.offsetTop + yRatio * record.container.offsetHeight;
-    this.elements.viewport.scrollTo({
-      left: Math.max(0, left - this.elements.viewport.clientWidth / 2),
-      top: Math.max(0, top - this.elements.viewport.clientHeight / 2),
-      behavior: "auto",
-    });
-    this.showJumpMarker(record, xRatio, yRatio);
+    const { xRatio, yRatio } = scrollViewportToTypstLocation(
+      this.elements.viewport,
+      record,
+      position,
+    );
+    showJumpMarker(record, xRatio, yRatio);
     this.scheduleViewportSnapshot();
   }
 
-  private showJumpMarker(record: PageRecord, xRatio: number, yRatio: number) {
-    record.jumpMarker.style.left = `${xRatio * 100}%`;
-    record.jumpMarker.style.top = `${yRatio * 100}%`;
-    record.jumpMarker.classList.remove("visible");
-    void record.jumpMarker.offsetWidth;
-    record.jumpMarker.classList.add("visible");
-    window.setTimeout(() => record.jumpMarker.classList.remove("visible"), 900);
-  }
-
   private renderCursor() {
-    for (const record of this.pageRecords.values()) {
-      record.cursor.classList.remove("visible");
-    }
-    if (!this.pendingCursor) {
-      return;
-    }
-
-    const record = this.pageRecords.get(this.pendingCursor.page - 1);
-    if (!record) {
-      return;
-    }
-
-    record.cursor.style.left = `${
-      clamp(this.pendingCursor.x / Math.max(record.width, 1), 0, 1) * 100
-    }%`;
-    record.cursor.style.top = `${
-      clamp(this.pendingCursor.y / Math.max(record.height, 1), 0, 1) * 100
-    }%`;
-    record.cursor.classList.add("visible");
-  }
-
-  private currentViewportPage(): number {
-    const viewportCenter =
-      this.elements.viewport.scrollTop + this.elements.viewport.clientHeight / 2;
-    let bestPage = 1;
-    let bestDistance = Number.POSITIVE_INFINITY;
-    for (const layout of this.collectPageLayouts()) {
-      const center = (layout.top + layout.bottom) / 2;
-      const distance = Math.abs(center - viewportCenter);
-      if (distance < bestDistance) {
-        bestDistance = distance;
-        bestPage = layout.index + 1;
-      }
-    }
-    return bestPage;
+    renderCursor(this.pageRecords.values(), this.pendingCursor);
   }
 
   private setCurrentSlidePage(page: number) {
@@ -1434,98 +547,19 @@ export class PageHost {
     for (const page of this.lastPages) {
       const record = this.pageRecords.get(page.index);
       if (record) {
-        this.applyPageLayout(record, page, metrics);
+        applyLayout(record, page, metrics, {
+          previewMode: this.previewMode,
+          currentSlidePage: this.currentSlidePage,
+          zoomRatio: this.zoomRatio,
+        });
       }
     }
     this.renderCursor();
   }
 
   private renderOutline() {
-    const items = Array.isArray(this.outlineData?.items) ? this.outlineData.items : [];
-    this.elements.outlinePanel.replaceChildren();
-    this.elements.outlinePanel.classList.toggle(
-      "hidden",
-      !this.contentPreview || items.length === 0,
+    renderOutline(this.elements.outlinePanel, this.outlineData, this.contentPreview, (position) =>
+      this.scrollToTypstLocation(position),
     );
-    if (!this.contentPreview || items.length === 0) {
-      return;
-    }
-
-    const fragment = document.createDocumentFragment();
-    for (const item of items) {
-      fragment.appendChild(this.createOutlineItem(item, 1));
-    }
-    this.elements.outlinePanel.appendChild(fragment);
-  }
-
-  private createOutlineItem(item: any, level: number): HTMLElement {
-    const container = document.createElement("div");
-    container.className = `typst-outline level-${Math.min(level, 5)}`;
-    const title = document.createElement("button");
-    title.type = "button";
-    title.className = "typst-outline-title";
-    title.textContent = String(item?.title ?? "");
-    const position = item?.position;
-    if (position) {
-      title.addEventListener("click", () => {
-        this.scrollToTypstLocation({
-          page: Number(position.page_no ?? position.page ?? 1),
-          x: Number(position.x ?? 0),
-          y: Number(position.y ?? 0),
-        });
-      });
-    }
-    container.appendChild(title);
-    for (const child of Array.isArray(item?.children) ? item.children : []) {
-      container.appendChild(this.createOutlineItem(child, level + 1));
-    }
-    return container;
-  }
-
-  private ensureInvertColors(strategy: InvertColorStrategy | InvertColorStrategyMap) {
-    const target = typeof strategy === "string" ? { rest: strategy } : strategy;
-    const decide = (value: InvertColorStrategy | undefined) => {
-      switch (value || "never") {
-        case "always":
-          return true;
-        case "auto":
-          return (this.autoInvertDecision ??= determineInvertColor());
-        case "never":
-        default:
-          return false;
-      }
-    };
-    this.elements.root.classList.toggle("invert-colors", decide(target.rest));
-    this.elements.root.classList.toggle("normal-image", !decide(target.image || target.rest));
   }
 }
-
-function determineInvertColor() {
-  const cls = document.body.classList;
-  return (
-    (cls.contains("vscode-dark") || cls.contains("vscode-high-contrast")) &&
-    !cls.contains("vscode-light")
-  );
-}
-
-function textHoverRect(text: TextInteraction, hitRect: PageRect | undefined) {
-  return hitRect || text.rect;
-}
-
-function rectContainsPage(rect: PageRect, x: number, y: number) {
-  return x >= rect.x && y >= rect.y && x <= rect.x + rect.width && y <= rect.y + rect.height;
-}
-
-function alignTextClipToVisualRect(clippedRect: PageRect, visualRect: PageRect): PageRect {
-  return {
-    x: clippedRect.x,
-    y: visualRect.y,
-    width: clippedRect.width,
-    height: visualRect.height,
-  };
-}
-
-const zoomFactors = [
-  0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.3, 1.5, 1.7, 1.9, 2.1, 2.4, 2.7, 3, 3.3,
-  3.7, 4.1, 4.6, 5.1, 5.7, 6.3, 7, 7.7, 8.5, 9.4, 10,
-];

--- a/tools/typst-preview-frontend-ng/src/page-record.ts
+++ b/tools/typst-preview-frontend-ng/src/page-record.ts
@@ -1,0 +1,58 @@
+import type { PageRecord, PageSpec } from "./types";
+
+export function createPageRecord(
+  page: PageSpec,
+  key: string,
+  widthPx: number,
+  heightPx: number,
+): PageRecord {
+  const container = document.createElement("div");
+  container.className = "typst-page canvas-mode";
+  container.dataset.pageNumber = String(page.index);
+
+  const shell = document.createElement("div");
+  shell.className = "typst-page-canvas";
+  shell.dataset.pageNumber = String(page.index);
+  shell.dataset.pageWidth = page.width.toFixed(3);
+  shell.dataset.pageHeight = page.height.toFixed(3);
+
+  const canvas = document.createElement("canvas");
+  canvas.className = "typst-full-canvas";
+  canvas.width = 1;
+  canvas.height = 1;
+
+  const interactionLayer = document.createElement("div");
+  interactionLayer.className = "typst-interaction-layer";
+
+  const linkLayer = document.createElement("div");
+  linkLayer.className = "typst-link-layer";
+
+  const cursor = document.createElement("div");
+  cursor.className = "typst-cursor";
+
+  const jumpMarker = document.createElement("div");
+  jumpMarker.className = "typst-jump-marker";
+
+  shell.append(canvas);
+  container.append(shell, linkLayer, interactionLayer, cursor, jumpMarker);
+
+  return {
+    index: page.index,
+    key,
+    container,
+    shell,
+    canvas,
+    linkLayer,
+    interactionLayer,
+    cursor,
+    jumpMarker,
+    transferred: false,
+    width: page.width,
+    height: page.height,
+    fullWidthPx: widthPx,
+    fullHeightPx: heightPx,
+    cssWidth: widthPx,
+    cssHeight: heightPx,
+    pixelPerPt: page.pixelPerPt,
+  };
+}

--- a/tools/typst-preview-frontend-ng/src/theme.ts
+++ b/tools/typst-preview-frontend-ng/src/theme.ts
@@ -1,0 +1,30 @@
+import type { InvertColorStrategy, InvertColorStrategyMap } from "./types";
+
+export class InvertColorController {
+  private autoDecision: boolean | undefined;
+
+  apply(root: HTMLElement, strategy: InvertColorStrategy | InvertColorStrategyMap) {
+    const target = typeof strategy === "string" ? { rest: strategy } : strategy;
+    const decide = (value: InvertColorStrategy | undefined) => {
+      switch (value || "never") {
+        case "always":
+          return true;
+        case "auto":
+          return (this.autoDecision ??= determineInvertColor());
+        case "never":
+        default:
+          return false;
+      }
+    };
+    root.classList.toggle("invert-colors", decide(target.rest));
+    root.classList.toggle("normal-image", !decide(target.image || target.rest));
+  }
+}
+
+function determineInvertColor() {
+  const cls = document.body.classList;
+  return (
+    (cls.contains("vscode-dark") || cls.contains("vscode-high-contrast")) &&
+    !cls.contains("vscode-light")
+  );
+}

--- a/tools/typst-preview-frontend-ng/src/types.ts
+++ b/tools/typst-preview-frontend-ng/src/types.ts
@@ -17,6 +17,15 @@ export interface PageSpec {
   pixelPerPt: number;
 }
 
+export interface PageLayout {
+  index: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  scale: number;
+}
+
 export interface PageRecord {
   index: number;
   key: string;

--- a/tools/typst-preview-frontend-ng/src/worker/types.ts
+++ b/tools/typst-preview-frontend-ng/src/worker/types.ts
@@ -1,11 +1,7 @@
 import type { PageInteractions } from "../interactions";
+import type { PageLayout, PageSpec } from "../types";
 
-export interface PageSpec {
-  index: number;
-  width: number;
-  height: number;
-  pixelPerPt: number;
-}
+export type { PageLayout, PageSpec } from "../types";
 
 export interface RenderRect {
   lo: { x: number; y: number };
@@ -14,15 +10,6 @@ export interface RenderRect {
 
 export interface PageRenderSpec extends PageSpec {
   window?: RenderRect;
-}
-
-export interface PageLayout {
-  index: number;
-  top: number;
-  bottom: number;
-  width: number;
-  height: number;
-  scale: number;
 }
 
 export type CanvasLayer = "full";


### PR DESCRIPTION
- Split preview-ng page host responsibilities into focused modules for interactions, layout, navigation, outline, page records, and theme handling.
- Share PageSpec and PageLayout definitions between the main preview thread and worker types.