### PR TITLE
fix(vscode): support gpu previewer in remote windows

### DIFF
--- a/.github/workflows/build-vscode-main.yml
+++ b/.github/workflows/build-vscode-main.yml
@@ -84,6 +84,14 @@ jobs:
           tar -xvf prebuilts/tinymist-${{ matrix.rust-target }}.tar.gz -C prebuilts
           mv prebuilts/tinymist-${{ matrix.rust-target }}/tinymist prebuilts/tinymist
         if: matrix.platform != 'win32' && (fromJson(env.isRelease) || fromJson(env.isNightly))
+      - name: Unzip tinymist-viewer binary artifact (Windows)
+        run: 7z x -y -oprebuilts prebuilts/tinymist-viewer-${{ matrix.rust-target }}.zip
+        if: matrix.platform == 'win32' && (fromJson(env.isRelease) || fromJson(env.isNightly))
+      - name: Unzip tinymist-viewer binary artifact (Linux)
+        run: |
+          tar -xvf prebuilts/tinymist-viewer-${{ matrix.rust-target }}.tar.gz -C prebuilts
+          mv prebuilts/tinymist-viewer-${{ matrix.rust-target }}/tinymist-viewer prebuilts/tinymist-viewer
+        if: matrix.platform != 'win32' && (fromJson(env.isRelease) || fromJson(env.isNightly))
 
       - name: Download VSC Assets
         uses: actions/download-artifact@v4
@@ -110,11 +118,20 @@ jobs:
           cp "prebuilts/tinymist${{ ( matrix.platform == 'win32' ) && '.exe' || '' }}" "editors/vscode/out/"
           cp "prebuilts/tinymist${{ ( matrix.platform == 'win32' ) && '.exe' || '' }}" "contrib/typst-preview/editors/vscode/out/"
           cp "prebuilts/tinymist${{ ( matrix.platform == 'win32' ) && '.exe' || '' }}" "tinymist-${{ env.target }}${{ ( matrix.platform == 'win32' ) && '.exe' || '' }}"
+          node -e "require('fs').mkdirSync('contrib/tinymist-gpu-viewer/editors/vscode/bin', { recursive: true })"
+          cp "prebuilts/tinymist-viewer${{ ( matrix.platform == 'win32' ) && '.exe' || '' }}" "contrib/tinymist-gpu-viewer/editors/vscode/bin/"
+      - name: Make tinymist-viewer executable
+        if: matrix.platform != 'win32' && (fromJson(env.isRelease) || fromJson(env.isNightly))
+        run: chmod +x contrib/tinymist-gpu-viewer/editors/vscode/bin/tinymist-viewer
 
       - name: Package typst-preview extension
         if: fromJson(env.isRelease)
         run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
         working-directory: ./contrib/typst-preview/editors/vscode
+      - name: Package tinymist-gpu-viewer extension
+        if: fromJson(env.isRelease)
+        run: yarn run package -- --target ${{ env.target }} -o tinymist-gpu-viewer-${{ env.target }}.vsix
+        working-directory: ./contrib/tinymist-gpu-viewer/editors/vscode
       - name: Package tinymist extension
         if: fromJson(env.isRelease)
         run: yarn run package -- --target ${{ env.target }} -o tinymist-${{ env.target }}.vsix
@@ -123,6 +140,10 @@ jobs:
         if: fromJson(env.isNightly)
         run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix --pre-release
         working-directory: ./contrib/typst-preview/editors/vscode
+      - name: Package tinymist-gpu-viewer extension (Nightly)
+        if: fromJson(env.isNightly)
+        run: yarn run package -- --target ${{ env.target }} -o tinymist-gpu-viewer-${{ env.target }}.vsix --pre-release
+        working-directory: ./contrib/tinymist-gpu-viewer/editors/vscode
       - name: Package tinymist extension (Nightly)
         if: fromJson(env.isNightly)
         run: yarn run package -- --target ${{ env.target }} -o tinymist-${{ env.target }}.vsix --pre-release
@@ -140,6 +161,12 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}.vsix
           path: contrib/typst-preview/editors/vscode/typst-preview-${{ env.target }}.vsix
