### PR TITLE
test(query): cover string path completions

### DIFF
--- a/crates/tinymist-query/src/fixtures/completion/import_package_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/import_package_positions.typ
@@ -1,0 +1,2 @@
+/// contains: "@preview/example:0.1.1"
+#import "@preview"/* range -9..0 */

--- a/crates/tinymist-query/src/fixtures/completion/path_escape_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_escape_positions.typ
@@ -1,0 +1,6 @@
+/// path: assets/logo.png
+png
+
+-----
+/// contains: assets/, assets/logo.png
+#read("assets\/lo"/* range -11..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/path_middle_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_middle_positions.typ
@@ -1,0 +1,10 @@
+/// path: assets/logo.png
+png
+
+-----
+/// path: assets/logo-dark.png
+png
+
+-----
+/// contains: assets/, assets/logo.png, assets/logo-dark.png
+#read("assets/lo"/* range -10..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/path_outside_root.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_outside_root.typ
@@ -1,0 +1,5 @@
+/// path: base.typ
+#let aa = 1
+
+-----
+#read("../"/* range -4..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/path_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/path_positions.typ
@@ -1,0 +1,10 @@
+/// path: assets/logo.png
+png
+
+-----
+/// path: chapters/intro.typ
+#let intro = 1
+
+-----
+/// contains: assets/, assets/logo.png, chapters/, chapters/intro.typ
+#read(""/* range -1..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@import_package_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@import_package_positions.typ.snap
@@ -1,0 +1,206 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on @preview\" (48..57)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/import_package_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 9,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 11,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 12,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 13,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 14,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 15,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1\"",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"@preview/example:0.1.1\"",
+    "textEdit": {
+     "newText": "\"@preview/example:0.1.1",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 8,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_escape_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_escape_positions.typ.snap
@@ -1,0 +1,185 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on assets\\/lo\" (46..57)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_escape_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": []
+ },
+ {
+  "isIncomplete": false,
+  "items": []
+ },
+ {
+  "isIncomplete": false,
+  "items": []
+ },
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_middle_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_middle_positions.typ.snap
@@ -1,0 +1,418 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on assets/lo\" (68..78)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_middle_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo-dark.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo-dark.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 16,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_outside_root.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_outside_root.typ.snap
@@ -1,0 +1,100 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on ../\" (7..11)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_outside_root.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "base.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "base.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 0
+      },
+      "start": {
+       "character": 7,
+       "line": 0
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "base.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "base.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 0
+      },
+      "start": {
+       "character": 7,
+       "line": 0
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "base.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "base.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 0
+      },
+      "start": {
+       "character": 7,
+       "line": 0
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "base.typ",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "base.typ",
+     "range": {
+      "end": {
+       "character": 10,
+       "line": 0
+      },
+      "start": {
+       "character": 7,
+       "line": 0
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@path_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@path_positions.typ.snap
@@ -1,0 +1,49 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on \" (77..78)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/path_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 17,
+    "label": "assets/logo.png",
+    "sortText": "000",
+    "textEdit": {
+     "newText": "assets/logo.png",
+     "range": {
+      "end": {
+       "character": 7,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   },
+   {
+    "kind": 17,
+    "label": "chapters/intro.typ",
+    "sortText": "001",
+    "textEdit": {
+     "newText": "chapters/intro.typ",
+     "range": {
+      "end": {
+       "character": 7,
+       "line": 1
+      },
+      "start": {
+       "character": 7,
+       "line": 1
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@string_enum_escape_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@string_enum_escape_positions.typ.snap
@@ -1,0 +1,146 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on New\\n\" (54..60)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/string_enum_escape_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 2
+      },
+      "start": {
+       "character": 17,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 18,
+       "line": 2
+      },
+      "start": {
+       "character": 18,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 2
+      },
+      "start": {
+       "character": 19,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 20,
+       "line": 2
+      },
+      "start": {
+       "character": 20,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 21,
+       "line": 2
+      },
+      "start": {
+       "character": 21,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern",
+     "range": {
+      "end": {
+       "character": 22,
+       "line": 2
+      },
+      "start": {
+       "character": 22,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@string_enum_positions.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@string_enum_positions.typ.snap
@@ -1,0 +1,100 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on New\" (54..58)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/string_enum_positions.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 17,
+       "line": 2
+      },
+      "start": {
+       "character": 17,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 18,
+       "line": 2
+      },
+      "start": {
+       "character": 18,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern\"",
+     "range": {
+      "end": {
+       "character": 19,
+       "line": 2
+      },
+      "start": {
+       "character": 19,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ },
+ {
+  "isIncomplete": false,
+  "items": [
+   {
+    "kind": 6,
+    "label": "\"New Computer Modern\"",
+    "sortText": "003",
+    "textEdit": {
+     "newText": "\"New Computer Modern",
+     "range": {
+      "end": {
+       "character": 20,
+       "line": 2
+      },
+      "start": {
+       "character": 20,
+       "line": 2
+      }
+     }
+    }
+   }
+  ]
+ }
+]

--- a/crates/tinymist-query/src/fixtures/completion/string_enum_escape_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/string_enum_escape_positions.typ
@@ -1,0 +1,3 @@
+/// contains: "New Computer Modern"
+
+#set text(font: "New\n"/* range -6..0 */)

--- a/crates/tinymist-query/src/fixtures/completion/string_enum_positions.typ
+++ b/crates/tinymist-query/src/fixtures/completion/string_enum_positions.typ
@@ -1,0 +1,3 @@
+/// contains: "New Computer Modern"
+
+#set text(font: "New"/* range -4..0 */)


### PR DESCRIPTION
Adds completion snapshot fixtures for string-literal cases:

- String enum completion across in-string cursor positions, including escaped content.
- Path completion fixtures for empty, middle, escaped, and root-escaping strings.
- Package import completion across in-string cursor positions.