### PR TITLE
docs(openspec): propose type VM bytecode plan

### DIFF
--- a/openspec/changes/add-ty-wasm-execution-cache/.openspec.yaml
+++ b/openspec/changes/add-ty-wasm-execution-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/add-ty-wasm-execution-cache/design.md
+++ b/openspec/changes/add-ty-wasm-execution-cache/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The type checker has previously hit timeouts when computations waited on each other through nested cache initialization. The type VM must support demand-driven function execution, but a running recursive dependency must produce a neutral residual rather than wait for another worker.
+
+The Wasmer backend is a long-term acceleration path. Most functions are likely cold, so the Rust interpreter must remain the default until profiling proves Wasmer is beneficial for hot programs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Run type bytecode through a Rust interpreter.
+- Define a backend trait so Wasmer execution can be added without changing checker semantics.
+- Add non-blocking local `Fresh/Running/Done/Stuck` state for closure calls.
+- Cache completed results globally while never globally blocking on running type computations.
+- Record enough metrics to decide when Wasmer should be used.
+
+**Non-Goals:**
+- Make Wasmer the default backend.
+- Move Rust type algebra into wasm memory.
+- Guarantee cache reuse across incompatible source revisions or meta epochs.
+
+## Decisions
+
+- Use the Rust interpreter as the source of truth. Wasmer must be checked against interpreter results before being trusted for a program subset.
+- Use local call states for cycle detection. `Running` means return a neutral residual; it never means wait.
+- Use global caches only for completed results. This prevents worker-to-worker deadlocks while still sharing work.
+- Key closure-call caches by closure prototype, captured environment key, argument shape, context key, and meta epoch.
+- Cache quote results separately from evaluation results because quoting can dominate runtime once semantic values are shared.
+
+## Risks / Trade-offs
+
+- [Risk] Wasmer startup and compilation overhead may exceed interpreter cost. -> Mitigation: keep Wasmer feature-gated and add hotness thresholds.
+- [Risk] Cache keys may be too precise and miss reuse. -> Mitigation: start conservative, then relax only with package-scan evidence.
+- [Risk] Local `Running` residuals could weaken results. -> Mitigation: add snapshots for recursive and non-recursive demand-driven calls.
+- [Risk] Metrics could add overhead. -> Mitigation: keep detailed counters behind existing tracing or debug configuration.

--- a/openspec/changes/add-ty-wasm-execution-cache/proposal.md
+++ b/openspec/changes/add-ty-wasm-execution-cache/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The bytecode model needs an execution strategy that is fast, incremental, and safe under recursive dependencies. Shared blocking caches such as `OnceLock` can stall worker threads when type computations depend on each other, so execution must separate local running state from globally reusable results.
+
+## What Changes
+
+- Add a Rust interpreter backend for type bytecode.
+- Add a Wasmer-backed execution backend behind an experimental feature flag.
+- Add non-blocking local execution state for closures and calls.
+- Add global caches only for completed bytecode programs, closure calls, and quoted results.
+- Add instrumentation for cache hits, residualized cycles, VM steps, and Wasmer compile/execute time.
+
+## Capabilities
+
+### New Capabilities
+- `ty-wasm-execution-cache`: Defines bytecode execution backends, non-blocking cycle handling, and cache behavior for type VM execution.
+
+### Modified Capabilities
+
+## Impact
+
+- Affects new type VM modules and the type checker integration points that request evaluation.
+- May add optional dependencies for Wasmer under a disabled-by-default feature.
+- Introduces performance counters used by package-scale validation.

