### PR TITLE
test(type-check): cover deferred inference cases

### DIFF
--- a/crates/tinymist-query/src/fixtures/type_check/at_default.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/at_default.typ
@@ -1,0 +1,6 @@
+#let dynamic-default(d, key) = d.at(key, default: none)
+#let static-param(d) = d.at("x", default: none)
+#let static-default = (:).at("missing", default: 1)
+#let static-existing = (value: 2).at("value", default: 1)
+#let static-no-default = (value: 2).at("value")
+#let tuple-default = (1, 2).at(1, default: none)

--- a/crates/tinymist-query/src/fixtures/type_check/binary_union.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/binary_union.typ
@@ -1,0 +1,12 @@
+#let f(flag) = {
+  let x = if flag { 1 } else { "s" }
+  x + x
+}
+
+#let sub-any(a, b) = a - b
+
+#let mul-any(a, b) = a * b
+
+#let cross(o, a, b) = (a.at(0) - o.at(0)) * (b.at(1) - o.at(1)) - (a.at(1) - o.at(1)) * (b.at(0) - o.at(0))
+
+#let call-sub(a, b) = sub-any(a, b)

--- a/crates/tinymist-query/src/fixtures/type_check/compound_assignment_loop.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/compound_assignment_loop.typ
@@ -1,0 +1,17 @@
+#let scan-backwards(s) = {
+  let len = s.len() - 1
+  let i = len
+  while i > 0 {
+    i -= 1
+  }
+  i
+}
+
+#let assign-from-unknown(unknown) = {
+  let i = 0
+  while unknown > 0 {
+    i = unknown - 1
+    unknown -= 1
+  }
+  i
+}

--- a/crates/tinymist-query/src/fixtures/type_check/content_return.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/content_return.typ
@@ -1,0 +1,8 @@
+#let interpolated(day, month, year) = {
+  let month-name = month
+  [#day de #month-name de #year]
+}
+
+#let final-unknown(x) = {
+  x
+}

--- a/crates/tinymist-query/src/fixtures/type_check/content_sequence.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/content_sequence.typ
@@ -1,0 +1,35 @@
+#let joined-context() = context {
+  [alpha]
+  [beta]
+}
+
+#let mixed-context(x) = context {
+  x
+  [suffix]
+}
+
+#let return-or-content(cond) = context {
+  if cond {
+    return [warn]
+  }
+  [ok]
+}
+
+#let repeated-content-loops(items) = {
+  for item in items {
+    [#item]
+  }
+  for item in items {
+    [#item]
+  }
+}
+
+#let conditional-content-loop(items, cond) = {
+  if cond {
+    for item in items {
+      [#item]
+    }
+  } else {
+    [fallback]
+  }
+}

--- a/crates/tinymist-query/src/fixtures/type_check/cyclic_scope_deferred.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/cyclic_scope_deferred.typ
@@ -1,0 +1,26 @@
+/// path: a.typ
+#import "b.typ": g
+
+#let f(flag) = if flag {
+  1
+} else {
+  g(true)
+}
+
+-----
+/// path: b.typ
+#import "a.typ": f
+
+#let g(flag) = if flag {
+  "done"
+} else {
+  f(true)
+}
+
+-----
+/// path: main.typ
+#import "a.typ": f
+#import "b.typ": g
+
+#let use-f() = f(false)
+#let use-g() = g(false)

--- a/crates/tinymist-query/src/fixtures/type_check/deferred_if_fold_after_bind.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/deferred_if_fold_after_bind.typ
@@ -1,0 +1,7 @@
+#let make-path(mode: "OPEN") = {
+  let close = mode != "OPEN"
+  (close: close)
+}
+
+#let default-path = make-path()
+#let pie-path = make-path(mode: "PIE")

--- a/crates/tinymist-query/src/fixtures/type_check/deferred_selected_apply.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/deferred_selected_apply.typ
@@ -1,0 +1,15 @@
+#let via-method(ctx, layer) = {
+  let mapping = (ctx.resolve-mapping)(layer)
+  mapping
+}
+
+#let known-layer = (mapping: (x: "x"))
+#let known-ctx = (
+  resolve-mapping: layer => if layer == none { none } else { layer.mapping },
+)
+#let known-result = (known-ctx.resolve-mapping)(known-layer)
+
+#let direct-known() = {
+  let obj = (f: x => if x == none { none } else { x.mapping })
+  obj.f((mapping: (y: "y")))
+}

--- a/crates/tinymist-query/src/fixtures/type_check/doc_param_annotation_survives_infer.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/doc_param_annotation_survives_infer.typ
@@ -1,0 +1,6 @@
+/// - name (string): Hook name.
+#let hook(name) = {
+  (type: "hook", name: name)
+}
+
+#let hook-value = hook("h")

--- a/crates/tinymist-query/src/fixtures/type_check/loop_mutation_then_record.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/loop_mutation_then_record.typ
@@ -1,0 +1,18 @@
+#let bucket-by(data, key-col) = {
+  let buckets = (:)
+  let order = ()
+  for row in data {
+    let key = str(row.at(key-col, default: ""))
+    if key == "" { continue }
+    if key in buckets {
+      let bucket = buckets.at(key)
+      bucket.push(row)
+      buckets.insert(key, bucket)
+    } else {
+      buckets.insert(key, (row,))
+      order.push(key)
+    }
+  }
+  (buckets: buckets, order: order)
+}
+

