### PR TITLE
fix(preview-ng): stabilize preview interactions

### DIFF
--- a/tools/typst-preview-frontend-ng/renderer-worker.ts
+++ b/tools/typst-preview-frontend-ng/renderer-worker.ts
@@ -7,15 +7,59 @@ declare const self: DedicatedWorkerGlobalScope & {
   loadSvg?: (
     data: BufferSource,
     format: string,
-    width: number,
-    height: number,
+    width?: number,
+    height?: number,
   ) => Promise<ImageBitmap>;
 };
 
-self.loadSvg = async (data, format) => {
-  const type = format.includes("/") ? format : "image/svg+xml";
-  const blob = new Blob([data], { type });
-  return createImageBitmap(blob);
+interface PendingSvgLoad {
+  resolve: (bitmap: ImageBitmap) => void;
+  reject: (error: Error) => void;
+  timeout: number;
+}
+
+let nextSvgLoadRequestId = 0;
+const pendingSvgLoads = new Map<number, PendingSvgLoad>();
+
+function copyBufferSource(data: BufferSource): ArrayBuffer {
+  const source =
+    data instanceof ArrayBuffer
+      ? new Uint8Array(data)
+      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  const copy = new Uint8Array(source.byteLength);
+  copy.set(source);
+  return copy.buffer;
+}
+
+self.loadSvg = (data, format, width, height) => {
+  const requestId = ++nextSvgLoadRequestId;
+  const bytes = copyBufferSource(data);
+
+  return new Promise<ImageBitmap>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingSvgLoads.delete(requestId);
+      reject(new Error(`timed out decoding SVG image ${requestId}`));
+    }, 30_000) as unknown as number;
+
+    pendingSvgLoads.set(requestId, { resolve, reject, timeout });
+    try {
+      postMessage(
+        {
+          type: "load-svg",
+          requestId,
+          data: bytes,
+          format,
+          width,
+          height,
+        },
+        [bytes],
+      );
+    } catch (error) {
+      clearTimeout(timeout);
+      pendingSvgLoads.delete(requestId);
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
 };
 
 let currentConfig: any;
@@ -74,6 +118,24 @@ self.addEventListener("message", (event) => {
         ),
       );
       break;