--- a/openspec/changes/add-ty-wasm-execution-cache/specs/ty-wasm-execution-cache/spec.md
+++ b/openspec/changes/add-ty-wasm-execution-cache/specs/ty-wasm-execution-cache/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Interpreter execution backend
+The system SHALL provide a Rust interpreter backend for type bytecode programs.
+
+#### Scenario: Execute bytecode in interpreter
+- **WHEN** the checker requests execution of a supported bytecode program
+- **THEN** the interpreter evaluates the program to a semantic type value without invoking Wasmer
+
+### Requirement: Non-blocking closure call state
+The system SHALL represent closure call execution with local states that distinguish fresh, running, completed, and stuck calls.
+
+#### Scenario: Recursive call while running
+- **WHEN** a closure call attempts to force a closure that is already running in the current VM
+- **THEN** execution returns a neutral residual value rather than blocking on the running call
+
+### Requirement: Completed-result global caches
+The system SHALL cache completed bytecode execution results globally while excluding in-progress computations from global blocking caches.
+
+#### Scenario: Reuse completed call
+- **WHEN** a later checker invocation evaluates the same completed closure call under a compatible key
+- **THEN** the VM may reuse the cached result without re-running the closure body
+
+### Requirement: Experimental Wasmer backend
+The system SHALL provide an experimental Wasmer backend behind an explicit feature flag.
+
+#### Scenario: Wasmer disabled by default
+- **WHEN** the workspace is built without the experimental Wasmer feature
+- **THEN** type bytecode execution uses the Rust interpreter and does not require Wasmer dependencies
+
+### Requirement: Execution metrics
+The system SHALL expose metrics for VM steps, cache hits and misses, residualized cycles, and Wasmer compile and run time when enabled.
+
+#### Scenario: Collect package scan metrics
+- **WHEN** package-scale type analysis runs with VM metrics enabled
+- **THEN** the output includes enough counters to compare interpreter, cache, and Wasmer behavior

--- a/openspec/changes/add-ty-wasm-execution-cache/tasks.md
+++ b/openspec/changes/add-ty-wasm-execution-cache/tasks.md
@@ -1,0 +1,23 @@
+## 1. Interpreter Backend
+
+- [ ] 1.1 Add the backend trait and Rust interpreter implementation.
+- [ ] 1.2 Implement stack, frame, environment, closure, and meta store handling for supported bytecode.
+- [ ] 1.3 Add recursion handling that converts local `Running` calls into neutral residuals.
+
+## 2. Caches
+
+- [ ] 2.1 Add local closure-call state maps for non-blocking demand-driven execution.
+- [ ] 2.2 Add global completed-result caches for programs, closure calls, and quoted values.
+- [ ] 2.3 Add cache invalidation keys for source revision, captured environment, argument shape, context, and meta epoch.
+
+## 3. Wasmer Backend
+
+- [ ] 3.1 Add optional Wasmer dependency and feature flag.
+- [ ] 3.2 Implement wasm module instantiation through the handle-based host ABI.
+- [ ] 3.3 Add interpreter-vs-Wasmer equivalence tests for the supported bytecode subset.
+
+## 4. Metrics
+
+- [ ] 4.1 Add VM counters for steps, cache hits, cache misses, and residualized cycles.
+- [ ] 4.2 Add Wasmer compile/run timing counters behind the experimental backend.
+- [ ] 4.3 Surface metrics in package scan output under `target/`.