--- a/crates/tinymist-query/src/fixtures/type_check/loop_result.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/loop_result.typ
@@ -1,0 +1,45 @@
+#let loop-none() = {
+  for i in range(4) {
+    let x = i
+  }
+}
+
+#let loop-tuple(size: 50) = {
+  for i in range(4) {
+    ((type: "move", steps: size), (type: "turn", degrees: 90))
+  }
+}
+
+#let loop-command() = {
+  for i in range(2) {
+    (ctx => ctx,)
+  }
+}
+
+#let loop-continue-command() = {
+  for i in range(2) {
+    if i == 0 { continue }
+    (ctx => ctx,)
+  }
+}
+
+#let loop-conditional-break() = {
+  for i in range(2) {
+    if i == 1 { break }
+    (ctx => ctx,)
+  }
+}
+
+#let loop-break() = {
+  for i in range(2) {
+    break
+  }
+  3
+}
+
+#let while-false() = {
+  while false {
+    [x]
+  }
+  3
+}

--- a/crates/tinymist-query/src/fixtures/type_check/loop_unknown_then_final.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/loop_unknown_then_final.typ
@@ -1,0 +1,12 @@
+#let loop-unknown-then-dict(..args) = {
+  let out = (:)
+  for (k, v) in args.named() {
+    if v == auto {
+      continue
+    }
+    out.insert(k, v)
+    v
+  }
+  out
+}
+

--- a/crates/tinymist-query/src/fixtures/type_check/method_split.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/method_split.typ
@@ -1,0 +1,2 @@
+#let resolve-key = key => key.split(".")
+#let split-literal = "a.b".split(".")

--- a/crates/tinymist-query/src/fixtures/type_check/mutation_methods.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/mutation_methods.typ
@@ -1,0 +1,43 @@
+#let array-push() = {
+  let a = ()
+  a.push(1)
+}
+
+#let dict-insert() = {
+  let d = (:)
+  d.insert("x", 1)
+}
+
+#let push-loop() = {
+  let a = ()
+  for i in range(2) {
+    a.push(i)
+  }
+  a
+}
+
+#let push-dict-loop() = {
+  let guides = ()
+  for grp in ((members: (1,),),) {
+    let g = (kind: "x")
+    g.insert("width", 1)
+    guides.push(g)
+  }
+  guides.sorted(key: g => g.kind)
+}
+
+#let push-dict-loop-if() = {
+  let guides = ()
+  for first in (true,) {
+    let g = if first {
+      let levels = ()
+      if first { levels = levels.rev() }
+      (kind: "swatch", levels: levels)
+    } else {
+      (kind: "other")
+    }
+    g.insert("width", 1)
+    guides.push(g)
+  }
+  guides.sorted(key: g => g.kind)
+}

--- a/crates/tinymist-query/src/fixtures/type_check/param_pollution_from_helper.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/param_pollution_from_helper.typ
@@ -1,0 +1,12 @@
+#let check-free-var(v) = {
+  if v == "i" {
+    panic("reserved variable")
+  }
+}
+
+#let public(expr, var) = {
+  check-free-var(var)
+  expr
+}
+
+#let use-public = public(1, "x")

--- a/crates/tinymist-query/src/fixtures/type_check/recursive_dispatch_deferred.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/recursive_dispatch_deferred.typ
@@ -1,0 +1,22 @@
+#let done(value) = (kind: "done", value: value)
+
+#let forward(handler, value) = {
+  if value == 0 {
+    done(value)
+  } else {
+    handler(value - 1)
+  }
+}
+
+#let dispatch(value) = {
+  if value == 0 {
+    done(value)
+  } else if value == 1 {
+    forward(dispatch, value)
+  } else {
+    forward(dispatch, value - 1)
+  }
+}
+
+#let use-zero = dispatch(0)
+#let use-one = dispatch(1)

--- a/crates/tinymist-query/src/fixtures/type_check/scope_deferred.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/scope_deferred.typ
@@ -1,0 +1,13 @@
+#let f() = {
+  let g() = {
+    return 1
+  }
+  return g()
+}
+
+#let h() = {
+  let g() = {
+    return 1
+  }
+  return 0
+}