+    case "load-svg-result": {
+      const pending = pendingSvgLoads.get(message.requestId);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        pendingSvgLoads.delete(message.requestId);
+        pending.resolve(message.bitmap);
+      }
+      break;
+    }
+    case "load-svg-error": {
+      const pending = pendingSvgLoads.get(message.requestId);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        pendingSvgLoads.delete(message.requestId);
+        pending.reject(new Error(message.message || "failed to decode SVG image"));
+      }
+      break;
+    }
     case "request-interactions":
       void renderer.requestInteractions({
         generation: message.generation,

--- a/tools/typst-preview-frontend-ng/src/app.ts
+++ b/tools/typst-preview-frontend-ng/src/app.ts
@@ -97,6 +97,9 @@ class PreviewApp {
       case "ensure-pages":
         this.handleEnsurePages(message);
         break;
+      case "load-svg":
+        void this.handleLoadSvg(message);
+        break;
       case "render-complete":
         this.pageHost.markRendered(
           message.generation,
@@ -146,6 +149,46 @@ class PreviewApp {
     }
   }
 
+  private async handleLoadSvg(message: any) {
+    try {
+      const bitmap = await decodeSvgImage(
+        message.data,
+        message.format,
+        message.width,
+        message.height,
+      );
+      this.postWorker(
+        {
+          type: "load-svg-result",
+          requestId: message.requestId,
+          bitmap,
+        },
+        [bitmap],
+      );
+    } catch (error) {
+      console.warn("[typst-preview-ng] failed to decode SVG image", error);
+      try {
+        const bitmap = createFallbackImageBitmap(message.width, message.height);
+        this.postWorker(
+          {
+            type: "load-svg-result",
+            requestId: message.requestId,
+            bitmap,
+          },
+          [bitmap],
+        );
+      } catch (fallbackError) {
+        const detail =
+          fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+        this.postWorker({
+          type: "load-svg-error",
+          requestId: message.requestId,
+          message: detail,
+        });
+      }
+    }
+  }
+
   private handleExtensionMessage(event: MessageEvent) {
     const message = event.data || {};
     switch (message.type) {
@@ -188,4 +231,52 @@ class PreviewApp {
     this.worker?.terminate();
     this.worker = undefined;
   }
+}
+
+function normalizeSvgMimeType(format: string | undefined) {
+  if (!format || format === "svg" || format === "svg+xml" || format === "image/svg") {
+    return "image/svg+xml";
+  }
+  return format.includes("/") ? format : `image/${format}`;
+}
+
+function loadImageElement(url: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("the source image could not be decoded"));
+    image.src = url;
+  });
+}
+
+async function decodeSvgImage(
+  data: BufferSource,
+  format?: string,
+  width?: number,
+  height?: number,
+) {
+  const blob = new Blob([data], { type: normalizeSvgMimeType(format) });
+  const url = URL.createObjectURL(blob);
+  try {
+    const image = await loadImageElement(url);
+    const bitmapWidth = width || image.naturalWidth || image.width;
+    const bitmapHeight = height || image.naturalHeight || image.height;
+    if (!bitmapWidth || !bitmapHeight) {
+      throw new Error("decoded SVG image has no dimensions");
+    }
+    const canvas = new OffscreenCanvas(bitmapWidth, bitmapHeight);
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("failed to create SVG decode canvas context");
+    }
+    context.drawImage(image, 0, 0, bitmapWidth, bitmapHeight);
+    return canvas.transferToImageBitmap();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function createFallbackImageBitmap(width?: number, height?: number) {
+  const canvas = new OffscreenCanvas(Math.max(1, width || 1), Math.max(1, height || 1));
+  return canvas.transferToImageBitmap();
 }

--- a/tools/typst-preview-frontend-ng/src/interactions.ts
+++ b/tools/typst-preview-frontend-ng/src/interactions.ts
@@ -73,11 +73,8 @@ interface PendingBoundHover extends PagePointer {
 
 type InteractionHighlightKind = "link" | "text" | "bound";
 
-const textHighlightEnabled = false;
-
-const interactionTagPattern = textHighlightEnabled
-  ? /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-(?:text|link)\b[^"]*"[^>]*)>/g
-  : /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-link\b[^"]*"[^>]*)>/g;
+const interactionTagPattern =
+  /<(span|a)\b([^>]*\bclass="[^"]*\btypst-content-(?:text|link)\b[^"]*"[^>]*)>/g;
 
 /** Extracts lightweight page-space hit-test metadata from renderer semantics HTML. */
 export function parsePageInteractions(pageIndex: number, html: string): PageInteractions {
@@ -98,7 +95,7 @@ export function parsePageInteractions(pageIndex: number, html: string): PageInte
       continue;
     }
 
-    if (textHighlightEnabled && hasClass(className, "typst-content-text")) {
+    if (hasClass(className, "typst-content-text")) {
       const rect = readPageRect(attrs);
       if (!rect) {
         continue;
@@ -129,9 +126,6 @@ export function hitTestText(
   x: number,
   y: number,
 ): TextInteraction | undefined {
-  if (!textHighlightEnabled) {
-    return undefined;
-  }
   if (!interactions) {
     return undefined;
   }
@@ -161,9 +155,6 @@ export function textHighlightsForLink(
   interactions: PageInteractions | undefined,
   link: LinkInteraction,
 ): LinkTextHighlight[] {
-  if (!textHighlightEnabled) {
-    return [];
-  }
   if (!interactions) {
     return [];
   }
@@ -287,6 +278,7 @@ export interface PageInteractionControllerOptions {
   isDragging: () => boolean;
   isContentPreview: () => boolean;
   scrollToTypstLocation: (position: LinkPosition) => void;
+  onSourceSyncRequest: () => void;
 }
 
 export class PageInteractionController {
@@ -687,10 +679,12 @@ export class PageInteractionController {
     }
 
     if (this.options.isContentPreview()) {
+      this.options.onSourceSyncRequest();
       this.options.postWorker({ type: "send", text: `outline-sync,${record.index + 1}` });
       return;
     }
 
+    this.options.onSourceSyncRequest();
     this.options.postWorker({
       type: "send",
       text: `src-point ${JSON.stringify({

--- a/tools/typst-preview-frontend-ng/src/navigation.ts
+++ b/tools/typst-preview-frontend-ng/src/navigation.ts
@@ -24,7 +24,7 @@ export function scrollViewportToTypstLocation(
   viewport.scrollTo({
     left: Math.max(0, left - viewport.clientWidth / 2),
     top: Math.max(0, top - viewport.clientHeight / 2),
-    behavior: "auto",
+    behavior: "smooth",
   });
   return { xRatio, yRatio };
 }

--- a/tools/typst-preview-frontend-ng/src/page-host.ts
+++ b/tools/typst-preview-frontend-ng/src/page-host.ts
@@ -57,6 +57,8 @@ export class PageHost {
   private lastViewportPostKey = "";
   private lastViewportTimer = 0;
   private scrollIdleTimer = 0;
+  private sourceSyncEchoIgnoreUntil = 0;
+  private sourceSyncEchoIgnoreCount = 0;
   private lastPages: PageSpec[] = [];
   private pendingCursor: PreviewPosition | undefined;
   private outlineData: any;
@@ -75,6 +77,7 @@ export class PageHost {
       isDragging: () => this.dragging,
       isContentPreview: () => this.contentPreview,
       scrollToTypstLocation: (position) => this.scrollToTypstLocation(position),
+      onSourceSyncRequest: () => this.markSourceSyncEchoSuppression(),
     });
   }
 
@@ -178,7 +181,6 @@ export class PageHost {
     this.updatePageCount(pages.length);
     if (this.interactions.startGeneration(generation)) {
       for (const record of this.pageRecords.values()) {
-        record.container.classList.remove("canvas-ready");
         record.container.classList.remove("full-ready");
       }
     }
@@ -330,6 +332,9 @@ export class PageHost {
     switch (kind) {
       case "jump":
       case "viewport":
+        if (this.shouldIgnoreSourceSyncEcho()) {
+          return;
+        }
         this.handleJumpMessage(text);
         break;
       case "cursor":
@@ -348,6 +353,23 @@ export class PageHost {
         } catch (_error) {}
         break;
     }
+  }
+
+  private markSourceSyncEchoSuppression() {
+    this.sourceSyncEchoIgnoreUntil = performance.now() + 1_200;
+    this.sourceSyncEchoIgnoreCount = 2;
+  }
+
+  private shouldIgnoreSourceSyncEcho() {
+    if (this.sourceSyncEchoIgnoreCount <= 0) {
+      return false;
+    }
+    if (performance.now() > this.sourceSyncEchoIgnoreUntil) {
+      this.sourceSyncEchoIgnoreCount = 0;
+      return false;
+    }
+    this.sourceSyncEchoIgnoreCount -= 1;
+    return true;
   }
 
   updateInteractions(
@@ -447,6 +469,8 @@ export class PageHost {
     this.lastPages = [];
     this.lastViewportPostKey = "";
     this.pendingCursor = undefined;
+    this.sourceSyncEchoIgnoreUntil = 0;
+    this.sourceSyncEchoIgnoreCount = 0;
     this.interactions.resetAll();
     this.updatePageCount(0);
   }

--- a/tools/typst-preview-frontend-ng/styles/base.css
+++ b/tools/typst-preview-frontend-ng/styles/base.css
@@ -6,6 +6,8 @@
   --border: var(--vscode-panel-border, #3c3c3c);
   --accent: var(--vscode-focusBorder, #0078d4);
   --surface: var(--vscode-sideBar-background, #252526);
+  --page-bg: #ffffff;
+  --inverted-page-bg: #111111;
   --page-shadow: color-mix(in srgb, #000000 30%, transparent);
   --cursor-color: var(--vscode-editorCursor-foreground, #aeafad);
   --jump-color: #66bab7;

--- a/tools/typst-preview-frontend-ng/styles/pages.css
+++ b/tools/typst-preview-frontend-ng/styles/pages.css
@@ -28,8 +28,12 @@
   position: relative;
   flex: 0 0 auto;
   overflow: hidden;
-  background: #ffffff;
+  background: var(--page-bg);
   box-shadow: 0 2px 8px var(--page-shadow);
+}
+
+.invert-colors .typst-page {
+  background: var(--inverted-page-bg);
 }
 
 .content-preview .typst-page {


### PR DESCRIPTION
- Keep rendered canvases visible across document updates to avoid white flashes.
- Restore hover highlight parsing for typst.ts semantic text/link metadata.
- Align inverted page fallback backgrounds with dark preview rendering.
- Use native smooth preview jumps while suppressing preview-to-source sync echoes.
- Decode SVG images on the webview side and fall back safely when browser decoding fails.