--- a/openspec/changes/compile-before-type-check/.openspec.yaml
+++ b/openspec/changes/compile-before-type-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/compile-before-type-check/design.md
+++ b/openspec/changes/compile-before-type-check/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The ongoing type-checker work introduced generated return variables, deferred calls, precise signature queries, and fixed-point inference. That validates the direction, but the implementation still spreads evaluation across syntax checking, deferred-body queues, call instantiation, and result normalization.
+
+The new pipeline should make bytecode evaluation the deduce stage. Checking becomes a consumer of evaluated semantic values instead of a second way to discover the same information.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Compile syntax into type bytecode before deducing expression and binding types.
+- Use the type VM to evaluate functions on demand when calls require their result.
+- Run compatibility checks after or during evaluation without sacrificing precision.
+- Preserve existing public analysis APIs and snapshot testing workflow.
+- Avoid shared blocking `get_or_init` waits between worker threads.
+
+**Non-Goals:**
+- Introduce Wasmer execution in this PR.
+- Complete all package-scale performance work in this PR.
+- Remove every existing `Ty` simplification helper immediately.
+
+## Decisions
+
+- Treat bytecode evaluation as the deduce stage. Function definitions create closures and return metas; function calls force closures when possible.
+- Keep checking logic as VM primitives or post-evaluation checks rather than duplicating expression traversal.
+- Make `precise_sig_of_def` force the relevant closure result through the VM and quote the final signature.
+- Represent cycles as neutral residuals, not as blocking waits or immediate `Any`.
+- Keep old checker paths behind tests during migration only if needed for diff analysis, not as a permanent dual implementation.
+
+## Risks / Trade-offs
+
+- [Risk] The migration can produce many snapshot diffs at once. -> Mitigation: add focused fixtures and classify diffs as stronger, weaker, or formatting-only before accepting.
+- [Risk] Some existing checker warnings depend on traversal order. -> Mitigation: encode those checks as VM primitives with explicit once-only warning behavior.
+- [Risk] Incomplete bytecode coverage can regress features. -> Mitigation: fall back only for unsupported syntax while logging coverage gaps in tests.
+- [Risk] Precise signature queries can accidentally get shallow results. -> Mitigation: make the analysis query force the relevant closure result and test docs/signature paths.

--- a/openspec/changes/compile-before-type-check/proposal.md
+++ b/openspec/changes/compile-before-type-check/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The current PR's deferred inference model improves precision but still leaves deduce and infer as visibly separate mechanisms. We need the checker to compile expressions first, use bytecode evaluation as the deduce engine, and then run compatibility checking over the evaluated semantic types.
+
+## What Changes
+
+- Replace the current deduce path with compile-to-bytecode followed by VM evaluation.
+- Keep a check phase that applies existing compatibility and warning logic after semantic results are available.
+- Preserve `precise_sig_of_def` as the public query for docs/signature consumers.
+- Avoid exposing shallow signatures through documentation APIs.
+- Retain snapshots as the primary correctness signal for this migration.
+
+## Capabilities
+
+### New Capabilities
+- `compile-before-type-check`: Defines the checker pipeline that compiles syntax before checking and uses type VM evaluation for deduced results.
+
+### Modified Capabilities
+
+## Impact
+
+- Affects the current deferred type-checker PR and its follow-up snapshot PR.
+- Reworks `crates/tinymist-query/src/analysis/tyck.rs`, `tyck/syntax.rs`, and `tyck/apply.rs`.
+- Requires careful snapshot review for stronger/weaker typings.

--- a/openspec/changes/compile-before-type-check/specs/compile-before-type-check/spec.md
+++ b/openspec/changes/compile-before-type-check/specs/compile-before-type-check/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Compile before deduce
+The checker SHALL compile supported syntax into type bytecode before computing deduced types.
+
+#### Scenario: Deduced function signature
+- **WHEN** the checker sees a supported function definition
+- **THEN** it records a closure-backed signature whose result is represented by a meta variable that can be forced by calls or precise signature queries
+
+### Requirement: Demand-driven function result evaluation
+The checker SHALL evaluate function bodies on demand when a call needs the callee result and the body can run without blocking on another worker.
+
+#### Scenario: Non-recursive helper call
+- **WHEN** a function body calls a same-scope helper whose closure is not running
+- **THEN** the VM evaluates the helper body and uses the resulting semantic type to compute the caller result
+
+### Requirement: Cycle residualization
+The checker SHALL residualize cyclic function-result dependencies as neutral values.
+
+#### Scenario: Recursive call cycle
+- **WHEN** evaluating a closure encounters a call to a closure already running in the current VM
+- **THEN** the result is a neutral residual and evaluation continues without waiting on a shared cache
+
+### Requirement: Check after semantic evaluation
+The checker SHALL apply compatibility checks and once-only experimental warnings to semantic operands rather than relying on a separate syntax-only pass.
+
+#### Scenario: Binary incompatibility
+- **WHEN** VM evaluation processes a binary operation whose semantic operand types are incompatible
+- **THEN** the checker records the experimental warning once and returns the appropriate semantic result or residual
+
+### Requirement: Precise signature query
+The public precise signature query SHALL force the relevant closure result before returning documentation or signature-help data.
+
+#### Scenario: Documentation asks for a function signature
+- **WHEN** documentation generation asks for a function definition signature
+- **THEN** it receives the precise quoted signature through the analysis query API and does not need to know checker internals