--- a/crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.typ
@@ -1,0 +1,108 @@
+#let f() = {
+  let id(x) = x
+  return id(1)
+}
+
+#let h() = {
+  let choose(x, y) = if true { x } else { y }
+  return choose(1, "x")
+}
+
+#let k() = {
+  let fill(d) = {
+    if "x" not in d {
+      d.insert("x", 1)
+    }
+    d
+  }
+  let entry = (:)
+  return fill(entry)
+}
+
+#let m() = {
+  let complete(key, definitions) = {
+    if "long" not in definitions {
+      panic("x")
+    }
+    if "short" not in definitions {
+      definitions.insert("short", key)
+    }
+    definitions
+  }
+  let entry = (:)
+  return complete("a", entry)
+}
+
+#let n() = {
+  let complete(key, definitions) = {
+    if "long" not in definitions {
+      panic("x")
+    }
+    if "short" not in definitions {
+      definitions.insert("short", key)
+    }
+    if "short-pl" not in definitions {
+      definitions.insert("short-pl", [#definitions.at("short")\s])
+    }
+    definitions
+  }
+  let entry = (:)
+  return complete("a", entry)
+}
+
+#let top-complete(key, definitions) = {
+  if "long" not in definitions {
+    panic("x")
+  }
+  if "short" not in definitions {
+    definitions.insert("short", key)
+  }
+  if "short-pl" not in definitions {
+    definitions.insert("short-pl", [#definitions.at("short")\s])
+  }
+  if "long-pl" not in definitions {
+    definitions.insert("long-pl", [#definitions.at("long")\s])
+  }
+  definitions
+}
+
+#let p(definitions) = {
+  let entry = (:)
+  return top-complete("a", entry)
+}
+
+#let q(definitions) = {
+  let entry = (:)
+  top-complete("a", entry)
+}
+
+#let r(definitions) = {
+  let entry = (:)
+  if type(definitions) == str {
+    entry.insert("long", definitions)
+  } else if type(definitions) == array {
+    let n_defs = definitions.len()
+    if n_defs == 0 {
+      panic("x")
+    } else if n_defs > 2 {
+      panic("x")
+    }
+    for (key, def) in ("long", "long-pl").zip(definitions) {
+      entry.insert(key, def)
+    }
+  } else if type(definitions) == dictionary {
+    if "long" not in definitions {
+      panic("x")
+    }
+    for (key, def) in definitions {
+      if key in ("short", "short-pl", "long", "long-pl") {
+        entry.insert(key, def)
+      } else {
+        panic("x")
+      }
+    }
+  } else {
+    panic("x")
+  }
+  top-complete("a", entry)
+}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@at_default.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@at_default.typ.snap
@@ -1,0 +1,43 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/at_default.typ
+---
+"dynamic-default" = (Any, Any) => (None | Apply(@v"d".at, (Any, "default": None) => any))
+"d" = Any
+"key" = Any
+"static-param" = (Any) => ( ⪰ Any | None)
+"d" = Any
+"static-default" = (1 | {}.missing)
+"static-existing" = (1 | {"value": 2}.value)
+"static-no-default" = {"value": 2}.value
+"tuple-default" = (None | 2)
+=====
+5..20 -> @dynamic-default
+21..22 -> @d
+24..27 -> @key
+31..32 -> @d
+31..35 -> @v"d".at
+31..55 -> (None | Apply(@v"d".at, (@key, "default": None) => any))
+36..39 -> @key
+61..73 -> @static-param
+74..75 -> @d
+79..80 -> @d
+79..83 -> @v"d".at
+79..103 -> ( ⪰ Any | None)
+109..123 -> @static-default
+126..129 -> {}
+126..132 -> (Func(at) | {}.at)
+126..155 -> (1 | {}.missing)
+161..176 -> @static-existing
+179..189 -> {"value": 2}
+179..192 -> (Func(at) | {"value": 2}.at)
+179..213 -> (1 | {"value": 2}.value)
+219..236 -> @static-no-default
+239..249 -> {"value": 2}
+239..252 -> (Func(at) | {"value": 2}.at)
+239..261 -> {"value": 2}.value
+267..280 -> @tuple-default
+283..289 -> (1, 2, )
+283..292 -> (Func(at) | (1, 2, ).at)
+283..310 -> (None | 2)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@binary_union.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@binary_union.typ.snap
@@ -1,0 +1,73 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/binary_union.typ
+---
+"f" = (Any) => (Type(int) | Type(str))
+"flag" = Any
+"x" = ("s" | 1)
+"sub-any" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Sub }
+"a" = Any
+"b" = Any
+"mul-any" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Mul }
+"a" = Any
+"b" = Any
+"cross" = (Any, Any, Any) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (Apply(@v"a".at, (0) => any), Apply(@v"o".at, (0) => any)), op: Sub }, TypeBinary { operands: (Apply(@v"b".at, (1) => any), Apply(@v"o".at, (1) => any)), op: Sub }), op: Mul }, TypeBinary { operands: (TypeBinary { operands: (Apply(@v"a".at, (1) => any), Apply(@v"o".at, (1) => any)), op: Sub }, TypeBinary { operands: (Apply(@v"b".at, (0) => any), Apply(@v"o".at, (0) => any)), op: Sub }), op: Mul }), op: Sub }
+"o" = Any
+"a" = Any
+"b" = Any
+"call-sub" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Sub }
+"a" = Any
+"b" = Any
+=====
+5..6 -> @f
+7..11 -> @flag
+23..24 -> @x
+30..34 -> @flag
+56..57 -> @x
+60..61 -> @x
+70..77 -> @sub-any
+78..79 -> @a
+81..82 -> @b
+86..87 -> @a
+90..91 -> @b
+98..105 -> @mul-any
+106..107 -> @a
+109..110 -> @b
+114..115 -> @a
+118..119 -> @b
+126..131 -> @cross
+132..133 -> @o
+135..136 -> @a
+138..139 -> @b
+144..145 -> @a
+144..148 -> @v"a".at
+144..151 -> Apply(@v"a".at, (0) => any)
+154..155 -> @o
+154..158 -> @v"o".at
+154..161 -> Apply(@v"o".at, (0) => any)
+166..167 -> @b
+166..170 -> @v"b".at
+166..173 -> Apply(@v"b".at, (1) => any)
+176..177 -> @o
+176..180 -> @v"o".at
+176..183 -> Apply(@v"o".at, (1) => any)
+188..189 -> @a
+188..192 -> @v"a".at
+188..195 -> Apply(@v"a".at, (1) => any)
+198..199 -> @o
+198..202 -> @v"o".at
+198..205 -> Apply(@v"o".at, (1) => any)
+210..211 -> @b
+210..214 -> @v"b".at
+210..217 -> Apply(@v"b".at, (0) => any)
+220..221 -> @o
+220..224 -> @v"o".at
+220..227 -> Apply(@v"o".at, (0) => any)
+235..243 -> @call-sub
+244..245 -> @a
+247..248 -> @b
+252..259 -> @sub-any
+252..265 -> TypeBinary { operands: (@a, @b), op: Sub }
+260..261 -> @a
+263..264 -> @b

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@compound_assignment_loop.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@compound_assignment_loop.typ.snap
@@ -1,0 +1,32 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/compound_assignment_loop.typ
+---
+"scan-backwards" = (Any) => TypeBinary { operands: (Apply(@v"s".len, () => any), 1), op: Sub }
+"s" = Any
+"len" = TypeBinary { operands: (Apply(@v"s".len, () => any), 1), op: Sub }
+"i" = TypeBinary { operands: (Apply(@v"s".len, () => any), 1), op: Sub }
+"assign-from-unknown" = (Any) => 0
+"unknown" = Any
+"i" = 0
+=====
+5..19 -> @scan-backwards
+20..21 -> @s
+33..36 -> @len
+39..40 -> @s
+39..44 -> @v"s".len
+39..46 -> Apply(@v"s".len, () => any)
+57..58 -> @i
+61..64 -> @len
+73..74 -> @i
+85..86 -> @i
+98..99 -> @i
+108..127 -> @assign-from-unknown
+128..135 -> @unknown
+147..148 -> @i
+161..168 -> @unknown
+179..180 -> @i
+183..190 -> @unknown
+199..206 -> @unknown
+218..219 -> @i

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_return.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_return.typ.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+assertion_line: 378
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/content_return.typ
+---
+"interpolated" = (Any, Any, Any) => Content
+"day" = Any
+"month" = Any
+"year" = Any
+"month-name" = Any
+"final-unknown" = (Any) => Any
+"x" = Any
+=====
+5..17 -> @interpolated
+18..21 -> @day
+23..28 -> @month
+30..34 -> @year
+46..56 -> @month-name
+59..64 -> @month
+69..72 -> @day
+77..87 -> @month-name
+92..96 -> @year
+106..119 -> @final-unknown
+120..121 -> @x
+129..130 -> @x

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_sequence.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_sequence.typ.snap
@@ -1,0 +1,41 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/content_sequence.typ
+---
+"joined-context" = () => TypeUnary { lhs: Content, op: Context }
+"mixed-context" = (Any) => TypeUnary { lhs: Content, op: Context }
+"x" = Any
+"return-or-content" = (Any) => (Content | TypeUnary { lhs: Content, op: Context })
+"cond" = Any
+"repeated-content-loops" = (Any) => Content
+"items" = Any
+"item" = Any
+"item" = Any
+"conditional-content-loop" = (Any, Any) => Content
+"items" = Any
+"cond" = Any
+"item" = Any
+=====
+5..19 -> @joined-context
+61..74 -> @mixed-context
+75..76 -> @x
+92..93 -> @x
+113..130 -> @return-or-content
+131..135 -> @cond
+154..158 -> @cond
+198..220 -> @repeated-content-loops
+221..226 -> @items
+238..242 -> @item
+246..251 -> @items
+260..264 -> @item
+276..280 -> @item
+284..289 -> @items
+298..302 -> @item
+316..340 -> @conditional-content-loop
+341..346 -> @items
+348..352 -> @cond
+363..367 -> @cond
+378..382 -> @item
+386..391 -> @items
+402..406 -> @item

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@cyclic_scope_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@cyclic_scope_deferred.typ.snap
@@ -1,0 +1,24 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/cyclic_scope_deferred.typ
+---
+"a" = Any
+"b" = Any
+"f" = Any
+"g" = Any
+"use-f" = () => ("done" | 1 | Apply(@v"".f, (true) => any))
+"use-g" = () => ("done" | Apply(@v"".f, (true) => any))
+=====
+0..0 -> @f
+0..0 -> @g
+1..18 -> @a
+17..18 -> @f
+20..37 -> @b
+36..37 -> @g
+44..49 -> @use-f
+54..55 -> @f
+54..62 -> ("done" | 1 | Apply(@v"".f, (true) => any))
+68..73 -> @use-g
+78..79 -> @g
+78..86 -> ("done" | Apply(@v"".f, (true) => any))

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_if_fold_after_bind.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_if_fold_after_bind.typ.snap
@@ -1,0 +1,23 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/deferred_if_fold_after_bind.typ
+---
+"make-path" = (("mode": Any) => {"close": Boolean}).with(..("mode": "OPEN") => any)
+"mode" = ( ⪰ Type(str) | "OPEN")
+"close" = Boolean
+"default-path" = {"close": false}
+"pie-path" = {"close": true}
+=====
+5..14 -> @make-path
+15..19 -> @mode
+39..44 -> @close
+47..51 -> @mode
+64..78 -> {"close": @close}
+72..77 -> @close
+87..99 -> @default-path
+102..111 -> @make-path
+102..113 -> {"close": false}
+119..127 -> @pie-path
+130..139 -> @make-path
+130..152 -> {"close": true}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_selected_apply.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_selected_apply.typ.snap
@@ -1,0 +1,56 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/deferred_selected_apply.typ
+---
+"via-method" = (Any, Any) => Apply(@v"ctx".resolve-mapping, (Any) => any)
+"ctx" = Any
+"layer" = Any
+"mapping" = Apply(@v"ctx".resolve-mapping, (Any) => any)
+"known-layer" = {"mapping": {"x": "x"}}
+"known-ctx" = {"resolve-mapping": (Any) => (None | {"x": "x"} | {"mapping": {"x": "x"}}.mapping)}
+"" = (Any) => (None | {"x": "x"} | {"mapping": {"x": "x"}}.mapping)
+"layer" = {"mapping": {"x": "x"}}
+"known-result" = (None | {"x": "x"} | {"mapping": {"x": "x"}}.mapping)
+"direct-known" = () => (None | {"y": "y"} | {"mapping": {"y": "y"}}.mapping)
+"obj" = {"f": (Any) => (None | {"y": "y"} | {"mapping": {"y": "y"}}.mapping)}
+"" = (Any) => (None | {"y": "y"} | {"mapping": {"y": "y"}}.mapping)
+"x" = {"mapping": {"y": "y"}}
+=====
+5..15 -> @via-method
+16..19 -> @ctx
+21..26 -> @layer
+38..45 -> @mapping
+48..76 -> Apply(@v"ctx".resolve-mapping, (@layer) => any)
+49..52 -> @ctx
+49..68 -> @v"ctx".resolve-mapping
+70..75 -> @layer
+79..86 -> @mapping
+95..106 -> @known-layer
+109..128 -> {"mapping": {"x": "x"}}
+119..127 -> {"x": "x"}
+134..143 -> @known-ctx
+146..227 -> {"resolve-mapping": (@layer) => @}
+167..172 -> @layer
+167..224 -> @
+179..184 -> @layer
+209..214 -> @layer
+209..222 -> ({"x": "x"} | @v"layer".mapping)
+233..245 -> @known-result
+248..288 -> (None | {"x": "x"} | {"mapping": {"x": "x"}}.mapping)
+249..258 -> @known-ctx
+249..274 -> ((@layer) => @ | @v"known-ctx".resolve-mapping)
+276..287 -> @known-layer
+295..307 -> @direct-known
+320..323 -> @obj
+326..376 -> {"f": (@x) => @}
+330..331 -> @x
+330..375 -> @
+338..339 -> @x
+364..365 -> @x
+364..373 -> ({"y": "y"} | @v"x".mapping)
+379..382 -> @obj
+379..384 -> ((@x) => @ | @v"obj".f)
+379..405 -> (None | {"y": "y"} | {"mapping": {"y": "y"}}.mapping)
+385..404 -> {"mapping": {"y": "y"}}
+395..403 -> {"y": "y"}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@doc_param_annotation_survives_infer.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@doc_param_annotation_survives_infer.typ.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/doc_param_annotation_survives_infer.typ
+---
+"hook" = (Type(str)) => {"name": Type(str), "type": "hook"}
+"name" = Type(str)
+"hook-value" = {"name": "h", "type": "hook"}
+=====
+37..41 -> @hook
+42..46 -> @name
+54..80 -> {"name": @name, "type": "hook"}
+75..79 -> @name
+89..99 -> @hook-value
+102..106 -> @hook
+102..111 -> {"name": "h", "type": "hook"}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_mutation_then_record.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_mutation_then_record.typ.snap
@@ -1,0 +1,60 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/loop_mutation_then_record.typ
+---
+"bucket-by" = (Any, Any) => {"buckets": {}, "order": ()}
+"data" = Any
+"key-col" = Any
+"buckets" = {}
+"order" = ()
+"row" = Any
+"key" = Type(str)
+"bucket" = Any
+=====
+5..14 -> @bucket-by
+15..19 -> @data
+21..28 -> @key-col
+40..47 -> @buckets
+50..53 -> {}
+60..65 -> @order
+68..70 -> ()
+77..80 -> @row
+84..88 -> @data
+99..102 -> @key
+105..108 -> Type(string)
+105..138 -> Type(str)
+109..112 -> @row
+109..115 -> @v"row".at
+109..137 -> ("" | Apply(@v"row".at, (@key-col, "default": "") => any))
+116..123 -> @key-col
+146..149 -> @key
+176..179 -> @key
+183..190 -> @buckets
+203..209 -> @bucket
+212..219 -> @buckets
+212..222 -> (Func(at) | @v"buckets".at)
+212..227 -> Any
+223..226 -> @key
+234..240 -> @bucket
+234..245 -> @v"bucket".push
+234..250 -> Apply(@v"bucket".push, (@row) => any)
+246..249 -> @row
+257..264 -> @buckets
+257..271 -> (Func(insert) | @v"buckets".insert)
+257..284 -> None
+272..275 -> @key
+277..283 -> @bucket
+304..311 -> @buckets
+304..318 -> (Func(insert) | @v"buckets".insert)
+304..331 -> None
+319..322 -> @key
+324..330 -> (@row, )
+325..328 -> @row
+338..343 -> @order
+338..348 -> (Func(push) | @v"order".push)
+338..353 -> None
+349..352 -> @key
+366..398 -> {"buckets": @buckets, "order": @order}
+376..383 -> @buckets
+392..397 -> @order

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_result.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_result.typ.snap
@@ -1,0 +1,73 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/loop_result.typ
+---
+"loop-none" = () => None
+"i" = Any
+"x" = Any
+"loop-tuple" = (("size": Any) => (None | Array<({"degrees": 90, "type": "turn"} | {"steps": Any, "type": "move"})>)).with(..("size": 50) => any)
+"size" = 50
+"i" = Any
+"loop-command" = () => (None | Array<(Any) => Any>)
+"i" = Any
+"" = (Any) => Any
+"ctx" = Any
+"loop-continue-command" = () => (None | Array<(Any) => Any>)
+"i" = Any
+"" = (Any) => Any
+"ctx" = Any
+"loop-conditional-break" = () => (None | Array<(Any) => Any>)
+"i" = Any
+"" = (Any) => Any
+"ctx" = Any
+"loop-break" = () => 3
+"i" = Any
+"while-false" = () => 3
+=====
+5..14 -> @loop-none
+27..28 -> @i
+32..37 -> Func(range)
+32..40 -> Type(array)
+51..52 -> @x
+55..56 -> @i
+69..79 -> @loop-tuple
+80..84 -> @size
+100..101 -> @i
+105..110 -> Func(range)
+105..113 -> Type(array)
+120..178 -> ({"steps": @size, "type": "move"}, {"degrees": 90, "type": "turn"}, )
+121..148 -> {"steps": @size, "type": "move"}
+143..147 -> @size
+150..177 -> {"degrees": 90, "type": "turn"}
+191..203 -> @loop-command
+216..217 -> @i
+221..226 -> Func(range)
+221..229 -> Type(array)
+236..249 -> ((@ctx) => @, )
+237..240 -> @ctx
+237..247 -> @
+244..247 -> @ctx
+262..283 -> @loop-continue-command
+296..297 -> @i
+301..306 -> Func(range)
+301..309 -> Type(array)
+319..320 -> @i
+343..356 -> ((@ctx) => @, )
+344..347 -> @ctx
+344..354 -> @
+351..354 -> @ctx
+369..391 -> @loop-conditional-break
+404..405 -> @i
+409..414 -> Func(range)
+409..417 -> Type(array)
+427..428 -> @i
+448..461 -> ((@ctx) => @, )
+449..452 -> @ctx
+449..459 -> @
+456..459 -> @ctx
+474..484 -> @loop-break
+497..498 -> @i
+502..507 -> Func(range)
+502..510 -> Type(array)
+539..550 -> @while-false

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_unknown_then_final.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_unknown_then_final.typ.snap
@@ -1,0 +1,28 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/loop_unknown_then_final.typ
+---
+"loop-unknown-then-dict" = (...: Any) => {}
+"args" = Args
+"out" = {}
+"k" = Any
+"v" = Any
+=====
+5..27 -> @loop-unknown-then-dict
+30..34 -> @args
+46..49 -> @out
+52..55 -> {}
+63..64 -> @k
+66..67 -> @v
+72..76 -> @args
+72..82 -> @v"args".named
+72..84 -> Apply(@v"args".named, () => any)
+94..95 -> @v
+131..134 -> @out
+131..141 -> (Func(insert) | @v"out".insert)
+131..147 -> None
+142..143 -> @k
+145..146 -> @v
+152..153 -> @v
+160..163 -> @out

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@method_split.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@method_split.typ.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/method_split.typ
+---
+"resolve-key" = (Type(str)) => Type(array)
+"" = (Type(str)) => Type(array)
+"key" = Any
+"split-literal" = Type(array)
+=====
+5..16 -> @resolve-key
+19..22 -> @key
+19..40 -> @
+26..29 -> @key
+26..35 -> (Func(split) | @v"key".split)
+26..40 -> Type(array)
+46..59 -> @split-literal
+62..73 -> (Func(split) | "a.b".split)
+62..78 -> Type(array)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@mutation_methods.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@mutation_methods.typ.snap
@@ -1,0 +1,103 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/mutation_methods.typ
+---
+"array-push" = () => None
+"a" = ()
+"dict-insert" = () => None
+"d" = {}
+"push-loop" = () => ()
+"a" = ()
+"i" = Any
+"push-dict-loop" = () => Type(array)
+"guides" = ()
+"grp" = {"members": (1, )}
+"g" = {"kind": "x"}
+"" = (Any) => @v"g".kind
+"g" = Any
+"push-dict-loop-if" = () => Type(array)
+"guides" = ()
+"first" = true
+"g" = ({"kind": "other"} | {"kind": "swatch", "levels": ( ⪰ Type(array) | ())})
+"levels" = ( ⪰ Type(array) | ())
+"" = (Any) => @v"g".kind
+"g" = Any
+=====
+5..15 -> @array-push
+28..29 -> @a
+32..34 -> ()
+37..38 -> @a
+37..43 -> (Func(push) | @v"a".push)
+37..46 -> None
+55..66 -> @dict-insert
+79..80 -> @d
+83..86 -> {}
+89..90 -> @d
+89..97 -> (Func(insert) | @v"d".insert)
+89..105 -> None
+114..123 -> @push-loop
+136..137 -> @a
+140..142 -> ()
+149..150 -> @i
+154..159 -> Func(range)
+154..162 -> Type(array)
+169..170 -> @a
+169..175 -> (Func(push) | @v"a".push)
+169..178 -> None
+176..177 -> @i
+185..186 -> @a
+195..209 -> @push-dict-loop
+222..228 -> @guides
+231..233 -> ()
+240..243 -> @grp
+247..266 -> ({"members": (1, )}, )
+248..264 -> {"members": (1, )}
+258..262 -> (1, )
+277..278 -> @g
+281..292 -> {"kind": "x"}
+297..298 -> @g
+297..305 -> (Func(insert) | Func(insert) | @v"g".insert)
+297..317 -> None
+322..328 -> @guides
+322..333 -> (Func(push) | @v"guides".push)
+322..336 -> None
+334..335 -> @g
+343..349 -> @guides
+343..356 -> (Func(sorted) | @v"guides".sorted)
+343..374 -> Type(array)
+362..363 -> @g
+362..373 -> @
+367..368 -> @g
+367..373 -> @v"g".kind
+383..400 -> @push-dict-loop-if
+413..419 -> @guides
+422..424 -> ()
+431..436 -> @first
+440..447 -> (true, )
+458..459 -> @g
+465..470 -> @first
+483..489 -> @levels
+492..494 -> ()
+504..509 -> @first
+512..518 -> @levels
+521..527 -> @levels
+521..531 -> (Func(rev) | @v"levels".rev)
+521..533 -> Type(array)
+542..574 -> {"kind": "swatch", "levels": @levels}
+567..573 -> @levels
+594..609 -> {"kind": "other"}
+620..621 -> @g
+620..628 -> (Func(insert) | Func(insert) | @v"g".insert)
+620..640 -> None
+645..651 -> @guides
+645..656 -> (Func(push) | @v"guides".push)
+645..659 -> None
+657..658 -> @g
+666..672 -> @guides
+666..679 -> (Func(sorted) | @v"guides".sorted)
+666..697 -> Type(array)
+685..686 -> @g
+685..696 -> @
+690..691 -> @g
+690..696 -> @v"g".kind

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@param_pollution_from_helper.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@param_pollution_from_helper.typ.snap
@@ -1,0 +1,27 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/param_pollution_from_helper.typ
+---
+"check-free-var" = (Any) => None
+"v" = Type(str)
+"public" = (Any, Any) => Any
+"expr" = Type(int)
+"var" = Type(str)
+"use-public" = 1
+=====
+5..19 -> @check-free-var
+20..21 -> @v
+32..33 -> @v
+47..52 -> Func(panic)
+47..73 -> FlowNone
+86..92 -> @public
+93..97 -> @expr
+99..102 -> @var
+110..124 -> @check-free-var
+110..129 -> None
+125..128 -> @var
+132..136 -> @expr
+145..155 -> @use-public
+158..164 -> @public
+158..172 -> 1

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_dispatch_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_dispatch_deferred.typ.snap
@@ -1,0 +1,50 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/recursive_dispatch_deferred.typ
+---
+"done" = (Any) => {"kind": "done", "value": Any}
+"value" = Type(int)
+"forward" = (Any, Any) => {"kind": "done", "value": Type(int)}
+"handler" = (Any) => {"kind": "done", "value": Type(int)}
+"value" = Type(int)
+"dispatch" = (Any) => {"kind": "done", "value": Type(int)}
+"value" = Type(int)
+"use-zero" = {"kind": "done", "value": Type(int)}
+"use-one" = {"kind": "done", "value": Type(int)}
+=====
+5..9 -> @done
+10..15 -> @value
+19..47 -> {"kind": "done", "value": @value}
+41..46 -> @value
+54..61 -> @forward
+62..69 -> @handler
+71..76 -> @value
+87..92 -> @value
+104..108 -> @done
+104..115 -> {"kind": "done", "value": Type(int)}
+109..114 -> @value
+131..138 -> @handler
+131..149 -> {"kind": "done", "value": Type(int)}
+139..144 -> @value
+162..170 -> @dispatch
+171..176 -> @value
+187..192 -> @value
+204..208 -> @done
+204..215 -> {"kind": "done", "value": Type(int)}
+209..214 -> @value
+228..233 -> @value
+245..252 -> @forward
+245..269 -> {"kind": "done", "value": Type(int)}
+253..261 -> @dispatch
+263..268 -> @value
+285..292 -> @forward
+285..313 -> {"kind": "done", "value": Type(int)}
+293..301 -> @dispatch
+303..308 -> @value
+326..334 -> @use-zero
+337..345 -> @dispatch
+337..348 -> {"kind": "done", "value": Type(int)}
+354..361 -> @use-one
+364..372 -> @dispatch
+364..375 -> {"kind": "done", "value": Type(int)}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred.typ.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred.typ
+---
+"f" = () => 1
+"g" = () => 1
+"h" = () => 0
+"g" = () => 1
+=====
+5..6 -> @f
+19..20 -> @g
+53..54 -> @g
+53..56 -> 1
+65..66 -> @h
+79..80 -> @g

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred_apply.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred_apply.typ.snap
@@ -1,0 +1,215 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.typ
+---
+"f" = () => 1
+"id" = (Any) => Any
+"x" = Type(int)
+"h" = () => 1
+"choose" = (Any, Any) => Any
+"x" = Type(int)
+"y" = Type(str)
+"k" = () => {}
+"fill" = (Any) => Any
+"d" = {}
+"entry" = {}
+"m" = () => {}
+"complete" = (Type(str), Any) => Any
+"key" = Type(str)
+"definitions" = {}
+"entry" = {}
+"n" = () => {}
+"complete" = (Type(str), Any) => Any
+"key" = Type(str)
+"definitions" = {}
+"entry" = {}
+"top-complete" = (Type(str), Any) => Any
+"key" = Type(str)
+"definitions" = {}
+"p" = (Any) => {}
+"definitions" = Any
+"entry" = {}
+"q" = (Any) => {}
+"definitions" = Any
+"entry" = {}
+"r" = (( ⪯ Any & Type(array) & Type(str))) => {}
+"definitions" = ( ⪰ Type(array) | Type(dictionary) | Type(string))
+"entry" = {}
+"n_defs" = Type(int)
+"key" = Any
+"def" = Any
+"key" = Any
+"def" = Any
+=====
+5..6 -> @f
+19..21 -> @id
+22..23 -> @x
+27..28 -> @x
+38..40 -> @id
+38..43 -> 1
+52..53 -> @h
+66..72 -> @choose
+73..74 -> @x
+76..77 -> @y
+91..92 -> @x
+102..103 -> @y
+115..121 -> @choose
+115..129 -> 1
+138..139 -> @k
+152..156 -> @fill
+157..158 -> @d
+182..183 -> @d
+192..193 -> @d
+192..200 -> (Func(insert) | @v"d".insert)
+192..208 -> None
+219..220 -> @d
+231..236 -> @entry
+239..242 -> {}
+252..256 -> @fill
+252..263 -> {}
+257..262 -> @entry
+272..273 -> @m
+286..294 -> @complete
+295..298 -> @key
+300..311 -> @definitions
+338..349 -> @definitions
+358..363 -> Func(panic)
+358..368 -> FlowNone
+397..408 -> @definitions
+417..428 -> @definitions
+417..435 -> (Func(insert) | @v"definitions".insert)
+417..449 -> None
+445..448 -> @key
+460..471 -> @definitions
+482..487 -> @entry
+490..493 -> {}
+503..511 -> @complete
+503..523 -> {}
+517..522 -> @entry
+532..533 -> @n
+546..554 -> @complete
+555..558 -> @key
+560..571 -> @definitions
+598..609 -> @definitions
+618..623 -> Func(panic)
+618..628 -> FlowNone
+657..668 -> @definitions
+677..688 -> @definitions
+677..695 -> (Func(insert) | @v"definitions".insert)
+677..709 -> None
+705..708 -> @key
+741..752 -> @definitions
+761..772 -> @definitions
+761..779 -> (Func(insert) | @v"definitions".insert)
+761..821 -> None
+794..805 -> @definitions
+794..808 -> (Func(at) | @v"definitions".at)
+794..817 -> @v"definitions".short
+832..843 -> @definitions
+854..859 -> @entry
+862..865 -> {}
+875..883 -> @complete
+875..895 -> {}
+889..894 -> @entry
+904..916 -> @top-complete
+917..920 -> @key
+922..933 -> @definitions
+958..969 -> @definitions
+976..981 -> Func(panic)
+976..986 -> FlowNone
+1011..1022 -> @definitions
+1029..1040 -> @definitions
+1029..1047 -> (Func(insert) | @v"definitions".insert)
+1029..1061 -> None
+1057..1060 -> @key
+1089..1100 -> @definitions
+1107..1118 -> @definitions
+1107..1125 -> (Func(insert) | @v"definitions".insert)
+1107..1167 -> None
+1140..1151 -> @definitions
+1140..1154 -> (Func(at) | @v"definitions".at)
+1140..1163 -> @v"definitions".short
+1194..1205 -> @definitions
+1212..1223 -> @definitions
+1212..1230 -> (Func(insert) | @v"definitions".insert)
+1212..1270 -> None
+1244..1255 -> @definitions
+1244..1258 -> (Func(at) | @v"definitions".at)
+1244..1266 -> @v"definitions".long
+1277..1288 -> @definitions
+1297..1298 -> @p
+1299..1310 -> @definitions
+1322..1327 -> @entry
+1330..1333 -> {}
+1343..1355 -> @top-complete
+1343..1367 -> {}
+1361..1366 -> @entry
+1376..1377 -> @q
+1378..1389 -> @definitions
+1401..1406 -> @entry
+1409..1412 -> {}
+1415..1427 -> @top-complete
+1415..1439 -> {}
+1433..1438 -> @entry
+1448..1449 -> @r
+1450..1461 -> @definitions
+1473..1478 -> @entry
+1481..1484 -> {}
+1490..1494 -> Type(type)
+1490..1507 -> (Type(type) | TypeUnary { lhs: @definitions, op: TypeOf })
+1495..1506 -> @definitions
+1511..1514 -> Type(string)
+1521..1526 -> @entry
+1521..1533 -> (Func(insert) | @v"entry".insert)
+1521..1554 -> None
+1542..1553 -> @definitions
+1567..1571 -> Type(type)
+1567..1584 -> (Type(type) | TypeUnary { lhs: @definitions, op: TypeOf })
+1572..1583 -> @definitions
+1588..1593 -> Type(array)
+1604..1610 -> @n_defs
+1613..1624 -> @definitions
+1613..1628 -> (Func(len) | Func(len) | Func(len) | @v"definitions".len)
+1613..1630 -> Type(int)
+1638..1644 -> @n_defs
+1658..1663 -> Func(panic)
+1658..1668 -> FlowNone
+1683..1689 -> @n_defs
+1702..1707 -> Func(panic)
+1702..1712 -> FlowNone
+1728..1731 -> @key
+1733..1736 -> @def
+1741..1760 -> ("long", "long-pl", )
+1741..1764 -> (Func(zip) | ("long", "long-pl", ).zip)
+1741..1777 -> Type(array)
+1765..1776 -> @definitions
+1786..1791 -> @entry
+1786..1798 -> (Func(insert) | @v"entry".insert)
+1786..1808 -> None
+1799..1802 -> @key
+1804..1807 -> @def
+1827..1831 -> Type(type)
+1827..1844 -> (Type(type) | TypeUnary { lhs: @definitions, op: TypeOf })
+1832..1843 -> @definitions
+1848..1858 -> Type(dictionary)
+1882..1893 -> @definitions
+1902..1907 -> Func(panic)
+1902..1912 -> FlowNone
+1928..1931 -> @key
+1933..1936 -> @def
+1941..1952 -> @definitions
+1964..1967 -> @key
+1971..2011 -> ("short", "short-pl", "long", "long-pl", )
+2022..2027 -> @entry
+2022..2034 -> (Func(insert) | @v"entry".insert)
+2022..2044 -> None
+2035..2038 -> @key
+2040..2043 -> @def
+2068..2073 -> Func(panic)
+2068..2078 -> FlowNone
+2108..2113 -> Func(panic)
+2108..2118 -> FlowNone
+2125..2137 -> @top-complete
+2125..2149 -> {}
+2143..2148 -> @entry


### PR DESCRIPTION
Add focused type-check fixtures and snapshots for deferred apply, cyclic scope inference, content returns, loops, mutation methods, and parameter isolation.