+      - name: Upload tinymist-gpu-viewer VSIX artifact
+        if: (fromJson(env.isRelease) || fromJson(env.isNightly))
+        uses: actions/upload-artifact@v4
+        with:
+          name: tinymist-gpu-viewer-${{ env.target }}.vsix
+          path: contrib/tinymist-gpu-viewer/editors/vscode/tinymist-gpu-viewer-${{ env.target }}.vsix
       - name: Upload VSIX artifact
         if: (fromJson(env.isRelease) || fromJson(env.isNightly))
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: '{tinymist,typst-preview}-*'
+          pattern: '{tinymist,typst-preview,tinymist-gpu-viewer}-*'
       - name: Display structure of downloaded files
         run: ls -R artifacts
       - uses: ncipollo/release-action@v1

--- a/contrib/tinymist-gpu-viewer/editors/vscode/README.md
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/README.md
@@ -19,6 +19,8 @@ Then configure Tinymist:
 
 Tinymist will activate this extension, start the regular preview server, and pass the preview data-plane websocket address to the native `tinymist-viewer` process. No VS Code webview preview panel is created for this provider.
 
+In VS Code Remote windows, Tinymist may run in the remote extension host while Tinymist GPU Viewer runs in the local UI extension host. The provider uses a command bridge in that case, and Tinymist passes a VS Code-forwarded websocket URL to the local native viewer. Install Tinymist in the remote workspace and Tinymist GPU Viewer in the local/UI side.
+
 For local development, the repository debug task builds the native viewer and copies the debug binary into this extension's `bin/` directory before launching the Extension Development Host:
 
 ```sh

--- a/contrib/tinymist-gpu-viewer/editors/vscode/package.json
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/package.json
@@ -26,9 +26,14 @@
   "extensionDependencies": [
     "myriad-dreamin.tinymist"
   ],
-    "extensionKind": [
-      "ui"
-    ],
+  "extensionKind": [
+    "ui"
+  ],
+  "activationEvents": [
+    "onCommand:myriad-dreamin.tinymist-gpu-viewer.provideTinymistPreviewer",
+    "onCommand:myriad-dreamin.tinymist-gpu-viewer.handleTinymistPreview",
+    "onCommand:myriad-dreamin.tinymist-gpu-viewer.disposeTinymistPreview"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {
@@ -55,17 +60,10 @@
       }
     }
   },
-  "files": [
-    "out",
-    "bin",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE"
-  ],
   "scripts": {
     "compile": "tsc -p .",
     "vscode:prepublish": "yarn run compile",
-    "package": "npx @vscode/vsce package --yarn",
+    "package": "npx @vscode/vsce package --yarn --no-dependencies",
     "type-check": "tsc --noEmit -p ."
   },
   "devDependencies": {

--- a/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
+++ b/contrib/tinymist-gpu-viewer/editors/vscode/src/extension.ts
@@ -15,6 +15,10 @@ const WINDOW_LAYOUT_TIMEOUT_MS = 10_000;
 const WINDOW_LAYOUT_POLL_MS = 250;
 const MIN_VIEWER_INNER_WIDTH = 800;
 const MIN_VIEWER_INNER_HEIGHT = 844;
+const COMMAND_PREFIX = "myriad-dreamin.tinymist-gpu-viewer";
+const PROVIDE_PREVIEWER_COMMAND = `${COMMAND_PREFIX}.provideTinymistPreviewer`;
+const HANDLE_PREVIEW_COMMAND = `${COMMAND_PREFIX}.handleTinymistPreview`;
+const DISPOSE_PREVIEW_COMMAND = `${COMMAND_PREFIX}.disposeTinymistPreview`;
 
 type WindowLayoutMode = "disabled" | "sideBySide";
 type PreviewTarget = "paged" | "html";
@@ -36,6 +40,12 @@ interface TinymistPreviewTask {
 
 interface TinymistPreviewerProvider {
   providePreviewer(): Promise<TinymistPreviewer> | TinymistPreviewer;
+}
+
+interface CommandBackedPreviewer {
+  compatibleTinymistVersion: string;
+  supportedTargets: PreviewTarget[];
+  hasHandlePreview: boolean;
 }
 
 interface ViewerWindowState {
@@ -72,18 +82,25 @@ export function activate(context: vscode.ExtensionContext): TinymistPreviewerPro
     },
   });
 
+  const previewer = createPreviewer(context, compatibleTinymistVersion);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(PROVIDE_PREVIEWER_COMMAND, () =>
+      commandBackedPreviewerMetadata(compatibleTinymistVersion),
+    ),
+    vscode.commands.registerCommand(HANDLE_PREVIEW_COMMAND, (task: unknown) =>
+      launchViewer(context, normalizePreviewTask(task)),
+    ),
+    vscode.commands.registerCommand(DISPOSE_PREVIEW_COMMAND, (task: unknown) => {
+      const taskId = taskIdFromCommandArg(task);
+      if (taskId) {
+        disposeViewer(taskId);
+      }
+    }),
+  );
+
   return {
     providePreviewer() {
-      return {
-        compatibleTinymistVersion,
-        supportedTargets: ["paged"],
-        isCompatible(tinymistVersion: string) {
-          return tinymistVersion === compatibleTinymistVersion;
-        },
-        handlePreview(task: TinymistPreviewTask) {
-          return launchViewer(context, task);
-        },
-      };
+      return previewer;
     },
   };
 }
@@ -94,7 +111,7 @@ async function launchViewer(
   context: vscode.ExtensionContext,
   task: TinymistPreviewTask,
 ): Promise<vscode.Disposable> {
-  activeViewers.get(task.taskId)?.kill();
+  disposeViewer(task.taskId);
 
   const executable = resolveViewerExecutable(context);
   const documentTitle = documentTitleForPath(task.documentPath);
@@ -103,7 +120,7 @@ async function launchViewer(
   const args = ["--data-plane-host", task.dataPlaneHost, "--document-title", documentTitle];
   const windowPlan = await windowLaunchPlanForTask(task, layoutMode);
   appendInitialWindowArgs(args, windowPlan.initialWindowState);
-  const cwd = path.dirname(task.documentPath);
+  const cwd = workingDirectoryForDocument(context, task.documentPath);
   appendLog(`Starting ${executable} ${args.join(" ")}`);
 
   const viewer = spawn(executable, args, {
@@ -135,18 +152,87 @@ async function launchViewer(
 
   return {
     dispose() {
-      deleteActiveViewer(task.taskId, viewer);
-      if (!viewer.killed) {
-        viewer.kill();
-      }
+      disposeViewer(task.taskId, viewer);
     },
   };
+}
+
+function createPreviewer(
+  context: vscode.ExtensionContext,
+  compatibleTinymistVersion: string,
+): TinymistPreviewer {
+  return {
+    compatibleTinymistVersion,
+    supportedTargets: ["paged"],
+    isCompatible(tinymistVersion: string) {
+      return tinymistVersion === compatibleTinymistVersion;
+    },
+    handlePreview(task: TinymistPreviewTask) {
+      return launchViewer(context, task);
+    },
+  };
+}
+
+function commandBackedPreviewerMetadata(compatibleTinymistVersion: string): CommandBackedPreviewer {
+  return {
+    compatibleTinymistVersion,
+    supportedTargets: ["paged"],
+    hasHandlePreview: true,
+  };
+}
+
+function disposeViewer(taskId: string, expectedViewer?: ChildProcessWithoutNullStreams) {
+  const viewer = activeViewers.get(taskId);
+  if (!viewer || (expectedViewer && viewer !== expectedViewer)) {
+    return;
+  }
+
+  activeViewers.delete(taskId);
+  if (!viewer.killed) {
+    viewer.kill();
+  }
 }
 
 function deleteActiveViewer(taskId: string, viewer: ChildProcessWithoutNullStreams) {
   if (activeViewers.get(taskId) === viewer) {
     activeViewers.delete(taskId);
   }
+}
+
+function normalizePreviewTask(value: unknown): TinymistPreviewTask {
+  if (!isObject(value)) {
+    throw new Error("Tinymist GPU Viewer preview task must be an object.");
+  }
+
+  const taskId = requiredString(value.taskId, "taskId");
+  const documentPath = requiredString(value.documentPath, "documentPath");
+  const dataPlaneHost = requiredString(value.dataPlaneHost, "dataPlaneHost");
+  const target = value.target === "html" ? "html" : "paged";
+  const initialWindowState = normalizeStoredWindowState(value.initialWindowState);
+
+  return {
+    taskId,
+    documentPath,
+    target,
+    dataPlaneHost,
+    initialWindowState,
+  };
+}
+
+function taskIdFromCommandArg(value: unknown): string | undefined {
+  if (!isObject(value) || typeof value.taskId !== "string" || value.taskId.trim() === "") {
+    return undefined;
+  }
+
+  return value.taskId;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Tinymist GPU Viewer preview task is missing ${field}.`);
+  }
+
+  return value;
 }
 
 async function windowLaunchPlanForTask(
@@ -291,8 +377,23 @@ function resolveViewerExecutable(context: vscode.ExtensionContext): string {
 }
 
 function documentTitleForPath(documentPath: string): string {
-  const title = path.basename(documentPath).trim();
+  const title = documentPath.split(/[\\/]/).pop()?.trim() || path.basename(documentPath).trim();
   return title || documentPath.trim() || VIEWER_WINDOW_TITLE;
+}
+
+function workingDirectoryForDocument(
+  context: vscode.ExtensionContext,
+  documentPath: string,
+): string {
+  const documentDir = path.dirname(documentPath);
+  if (documentDir && fs.existsSync(documentDir)) {
+    return documentDir;
+  }
+
+  appendLog(
+    `Document directory is not available on this extension host; using GPU viewer extension directory as cwd.`,
+  );
+  return context.extensionUri.fsPath;
 }
 
 function viewerWindowTitle(documentTitle: string): string {
@@ -508,13 +609,7 @@ async function prepareSideBySideLayoutBeforeSpawnLinux(): Promise<WindowRect> {
   }
 
   const rects = splitSideBySideWorkArea(await getLinuxWorkArea());
-  await moveLinuxWindow(
-    code.id,
-    rects.code.x,
-    rects.code.y,
-    rects.code.width,
-    rects.code.height,
-  );
+  await moveLinuxWindow(code.id, rects.code.x, rects.code.y, rects.code.width, rects.code.height);
   return rects.viewer;
 }
 

--- a/editors/vscode/src/features/preview.ts
+++ b/editors/vscode/src/features/preview.ts
@@ -441,9 +441,7 @@ export async function openPreviewInWebView({
   html = html.replace("preview-arg:state:", `preview-arg:state:${previewStateEncoded}`);
   // Forwards the localhost port to the external URL. Since WebSocket runs over HTTP, it should be fine.
   // https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost
-  let wsURI = await vscode.env.asExternalUri(vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`));
-  let wsURIString = wsURI.toString().replace(/^http/, "ws");
-  html = html.replace("ws://127.0.0.1:23625", wsURIString);
+  html = html.replace("ws://127.0.0.1:23625", await externalDataPlaneHost(dataPlanePort));
 
   // Sets the HTML content to the webview panel.
   // This will reload the webview panel if it's already opened.
@@ -529,13 +527,16 @@ async function launchPreviewLsp(task: LaunchInBrowserTask | LaunchInWebViewTask)
     case "webview": {
       if (resolvedPreviewer?.handlePreview) {
         try {
+          const dataPlaneHost = resolvedPreviewer.preferExternalDataPlaneHost
+            ? await externalDataPlaneHost(dataPlanePort)
+            : localDataPlaneHost(dataPlanePort);
           const previewHandle = await resolvedPreviewer.handlePreview({
             taskId,
             documentUri: bindDocument.uri.toString(),
             documentPath: filePath,
             mode: task.mode,
             target: resolvedPreviewer.source.target ?? "paged",
-            dataPlaneHost: `ws://127.0.0.1:${dataPlanePort}`,
+            dataPlaneHost,
             dataPlanePort,
             staticServerPort,
             initialWindowState: loadStoredViewerWindowState(context),
@@ -705,6 +706,15 @@ async function launchPreviewLsp(task: LaunchInBrowserTask | LaunchInWebViewTask)
     };
     scrollPreviewPanel(taskId, scrollRequest);
   }
+}
+
+function localDataPlaneHost(dataPlanePort: string | number): string {
+  return `ws://127.0.0.1:${dataPlanePort}`;
+}
+
+async function externalDataPlaneHost(dataPlanePort: string | number): Promise<string> {
+  const uri = await vscode.env.asExternalUri(vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`));
+  return uri.toString().replace(/^http/, "ws");
 }
 
 function addPreviewHandleDispose(disposes: DisposeList, previewHandle: unknown) {

--- a/editors/vscode/src/features/previewer.ts
+++ b/editors/vscode/src/features/previewer.ts
@@ -43,6 +43,7 @@ export interface ResolvedPreviewer {
   html: string;
   htmlUri: vscode.Uri;
   localResourceRoots: vscode.Uri[];
+  preferExternalDataPlaneHost?: boolean;
   handlePreview?: (
     task: TinymistPreviewTask,
   ) => Promise<TinymistPreviewHandle> | TinymistPreviewHandle;
@@ -61,6 +62,19 @@ export interface TinymistPreviewerProvider {
   providePreviewer(): Promise<TinymistPreviewer> | TinymistPreviewer;
 }
 
+interface CommandBackedPreviewer {
+  compatibleTinymistVersion: string;
+  supportedTargets?: PreviewTarget[];
+  hasHandlePreview?: boolean;
+  htmlPath?: string;
+}
+
+interface PreviewerCommandApi {
+  providePreviewer: string;
+  handlePreview: string;
+  disposePreview: string;
+}
+
 interface PreviewerExtension {
   extensionUri: vscode.Uri;
   activate(): Thenable<unknown>;
@@ -75,6 +89,7 @@ export interface PreviewerResolverEnvironment {
   builtinPreviewer: () => Promise<ResolvedPreviewer>;
   readHtmlFile?: (uri: vscode.Uri) => Promise<string>;
   getExtension?: (id: string) => PreviewerExtension | undefined;
+  executeCommand?: <T>(command: string, ...args: unknown[]) => Thenable<T>;
   showWarning?: (message: string) => void;
 }
 
@@ -201,6 +216,7 @@ export async function resolvePreviewer(
       void vscode.window.showWarningMessage(message);
     },
     getExtension: (extensionId) => vscode.extensions.getExtension(extensionId),
+    executeCommand: (command, ...args) => vscode.commands.executeCommand(command, ...args),
   });
 
   cachedPreviewer = { key: cacheKey, previewer };
@@ -292,6 +308,15 @@ async function resolveExtensionPreviewer(
 ): Promise<ResolvedPreviewer> {
   const extension = environment.getExtension?.(extensionId);
   if (!extension) {
+    const commandBackedPreviewer = await resolveCommandBackedExtensionPreviewer(
+      environment,
+      provider,
+      extensionId,
+    );
+    if (commandBackedPreviewer) {
+      return commandBackedPreviewer;
+    }
+
     throw previewerResolutionError(
       provider,
       `could not find previewer provider extension \`${extensionId}\``,
@@ -309,6 +334,15 @@ async function resolveExtensionPreviewer(
   }
 
   if (!isPreviewerProvider(providerExports)) {
+    const commandBackedPreviewer = await resolveCommandBackedExtensionPreviewer(
+      environment,
+      provider,
+      extensionId,
+    );
+    if (commandBackedPreviewer) {
+      return commandBackedPreviewer;
+    }
+
     throw previewerResolutionError(
       provider,
       `extension \`${extensionId}\` does not export a \`providePreviewer()\` previewer provider`,
@@ -412,6 +446,110 @@ async function resolveExtensionPreviewer(
       compatibleTinymistVersion: previewer.compatibleTinymistVersion,
     },
   });
+}
+
+async function resolveCommandBackedExtensionPreviewer(
+  environment: PreviewerResolverEnvironment,
+  provider: string | undefined,
+  extensionId: string,
+): Promise<ResolvedPreviewer | undefined> {
+  const executeCommand = environment.executeCommand;
+  if (!executeCommand) {
+    return undefined;
+  }
+
+  const commands = previewerCommandApi(extensionId);
+  let previewer: CommandBackedPreviewer | undefined;
+  try {
+    previewer = await executeCommand<CommandBackedPreviewer>(commands.providePreviewer);
+  } catch (error) {
+    if (isCommandMissingError(error, commands.providePreviewer)) {
+      return undefined;
+    }
+
+    throw previewerResolutionError(
+      provider,
+      `failed to activate previewer provider command \`${commands.providePreviewer}\`: ${errorMessage(error)}`,
+    );
+  }
+
+  if (
+    !previewer ||
+    typeof previewer.compatibleTinymistVersion !== "string" ||
+    previewer.compatibleTinymistVersion.trim() === ""
+  ) {
+    throw previewerResolutionError(
+      provider,
+      `extension \`${extensionId}\` did not declare \`compatibleTinymistVersion\``,
+    );
+  }
+
+  if (previewer.compatibleTinymistVersion !== environment.tinymistVersion) {
+    throw previewerResolutionError(
+      provider,
+      `extension \`${extensionId}\` is not compatible with Tinymist ${environment.tinymistVersion}`,
+    );
+  }
+
+  const previewTarget = getPreviewTarget(environment);
+  const supportedTargets = normalizeSupportedTargets(previewer.supportedTargets);
+  if (!supportsPreviewTarget(supportedTargets, previewTarget)) {
+    return fallbackToBuiltin(
+      environment,
+      provider,
+      `does not support the \`${previewTarget}\` preview target`,
+    );
+  }
+
+  if (previewer.hasHandlePreview) {
+    return {
+      html: "",
+      htmlUri: vscode.Uri.parse(`command:${commands.providePreviewer}`),
+      localResourceRoots: [],
+      preferExternalDataPlaneHost: true,
+      handlePreview: async (task) => {
+        await executeCommand<void>(commands.handlePreview, task);
+        return () => {
+          void executeCommand<void>(commands.disposePreview, { taskId: task.taskId });
+        };
+      },
+      source: {
+        kind: "extension",
+        trusted: environment.workspaceTrusted,
+        target: previewTarget,
+        configuredProvider: provider,
+        extensionId,
+        handler: "documentPreview",
+        supportedTargets,
+        compatibleTinymistVersion: previewer.compatibleTinymistVersion,
+      },
+    };
+  }
+
+  if (typeof previewer.htmlPath === "string" && previewer.htmlPath.trim() !== "") {
+    throw previewerResolutionError(
+      provider,
+      `extension \`${extensionId}\` returned an HTML previewer through a command bridge, which is not supported`,
+    );
+  }
+
+  throw previewerResolutionError(
+    provider,
+    `extension \`${extensionId}\` did not export a \`handlePreview()\` handler or return an HTML path`,
+  );
+}
+
+function previewerCommandApi(extensionId: string): PreviewerCommandApi {
+  return {
+    providePreviewer: `${extensionId}.provideTinymistPreviewer`,
+    handlePreview: `${extensionId}.handleTinymistPreview`,
+    disposePreview: `${extensionId}.disposeTinymistPreview`,
+  };
+}
+
+function isCommandMissingError(error: unknown, command: string): boolean {
+  const message = errorMessage(error).toLowerCase();
+  return message.includes(command.toLowerCase()) && message.includes("not found");
 }
 
 async function resolveHtmlFilePreviewer(

--- a/editors/vscode/src/test/e2e/preview-provider.test.ts
+++ b/editors/vscode/src/test/e2e/preview-provider.test.ts
@@ -107,6 +107,63 @@ export async function getTests(ctx: Context) {
     });
 
     suite.addTest(
+      "uses command-backed extension previewers from another extension host",
+      async () => {
+        const provider = "myriad-dreamin.tinymist-command-previewer";
+        const tinymistVersion = "1.2.3";
+        const commands: { command: string; args: unknown[] }[] = [];
+
+        const result = await resolveConfiguredPreviewer({
+          provider,
+          workspaceTrusted: true,
+          tinymistVersion,
+          builtinPreviewer: async () => builtinPreviewer(),
+          getExtension: () => undefined,
+          executeCommand: async <T>(command: string, ...args: unknown[]): Promise<T> => {
+            commands.push({ command, args });
+            if (command === `${provider}.provideTinymistPreviewer`) {
+              return {
+                compatibleTinymistVersion: tinymistVersion,
+                supportedTargets: ["paged"],
+                hasHandlePreview: true,
+              } as T;
+            }
+            return undefined as T;
+          },
+        });
+
+        workspaceCtx.expect(result.source.kind).to.be.equal("extension");
+        workspaceCtx.expect(result.source.extensionId).to.be.equal(provider);
+        workspaceCtx.expect(result.source.handler).to.be.equal("documentPreview");
+        workspaceCtx.expect(result.preferExternalDataPlaneHost).to.be.equal(true);
+        workspaceCtx.expect(result.handlePreview).to.be.a("function");
+
+        const previewHandle = await result.handlePreview?.({
+          taskId: "preview-task",
+          documentUri: "file:///workspace/main.typ",
+          documentPath: "/workspace/main.typ",
+          mode: "doc",
+          target: "paged",
+          dataPlaneHost: "ws://forwarded.example",
+          dataPlanePort: 1234,
+          staticServerPort: 5678,
+          isBrowsing: false,
+          isPrimary: true,
+        });
+        workspaceCtx
+          .expect(commands.some((entry) => entry.command === `${provider}.handleTinymistPreview`))
+          .to.be.equal(true);
+
+        if (typeof previewHandle === "function") {
+          previewHandle();
+        }
+        workspaceCtx
+          .expect(commands.some((entry) => entry.command === `${provider}.disposeTinymistPreview`))
+          .to.be.equal(true);
+      },
+    );
+
+    suite.addTest(
       "treats previewers without target declarations as supporting every target",
       async () => {
         const provider = "myriad-dreamin.tinymist-default-target-previewer";


### PR DESCRIPTION
- Add a command bridge so Tinymist can resolve UI-host previewer providers from VS Code Remote workspace hosts.
- Pass VS Code-forwarded data-plane websocket URLs to command-backed native previewers.
- Package Tinymist GPU Viewer VSIX artifacts in the VS Code CI workflow with bundled tinymist-viewer binaries.