--- a/openspec/changes/compile-before-type-check/tasks.md
+++ b/openspec/changes/compile-before-type-check/tasks.md
@@ -1,0 +1,23 @@
+## 1. Pipeline Integration
+
+- [ ] 1.1 Add compile-before-check entry points in the type checker.
+- [ ] 1.2 Route supported expressions through bytecode evaluation for deduced types.
+- [ ] 1.3 Preserve `TypeInfo` population by quoting semantic values back to `Ty`.
+
+## 2. Function Calls
+
+- [ ] 2.1 Replace deferred function body vectors with closure state in the VM path.
+- [ ] 2.2 Force non-running closures on demand at call sites.
+- [ ] 2.3 Residualize recursive or blocked calls as neutral values.
+
+## 3. Checking Semantics
+
+- [ ] 3.1 Move binary operation compatibility and folding into VM primitives.
+- [ ] 3.2 Move selection and apply resultant logic into VM primitives.
+- [ ] 3.3 Keep experimental warnings once-only and non-user-facing.
+
+## 4. Queries and Snapshots
+
+- [ ] 4.1 Make `precise_sig_of_def` force closure results through the VM.
+- [ ] 4.2 Add fixtures covering non-recursive helpers, recursive calls, binary folding, and documentation signatures.
+- [ ] 4.3 Run and review `tinymist-query` type-check snapshots for stronger/weaker changes.

--- a/openspec/changes/measure-typst-knowledge-type-vm/.openspec.yaml
+++ b/openspec/changes/measure-typst-knowledge-type-vm/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/measure-typst-knowledge-type-vm/design.md
+++ b/openspec/changes/measure-typst-knowledge-type-vm/design.md
@@ -1,0 +1,34 @@
+## Context
+
+Previous package scans exposed timeouts and typing regressions. JSONL-only output was hard to inspect, and generated data must not inflate git history. The measurement workflow needs deterministic per-package reports and enough detail to explain changed typings.
+
+The package corpus is large, so the tool must support incremental runs, resume behavior, timeouts, and summaries without requiring sparse checkouts in temporary directories.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Measure package-level and file-level type-check timing.
+- Compare baseline and current quoted typings.
+- Classify typing changes as stronger, weaker, changed, or formatting-only where possible.
+- Store reports under `target/`.
+- Detect timeout regressions and cache behavior changes.
+
+**Non-Goals:**
+- Commit generated package scan outputs.
+- Fetch multi-gigabyte sparse checkouts into `/tmp`.
+- Decide semantic correctness solely from automated classification.
+
+## Decisions
+
+- Use existing local package data or registry fetch paths configured by the repo; avoid writing package data to `/tmp`.
+- Emit both machine-readable and pretty per-package reports. Pretty reports make review possible without opening giant JSONL files.
+- Use per-package directories under `target/tyck-package-scan/` so reports can be inspected and cleaned independently.
+- Include hashes of SCIP/API outputs when comparing behavior across optimization runs.
+- Treat timeout absence as a first-class acceptance criterion, separate from precision diffs.
+
+## Risks / Trade-offs
+
+- [Risk] Full package scans can take too long for normal CI. -> Mitigation: keep the full scan manual and add a small smoke subset for CI.
+- [Risk] Automated stronger/weaker classification can be wrong. -> Mitigation: preserve raw before/after typings and include examples in summaries.
+- [Risk] Generated reports can become huge. -> Mitigation: split by package and keep everything under `target/`.
+- [Risk] Baseline revisions may be lost. -> Mitigation: record git SHAs, command config, and output hashes with each run.

