### PR TITLE
build: bump typst.ts to 0.8.0-rc3

### DIFF
--- a/.github/workflows/build-vsc-assets.yml
+++ b/.github/workflows/build-vsc-assets.yml
@@ -69,6 +69,9 @@ jobs:
           yarn
           yarn run compile
         working-directory: ./contrib/typst-preview/editors/vscode
+      - name: Build typst-preview-ng vscode extension
+        run: yarn run compile
+        working-directory: ./contrib/typst-preview-ng/editors/vscode
       - name: Build tinymist vscode extension
         run: |
           yarn
@@ -93,4 +96,10 @@ jobs:
         with:
           name: vscode-artifacts-typst-preview
           path: contrib/typst-preview/editors/vscode/out
-
+      - name: Pre-bundle typst-preview-ng vscode extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-artifacts-typst-preview-ng
+          path: |
+            contrib/typst-preview-ng/editors/vscode/out
+            contrib/typst-preview-ng/editors/vscode/previewer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,8 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo"
-version = "0.8.0-rc2"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=bd58ec034584828c272fac1b842acad5b1d79e61#bd58ec034584828c272fac1b842acad5b1d79e61"
+version = "0.8.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b95f4f301964673cc454985f793c5ce8177ec9dc6f134d76d8751c30d23af61"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -5352,8 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst"
-version = "0.8.0-rc2"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=bd58ec034584828c272fac1b842acad5b1d79e61#bd58ec034584828c272fac1b842acad5b1d79e61"
+version = "0.8.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0e6f39e411443742c6644ca95f9c603c8681222716ffd288c56d132c60f457"
 dependencies = [
  "codespan-reporting 0.11.1",
  "comemo",
@@ -5384,8 +5386,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst2vec"
-version = "0.8.0-rc2"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=bd58ec034584828c272fac1b842acad5b1d79e61#bd58ec034584828c272fac1b842acad5b1d79e61"
+version = "0.8.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c09d4ea8296270cee0e90c735760ce1cba0aef1dbb46a3f60e0177678c333cb"
 dependencies = [
  "bitvec",
  "comemo",
@@ -5413,8 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2svg"
-version = "0.8.0-rc2"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts.git?rev=bd58ec034584828c272fac1b842acad5b1d79e61#bd58ec034584828c272fac1b842acad5b1d79e61"
+version = "0.8.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2153dbe9eac42142cada8529ea42b26337962c8760164622a48b726b7f9849c5"
 dependencies = [
  "base64 0.22.1",
  "comemo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,11 +173,11 @@ masonry_winit = { git = "https://github.com/Myriad-dreamin/xilem", rev = "abe7da
 
 
 # Typst
-reflexo = { version = "0.8.0-rc2", default-features = false, features = [
+reflexo = { version = "0.8.0-rc3", default-features = false, features = [
     "flat-vector",
 ] }
-reflexo-typst = { version = "0.8.0-rc2", default-features = false }
-reflexo-vec2svg = { version = "0.8.0-rc2" }
+reflexo-typst = { version = "0.8.0-rc3", default-features = false }
+reflexo-vec2svg = { version = "0.8.0-rc3" }
 
 typst = "0.15.0"
 typst-bundle = "0.15.0"
@@ -359,13 +359,6 @@ typstyle-core = { git = "https://github.com/Myriad-Dreamin/typstyle.git", rev = 
 
 # These patches use local `typstyle-core` for development.
 # typstyle-core = { path = "../typstyle/crates/typstyle-core" }
-
-# These patches use a different version of `reflexo`.
-#
-# A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
-reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
-reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
-reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
 
 # These patches use local `reflexo` for development.
 # reflexo = { path = "../typst.ts/crates/reflexo/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,6 +360,13 @@ typstyle-core = { git = "https://github.com/Myriad-Dreamin/typstyle.git", rev = 
 # These patches use local `typstyle-core` for development.
 # typstyle-core = { path = "../typstyle/crates/typstyle-core" }
 
+# These patches use a different version of `reflexo`.
+#
+# A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
+# reflexo = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
+# reflexo-typst = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
+# reflexo-vec2svg = { git = "https://github.com/Myriad-Dreamin/typst.ts.git", rev = "bd58ec034584828c272fac1b842acad5b1d79e61" }
+
 # These patches use local `reflexo` for development.
 # reflexo = { path = "../typst.ts/crates/reflexo/" }
 # reflexo-typst = { path = "../typst.ts/crates/reflexo-typst/" }

--- a/tools/typst-dom/package.json
+++ b/tools/typst-dom/package.json
@@ -13,12 +13,12 @@
     "unlink:local": "yarn unlink @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.7.0-rc1",
-    "@myriaddreamin/typst.ts": "=0.7.0-rc1"
+    "@myriaddreamin/typst-ts-renderer": "=0.8.0-rc3",
+    "@myriaddreamin/typst.ts": "=0.8.0-rc3"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.7.0-rc1",
-    "@myriaddreamin/typst.ts": "=0.7.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "=0.8.0-rc3",
+    "@myriaddreamin/typst.ts": "=0.8.0-rc3",
     "typescript": "^5.0.2"
   },
   "exports": {

--- a/tools/typst-preview-frontend-ng/package.json
+++ b/tools/typst-preview-frontend-ng/package.json
@@ -11,7 +11,7 @@
     "unlink:local": "yarn unlink @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.8.0-rc2",
-    "@myriaddreamin/typst.ts": "=0.8.0-rc2"
+    "@myriaddreamin/typst-ts-renderer": "=0.8.0-rc3",
+    "@myriaddreamin/typst.ts": "=0.8.0-rc3"
   }
 }

--- a/tools/typst-preview-frontend/package.json
+++ b/tools/typst-preview-frontend/package.json
@@ -13,8 +13,8 @@
     "unlink:local": "yarn unlink @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "=0.7.0-rc1",
-    "@myriaddreamin/typst.ts": "=0.7.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "=0.8.0-rc3",
+    "@myriaddreamin/typst.ts": "=0.8.0-rc3",
     "typst-dom": "link:../typst-dom",
     "rxjs": "^7.8.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,27 +486,15 @@
   resolved "https://registry.npmjs.org/@jspm/core/-/core-2.1.0.tgz#ee21ff64591d68de98b79ca8e4bd6c5249fded53"
   integrity sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==
 
-"@myriaddreamin/typst-ts-renderer@=0.7.0-rc1":
-  version "0.7.0-rc1"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.7.0-rc1.tgz#9b08082f816c40591100f40d6a7e777399ea7192"
-  integrity sha512-Dd0xP0THKiUwYVTX+2FW4gzBl4i3BNWLAO/ZAReSCkbaPiFb6py5heSvXX0vtH8sXsFQOB3qhxz68sEcq9oRKg==
+"@myriaddreamin/typst-ts-renderer@=0.8.0-rc3":
+  version "0.8.0-rc3"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.8.0-rc3.tgz#c8f2ac16e4c59317663a3995f9aeec7f80091cdf"
+  integrity sha512-z4e5AXSnZcY00jyK3Jp/OLO1i3bbkJmEzC946KsFnIsd7PEjjttLOIrv4n+AEClQcd7trkU6d+RprioiTIsI6A==
 
-"@myriaddreamin/typst-ts-renderer@=0.8.0-rc2":
-  version "0.8.0-rc2"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.8.0-rc2.tgz#3a5cb0f822586d5771882f3665e9b90949286212"
-  integrity sha512-OLDLWcGEDNMiWu0hiNOYT+RMMMp7lPoVZoNNIjRXzZXUh/iYhoDsbd6mnbwDgSN4Ud5SE6wkb+lGUCg06phyJA==
-
-"@myriaddreamin/typst.ts@=0.7.0-rc1":
-  version "0.7.0-rc1"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.7.0-rc1.tgz#8542a77ff6ac8ff12a6de06a57ce6da544fcb03b"
-  integrity sha512-IZ78l1iLTMM61pf1SmqtojkgM2aloQVSzlNvStKtYu+qleOEzh/ph7zTNmfM8j5vlflCkos85E+UKQvLdC9C7Q==
-  dependencies:
-    idb "^7.1.1"
-
-"@myriaddreamin/typst.ts@=0.8.0-rc2":
-  version "0.8.0-rc2"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.8.0-rc2.tgz#b46088204077fe7fd348ba25a578de9f4defabc7"
-  integrity sha512-TNZmxuJCMxEIjcMnXsV6mQfnNd1Ap29QCaYNY2jjiqDL//o7atZG8i28XbwxIScdKADMITPA/29hII1GiCswGw==
+"@myriaddreamin/typst.ts@=0.8.0-rc3":
+  version "0.8.0-rc3"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.8.0-rc3.tgz#45667ab43dcc865b42fc2c11193c9e15f5102328"
+  integrity sha512-Z5SzwBRNV3a8Zz6BCdUBnAKRQj2khNM90dhwFpGkefIYiFJ5AUj/F02uoyDZmY2TvziDKEsJn0800BeF7J8mAw==
   dependencies:
     idb "^7.1.1"
 


### PR DESCRIPTION
- Bump typst.ts and typst-ts-renderer package pins to 0.8.0-rc3.
- Use crates.io reflexo 0.8.0-rc3 packages instead of the typst.ts git patch.
- Keep the old reflexo git patch entries commented as future reference.
- Build and upload typst-preview-ng extension assets in the VSC assets workflow.