--- a/openspec/changes/measure-typst-knowledge-type-vm/proposal.md
+++ b/openspec/changes/measure-typst-knowledge-type-vm/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The type VM and compile-before-check migration must be validated against real packages, not only focused fixtures. We need package-scale timing and typing-diff reports under `target/` to prove that precision and performance improve without recreating the previous timeout behavior.
+
+## What Changes
+
+- Add package-scale measurement for Typst knowledge/package data using existing local package inputs.
+- Write all generated reports under `target/`.
+- Compare baseline and current typings per package and per file.
+- Measure file and package elapsed time, timeout count, VM cache behavior, and output precision changes.
+- Produce reviewer-friendly summaries for stronger/weaker/changed typings.
+
+## Capabilities
+
+### New Capabilities
+- `typst-knowledge-type-vm-benchmark`: Defines package-scale performance and typing-diff validation for the type VM pipeline.
+
+### Modified Capabilities
+
+## Impact
+
+- Adds measurement tooling and report formats under `target/`.
+- Does not vendor or checkout package registries into `/tmp`.
+- Supports review of current PRs before and after low-level checker changes.

--- a/openspec/changes/measure-typst-knowledge-type-vm/specs/typst-knowledge-type-vm-benchmark/spec.md
+++ b/openspec/changes/measure-typst-knowledge-type-vm/specs/typst-knowledge-type-vm-benchmark/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Package scan output location
+The package scan tooling SHALL write generated reports and intermediate results under `target/`.
+
+#### Scenario: Run package scan
+- **WHEN** a developer runs the package-scale type checker measurement
+- **THEN** generated typings, timing reports, diffs, summaries, and intermediate files are written under `target/tyck-package-scan/`
+
+### Requirement: Per-package pretty reports
+The package scan tooling SHALL produce pretty per-package typing reports in addition to machine-readable data.
+
+#### Scenario: Inspect one package
+- **WHEN** a package has changed typings
+- **THEN** the developer can open a package-specific pretty report showing relevant `#let` typings and changed entries
+
+### Requirement: Baseline-current comparison
+The package scan tooling SHALL compare baseline and current outputs by package and file.
+
+#### Scenario: Compare revisions
+- **WHEN** baseline and current scan outputs are available
+- **THEN** the tooling reports changed, stronger, weaker, unchanged, timeout, and error counts per package
+
+### Requirement: Performance metrics
+The package scan tooling SHALL record elapsed time per file and per package.
+
+#### Scenario: Identify slow files
+- **WHEN** a package scan completes
+- **THEN** the summary identifies the slowest files and packages with measured elapsed time
+
+### Requirement: Timeout regression detection
+The package scan tooling SHALL report timeout regressions separately from typing diffs.
+
+#### Scenario: Timeout appears
+- **WHEN** the current run times out on a file or package that baseline completed
+- **THEN** the summary marks it as a timeout regression

--- a/openspec/changes/measure-typst-knowledge-type-vm/tasks.md
+++ b/openspec/changes/measure-typst-knowledge-type-vm/tasks.md
@@ -1,0 +1,23 @@
+## 1. Scan Runner
+
+- [ ] 1.1 Add or update package scan command wiring to use local package data without writing package checkouts to `/tmp`.
+- [ ] 1.2 Store run configuration, git SHA, and output directories under `target/tyck-package-scan/`.
+- [ ] 1.3 Add timeout handling and resume support for large package sets.
+
+## 2. Typing Reports
+
+- [ ] 2.1 Emit machine-readable per-file typings and timing data.
+- [ ] 2.2 Emit pretty per-package markdown reports split by package.
+- [ ] 2.3 Include SCIP/API output hashes when available for behavior-preservation comparisons.
+
+## 3. Diff Analysis
+
+- [ ] 3.1 Compare baseline and current typings by package, file, symbol, and type text.
+- [ ] 3.2 Classify changes into stronger, weaker, changed, unchanged, errors, and timeouts.
+- [ ] 3.3 Generate summary tables for worst regressions, slowest files, and largest resultant/output sizes.
+
+## 4. Validation
+
+- [ ] 4.1 Add a small package subset smoke test for the scan tooling.
+- [ ] 4.2 Document the manual full-corpus scan command and expected output paths.
+- [ ] 4.3 Run the scanner before and after the type VM migration and attach summaries to review comments, not PR descriptions.

--- a/openspec/changes/model-ty-wasm-bytecode/.openspec.yaml
+++ b/openspec/changes/model-ty-wasm-bytecode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/model-ty-wasm-bytecode/design.md
+++ b/openspec/changes/model-ty-wasm-bytecode/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The current checker directly maps syntax to `Ty` and uses deferred `Ty::Apply`, generated variables, and post-processing to infer function result types. That model is too close to syntax and too far from evaluation: calls, selection, conditionals, and binary operations are repeatedly interpreted through ad hoc code paths.
+
+Typst's concrete evaluator already demonstrates the shape we want: closures capture scopes, calls run in a new VM, imports are route-aware, and expensive computations are cached. For type checking, however, the value domain must support metas and neutral residuals, so a tiny type VM is needed instead of reusing Typst's evaluator.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a small bytecode instruction set for type-level evaluation.
+- Define semantic values that can represent computed types, closures, metas, and stuck neutral terms.
+- Provide a deterministic quote step from semantic values back to existing `Ty`.
+- Provide an emitter contract that can compile bytecode to WebAssembly later.
+
+**Non-Goals:**
+- Execute the bytecode in Wasmer.
+- Replace the existing checker behavior.
+- Type-check every Typst expression kind in the first bytecode model.
+- Expose semantic values in public analysis APIs.
+
+## Decisions
+
+- Use `Ty` as the external format and semantic values as the VM-internal format. This avoids snapshot/API churn while allowing NbE-style execution internally.
+- Model functions as bytecode closures with captured type scopes and a return meta. This mirrors Typst closure evaluation while allowing recursive calls to residualize instead of block.
+- Model stuck operations as neutral values rather than immediate `Ty::Apply` terms. Quoting can still produce `Ty::Apply`, but the evaluator retains more structure while running.
+- Keep the first WebAssembly emitter host-driven. Wasm code should operate on handles and call host functions for type algebra rather than owning Rust `Ty` layouts.
+- Keep bytecode stable enough for tests but not a public compatibility boundary.
+
+## Risks / Trade-offs
+
+- [Risk] The bytecode model may grow too much if it tries to encode all Typst semantics. -> Mitigation: only encode operations needed by type deduction and leave concrete Typst eval separate.
+- [Risk] Quoting semantic values can become expensive. -> Mitigation: design quote cache keys around semantic value IDs and quote mode from the start.
+- [Risk] Wasm emission could constrain the interpreter too early. -> Mitigation: define a wasm-friendly instruction set but validate semantics first in Rust.
+- [Risk] Existing `Ty` operations may duplicate semantic operations. -> Mitigation: migrate only after snapshots show equivalent or stronger results.

--- a/openspec/changes/model-ty-wasm-bytecode/proposal.md
+++ b/openspec/changes/model-ty-wasm-bytecode/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The current type checker mixes syntax traversal, deferred terms, and result inference, which makes scope-based deduce hard to reason about and hard to optimize. We need a compact execution model that can evaluate type operations uniformly and later emit the same program to WebAssembly.
+
+## What Changes
+
+- Introduce a type bytecode model for expressions relevant to type deduction.
+- Define a semantic type value domain with meta variables, neutral residuals, closures, arguments, records, and quoted `Ty` output.
+- Add a compiler from the existing expression/type-checker representation to bytecode programs.
+- Add an experimental WebAssembly emitter for the bytecode without changing the default checker execution path.
+- Keep `Ty` as the public representation used by snapshots, signatures, docs, and analysis APIs.
+
+## Capabilities
+
+### New Capabilities
+- `ty-wasm-bytecode-model`: Defines the type-level bytecode, semantic values, closure model, neutral residuals, and WebAssembly emission contract.
+
+### Modified Capabilities
+
+## Impact
+
+- Affects `crates/tinymist-query/src/analysis/tyck*` and may add a new internal bytecode module under `tinymist-query` or `tinymist-analysis`.
+- Adds no runtime dependency for the default path in this phase.
+- Establishes the intermediate representation required by later execution/cache and compile-before-check work.

--- a/openspec/changes/model-ty-wasm-bytecode/specs/ty-wasm-bytecode-model/spec.md
+++ b/openspec/changes/model-ty-wasm-bytecode/specs/ty-wasm-bytecode-model/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Type bytecode model
+The system SHALL define an internal bytecode representation for type deduction programs.
+
+#### Scenario: Compile expression to bytecode
+- **WHEN** the checker compiles a supported expression for type deduction
+- **THEN** it produces a bytecode program containing deterministic instructions for constants, locals, globals, closures, calls, selection, conditionals, binary operations, and returns
+
+### Requirement: Semantic type value domain
+The system SHALL define semantic type values for computed types, function closures, arguments, records, arrays, tuples, meta variables, and neutral residual operations.
+
+#### Scenario: Represent a stuck call
+- **WHEN** evaluation reaches a call whose callee or result cannot be reduced because of a meta, unknown variable, or recursive running closure
+- **THEN** the VM represents the result as a neutral call value instead of blocking or immediately erasing it to `Any`
+
+### Requirement: Quote semantic values to Ty
+The system SHALL quote semantic type values back to existing `Ty` values for storage in `TypeInfo`, signatures, docs, and snapshots.
+
+#### Scenario: Quote public output
+- **WHEN** a bytecode evaluation result is recorded in `TypeInfo`
+- **THEN** the result is converted to `Ty` without exposing VM-only semantic value types through public analysis APIs
+
+### Requirement: WebAssembly emission contract
+The system SHALL define a WebAssembly emission contract for type bytecode that uses handles and host functions for type values.
+
+#### Scenario: Emit wasm-compatible bytecode
+- **WHEN** a supported type bytecode program is emitted to WebAssembly
+- **THEN** the emitted module uses host calls and numeric handles rather than embedding Rust `Ty` memory layout in wasm memory

--- a/openspec/changes/model-ty-wasm-bytecode/tasks.md
+++ b/openspec/changes/model-ty-wasm-bytecode/tasks.md
@@ -1,0 +1,17 @@
+## 1. Bytecode Model
+
+- [ ] 1.1 Add internal bytecode data structures for programs, instructions, constants, and closure prototypes.
+- [ ] 1.2 Add semantic value and neutral residual data structures with stable debug formatting for snapshots.
+- [ ] 1.3 Add quote support from semantic values to existing `Ty`.
+
+## 2. Compiler
+
+- [ ] 2.1 Compile supported expression nodes into type bytecode programs.
+- [ ] 2.2 Compile function definitions into closure prototypes with captured scope metadata and return metas.
+- [ ] 2.3 Add unit tests for bytecode generation on calls, selection, binary operations, conditionals, and recursive functions.
+
+## 3. WebAssembly Contract
+
+- [ ] 3.1 Define the wasm host ABI for value, args, env, string, meta, and closure handles.
+- [ ] 3.2 Add an experimental wasm emitter that produces modules for a small supported bytecode subset.
+- [ ] 3.3 Add validation tests that compare emitted wasm structure against bytecode programs without executing Wasmer.


### PR DESCRIPTION
- Add OpenSpec proposals for type bytecode modeling and wasm emission
- Add execution/cache proposal for interpreter and optional Wasmer backend
- Add compile-before-check proposal for the current type-checker PR
- Add typst knowledge package-scan performance proposal