### PR TITLE
fix(query): improve cetz type inference

### DIFF
--- a/crates/tinymist-analysis/src/ty/builtin.rs
+++ b/crates/tinymist-analysis/src/ty/builtin.rs
@@ -208,6 +208,15 @@ pub enum BuiltinSig<'a> {
     TupleMap(&'a Ty),
     /// Gets element of a tuple: `(a, b, c).at`
     TupleAt(&'a Ty),
+    /// Gets the positional values of arguments: `arguments.pos`
+    ArgumentsPos(&'a Ty),
+}
+
+impl<'a> BuiltinSig<'a> {
+    /// Gets a dependent method signature for an arguments receiver.
+    pub fn arguments_method(receiver: &'a Ty, method: &str) -> Option<Self> {
+        (method == "pos").then_some(Self::ArgumentsPos(receiver))
+    }
 }
 
 /// A package identifier.
@@ -252,6 +261,8 @@ pub enum BuiltinTy {
     Break,
     /// A continue type: `continue`
     Continue,
+    /// A never type for expressions that do not continue normally.
+    Never,
     /// An infer type: `any`
     Infer,
     /// A flow none type: `none`
@@ -333,6 +344,7 @@ impl fmt::Debug for BuiltinTy {
             BuiltinTy::None => f.write_str("None"),
             BuiltinTy::Break => f.write_str("Break"),
             BuiltinTy::Continue => f.write_str("Continue"),
+            BuiltinTy::Never => f.write_str("Never"),
             BuiltinTy::Infer => f.write_str("Infer"),
             BuiltinTy::FlowNone => f.write_str("FlowNone"),
             BuiltinTy::Auto => f.write_str("Auto"),
@@ -425,6 +437,7 @@ impl BuiltinTy {
             BuiltinTy::None => "none",
             BuiltinTy::Break => "break",
             BuiltinTy::Continue => "continue",
+            BuiltinTy::Never => "never",
             BuiltinTy::Infer => "any",
             BuiltinTy::FlowNone => "none",
             BuiltinTy::Auto => "auto",

--- a/crates/tinymist-analysis/src/ty/describe.rs
+++ b/crates/tinymist-analysis/src/ty/describe.rs
@@ -183,7 +183,10 @@ impl TypeDescriber {
                 return "content".into();
             }
             // Doesn't provide any information, hence we doesn't describe it intermediately here.
-            Ty::Any | Ty::Builtin(BuiltinTy::Clause | BuiltinTy::Undef | BuiltinTy::Infer) => {}
+            Ty::Any
+            | Ty::Builtin(
+                BuiltinTy::Clause | BuiltinTy::Undef | BuiltinTy::Never | BuiltinTy::Infer,
+            ) => {}
             Ty::Builtin(BuiltinTy::FlowNone | BuiltinTy::None) => {
                 return "none".into();
             }

--- a/crates/tinymist-analysis/src/ty/iface.rs
+++ b/crates/tinymist-analysis/src/ty/iface.rs
@@ -13,6 +13,11 @@ pub enum Iface<'a> {
     Tuple(&'a Interned<Vec<Ty>>),
     /// A dictionary type.
     Dict(&'a Interned<RecordTy>),
+    /// An arguments type.
+    Args {
+        /// The original type.
+        at: &'a Ty,
+    },
     /// A content type.
     Content {
         /// The element type.
@@ -71,7 +76,8 @@ impl Iface<'_> {
             Iface::Array(ty) => Ty::Array(ty.clone()),
             Iface::Tuple(tys) => Ty::Tuple(tys.clone()),
             Iface::Dict(dict) => Ty::Dict(dict.clone()),
-            Iface::Content { at, .. }
+            Iface::Args { at }
+            | Iface::Content { at, .. }
             | Iface::TypeType { at, .. }
             | Iface::Type { at, .. }
             | Iface::Func { at, .. }
@@ -90,6 +96,12 @@ impl Iface<'_> {
                 select_scope(Some(Type::of::<typst::foundations::Array>().scope()), key)
             }
             Iface::Dict(dict) => dict.field_by_name(key).cloned(),
+            Iface::Args { at } => {
+                if BuiltinSig::arguments_method(at, key).is_some() {
+                    return None;
+                }
+                select_scope(Some(Type::of::<typst::foundations::Args>().scope()), key)
+            }
             Iface::Content { val, .. } => select_scope(Some(val.scope()), key),
             // todo: distinguish TypeType and Type
             Iface::TypeType { val, .. } | Iface::Type { val, .. } => {
@@ -200,6 +212,9 @@ impl IfaceCheckDriver<'_> {
                 self.checker
                     .check(Iface::Dict(&FLOW_TEXT_FONT_DICT), &mut self.ctx, pol);
             }
+            Ty::Builtin(BuiltinTy::Args) => {
+                self.checker.check(Iface::Args { at }, &mut self.ctx, pol);
+            }
             Ty::Value(ins_ty) => {
                 // todo: deduplicate checking early
                 if self.value_as_iface() {
@@ -219,6 +234,9 @@ impl IfaceCheckDriver<'_> {
                         Value::Func(func) => {
                             self.checker
                                 .check(Iface::Func { val: func, at }, &mut self.ctx, pol);
+                        }
+                        Value::Args(..) => {
+                            self.checker.check(Iface::Args { at }, &mut self.ctx, pol);
                         }
                         Value::None
                         | Value::Auto
@@ -244,7 +262,6 @@ impl IfaceCheckDriver<'_> {
                         | Value::Content(..)
                         | Value::Styles(..)
                         | Value::Array(..)
-                        | Value::Args(..)
                         | Value::Dyn(..) => {
                             self.checker.check(
                                 Iface::Type {
@@ -309,6 +326,9 @@ impl IfaceCheckDriver<'_> {
             Ty::Array(sig) if self.array_as_iface() => {
                 // self.check_dict_signature(sig, pol, self.checker);
                 self.checker.check(Iface::Array(sig), &mut self.ctx, pol);
+            }
+            Ty::Args(..) => {
+                self.checker.check(Iface::Args { at }, &mut self.ctx, pol);
             }
             Ty::Dict(..) => {
                 self.checker.check(

--- a/crates/tinymist-analysis/src/ty/mutate.rs
+++ b/crates/tinymist-analysis/src/ty/mutate.rs
@@ -1,3 +1,4 @@
+use crate::syntax::UnaryOp;
 use crate::ty::def::*;
 
 /// A trait to mutate a type.
@@ -16,14 +17,14 @@ pub trait TyMutator {
             Var(..) | Let(..) => None,
             Array(arr) => Some(Array(self.mutate(arr, pol)?.into())),
             Dict(dict) => Some(Dict(self.mutate_record(dict, pol)?.into())),
-            Tuple(tup) => Some(Tuple(self.mutate_vec(tup, pol)?)),
+            Tuple(tup) => self.mutate_tuple(tup, pol),
             Func(func) => Some(Func(self.mutate_func(func, pol)?.into())),
             Args(args) => Some(Args(self.mutate_func(args, pol)?.into())),
             Pattern(pat) => Some(Pattern(self.mutate_func(pat, pol)?.into())),
             Param(param) => Some(Param(self.mutate_param(param, pol)?.into())),
             Select(sel) => Some(Select(self.mutate_select(sel, pol)?.into())),
             With(sig) => Some(With(self.mutate_with_sig(sig, pol)?.into())),
-            Unary(unary) => Some(Unary(self.mutate_unary(unary, pol)?.into())),
+            Unary(unary) => self.mutate_unary_ty(unary, pol),
             Binary(binary) => Some(Binary(self.mutate_binary(binary, pol)?.into())),
             If(if_expr) => Some(If(self.mutate_if(if_expr, pol)?.into())),
         }
@@ -45,6 +46,60 @@ pub trait TyMutator {
         }
 
         if mutated { Some(types.into()) } else { None }
+    }
+
+    /// Mutates and normalizes a tuple type.
+    fn mutate_tuple(&mut self, ty: &[Ty], pol: bool) -> Option<Ty> {
+        let mut mutated = false;
+        let mut types = Vec::with_capacity(ty.len());
+
+        for ty in ty.iter() {
+            let ty = match self.mutate(ty, pol) {
+                Some(ty) => {
+                    mutated = true;
+                    ty
+                }
+                None => ty.clone(),
+            };
+
+            if Self::push_spread_tuple_elements(&mut types, &ty) {
+                mutated = true;
+            } else {
+                types.push(ty);
+            }
+        }
+
+        mutated.then(|| Ty::Tuple(types.into()))
+    }
+
+    /// Pushes known tuple elements from an internal spread marker.
+    fn push_spread_tuple_elements(types: &mut Vec<Ty>, ty: &Ty) -> bool {
+        let Ty::Unary(unary) = ty else {
+            return false;
+        };
+        if unary.op != UnaryOp::Spread {
+            return false;
+        }
+
+        match &unary.lhs {
+            Ty::Tuple(elems) => {
+                types.extend(elems.iter().cloned());
+                true
+            }
+            Ty::Args(args) => {
+                types.extend(args.positional_params().cloned());
+                if let Some(rest) = args.rest_param()
+                    && !Self::push_spread_tuple_elements(
+                        types,
+                        &Ty::Unary(TypeUnary::new(UnaryOp::Spread, rest.clone())),
+                    )
+                {
+                    types.push(Ty::Unary(TypeUnary::new(UnaryOp::Spread, rest.clone())));
+                }
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Mutates the given option of type.
@@ -106,10 +161,66 @@ pub trait TyMutator {
     }
 
     /// Mutates the given unary type.
-    fn mutate_unary(&mut self, ty: &Interned<TypeUnary>, pol: bool) -> Option<TypeUnary> {
+    fn mutate_unary_ty(&mut self, ty: &Interned<TypeUnary>, pol: bool) -> Option<Ty> {
         let lhs = self.mutate(&ty.lhs, pol)?;
+        if ty.op == UnaryOp::ElementOf
+            && let Some(elem) = Self::known_element_type(&lhs)
+        {
+            return Some(elem);
+        }
 
-        Some(TypeUnary { lhs, op: ty.op })
+        Some(Ty::Unary(TypeUnary { lhs, op: ty.op }.into()))
+    }
+
+    /// Gets the known element type of an iterable-like type.
+    fn known_element_type(ty: &Ty) -> Option<Ty> {
+        match ty {
+            Ty::Array(elem) => Some(elem.as_ref().clone()),
+            Ty::Tuple(elems) => Self::known_tuple_element_type(elems),
+            Ty::Args(args) => Self::known_args_element_type(args),
+            Ty::Let(bounds) => Self::known_element_types(bounds.lbs.iter()),
+            Ty::Union(types) => Self::known_element_types(types.iter()),
+            _ => None,
+        }
+    }
+
+    /// Gets known element types from multiple iterable-like types.
+    fn known_element_types<'a>(types: impl Iterator<Item = &'a Ty>) -> Option<Ty> {
+        let types = types
+            .filter_map(Self::known_element_type)
+            .collect::<Vec<_>>();
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
+    /// Gets the known element type of a tuple.
+    fn known_tuple_element_type(elems: &[Ty]) -> Option<Ty> {
+        let mut types = vec![];
+        for elem in elems {
+            if let Ty::Unary(unary) = elem
+                && unary.op == UnaryOp::Spread
+            {
+                if let Some(elem) = Self::known_element_type(&unary.lhs) {
+                    types.push(elem);
+                }
+                continue;
+            }
+
+            types.push(elem.clone());
+        }
+
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
+    /// Gets the known positional element type of arguments.
+    fn known_args_element_type(args: &ArgsTy) -> Option<Ty> {
+        let mut types = args.positional_params().cloned().collect::<Vec<_>>();
+        if let Some(rest) = args.rest_param()
+            && let Some(elem) = Self::known_element_type(rest)
+        {
+            types.push(elem);
+        }
+
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
     }
 
     /// Mutates the given binary type.

--- a/crates/tinymist-analysis/src/ty/sig.rs
+++ b/crates/tinymist-analysis/src/ty/sig.rs
@@ -274,7 +274,14 @@ impl SigCheckDriver<'_> {
                 self.ty(&sig.sig, pol);
                 self.ctx.args.pop();
             }
-            Ty::Select(sel) => sel.ty.bounds(pol, &mut MethodDriver(self, &sel.select)),
+            Ty::Select(sel) => sel.ty.bounds(
+                pol,
+                &mut MethodDriver {
+                    driver: self,
+                    receiver: sel.ty.as_ref(),
+                    method: &sel.select,
+                },
+            ),
             // todo: calculate these operators
             Ty::Unary(_) => {}
             Ty::Binary(_) => {}
@@ -298,38 +305,51 @@ impl BoundChecker for SigCheckDriver<'_> {
 
 /// A driver to check a method.
 #[derive(BindTyCtx)]
-#[bind(0)]
-struct MethodDriver<'a, 'b>(&'a mut SigCheckDriver<'b>, &'a StrRef);
+#[bind(driver)]
+struct MethodDriver<'a, 'b> {
+    driver: &'a mut SigCheckDriver<'b>,
+    receiver: &'a Ty,
+    method: &'a StrRef,
+}
 
 impl MethodDriver<'_, '_> {
     fn is_binder(&self) -> bool {
-        matches!(self.1.as_ref(), "with" | "where")
+        matches!(self.method.as_ref(), "with" | "where")
     }
 
     fn array_method(&mut self, ty: &Ty, pol: bool) {
-        let method = match self.1.as_ref() {
+        let method = match self.method.as_ref() {
             "map" => BuiltinSig::TupleMap(ty),
             "at" => BuiltinSig::TupleAt(ty),
             _ => return,
         };
-        self.0
+        self.driver
             .checker
-            .check(Sig::Builtin(method), &mut self.0.ctx, pol);
+            .check(Sig::Builtin(method), &mut self.driver.ctx, pol);
+    }
+
+    fn arguments_method(&mut self, pol: bool) {
+        let Some(method) = BuiltinSig::arguments_method(self.receiver, self.method.as_ref()) else {
+            return;
+        };
+        self.driver
+            .checker
+            .check(Sig::Builtin(method), &mut self.driver.ctx, pol);
     }
 }
 
 impl BoundChecker for MethodDriver<'_, '_> {
     fn collect(&mut self, ty: &Ty, pol: bool) {
-        crate::log_debug_ct!("check method: {ty:?}.{}", self.1.as_ref());
+        crate::log_debug_ct!("check method: {ty:?}.{}", self.method.as_ref());
         match ty {
             // todo: deduplicate checking early
             Ty::Value(v) => {
                 match &v.val {
                     Value::Func(func) => {
                         if self.is_binder() {
-                            self.0.checker.check(
+                            self.driver.checker.check(
                                 Sig::Partialize(&Sig::Value { val: func, at: ty }),
-                                &mut self.0.ctx,
+                                &mut self.driver.ctx,
                                 pol,
                             );
                         } else {
@@ -337,6 +357,7 @@ impl BoundChecker for MethodDriver<'_, '_> {
                         }
                     }
                     Value::Array(..) => self.array_method(ty, pol),
+                    Value::Args(..) => self.arguments_method(pol),
                     _ => {}
                 }
             }
@@ -344,9 +365,9 @@ impl BoundChecker for MethodDriver<'_, '_> {
                 // todo: distinguish between element and function
                 if self.is_binder() {
                     let func = (*elem).into();
-                    self.0.checker.check(
+                    self.driver.checker.check(
                         Sig::Partialize(&Sig::Value { val: &func, at: ty }),
-                        &mut self.0.ctx,
+                        &mut self.driver.ctx,
                         pol,
                     );
                 } else {
@@ -355,20 +376,27 @@ impl BoundChecker for MethodDriver<'_, '_> {
             }
             Ty::Func(sig) => {
                 if self.is_binder() {
-                    self.0
-                        .checker
-                        .check(Sig::Partialize(&Sig::Type(sig)), &mut self.0.ctx, pol);
+                    self.driver.checker.check(
+                        Sig::Partialize(&Sig::Type(sig)),
+                        &mut self.driver.ctx,
+                        pol,
+                    );
                 } else {
                     // todo: general select operator
                 }
             }
             Ty::With(w) => {
-                self.0.ctx.args.push(w.with.clone());
+                self.driver.ctx.args.push(w.with.clone());
                 w.sig.bounds(pol, self);
-                self.0.ctx.args.pop();
+                self.driver.ctx.args.pop();
             }
             Ty::Tuple(..) => self.array_method(ty, pol),
             Ty::Array(..) => self.array_method(ty, pol),
+            Ty::Args(..) | Ty::Builtin(BuiltinTy::Args) => self.arguments_method(pol),
+            Ty::If(if_ty) => {
+                self.collect(&if_ty.then, pol);
+                self.collect(&if_ty.else_, pol);
+            }
             // todo: general select operator
             _ => {}
         }

--- a/crates/tinymist-analysis/src/ty/simplify.rs
+++ b/crates/tinymist-analysis/src/ty/simplify.rs
@@ -2,6 +2,7 @@
 
 use ecow::EcoVec;
 
+use crate::syntax::UnaryOp;
 use crate::{syntax::DeclExpr, ty::prelude::*};
 
 /// A compact type.
@@ -15,11 +16,56 @@ struct CompactTy {
     is_final: bool,
 }
 
+fn collect_input_type_vars(ty: &Ty, vars: &mut FxHashSet<DeclExpr>) {
+    match ty {
+        Ty::Var(var) => {
+            vars.insert(var.def.clone());
+        }
+        Ty::Func(_) | Ty::With(_) => {}
+        Ty::Param(param) => collect_input_type_vars(&param.ty, vars),
+        Ty::Union(types) | Ty::Tuple(types) => {
+            for ty in types.iter() {
+                collect_input_type_vars(ty, vars);
+            }
+        }
+        Ty::Let(bounds) => {
+            for ty in bounds.lbs.iter().chain(&bounds.ubs) {
+                collect_input_type_vars(ty, vars);
+            }
+        }
+        Ty::Dict(record) => {
+            for ty in record.types.iter() {
+                collect_input_type_vars(ty, vars);
+            }
+        }
+        Ty::Array(elem) => collect_input_type_vars(elem, vars),
+        Ty::Args(sig) | Ty::Pattern(sig) => {
+            for input in sig.inputs() {
+                collect_input_type_vars(input, vars);
+            }
+        }
+        Ty::Select(select) => collect_input_type_vars(&select.ty, vars),
+        Ty::Unary(unary) => collect_input_type_vars(&unary.lhs, vars),
+        Ty::Binary(binary) => {
+            let [lhs, rhs] = binary.operands();
+            collect_input_type_vars(lhs, vars);
+            collect_input_type_vars(rhs, vars);
+        }
+        Ty::If(if_ty) => {
+            collect_input_type_vars(&if_ty.cond, vars);
+            collect_input_type_vars(&if_ty.then, vars);
+            collect_input_type_vars(&if_ty.else_, vars);
+        }
+        Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
+    }
+}
+
 impl TypeInfo {
     /// Simplifies (canonicalizes) the given type with the given type scheme.
     pub fn simplify(&self, ty: Ty, principal: bool) -> Ty {
         let mut cache = self.cano_cache.lock();
         let cache = &mut *cache;
+        let mut signature_binders = FxHashSet::default();
 
         cache.transform_cache.clear();
         cache.cano_local_cache.clear();
@@ -37,7 +83,7 @@ impl TypeInfo {
             negatives: &mut cache.negatives,
         };
 
-        worker.simplify(ty, principal)
+        worker.simplify(ty, principal, &mut signature_binders)
     }
 }
 
@@ -56,112 +102,133 @@ struct TypeSimplifier<'a, 'b> {
 
 impl TypeSimplifier<'_, '_> {
     /// Simplifies the given type.
-    fn simplify(&mut self, ty: Ty, principal: bool) -> Ty {
+    fn simplify(
+        &mut self,
+        ty: Ty,
+        principal: bool,
+        signature_binders: &mut FxHashSet<DeclExpr>,
+    ) -> Ty {
         if let Some(cano) = self.cano_cache.get(&(ty.clone(), principal)) {
             return cano.clone();
         }
 
-        self.analyze(&ty, true);
-        let cano = self.transform(&ty, true);
+        self.analyze(&ty, true, signature_binders);
+        let cano = self.transform(&ty, true, signature_binders);
         self.cano_cache.insert((ty, principal), cano.clone());
         cano
     }
 
     /// Analyzes the given type.
-    fn analyze(&mut self, ty: &Ty, pol: bool) {
+    fn analyze(&mut self, ty: &Ty, pol: bool, signature_binders: &mut FxHashSet<DeclExpr>) {
         match ty {
             Ty::Var(var) => {
-                let w = self.vars.get(&var.def).unwrap();
+                if self.principal && signature_binders.contains(&var.def) {
+                    return;
+                }
+                let Some(w) = self.vars.get(&var.def) else {
+                    return;
+                };
+
+                let inserted = if pol {
+                    self.positives.insert(var.def.clone())
+                } else {
+                    self.negatives.insert(var.def.clone())
+                };
+                if !inserted {
+                    return;
+                }
+
                 match &w.bounds {
                     FlowVarKind::Strong(w) | FlowVarKind::Weak(w) => {
                         let bounds = w.read();
-                        let inserted = if pol {
-                            self.positives.insert(var.def.clone())
-                        } else {
-                            self.negatives.insert(var.def.clone())
-                        };
-                        if !inserted {
-                            return;
-                        }
-
                         if pol {
                             for lb in bounds.lbs.iter() {
-                                self.analyze(lb, pol);
+                                self.analyze(lb, pol, signature_binders);
                             }
                         } else {
                             for ub in bounds.ubs.iter() {
-                                self.analyze(ub, pol);
+                                self.analyze(ub, pol, signature_binders);
                             }
                         }
                     }
                 }
             }
             Ty::Func(func) => {
+                if self.principal {
+                    for input in func.inputs() {
+                        collect_input_type_vars(input, signature_binders);
+                    }
+                }
                 for input_ty in func.inputs() {
-                    self.analyze(input_ty, !pol);
+                    self.analyze(input_ty, !pol, signature_binders);
                 }
                 if let Some(ret_ty) = &func.body {
-                    self.analyze(ret_ty, pol);
+                    self.analyze(ret_ty, pol, signature_binders);
                 }
             }
             Ty::Dict(record) => {
                 for member in record.types.iter() {
-                    self.analyze(member, pol);
+                    self.analyze(member, pol, signature_binders);
                 }
             }
             Ty::Tuple(elems) => {
                 for elem in elems.iter() {
-                    self.analyze(elem, pol);
+                    self.analyze(elem, pol, signature_binders);
                 }
             }
             Ty::Array(arr) => {
-                self.analyze(arr, pol);
+                self.analyze(arr, pol, signature_binders);
             }
             Ty::With(with) => {
-                self.analyze(&with.sig, pol);
+                self.analyze(&with.sig, pol, signature_binders);
                 for input in with.with.inputs() {
-                    self.analyze(input, pol);
+                    self.analyze(input, pol, signature_binders);
                 }
             }
             Ty::Args(args) => {
                 for input in args.inputs() {
-                    self.analyze(input, pol);
+                    self.analyze(input, pol, signature_binders);
                 }
             }
             Ty::Pattern(pat) => {
+                if self.principal {
+                    for input in pat.inputs() {
+                        collect_input_type_vars(input, signature_binders);
+                    }
+                }
                 for input in pat.inputs() {
-                    self.analyze(input, pol);
+                    self.analyze(input, pol, signature_binders);
                 }
             }
-            Ty::Unary(unary) => self.analyze(&unary.lhs, pol),
+            Ty::Unary(unary) => self.analyze(&unary.lhs, pol, signature_binders),
             Ty::Binary(binary) => {
                 let [lhs, rhs] = binary.operands();
-                self.analyze(lhs, pol);
-                self.analyze(rhs, pol);
+                self.analyze(lhs, pol, signature_binders);
+                self.analyze(rhs, pol, signature_binders);
             }
             Ty::If(if_expr) => {
-                self.analyze(&if_expr.cond, pol);
-                self.analyze(&if_expr.then, pol);
-                self.analyze(&if_expr.else_, pol);
+                self.analyze(&if_expr.cond, pol, signature_binders);
+                self.analyze(&if_expr.then, pol, signature_binders);
+                self.analyze(&if_expr.else_, pol, signature_binders);
             }
             Ty::Union(types) => {
                 for ty in types.iter() {
-                    self.analyze(ty, pol);
+                    self.analyze(ty, pol, signature_binders);
                 }
             }
             Ty::Select(select) => {
-                self.analyze(&select.ty, pol);
+                self.analyze(&select.ty, pol, signature_binders);
             }
             Ty::Let(bounds) => {
                 for lb in bounds.lbs.iter() {
-                    self.analyze(lb, !pol);
+                    self.analyze(lb, !pol, signature_binders);
                 }
                 for ub in bounds.ubs.iter() {
-                    self.analyze(ub, pol);
+                    self.analyze(ub, pol, signature_binders);
                 }
             }
             Ty::Param(param) => {
-                self.analyze(&param.ty, pol);
+                self.analyze(&param.ty, pol, signature_binders);
             }
             Ty::Value(_v) => {}
             Ty::Any => {}
@@ -171,14 +238,27 @@ impl TypeSimplifier<'_, '_> {
     }
 
     /// Transforms the given type.
-    fn transform(&mut self, ty: &Ty, pol: bool) -> Ty {
-        if let Some(cano) = self.transform_cache.get(&(ty.clone(), pol)) {
+    fn transform(&mut self, ty: &Ty, pol: bool, signature_binders: &FxHashSet<DeclExpr>) -> Ty {
+        let cache_key = (ty.clone(), pol);
+        if let Some(cano) = self.transform_cache.get(&cache_key) {
             return cano.clone();
         }
 
         let cano = match ty {
-            Ty::Let(bounds) => self.transform_let(bounds.lbs.iter(), bounds.ubs.iter(), None, pol),
+            Ty::Let(bounds) => self.transform_let(
+                bounds.lbs.iter(),
+                bounds.ubs.iter(),
+                None,
+                pol,
+                signature_binders,
+            ),
             Ty::Var(var) => {
+                if self.principal && signature_binders.contains(&var.def) {
+                    return Ty::Var(var.clone());
+                }
+                let Some(bounds) = self.vars.get(&var.def) else {
+                    return Ty::Var(var.clone());
+                };
                 if let Some(cano) = self
                     .cano_local_cache
                     .get(&(var.def.clone(), self.principal))
@@ -189,11 +269,17 @@ impl TypeSimplifier<'_, '_> {
                 self.cano_local_cache
                     .insert((var.def.clone(), self.principal), Ty::Any);
 
-                let res = match &self.vars.get(&var.def).unwrap().bounds {
+                let res = match &bounds.bounds {
                     FlowVarKind::Strong(w) | FlowVarKind::Weak(w) => {
                         let w = w.read();
 
-                        self.transform_let(w.lbs.iter(), w.ubs.iter(), Some(&var.def), pol)
+                        self.transform_let(
+                            w.lbs.iter(),
+                            w.ubs.iter(),
+                            Some(&var.def),
+                            pol,
+                            signature_binders,
+                        )
                     }
                 };
 
@@ -202,56 +288,56 @@ impl TypeSimplifier<'_, '_> {
 
                 res
             }
-            Ty::Func(func) => Ty::Func(self.transform_sig(func, pol)),
+            Ty::Func(func) => Ty::Func(self.transform_sig(func, pol, signature_binders)),
             Ty::Dict(record) => {
                 let mut mutated = record.as_ref().clone();
-                mutated.types = self.transform_seq(&mutated.types, pol);
+                mutated.types = self.transform_seq(&mutated.types, pol, signature_binders);
 
                 Ty::Dict(mutated.into())
             }
-            Ty::Tuple(tup) => Ty::Tuple(self.transform_seq(tup, pol)),
-            Ty::Array(arr) => Ty::Array(self.transform(arr, pol).into()),
+            Ty::Tuple(tup) => self.transform_tuple(tup, pol, signature_binders),
+            Ty::Array(arr) => Ty::Array(self.transform(arr, pol, signature_binders).into()),
             Ty::With(with) => {
-                let sig = self.transform(&with.sig, pol).into();
+                let sig = self.transform(&with.sig, pol, signature_binders).into();
                 // Negate the pol to make correct covariance
-                let mutated = self.transform_sig(&with.with, !pol);
+                let mutated = self.transform_sig(&with.with, !pol, signature_binders);
 
                 Ty::With(SigWithTy::new(sig, mutated))
             }
             // Negate the pol to make correct covariance
             // todo: negate?
-            Ty::Args(args) => Ty::Args(self.transform_sig(args, !pol)),
-            Ty::Pattern(pat) => Ty::Pattern(self.transform_sig(pat, !pol)),
-            Ty::Unary(unary) => {
-                Ty::Unary(TypeUnary::new(unary.op, self.transform(&unary.lhs, pol)))
-            }
+            Ty::Args(args) => Ty::Args(self.transform_sig(args, !pol, signature_binders)),
+            Ty::Pattern(pat) => Ty::Pattern(self.transform_sig(pat, !pol, signature_binders)),
+            Ty::Unary(unary) => self.transform_unary(unary, pol, signature_binders),
             Ty::Binary(binary) => {
                 let [lhs, rhs] = binary.operands();
-                let lhs = self.transform(lhs, pol);
-                let rhs = self.transform(rhs, pol);
+                let lhs = self.transform(lhs, pol, signature_binders);
+                let rhs = self.transform(rhs, pol, signature_binders);
 
                 Ty::Binary(TypeBinary::new(binary.op, lhs, rhs))
             }
             Ty::If(if_ty) => Ty::If(IfTy::new(
-                self.transform(&if_ty.cond, pol).into(),
-                self.transform(&if_ty.then, pol).into(),
-                self.transform(&if_ty.else_, pol).into(),
+                self.transform(&if_ty.cond, pol, signature_binders).into(),
+                self.transform(&if_ty.then, pol, signature_binders).into(),
+                self.transform(&if_ty.else_, pol, signature_binders).into(),
             )),
             Ty::Union(types) => {
-                let seq = types.iter().map(|ty| self.transform(ty, pol));
+                let seq = types
+                    .iter()
+                    .map(|ty| self.transform(ty, pol, signature_binders));
                 let seq_no_any = seq.filter(|ty| !matches!(ty, Ty::Any));
                 let seq = seq_no_any.collect::<Vec<_>>();
                 Ty::from_types(seq.into_iter())
             }
             Ty::Param(param) => {
                 let mut param = param.as_ref().clone();
-                param.ty = self.transform(&param.ty, pol);
+                param.ty = self.transform(&param.ty, pol, signature_binders);
 
                 Ty::Param(param.into())
             }
             Ty::Select(sel) => {
                 let mut sel = sel.as_ref().clone();
-                sel.ty = self.transform(&sel.ty, pol).into();
+                sel.ty = self.transform(&sel.ty, pol, signature_binders).into();
 
                 Ty::Select(sel.into())
             }
@@ -262,13 +348,20 @@ impl TypeSimplifier<'_, '_> {
             Ty::Builtin(ty) => Ty::Builtin(ty.clone()),
         };
 
-        self.transform_cache.insert((ty.clone(), pol), cano.clone());
+        self.transform_cache.insert(cache_key, cano.clone());
         cano
     }
 
     /// Transforms the given sequence of types.
-    fn transform_seq(&mut self, types: &[Ty], pol: bool) -> Interned<Vec<Ty>> {
-        let seq = types.iter().map(|ty| self.transform(ty, pol));
+    fn transform_seq(
+        &mut self,
+        types: &[Ty],
+        pol: bool,
+        signature_binders: &FxHashSet<DeclExpr>,
+    ) -> Interned<Vec<Ty>> {
+        let seq = types
+            .iter()
+            .map(|ty| self.transform(ty, pol, signature_binders));
         seq.collect::<Vec<_>>().into()
     }
 
@@ -280,6 +373,7 @@ impl TypeSimplifier<'_, '_> {
         ubs_iter: impl ExactSizeIterator<Item = &'a Ty>,
         decl: Option<&DeclExpr>,
         pol: bool,
+        signature_binders: &FxHashSet<DeclExpr>,
     ) -> Ty {
         let mut lbs = HashSet::with_capacity(lbs_iter.len());
         let mut ubs = HashSet::with_capacity(ubs_iter.len());
@@ -288,12 +382,12 @@ impl TypeSimplifier<'_, '_> {
 
         if !self.principal || ((pol) && !decl.is_some_and(|decl| self.negatives.contains(decl))) {
             for lb in lbs_iter {
-                lbs.insert(self.transform(lb, pol));
+                lbs.insert(self.transform(lb, pol, signature_binders));
             }
         }
         if !self.principal || ((!pol) && !decl.is_some_and(|decl| self.positives.contains(decl))) {
             for ub in ubs_iter {
-                ubs.insert(self.transform(ub, !pol));
+                ubs.insert(self.transform(ub, !pol, signature_binders));
             }
         }
 
@@ -317,12 +411,127 @@ impl TypeSimplifier<'_, '_> {
         Ty::Let(TypeBounds { lbs, ubs }.into())
     }
 
+    fn transform_tuple(
+        &mut self,
+        tup: &[Ty],
+        pol: bool,
+        signature_binders: &FxHashSet<DeclExpr>,
+    ) -> Ty {
+        let mut types = Vec::with_capacity(tup.len());
+
+        for elem in tup.iter() {
+            let elem = self.transform(elem, pol, signature_binders);
+            if !Self::push_spread_tuple_elements(&mut types, &elem) {
+                types.push(elem);
+            }
+        }
+
+        Ty::Tuple(types.into())
+    }
+
+    fn push_spread_tuple_elements(types: &mut Vec<Ty>, ty: &Ty) -> bool {
+        let Ty::Unary(unary) = ty else {
+            return false;
+        };
+        if unary.op != UnaryOp::Spread {
+            return false;
+        }
+
+        match &unary.lhs {
+            Ty::Tuple(elems) => {
+                types.extend(elems.iter().cloned());
+                true
+            }
+            Ty::Args(args) => {
+                types.extend(args.positional_params().cloned());
+                if let Some(rest) = args.rest_param()
+                    && !Self::push_spread_tuple_elements(
+                        types,
+                        &Ty::Unary(TypeUnary::new(UnaryOp::Spread, rest.clone())),
+                    )
+                {
+                    types.push(Ty::Unary(TypeUnary::new(UnaryOp::Spread, rest.clone())));
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn transform_unary(
+        &mut self,
+        unary: &TypeUnary,
+        pol: bool,
+        signature_binders: &FxHashSet<DeclExpr>,
+    ) -> Ty {
+        let lhs = self.transform(&unary.lhs, pol, signature_binders);
+        if unary.op == UnaryOp::ElementOf
+            && let Some(elem) = Self::known_element_type(&lhs)
+        {
+            return elem;
+        }
+
+        Ty::Unary(TypeUnary::new(unary.op, lhs))
+    }
+
+    fn known_element_type(ty: &Ty) -> Option<Ty> {
+        match ty {
+            Ty::Array(elem) => Some(elem.as_ref().clone()),
+            Ty::Tuple(elems) => Self::known_tuple_element_type(elems),
+            Ty::Args(args) => Self::known_args_element_type(args),
+            Ty::Let(bounds) => Self::known_element_types(bounds.lbs.iter()),
+            Ty::Union(types) => Self::known_element_types(types.iter()),
+            _ => None,
+        }
+    }
+
+    fn known_element_types<'a>(types: impl Iterator<Item = &'a Ty>) -> Option<Ty> {
+        let types = types
+            .filter_map(Self::known_element_type)
+            .collect::<Vec<_>>();
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
+    fn known_tuple_element_type(elems: &[Ty]) -> Option<Ty> {
+        let mut types = vec![];
+        for elem in elems {
+            if let Ty::Unary(unary) = elem
+                && unary.op == UnaryOp::Spread
+            {
+                if let Some(elem) = Self::known_element_type(&unary.lhs) {
+                    types.push(elem);
+                }
+                continue;
+            }
+
+            types.push(elem.clone());
+        }
+
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
+    fn known_args_element_type(args: &ArgsTy) -> Option<Ty> {
+        let mut types = args.positional_params().cloned().collect::<Vec<_>>();
+        if let Some(rest) = args.rest_param()
+            && let Some(elem) = Self::known_element_type(rest)
+        {
+            types.push(elem);
+        }
+
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
     /// Transforms the given signature.
-    fn transform_sig(&mut self, sig: &SigTy, pol: bool) -> Interned<SigTy> {
+    fn transform_sig(
+        &mut self,
+        sig: &SigTy,
+        pol: bool,
+        signature_binders: &FxHashSet<DeclExpr>,
+    ) -> Interned<SigTy> {
         let mut sig = sig.clone();
-        sig.inputs = self.transform_seq(&sig.inputs, !pol);
+        sig.inputs = self.transform_seq(&sig.inputs, !pol, signature_binders);
         if let Some(ret) = &sig.body {
-            sig.body = Some(self.transform(ret, pol));
+            sig.body = Some(self.transform(ret, pol, signature_binders));
         }
 
         // todo: we can reduce one clone by early compare on sig.types
@@ -441,5 +650,53 @@ mod tests {
             "simplify should memoize the top-level result"
         );
         assert_eq!(first_cache_len, second_cache_len);
+    }
+
+    #[test]
+    fn test_signature_inputs_are_principal_binders() {
+        let binder = TypeVar::new("body".into(), Decl::lit("body").into());
+        let binder_ty = Ty::Var(binder.clone());
+        let content = Ty::Builtin(BuiltinTy::Content(None));
+        let sig = SigTy::unary(binder_ty.clone(), binder_ty);
+
+        let sig_ty = Ty::Func(sig);
+        let mut dynamic_bounds = DynTypeBounds::default();
+        dynamic_bounds.ubs.insert_mut(content);
+        let mut info = TypeInfo::default();
+        info.vars.insert(
+            binder.def.clone(),
+            TypeVarBounds::new(binder.as_ref().clone(), dynamic_bounds),
+        );
+        assert_eq!(
+            format!("{:?}", info.simplify(sig_ty.clone(), false)),
+            "(Content) => Content"
+        );
+        assert_eq!(
+            format!("{:?}", info.simplify(sig_ty, true)),
+            "(@body) => @body"
+        );
+        assert_eq!(info.vars.len(), 1);
+    }
+
+    #[test]
+    fn test_principal_simplify_preserves_unused_signature_binder() {
+        let binder = TypeVar::new("body".into(), Decl::lit("body").into());
+        let binder_ty = Ty::Var(binder.clone());
+        let sig = SigTy::unary(binder_ty, Ty::Builtin(BuiltinTy::Color));
+
+        let mut dynamic_bounds = DynTypeBounds::default();
+        dynamic_bounds
+            .ubs
+            .insert_mut(Ty::Builtin(BuiltinTy::Content(None)));
+        let mut info = TypeInfo::default();
+        info.vars.insert(
+            binder.def.clone(),
+            TypeVarBounds::new(binder.as_ref().clone(), dynamic_bounds),
+        );
+
+        assert_eq!(
+            format!("{:?}", info.simplify(Ty::Func(sig), true)),
+            "(@body) => Color"
+        );
     }
 }

--- a/crates/tinymist-analysis/src/ty/subst.rs
+++ b/crates/tinymist-analysis/src/ty/subst.rs
@@ -21,6 +21,8 @@ impl Sig<'_> {
         // todo: check if the signature has free variables
         // let has_free_vars = sig.has_free_variables;
 
+        let rest_bind = Self::rest_bind(&sig, args, withs);
+
         for (arg_recv, arg_ins) in sig.matches(args, withs) {
             if let Ty::Var(arg_recv) = arg_recv {
                 crate::log_debug_ct!("bind {arg_recv:?} {arg_ins:?}");
@@ -28,7 +30,43 @@ impl Sig<'_> {
             }
         }
 
+        if let Some((rest_var, rest_ty)) = rest_bind {
+            crate::log_debug_ct!("bind rest {rest_var:?} {rest_ty:?}");
+            ctx.bind_local(&rest_var, rest_ty);
+        }
+
         sig.body.clone()
+    }
+
+    fn rest_bind(
+        sig: &Interned<SigTy>,
+        args: &Interned<ArgsTy>,
+        withs: Option<&Vec<Interned<SigTy>>>,
+    ) -> Option<(Interned<TypeVar>, Ty)> {
+        let Ty::Var(rest_var) = sig.rest_param()? else {
+            return None;
+        };
+
+        let fixed_pos = sig.positional_params().len();
+        let rest_pos = withs
+            .into_iter()
+            .flat_map(|withs| withs.iter().rev())
+            .flat_map(|with| with.positional_params())
+            .chain(args.positional_params())
+            .skip(fixed_pos)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let rest_named = args
+            .named_params()
+            .filter(|(name, _)| sig.named(name).is_none())
+            .map(|(name, ty)| (name.clone(), ty.clone()))
+            .collect::<Vec<_>>();
+
+        let rest = args.rest_param().cloned();
+        let rest_args = ArgsTy::new(rest_pos.into_iter(), rest_named, None, rest, None);
+
+        Some((rest_var.clone(), Ty::Args(rest_args.into())))
     }
 }
 
@@ -47,12 +85,28 @@ impl<T: TyCtxMut> SubstituteChecker<'_, T> {
 impl<T: TyCtxMut> TyMutator for SubstituteChecker<'_, T> {
     fn mutate(&mut self, ty: &Ty, pol: bool) -> Option<Ty> {
         // todo: extrude the type into a polarized type
-        let _ = pol;
-
-        if let Ty::Var(v) = ty {
-            self.ctx.local_bind_of(v)
-        } else {
-            self.mutate_rec(ty, pol)
+        match ty {
+            Ty::Var(var) => self.ctx.local_bind_of(var),
+            Ty::Let(bounds) => {
+                let mut lbs = bounds
+                    .lbs
+                    .iter()
+                    .map(|bound| self.mutate(bound, !pol).unwrap_or_else(|| bound.clone()))
+                    .collect::<Vec<_>>();
+                let mut ubs = bounds
+                    .ubs
+                    .iter()
+                    .map(|bound| self.mutate(bound, pol).unwrap_or_else(|| bound.clone()))
+                    .collect::<Vec<_>>();
+                if ubs.is_empty() && lbs.len() == 1 {
+                    return lbs.pop();
+                }
+                if lbs.is_empty() && ubs.len() == 1 {
+                    return ubs.pop();
+                }
+                Some(Ty::Let(TypeBounds { lbs, ubs }.into()))
+            }
+            _ => self.mutate_rec(ty, pol),
         }
     }
 }

--- a/crates/tinymist-query/src/analysis/completion/kind.rs
+++ b/crates/tinymist-query/src/analysis/completion/kind.rs
@@ -190,6 +190,7 @@ impl FnCompletionFeat {
                 | BuiltinTy::None
                 | BuiltinTy::Break
                 | BuiltinTy::Continue
+                | BuiltinTy::Never
                 | BuiltinTy::Infer
                 | BuiltinTy::FlowNone
                 | BuiltinTy::Auto

--- a/crates/tinymist-query/src/analysis/completion/scope.rs
+++ b/crates/tinymist-query/src/analysis/completion/scope.rs
@@ -1,6 +1,6 @@
 //! Completion of definitions in scope.
 
-use typst::foundations::{Array, Dict};
+use typst::foundations::{Args, Array, Dict};
 
 use crate::ty::SigWithTy;
 
@@ -313,6 +313,9 @@ impl IfaceChecker for CompletionScopeChecker<'_> {
             Iface::Type { val, at } if self.is_field_access() => {
                 self.type_methods(Some(at.clone()), *val);
             }
+            Iface::Args { at } if self.is_field_access() => {
+                self.type_methods(Some(at.clone()), Type::of::<Args>());
+            }
             Iface::TypeType { val, .. } if self.is_field_access() => {
                 self.type_methods(None, *val);
             }
@@ -327,6 +330,9 @@ impl IfaceChecker for CompletionScopeChecker<'_> {
             }
             Iface::Content { val, .. } => {
                 self.defines.insert_scope(val.scope());
+            }
+            Iface::Args { .. } => {
+                self.defines.insert_scope(Type::of::<Args>().scope());
             }
             // todo: distingusish TypeType and Type
             Iface::TypeType { val, .. } | Iface::Type { val, .. } => {

--- a/crates/tinymist-query/src/analysis/completion/type.rs
+++ b/crates/tinymist-query/src/analysis/completion/type.rs
@@ -158,6 +158,7 @@ impl TypeCompletionWorker<'_, '_, '_, '_> {
             BuiltinTy::Space => return None,
             BuiltinTy::Break => return None,
             BuiltinTy::Continue => return None,
+            BuiltinTy::Never => return None,
             BuiltinTy::Content(..) => return None,
             BuiltinTy::Infer => return None,
             BuiltinTy::FlowNone => return None,

--- a/crates/tinymist-query/src/analysis/tyck.rs
+++ b/crates/tinymist-query/src/analysis/tyck.rs
@@ -1,6 +1,9 @@
 //! Type checking on source file
 
-use std::sync::OnceLock;
+use std::{
+    collections::hash_map::Entry,
+    sync::{Arc, OnceLock},
+};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use tinymist_derive::BindTyCtx;
@@ -10,6 +13,7 @@ use super::{
     TypeVarBounds, prelude::*,
 };
 use crate::{
+    docs::UntypedDefDocs,
     syntax::{Decl, DeclExpr, Expr, ExprInfo, UnaryOp},
     ty::*,
 };
@@ -52,6 +56,9 @@ pub(crate) fn type_check(
         env,
         call_cache: Default::default(),
         module_exports: Default::default(),
+        overwritten_vars: Default::default(),
+        live_input_vars: Default::default(),
+        input_contract_bounds: Default::default(),
     };
 
     let type_check_start = tinymist_std::time::Instant::now();
@@ -89,6 +96,10 @@ pub(crate) struct TypeChecker<'a> {
     module_exports: FxHashMap<(TypstFileId, Interned<str>), OnceLock<Option<Ty>>>,
 
     call_cache: FxHashSet<CallCacheDesc>,
+    overwritten_vars: FxHashSet<DeclExpr>,
+    // A binder remains live while the current flow value can still be the function input.
+    live_input_vars: FxHashSet<DeclExpr>,
+    input_contract_bounds: FxHashMap<DeclExpr, DynTypeBounds>,
 
     env: &'a mut TypeEnv,
 }
@@ -168,48 +179,41 @@ impl TypeChecker<'_> {
 
     fn get_var(&mut self, decl: &DeclExpr) -> Interned<TypeVar> {
         crate::log_debug_ct!("get_var {decl:?}");
-        let entry = self.info.vars.entry(decl.clone()).or_insert_with(|| {
-            let name = decl.name().clone();
-            let decl = decl.clone();
+        let mut imported_docs = None;
+        let mut imported_input_bounds = vec![];
+        let var = match self.info.vars.entry(decl.clone()) {
+            Entry::Occupied(entry) => entry.get().var.clone(),
+            Entry::Vacant(entry) => {
+                let name = decl.name().clone();
+                let init = Self::external_var_bounds(&self.ctx, self.env, self.ei.fid, decl, &name)
+                    .map(|(bounds, docs, input_bounds)| {
+                        imported_docs = docs;
+                        imported_input_bounds = input_bounds;
+                        bounds
+                    })
+                    .unwrap_or_default();
+                let bounds = TypeVarBounds::new(
+                    TypeVar {
+                        name,
+                        def: decl.clone(),
+                    },
+                    init,
+                );
+                let var = bounds.var.clone();
+                entry.insert(bounds);
+                var
+            }
+        };
 
-            // Check External variables
-            let init = decl.file_id().and_then(|fid| {
-                if fid == self.ei.fid {
-                    return None;
-                }
-
-                crate::log_debug_ct!("import_ty {name} from {fid:?}");
-
-                let ext_def_use_info = self.ctx.expr_stage_by_id(fid)?;
-                let source = &ext_def_use_info.source;
-                // todo: check types in cycle
-                let ext_type_info = if let Some(scheme) = self.env.visiting.get(&source.id()) {
-                    scheme.clone()
-                } else {
-                    self.ctx.clone().type_check_(source, self.env)
-                };
-                let ext_def = ext_def_use_info.exports.get(&name)?;
-
-                // todo: rest expressions
-                let def = match ext_def {
-                    Expr::Decl(decl) => {
-                        let ext_ty = ext_type_info.vars.get(decl)?.as_type();
-                        if let Some(ext_docs) = ext_type_info.var_docs.get(decl) {
-                            self.info.var_docs.insert(decl.clone(), ext_docs.clone());
-                        }
-
-                        ext_type_info.simplify(ext_ty, false)
-                    }
-                    _ => return None,
-                };
-
-                Some(ext_type_info.to_bounds(def))
-            });
-
-            TypeVarBounds::new(TypeVar { name, def: decl }, init.unwrap_or_default())
-        });
-
-        let var = entry.var.clone();
+        if let Some(docs) = imported_docs {
+            self.info.var_docs.entry(decl.clone()).or_insert(docs);
+        }
+        for bounds in imported_input_bounds {
+            self.info
+                .vars
+                .entry(bounds.var.def.clone())
+                .or_insert(bounds);
+        }
 
         let s = decl.span();
         if !s.is_detached() {
@@ -225,6 +229,223 @@ impl TypeChecker<'_> {
         var
     }
 
+    fn external_var_bounds(
+        ctx: &Arc<SharedContext>,
+        env: &mut TypeEnv,
+        current_fid: TypstFileId,
+        decl: &DeclExpr,
+        name: &Interned<str>,
+    ) -> Option<(
+        DynTypeBounds,
+        Option<Arc<UntypedDefDocs>>,
+        Vec<TypeVarBounds>,
+    )> {
+        let fid = decl.file_id()?;
+        if fid == current_fid {
+            return None;
+        }
+
+        crate::log_debug_ct!("import_ty {name} from {fid:?}");
+
+        let ext_def_use_info = ctx.expr_stage_by_id(fid)?;
+        let source = &ext_def_use_info.source;
+        // todo: check types in cycle
+        let ext_type_info = if let Some(scheme) = env.visiting.get(&source.id()) {
+            scheme.clone()
+        } else {
+            ctx.clone().type_check_(source, env)
+        };
+        let ext_def = ext_def_use_info.exports.get(name)?;
+
+        // todo: rest expressions
+        let Expr::Decl(decl) = ext_def else {
+            return None;
+        };
+
+        let ext_ty = ext_type_info.vars.get(decl)?.as_type();
+        let docs = ext_type_info.var_docs.get(decl).cloned();
+
+        let def = ext_type_info.simplify(ext_ty, true);
+        let input_bounds = Self::copy_external_input_bounds(&ext_type_info, &def);
+        let mut bounds = DynTypeBounds::default();
+        bounds.lbs.insert_mut(def);
+        Some((bounds, docs, input_bounds))
+    }
+
+    fn copy_external_input_bounds(type_info: &TypeInfo, ty: &Ty) -> Vec<TypeVarBounds> {
+        let mut pending = vec![];
+        let mut seen = FxHashSet::default();
+        Self::collect_signature_input_binders(ty, &FxHashSet::default(), &mut seen, &mut pending);
+
+        let mut copied = vec![];
+        let mut idx = 0;
+        while idx < pending.len() {
+            let (binder, escaped) = pending[idx].clone();
+            idx += 1;
+
+            let Some(source) = type_info.vars.get(&binder.def) else {
+                continue;
+            };
+            let source_is_weak = matches!(&source.bounds, FlowVarKind::Weak(_));
+            let bounds = source.bounds.bounds().read().freeze();
+
+            for bound in bounds.lbs.iter().chain(&bounds.ubs) {
+                Self::collect_signature_input_binders(bound, &escaped, &mut seen, &mut pending);
+            }
+
+            let mut closer = FunctionResultantCloser {
+                vars: &type_info.vars,
+                params: escaped,
+                visiting: FxHashSet::default(),
+                visited: 0,
+            };
+            let bounds = closer.close_bounds(&bounds);
+            let mut imported =
+                TypeVarBounds::new(binder.as_ref().clone(), DynTypeBounds::from(bounds));
+            if source_is_weak {
+                imported.weaken();
+            }
+            copied.push(imported);
+        }
+
+        copied
+    }
+
+    fn collect_signature_input_binders(
+        ty: &Ty,
+        escaped: &FxHashSet<DeclExpr>,
+        seen: &mut FxHashSet<DeclExpr>,
+        binders: &mut Vec<(Interned<TypeVar>, FxHashSet<DeclExpr>)>,
+    ) {
+        match ty {
+            Ty::Func(sig) => {
+                let mut direct = vec![];
+                let mut direct_seen = FxHashSet::default();
+                for input in sig.inputs() {
+                    Self::collect_input_binders(input, &mut direct_seen, &mut direct);
+                }
+
+                let mut scope = escaped.clone();
+                for binder in direct {
+                    if seen.insert(binder.def.clone()) {
+                        binders.push((binder.clone(), scope.clone()));
+                    }
+                    scope.insert(binder.def.clone());
+                }
+
+                for input in sig.inputs() {
+                    Self::collect_signature_input_binders(input, &scope, seen, binders);
+                }
+                if let Some(body) = &sig.body {
+                    Self::collect_signature_input_binders(body, &scope, seen, binders);
+                }
+            }
+            Ty::With(with) => {
+                Self::collect_signature_input_binders(&with.sig, escaped, seen, binders);
+                for input in with.with.inputs() {
+                    Self::collect_signature_input_binders(input, escaped, seen, binders);
+                }
+                if let Some(body) = &with.with.body {
+                    Self::collect_signature_input_binders(body, escaped, seen, binders);
+                }
+            }
+            Ty::Args(sig) | Ty::Pattern(sig) => {
+                for input in sig.inputs() {
+                    Self::collect_signature_input_binders(input, escaped, seen, binders);
+                }
+                if let Some(body) = &sig.body {
+                    Self::collect_signature_input_binders(body, escaped, seen, binders);
+                }
+            }
+            Ty::Param(param) => {
+                Self::collect_signature_input_binders(&param.ty, escaped, seen, binders)
+            }
+            Ty::Union(types) | Ty::Tuple(types) => {
+                for ty in types.iter() {
+                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                }
+            }
+            Ty::Let(bounds) => {
+                for ty in bounds.lbs.iter().chain(&bounds.ubs) {
+                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                }
+            }
+            Ty::Dict(record) => {
+                for ty in record.types.iter() {
+                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                }
+            }
+            Ty::Array(elem) => Self::collect_signature_input_binders(elem, escaped, seen, binders),
+            Ty::Select(select) => {
+                Self::collect_signature_input_binders(&select.ty, escaped, seen, binders)
+            }
+            Ty::Unary(unary) => {
+                Self::collect_signature_input_binders(&unary.lhs, escaped, seen, binders)
+            }
+            Ty::Binary(binary) => {
+                let [lhs, rhs] = binary.operands();
+                Self::collect_signature_input_binders(lhs, escaped, seen, binders);
+                Self::collect_signature_input_binders(rhs, escaped, seen, binders);
+            }
+            Ty::If(if_ty) => {
+                Self::collect_signature_input_binders(&if_ty.cond, escaped, seen, binders);
+                Self::collect_signature_input_binders(&if_ty.then, escaped, seen, binders);
+                Self::collect_signature_input_binders(&if_ty.else_, escaped, seen, binders);
+            }
+            Ty::Var(_) | Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
+        }
+    }
+
+    fn collect_input_binders(
+        ty: &Ty,
+        seen: &mut FxHashSet<DeclExpr>,
+        binders: &mut Vec<Interned<TypeVar>>,
+    ) {
+        match ty {
+            Ty::Var(var) => {
+                if seen.insert(var.def.clone()) {
+                    binders.push(var.clone());
+                }
+            }
+            Ty::Func(_) | Ty::With(_) => {}
+            Ty::Param(param) => Self::collect_input_binders(&param.ty, seen, binders),
+            Ty::Union(types) | Ty::Tuple(types) => {
+                for ty in types.iter() {
+                    Self::collect_input_binders(ty, seen, binders);
+                }
+            }
+            Ty::Let(bounds) => {
+                for ty in bounds.lbs.iter().chain(&bounds.ubs) {
+                    Self::collect_input_binders(ty, seen, binders);
+                }
+            }
+            Ty::Dict(record) => {
+                for ty in record.types.iter() {
+                    Self::collect_input_binders(ty, seen, binders);
+                }
+            }
+            Ty::Array(elem) => Self::collect_input_binders(elem, seen, binders),
+            Ty::Args(sig) | Ty::Pattern(sig) => {
+                for input in sig.inputs() {
+                    Self::collect_input_binders(input, seen, binders);
+                }
+            }
+            Ty::Select(select) => Self::collect_input_binders(&select.ty, seen, binders),
+            Ty::Unary(unary) => Self::collect_input_binders(&unary.lhs, seen, binders),
+            Ty::Binary(binary) => {
+                let [lhs, rhs] = binary.operands();
+                Self::collect_input_binders(lhs, seen, binders);
+                Self::collect_input_binders(rhs, seen, binders);
+            }
+            Ty::If(if_ty) => {
+                Self::collect_input_binders(&if_ty.cond, seen, binders);
+                Self::collect_input_binders(&if_ty.then, seen, binders);
+                Self::collect_input_binders(&if_ty.else_, seen, binders);
+            }
+            Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
+        }
+    }
+
     fn constrain_sig_inputs(
         &mut self,
         sig: &Interned<SigTy>,
@@ -236,8 +457,313 @@ impl TypeChecker<'_> {
             return;
         }
 
+        let rest_bind = Self::rest_arg_bind(sig, args, with);
+
         for (arg_recv, arg_ins) in sig.matches(args, with) {
-            self.constrain(arg_ins, arg_recv);
+            if rest_bind.as_ref().is_some_and(
+                |(rest_var, _)| matches!(arg_recv, Ty::Var(var) if var.def == rest_var.def),
+            ) {
+                continue;
+            }
+            if matches!(arg_recv, Ty::Var(var) if !self.info.vars.contains_key(&var.def)) {
+                continue;
+            }
+
+            self.constrain_sig_input(arg_ins, arg_recv);
+        }
+
+        if let Some((rest_var, rest_ty)) = rest_bind
+            && self.info.vars.contains_key(&rest_var.def)
+        {
+            self.constrain_sig_input(&rest_ty, &Ty::Var(rest_var));
+        }
+    }
+
+    fn constrain_sig_input(&mut self, actual: &Ty, input: &Ty) {
+        let Ty::Var(input_var) = input else {
+            self.constrain(actual, input);
+            return;
+        };
+
+        let is_external = input_var
+            .def
+            .file_id()
+            .is_some_and(|fid| !Self::same_file_id(fid, self.ei.fid));
+        if is_external {
+            let contract = self.info.simplify(input.clone(), false);
+            self.constrain(actual, &contract);
+            return;
+        }
+
+        if matches!(input_var.def.as_ref(), Decl::Docs(..)) {
+            // Rebound inputs keep call inference, but never retain a live caller flow variable.
+            let input_bounds = self
+                .info
+                .vars
+                .get(&input_var.def)
+                .map(|input| input.bounds.bounds().read().freeze())
+                .unwrap_or_default();
+            let has_contract = !input_bounds.lbs.is_empty() || !input_bounds.ubs.is_empty();
+            if has_contract {
+                let contract = self.info.simplify(Ty::Let(input_bounds.into()), false);
+                let actual_snapshot = self.close_lower_snapshot(actual);
+                if !matches!(actual_snapshot, Ty::Any) {
+                    self.constrain(&actual_snapshot, input);
+                }
+                self.constrain(actual, &contract);
+            }
+            return;
+        }
+
+        self.constrain(actual, input);
+    }
+
+    fn close_lower_snapshot(&self, ty: &Ty) -> Ty {
+        let bounds = match ty {
+            Ty::Var(var) => {
+                let Some(bounds) = self.info.vars.get(&var.def) else {
+                    return Ty::Any;
+                };
+                let bounds = bounds.bounds.bounds().read();
+                TypeBounds {
+                    lbs: bounds.lbs.iter().cloned().collect(),
+                    ubs: vec![],
+                }
+            }
+            Ty::Let(bounds) => TypeBounds {
+                lbs: bounds.lbs.clone(),
+                ubs: vec![],
+            },
+            ty => TypeBounds {
+                lbs: vec![ty.clone()],
+                ubs: vec![],
+            },
+        };
+        if bounds.lbs.is_empty() {
+            return Ty::Any;
+        }
+
+        let mut closer = FunctionResultantCloser {
+            vars: &self.info.vars,
+            params: FxHashSet::default(),
+            visiting: FxHashSet::default(),
+            visited: 0,
+        };
+        let mut bounds = closer.close_bounds(&bounds);
+        if bounds.ubs.is_empty() && bounds.lbs.len() == 1 {
+            return bounds.lbs.pop().unwrap();
+        }
+        Ty::Let(bounds.into())
+    }
+
+    fn same_file_id(left: TypstFileId, right: TypstFileId) -> bool {
+        left.root() == right.root() && left.vpath() == right.vpath()
+    }
+
+    fn snapshot_function_input_bounds(&self, sig: &SigTy) -> Vec<(Interned<TypeVar>, TypeBounds)> {
+        let mut seen = FxHashSet::default();
+        let mut binders = vec![];
+        for input in sig.inputs() {
+            Self::collect_input_binders(input, &mut seen, &mut binders);
+        }
+
+        binders
+            .into_iter()
+            .map(|binder| {
+                let bounds = self
+                    .info
+                    .vars
+                    .get(&binder.def)
+                    .map(|bounds| bounds.bounds.bounds().read().freeze())
+                    .unwrap_or_default();
+                (binder, bounds)
+            })
+            .collect()
+    }
+
+    fn close_function_resultant_type(
+        &self,
+        body: Ty,
+        input_bounds: &[(Interned<TypeVar>, TypeBounds)],
+        escaped: &FxHashSet<DeclExpr>,
+    ) -> Ty {
+        let mut resultant_params = escaped.clone();
+        resultant_params.extend(
+            input_bounds
+                .iter()
+                .map(|(binder, _)| &binder.def)
+                .filter(|def| !self.overwritten_vars.contains(*def))
+                .cloned(),
+        );
+
+        let mut closer = FunctionResultantCloser {
+            vars: &self.info.vars,
+            params: resultant_params,
+            visiting: FxHashSet::default(),
+            visited: 0,
+        };
+
+        closer.mutate(&body, true).unwrap_or(body)
+    }
+
+    fn rebind_overwritten_function_inputs(
+        &mut self,
+        mut sig: SigTy,
+        input_bounds: Vec<(Interned<TypeVar>, TypeBounds)>,
+        escaped: &FxHashSet<DeclExpr>,
+    ) -> SigTy {
+        let mut scope = escaped.clone();
+        let mut replacements: Vec<(Interned<TypeVar>, Interned<TypeVar>)> = Vec::new();
+
+        for (binder, mut bounds) in input_bounds {
+            if !self.overwritten_vars.contains(&binder.def) {
+                scope.insert(binder.def.clone());
+                continue;
+            }
+            if let Some(input_bounds) = self.input_contract_bounds.get(&binder.def) {
+                let input_bounds = input_bounds.freeze();
+                bounds.lbs.extend(input_bounds.lbs);
+                bounds.ubs.extend(input_bounds.ubs);
+            }
+            bounds.lbs.sort();
+            bounds.lbs.dedup();
+            bounds.ubs.sort();
+            bounds.ubs.dedup();
+
+            let mut closer = FunctionResultantCloser {
+                vars: &self.info.vars,
+                params: scope.clone(),
+                visiting: FxHashSet::default(),
+                visited: 0,
+            };
+            let mut bounds = closer.close_bounds(&bounds);
+            bounds.lbs.sort();
+            bounds.lbs.dedup();
+            bounds.ubs.sort();
+            bounds.ubs.dedup();
+
+            for (original, replacement) in &replacements {
+                for bound in bounds.lbs.iter_mut().chain(&mut bounds.ubs) {
+                    *bound =
+                        Self::replace_var(bound.clone(), original, Ty::Var(replacement.clone()));
+                }
+            }
+
+            let fresh_def: DeclExpr = Decl::docs(binder.def.clone(), binder.clone()).into();
+            let fresh = TypeVar {
+                name: binder.name.clone(),
+                def: fresh_def.clone(),
+            };
+            let fresh = TypeVarBounds::new(fresh, DynTypeBounds::from(bounds));
+            let fresh_var = fresh.var.clone();
+            self.info.vars.insert(fresh_def, fresh);
+            replacements.push((binder.clone(), fresh_var));
+            scope.insert(binder.def.clone());
+        }
+
+        if !replacements.is_empty() {
+            let mut inputs = sig.inputs.as_ref().clone();
+            for input in &mut inputs {
+                for (original, replacement) in &replacements {
+                    *input =
+                        Self::replace_var(input.clone(), original, Ty::Var(replacement.clone()));
+                }
+            }
+            sig.inputs = inputs.into();
+        }
+
+        sig
+    }
+
+    fn rest_arg_bind(
+        sig: &Interned<SigTy>,
+        args: &Interned<SigTy>,
+        with: Option<&Vec<Interned<SigTy>>>,
+    ) -> Option<(Interned<TypeVar>, Ty)> {
+        let Ty::Var(rest_var) = sig.rest_param()? else {
+            return None;
+        };
+
+        let fixed_pos = sig.positional_params().len();
+        let rest_pos = with
+            .into_iter()
+            .flat_map(|withs| withs.iter().rev())
+            .flat_map(|with| with.positional_params())
+            .chain(args.positional_params())
+            .skip(fixed_pos)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let rest_named = args
+            .named_params()
+            .filter(|(name, _)| sig.named(name).is_none())
+            .map(|(name, ty)| (name.clone(), ty.clone()))
+            .collect::<Vec<_>>();
+
+        let rest = args.rest_param().cloned();
+        let rest_args = ArgsTy::new(rest_pos.into_iter(), rest_named, None, rest, None);
+
+        Some((rest_var.clone(), Ty::Args(rest_args.into())))
+    }
+
+    fn collect_type_vars(
+        ty: &Ty,
+        vars: &mut FxHashSet<DeclExpr>,
+        binders: &mut Vec<Interned<TypeVar>>,
+    ) {
+        match ty {
+            Ty::Var(var) => {
+                if vars.insert(var.def.clone()) {
+                    binders.push(var.clone());
+                }
+            }
+            Ty::Param(param) => Self::collect_type_vars(&param.ty, vars, binders),
+            Ty::Union(types) | Ty::Tuple(types) => {
+                for ty in types.iter() {
+                    Self::collect_type_vars(ty, vars, binders);
+                }
+            }
+            Ty::Let(bounds) => {
+                for ty in bounds.lbs.iter().chain(bounds.ubs.iter()) {
+                    Self::collect_type_vars(ty, vars, binders);
+                }
+            }
+            Ty::Dict(record) => {
+                for ty in record.types.iter() {
+                    Self::collect_type_vars(ty, vars, binders);
+                }
+            }
+            Ty::Array(elem) => Self::collect_type_vars(elem, vars, binders),
+            Ty::Func(sig) | Ty::Args(sig) | Ty::Pattern(sig) => {
+                for ty in sig.inputs() {
+                    Self::collect_type_vars(ty, vars, binders);
+                }
+                if let Some(body) = &sig.body {
+                    Self::collect_type_vars(body, vars, binders);
+                }
+            }
+            Ty::With(with) => {
+                Self::collect_type_vars(&with.sig, vars, binders);
+                for ty in with.with.inputs() {
+                    Self::collect_type_vars(ty, vars, binders);
+                }
+                if let Some(body) = &with.with.body {
+                    Self::collect_type_vars(body, vars, binders);
+                }
+            }
+            Ty::Select(sel) => Self::collect_type_vars(&sel.ty, vars, binders),
+            Ty::Unary(unary) => Self::collect_type_vars(&unary.lhs, vars, binders),
+            Ty::Binary(binary) => {
+                let [lhs, rhs] = binary.operands();
+                Self::collect_type_vars(lhs, vars, binders);
+                Self::collect_type_vars(rhs, vars, binders);
+            }
+            Ty::If(if_ty) => {
+                Self::collect_type_vars(&if_ty.cond, vars, binders);
+                Self::collect_type_vars(&if_ty.then, vars, binders);
+                Self::collect_type_vars(&if_ty.else_, vars, binders);
+            }
+            Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
         }
     }
 
@@ -255,11 +781,14 @@ impl TypeChecker<'_> {
         static FLOW_TEXT_FONT_DICT_TYPE: LazyLock<Ty> =
             LazyLock::new(|| Ty::Dict(FLOW_TEXT_FONT_DICT.clone()));
 
-        fn is_ty(ty: &Ty) -> bool {
+        fn type_value_instance(ty: &Ty) -> Option<Ty> {
             match ty {
-                Ty::Builtin(BuiltinTy::Type(..)) => true,
-                Ty::Value(val) => matches!(val.val, Value::Type(..)),
-                _ => false,
+                Ty::Builtin(ty @ BuiltinTy::Type(..)) => Some(Ty::Builtin(ty.clone())),
+                Ty::Value(val) => match val.val {
+                    Value::Type(ty) => Some(Ty::Builtin(BuiltinTy::Type(ty))),
+                    _ => None,
+                },
+                _ => None,
             }
         }
 
@@ -272,34 +801,44 @@ impl TypeChecker<'_> {
                 if v.def == w.def {
                     return;
                 }
-
-                // todo: merge
-
-                let _ = v.def;
-                let _ = w.def;
+                let Some(rhs) = self.info.vars.get(&w.def) else {
+                    return;
+                };
+                match &rhs.bounds {
+                    FlowVarKind::Strong(bounds) | FlowVarKind::Weak(bounds) => {
+                        bounds.write().lbs.insert_mut(Ty::Var(v.clone()));
+                    }
+                }
+                self.record_input_lower_bound(&w.def, Ty::Var(v.clone()));
             }
             (Ty::Var(v), rhs) => {
                 crate::log_debug_ct!("constrain var {v:?} ⪯ {rhs:?}");
-                let w = self.info.vars.get_mut(&v.def).unwrap();
+                let Some(w) = self.info.vars.get_mut(&v.def) else {
+                    return;
+                };
                 // strict constraint on upper bound
                 let bound = rhs.clone();
                 match &w.bounds {
                     FlowVarKind::Strong(w) | FlowVarKind::Weak(w) => {
                         let mut w = w.write();
-                        w.ubs.insert_mut(bound);
+                        w.ubs.insert_mut(bound.clone());
                     }
                 }
+                self.record_input_upper_bound(&v.def, bound);
             }
             (lhs, Ty::Var(v)) => {
-                let w = self.info.vars.get(&v.def).unwrap();
+                let Some(w) = self.info.vars.get(&v.def) else {
+                    return;
+                };
                 let bound = self.weaken_constraint(lhs, &w.bounds);
                 crate::log_debug_ct!("constrain var {v:?} ⪰ {bound:?}");
                 match &w.bounds {
                     FlowVarKind::Strong(v) | FlowVarKind::Weak(v) => {
                         let mut v = v.write();
-                        v.lbs.insert_mut(bound);
+                        v.lbs.insert_mut(bound.clone());
                     }
                 };
+                self.record_input_lower_bound(&v.def, bound);
             }
             (Ty::Select(sel), rhs) => {
                 // Constrain field access `base.field` by constraining `base` with a record type
@@ -318,9 +857,10 @@ impl TypeChecker<'_> {
                 }
             }
             (Ty::Tuple(lhs), Ty::Tuple(rhs)) => {
-                for (lhs, rhs) in lhs.iter().zip(rhs.iter()) {
-                    self.constrain(lhs, rhs);
-                }
+                self.constrain_tuple_positions(lhs, rhs.iter());
+            }
+            (Ty::Tuple(lhs), Ty::Pattern(rhs)) => {
+                self.constrain_tuple_positions(lhs, rhs.positional_params());
             }
             (Ty::Dict(lhs), Ty::Dict(rhs)) => {
                 for (key, lhs, rhs) in lhs.common_iface_fields(rhs) {
@@ -411,17 +951,20 @@ impl TypeChecker<'_> {
                 // e.g. type(l) == type(r)
                 self.constrain(&lhs.lhs, &rhs.lhs);
             }
-            (Ty::Unary(lhs), rhs) if lhs.op == UnaryOp::TypeOf && is_ty(rhs) => {
-                crate::log_debug_ct!("constrain type of {lhs:?} ⪯ {rhs:?}");
-
-                self.constrain(&lhs.lhs, rhs);
+            (Ty::Unary(lhs), rhs) if lhs.op == UnaryOp::TypeOf => {
+                if let Some(rhs) = type_value_instance(rhs) {
+                    crate::log_debug_ct!("constrain type of {lhs:?} ⪯ {rhs:?}");
+                    self.constrain(&lhs.lhs, &rhs);
+                }
             }
-            (lhs, Ty::Unary(rhs)) if rhs.op == UnaryOp::TypeOf && is_ty(lhs) => {
-                crate::log_debug_ct!(
-                    "constrain type of {lhs:?} ⪯ {rhs:?} {:?}",
-                    matches!(lhs, Ty::Builtin(..)),
-                );
-                self.constrain(lhs, &rhs.lhs);
+            (lhs, Ty::Unary(rhs)) if rhs.op == UnaryOp::TypeOf => {
+                if let Some(lhs) = type_value_instance(lhs) {
+                    crate::log_debug_ct!(
+                        "constrain type of {lhs:?} ⪯ {rhs:?} {:?}",
+                        matches!(lhs, Ty::Builtin(..)),
+                    );
+                    self.constrain(&lhs, &rhs.lhs);
+                }
             }
             (Ty::Func(lhs), Ty::Func(rhs)) => {
                 crate::log_debug_ct!("constrain func {lhs:?} ⪯ {rhs:?}");
@@ -446,6 +989,170 @@ impl TypeChecker<'_> {
         }
     }
 
+    fn constrain_tuple_positions<'a>(
+        &mut self,
+        lhs: &[Ty],
+        rhs: impl ExactSizeIterator<Item = &'a Ty>,
+    ) {
+        for (idx, rhs) in rhs.enumerate() {
+            let mut any = false;
+            for lhs in self.tuple_pos_candidates(lhs, idx) {
+                any = true;
+                self.constrain(&lhs, rhs);
+            }
+
+            if !any && let Some(spread) = self.tuple_open_spread(lhs, idx) {
+                self.constrain(spread, &Ty::Array(rhs.clone().into()));
+            }
+        }
+    }
+
+    fn record_input_lower_bound(&mut self, def: &DeclExpr, bound: Ty) {
+        if self.live_input_vars.contains(def) {
+            self.input_contract_bounds
+                .entry(def.clone())
+                .or_default()
+                .lbs
+                .insert_mut(bound);
+        }
+    }
+
+    fn record_input_upper_bound(&mut self, def: &DeclExpr, bound: Ty) {
+        // `Any` is the identity of an upper-bound intersection and carries no contract fact.
+        if !matches!(bound, Ty::Any) && self.live_input_vars.contains(def) {
+            self.input_contract_bounds
+                .entry(def.clone())
+                .or_default()
+                .ubs
+                .insert_mut(bound);
+        }
+    }
+
+    fn tuple_pos_candidates(&self, elems: &[Ty], idx: usize) -> Vec<Ty> {
+        let mut pos = 0;
+        let mut candidates = vec![];
+
+        for elem in elems {
+            if let Some(spread) = Self::spread_operand(elem) {
+                let spread_idx = idx.saturating_sub(pos);
+                self.collect_spread_pos_candidates(spread, spread_idx, &mut candidates);
+                if !candidates.is_empty() {
+                    return candidates;
+                }
+
+                if let Some(len) = self.fixed_spread_len(spread) {
+                    pos += len;
+                    continue;
+                }
+
+                if idx >= pos {
+                    return candidates;
+                }
+            } else if pos == idx {
+                candidates.push(elem.clone());
+                return candidates;
+            } else {
+                pos += 1;
+            }
+        }
+
+        candidates
+    }
+
+    fn tuple_open_spread<'a>(&self, elems: &'a [Ty], idx: usize) -> Option<&'a Ty> {
+        let mut pos = 0;
+
+        for elem in elems {
+            if let Some(spread) = Self::spread_operand(elem) {
+                if idx >= pos {
+                    if let Some(len) = self.fixed_spread_len(spread) {
+                        if idx < pos + len {
+                            return Some(spread);
+                        }
+                        pos += len;
+                        continue;
+                    }
+                    return Some(spread);
+                }
+            } else if pos == idx {
+                return None;
+            } else {
+                pos += 1;
+            }
+        }
+
+        None
+    }
+
+    fn spread_operand(ty: &Ty) -> Option<&Ty> {
+        let Ty::Unary(unary) = ty else {
+            return None;
+        };
+        (unary.op == UnaryOp::Spread).then_some(&unary.lhs)
+    }
+
+    fn fixed_spread_len(&self, ty: &Ty) -> Option<usize> {
+        match ty {
+            Ty::Tuple(elems) => Some(elems.len()),
+            Ty::Args(args) if args.rest_param().is_none() => Some(args.positional_params().len()),
+            Ty::Var(var) => {
+                let bounds = self.info.vars.get(&var.def)?;
+                let lbs = bounds.bounds.bounds().read().lbs.clone();
+                let mut len = None;
+                for lb in lbs.iter() {
+                    let next = self.fixed_spread_len(lb)?;
+                    if len.is_some_and(|prev| prev != next) {
+                        return None;
+                    }
+                    len = Some(next);
+                }
+                len
+            }
+            Ty::Let(bounds) => {
+                let mut len = None;
+                for lb in bounds.lbs.iter() {
+                    let next = self.fixed_spread_len(lb)?;
+                    if len.is_some_and(|prev| prev != next) {
+                        return None;
+                    }
+                    len = Some(next);
+                }
+                len
+            }
+            _ => None,
+        }
+    }
+
+    fn collect_spread_pos_candidates(&self, ty: &Ty, idx: usize, candidates: &mut Vec<Ty>) {
+        match ty {
+            Ty::Array(elem) => candidates.push(elem.as_ref().clone()),
+            Ty::Tuple(elems) => {
+                if let Some(elem) = elems.get(idx) {
+                    candidates.push(elem.clone());
+                }
+            }
+            Ty::Args(args) => {
+                if let Some(elem) = args.pos_or_rest(idx) {
+                    candidates.push(elem);
+                }
+            }
+            Ty::Var(var) => {
+                if let Some(bounds) = self.info.vars.get(&var.def) {
+                    let lbs = bounds.bounds.bounds().read().lbs.clone();
+                    for lb in lbs.iter() {
+                        self.collect_spread_pos_candidates(lb, idx, candidates);
+                    }
+                }
+            }
+            Ty::Let(bounds) => {
+                for lb in bounds.lbs.iter() {
+                    self.collect_spread_pos_candidates(lb, idx, candidates);
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn check_comparable(&self, lhs: &Ty, rhs: &Ty) {
         let _ = lhs;
         let _ = rhs;
@@ -454,6 +1161,150 @@ impl TypeChecker<'_> {
     fn check_assignable(&self, lhs: &Ty, rhs: &Ty) {
         let _ = lhs;
         let _ = rhs;
+    }
+
+    fn constrain_assignment(&mut self, lhs: &Ty, rhs: &Ty) {
+        match lhs {
+            Ty::Var(var) => {
+                if !self.assign_var(var, rhs) {
+                    self.possible_ever_be(lhs, rhs);
+                }
+            }
+            Ty::Tuple(_) | Ty::Pattern(_) => self.constrain(rhs, lhs),
+            Ty::Union(types) => {
+                for lhs in types.iter() {
+                    self.constrain_assignment(lhs, rhs);
+                }
+            }
+            Ty::Let(bounds) => {
+                for lhs in bounds.lbs.iter().chain(bounds.ubs.iter()) {
+                    self.constrain_assignment(lhs, rhs);
+                }
+            }
+            _ => self.possible_ever_be(lhs, rhs),
+        }
+
+        let mut vars = FxHashSet::default();
+        let mut binders = vec![];
+        Self::collect_type_vars(lhs, &mut vars, &mut binders);
+        for binder in binders {
+            self.live_input_vars.remove(&binder.def);
+        }
+    }
+
+    fn assign_var(&mut self, var: &Interned<TypeVar>, rhs: &Ty) -> bool {
+        if !Self::assignment_rhs_overwrites(rhs) {
+            return false;
+        }
+
+        let rhs_mentions_var = match Self::type_contains_var(rhs, &var.def) {
+            Some(rhs_mentions_var) => rhs_mentions_var,
+            None => return false,
+        };
+
+        let rhs = if rhs_mentions_var {
+            let mut snapshot = self.shallow_lower_bound(Ty::Var(var.clone()));
+            if !matches!(Self::type_contains_var(&snapshot, &var.def), Some(false)) {
+                snapshot = Ty::Any;
+            }
+
+            let rhs = Self::replace_var(rhs.clone(), var, snapshot);
+            if !matches!(Self::type_contains_var(&rhs, &var.def), Some(false)) {
+                return false;
+            }
+            rhs
+        } else {
+            rhs.clone()
+        };
+        let rhs = self.shallow_lower_bound(rhs);
+        // Preserve the input contract before the body-flow variable is overwritten.
+        if self.live_input_vars.contains(&var.def)
+            && let Some(bounds) = self.info.vars.get(&var.def)
+        {
+            let bounds = bounds.bounds.bounds().read().freeze();
+            let input = self
+                .input_contract_bounds
+                .entry(var.def.clone())
+                .or_default();
+            for bound in bounds.lbs {
+                input.lbs.insert_mut(bound);
+            }
+            for bound in bounds.ubs {
+                input.ubs.insert_mut(bound);
+            }
+        }
+        let Some(bounds) = self.info.vars.get_mut(&var.def) else {
+            return false;
+        };
+        self.overwritten_vars.insert(var.def.clone());
+        let mut bounds = bounds.bounds.bounds().write();
+        bounds.lbs = [rhs].into_iter().collect();
+        true
+    }
+
+    fn assignment_rhs_overwrites(rhs: &Ty) -> bool {
+        !matches!(rhs, Ty::Any | Ty::Select(_) | Ty::Binary(_))
+    }
+
+    fn replace_var(ty: Ty, var: &Interned<TypeVar>, with: Ty) -> Ty {
+        let mut replacer = VarReplacer {
+            def: var.def.clone(),
+            with,
+        };
+        ty.mutate(true, &mut replacer).unwrap_or(ty)
+    }
+
+    fn type_contains_var(ty: &Ty, def: &DeclExpr) -> Option<bool> {
+        const NODE_BUDGET: usize = 4096;
+
+        let mut stack = vec![ty];
+        let mut visited = 0usize;
+        while let Some(ty) = stack.pop() {
+            visited += 1;
+            if visited > NODE_BUDGET {
+                return None;
+            }
+
+            match ty {
+                Ty::Var(var) if var.def == *def => return Some(true),
+                Ty::Param(param) => stack.push(&param.ty),
+                Ty::Union(types) | Ty::Tuple(types) => stack.extend(types.iter()),
+                Ty::Let(bounds) => {
+                    stack.extend(bounds.lbs.iter());
+                    stack.extend(bounds.ubs.iter());
+                }
+                Ty::Dict(record) => stack.extend(record.types.iter()),
+                Ty::Array(elem) => stack.push(elem),
+                Ty::Func(sig) | Ty::Args(sig) | Ty::Pattern(sig) => {
+                    stack.extend(sig.inputs());
+                    if let Some(body) = &sig.body {
+                        stack.push(body);
+                    }
+                }
+                Ty::With(with) => {
+                    stack.push(&with.sig);
+                    stack.extend(with.with.inputs());
+                    if let Some(body) = &with.with.body {
+                        stack.push(body);
+                    }
+                }
+                Ty::Select(sel) => stack.push(&sel.ty),
+                Ty::Unary(unary) => stack.push(&unary.lhs),
+                Ty::Binary(binary) => {
+                    let [lhs, rhs] = binary.operands();
+                    stack.push(lhs);
+                    stack.push(rhs);
+                }
+                Ty::If(if_ty) => {
+                    stack.push(&if_ty.cond);
+                    stack.push(&if_ty.then);
+                    stack.push(&if_ty.else_);
+                }
+                Ty::Var(_) | Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
+            }
+        }
+
+        Some(false)
     }
 
     fn check_containing(&mut self, container: &Ty, elem: &Ty, expected_in: bool) {
@@ -559,29 +1410,239 @@ impl TypeChecker<'_> {
     }
 }
 
+struct ControlSplit {
+    normal: Option<Ty>,
+    returns: Vec<Ty>,
+    terminal: bool,
+}
+
+struct FunctionResultantCloser<'a> {
+    vars: &'a FxHashMap<DeclExpr, TypeVarBounds>,
+    params: FxHashSet<DeclExpr>,
+    visiting: FxHashSet<DeclExpr>,
+    visited: usize,
+}
+
+impl FunctionResultantCloser<'_> {
+    const NODE_BUDGET: usize = 4096;
+
+    fn close_scoped_sig(&mut self, sig: &SigTy, pol: bool) -> Option<SigTy> {
+        let mut seen = FxHashSet::default();
+        let mut binders = vec![];
+        for input in sig.inputs() {
+            TypeChecker::collect_input_binders(input, &mut seen, &mut binders);
+        }
+        let inserted = binders
+            .into_iter()
+            .filter_map(|binder| {
+                self.params
+                    .insert(binder.def.clone())
+                    .then_some(binder.def.clone())
+            })
+            .collect::<Vec<_>>();
+
+        let inputs = self.mutate_vec(&sig.inputs, pol);
+        let body = self.mutate_option(sig.body.as_ref(), pol);
+
+        for def in inserted {
+            self.params.remove(&def);
+        }
+        if inputs.is_none() && body.is_none() {
+            return None;
+        }
+
+        let mut sig = sig.clone();
+        if let Some(inputs) = inputs {
+            sig.inputs = inputs;
+        }
+        if let Some(body) = body {
+            sig.body = body;
+        }
+        Some(sig)
+    }
+
+    fn lower_bounds_of(&mut self, var: &Interned<TypeVar>) -> Option<Ty> {
+        self.visited += 1;
+        if self.visited > Self::NODE_BUDGET {
+            return Some(Ty::Any);
+        }
+
+        if self.params.contains(&var.def) {
+            return None;
+        }
+        if !self.visiting.insert(var.def.clone()) {
+            return Some(Ty::Any);
+        }
+
+        let Some(bounds) = self.vars.get(&var.def) else {
+            self.visiting.remove(&var.def);
+            return Some(Ty::Any);
+        };
+        let bounds = bounds.bounds.bounds().read().freeze();
+        if bounds.lbs.is_empty() && bounds.ubs.is_empty() {
+            self.visiting.remove(&var.def);
+            return Some(Ty::Any);
+        }
+
+        let bounds = self.close_bounds(&bounds);
+        self.visiting.remove(&var.def);
+        Some(Ty::Let(Interned::new(bounds)))
+    }
+
+    fn close_bounds(&mut self, bounds: &TypeBounds) -> TypeBounds {
+        let lbs = bounds
+            .lbs
+            .iter()
+            .map(|bound| self.mutate(bound, false).unwrap_or_else(|| bound.clone()))
+            .collect();
+        let ubs = bounds
+            .ubs
+            .iter()
+            .map(|bound| self.mutate(bound, true).unwrap_or_else(|| bound.clone()))
+            .collect();
+        TypeBounds { lbs, ubs }
+    }
+}
+
+impl TyMutator for FunctionResultantCloser<'_> {
+    fn mutate(&mut self, ty: &Ty, pol: bool) -> Option<Ty> {
+        match ty {
+            Ty::Var(var) => self.lower_bounds_of(var),
+            Ty::Let(bounds) => Some(Ty::Let(Interned::new(self.close_bounds(bounds)))),
+            Ty::Func(sig) => self
+                .close_scoped_sig(sig, pol)
+                .map(|sig| Ty::Func(Interned::new(sig))),
+            Ty::Pattern(sig) => self
+                .close_scoped_sig(sig, pol)
+                .map(|sig| Ty::Pattern(Interned::new(sig))),
+            _ => self.mutate_rec(ty, pol),
+        }
+    }
+}
+
 struct Joiner {
     break_or_continue_or_return: bool,
     definite: Ty,
     possibles: Vec<Ty>,
+    returns: Vec<Ty>,
 }
 impl Joiner {
     fn finalize(self) -> Ty {
-        crate::log_debug_ct!("join: {:?} {:?}", self.possibles, self.definite);
-        if self.possibles.is_empty() {
-            return self.definite;
-        }
-        if self.possibles.len() == 1 {
-            return self.possibles.into_iter().next().unwrap();
+        crate::log_debug_ct!(
+            "join: {:?} {:?} returns {:?}",
+            self.possibles,
+            self.definite,
+            self.returns
+        );
+
+        let normal = Self::finalize_normal(self.definite, self.possibles);
+        if self.returns.is_empty() {
+            if self.break_or_continue_or_return {
+                return Ty::Builtin(BuiltinTy::Never);
+            }
+            return normal;
         }
 
-        // let mut definite = self.definite.clone();
-        // for p in &self.possibles {
+        let returned = Self::finalize_types(self.returns);
+        if self.break_or_continue_or_return {
+            return Ty::Unary(TypeUnary::new(UnaryOp::Return, returned));
+        }
+
+        if Self::is_none_like(&normal) {
+            return Ty::Any;
+        }
+        if normal == returned {
+            return normal;
+        }
+
+        Ty::from_types([normal, returned].into_iter())
+    }
+
+    fn finalize_normal(definite: Ty, possibles: Vec<Ty>) -> Ty {
+        if possibles.is_empty() {
+            return definite;
+        }
+        if possibles.len() == 1 {
+            return possibles.into_iter().next().unwrap();
+        }
+
+        // let mut definite = definite.clone();
+        // for p in &possibles {
         //     definite = definite.join(p);
         // }
 
-        // crate::log_debug_ct!("possibles: {:?} {:?}", self.definite, self.possibles);
+        // crate::log_debug_ct!("possibles: {:?} {:?}", definite, possibles);
 
         Ty::Any
+    }
+
+    fn finalize_types(types: Vec<Ty>) -> Ty {
+        if types.len() == 1 {
+            return types.into_iter().next().unwrap();
+        }
+
+        Ty::from_types(types.into_iter())
+    }
+
+    fn is_none_like(ty: &Ty) -> bool {
+        matches!(
+            ty,
+            Ty::Builtin(
+                BuiltinTy::Space | BuiltinTy::None | BuiltinTy::Clause | BuiltinTy::FlowNone
+            )
+        )
+    }
+
+    fn split_control(child: Ty) -> ControlSplit {
+        match child {
+            Ty::Unary(unary) if unary.op == UnaryOp::Return => ControlSplit {
+                normal: None,
+                returns: vec![unary.lhs.clone()],
+                terminal: true,
+            },
+            Ty::Builtin(BuiltinTy::Break | BuiltinTy::Continue | BuiltinTy::Never) => {
+                ControlSplit {
+                    normal: None,
+                    returns: vec![],
+                    terminal: true,
+                }
+            }
+            Ty::If(if_ty) => {
+                let then = Self::split_control(if_ty.then.as_ref().clone());
+                let else_ = Self::split_control(if_ty.else_.as_ref().clone());
+
+                let mut returns = then.returns;
+                returns.extend(else_.returns);
+
+                let then_normal = then.normal.filter(|ty| !Self::is_none_like(ty));
+                let else_normal = else_.normal.filter(|ty| !Self::is_none_like(ty));
+                let normal = if then_normal.is_none() && else_normal.is_none() {
+                    None
+                } else {
+                    Some(Ty::If(IfTy::new(
+                        if_ty.cond.clone(),
+                        then_normal.unwrap_or(Ty::Builtin(BuiltinTy::None)).into(),
+                        else_normal.unwrap_or(Ty::Builtin(BuiltinTy::None)).into(),
+                    )))
+                };
+
+                ControlSplit {
+                    normal,
+                    returns,
+                    terminal: then.terminal && else_.terminal,
+                }
+            }
+            normal if Self::is_none_like(&normal) => ControlSplit {
+                normal: None,
+                returns: vec![],
+                terminal: false,
+            },
+            normal => ControlSplit {
+                normal: Some(normal),
+                returns: vec![],
+                terminal: false,
+            },
+        }
     }
 
     fn join(&mut self, child: Ty) {
@@ -589,10 +1650,30 @@ impl Joiner {
             return;
         }
 
+        let ControlSplit {
+            normal,
+            returns,
+            terminal,
+        } = Self::split_control(child);
+
+        self.returns.extend(returns);
+        if let Some(normal) = normal {
+            self.join_normal(normal);
+        }
+        if terminal {
+            self.break_or_continue_or_return = true;
+        }
+    }
+
+    fn join_normal(&mut self, child: Ty) {
+        if matches!(self.definite, Ty::Any) && !matches!(child, Ty::Any) {
+            self.definite = Ty::Builtin(BuiltinTy::None);
+        }
+
         match (child, &self.definite) {
             (Ty::Builtin(BuiltinTy::Space | BuiltinTy::None), _) => {}
             (Ty::Builtin(BuiltinTy::Clause | BuiltinTy::FlowNone), _) => {}
-            (Ty::Any, _) | (_, Ty::Any) => {}
+            (Ty::Any, _) => self.definite = Ty::Any,
             (Ty::Var(var), _) => self.possibles.push(Ty::Var(var)),
             // todo: check possibles
             (Ty::Array(arr), Ty::Builtin(BuiltinTy::None)) => self.definite = Ty::Array(arr),
@@ -643,6 +1724,24 @@ impl Default for Joiner {
             break_or_continue_or_return: false,
             definite: Ty::Builtin(BuiltinTy::None),
             possibles: Vec::new(),
+            returns: Vec::new(),
         }
+    }
+}
+
+struct VarReplacer {
+    def: DeclExpr,
+    with: Ty,
+}
+
+impl TyMutator for VarReplacer {
+    fn mutate(&mut self, ty: &Ty, pol: bool) -> Option<Ty> {
+        if let Ty::Var(var) = ty
+            && var.def == self.def
+        {
+            return Some(self.with.clone());
+        }
+
+        self.mutate_rec(ty, pol)
     }
 }

--- a/crates/tinymist-query/src/analysis/tyck/apply.rs
+++ b/crates/tinymist-query/src/analysis/tyck/apply.rs
@@ -134,6 +134,29 @@ impl ApplyChecker for ApplyTypeChecker<'_, '_> {
                     crate::log_debug_ct!("resultant: {resultants:?}");
                 }
             }
+            Sig::Builtin(BuiltinSig::ArgumentsPos(this)) => {
+                if args.positional_params().len() == 0
+                    && args.named_params().len() == 0
+                    && args.rest_param().is_none()
+                {
+                    let res = match this {
+                        Ty::Args(args) => {
+                            let mut elements =
+                                args.positional_params().cloned().collect::<Vec<_>>();
+                            if let Some(rest) = args.rest_param() {
+                                elements
+                                    .push(Ty::Unary(TypeUnary::new(UnaryOp::Spread, rest.clone())));
+                            }
+                            Ty::Tuple(elements.into())
+                        }
+                        Ty::Builtin(BuiltinTy::Args) => Ty::Array(Ty::Any.into()),
+                        this => Ty::Tuple(
+                            vec![Ty::Unary(TypeUnary::new(UnaryOp::Spread, this.clone()))].into(),
+                        ),
+                    };
+                    self.resultant.push(res);
+                }
+            }
             _ => {}
         }
 

--- a/crates/tinymist-query/src/analysis/tyck/syntax.rs
+++ b/crates/tinymist-query/src/analysis/tyck/syntax.rs
@@ -112,8 +112,9 @@ impl TypeChecker<'_> {
                 ArgExpr::Pos(pos) => {
                     elements.push(self.check(pos));
                 }
-                ArgExpr::Spread(..) => {
-                    // todo: handle spread args
+                ArgExpr::Spread(spread) => {
+                    let spread = self.check(spread);
+                    Self::push_tuple_spread(&mut elements, spread);
                 }
                 ArgExpr::NamedRt(..) | ArgExpr::Named(..) => unreachable!(),
             }
@@ -143,8 +144,9 @@ impl TypeChecker<'_> {
                         fields.push((const_key, val));
                     }
                 }
-                ArgExpr::Spread(..) => {
-                    // todo: handle spread args
+                ArgExpr::Spread(spread) => {
+                    let spread = self.check(spread);
+                    Self::push_dict_spread(&mut fields, spread);
                 }
                 ArgExpr::Pos(..) => unreachable!(),
             }
@@ -158,6 +160,7 @@ impl TypeChecker<'_> {
     fn check_args(&mut self, args: &[ArgExpr]) -> Ty {
         let mut args_res = Vec::new();
         let mut named = vec![];
+        let mut rest = None;
 
         for arg in args.iter() {
             match arg {
@@ -179,15 +182,85 @@ impl TypeChecker<'_> {
                         named.push((const_key, val));
                     }
                 }
-                ArgExpr::Spread(..) => {
-                    // todo: handle spread args
+                ArgExpr::Spread(spread) => {
+                    let spread = self.check(spread);
+                    Self::push_arg_spread(&mut args_res, &mut named, &mut rest, spread);
                 }
             }
         }
 
-        let args = ArgsTy::new(args_res.into_iter(), named, None, None, None);
+        let args = ArgsTy::new(args_res.into_iter(), named, None, rest, None);
 
         Ty::Args(args.into())
+    }
+
+    fn push_tuple_spread(elements: &mut Vec<Ty>, spread: Ty) {
+        match spread {
+            Ty::Tuple(elems) => elements.extend(elems.iter().cloned()),
+            Ty::Args(args) => {
+                elements.extend(args.positional_params().cloned());
+                if let Some(rest) = args.rest_param() {
+                    Self::push_tuple_spread(elements, rest.clone());
+                }
+            }
+            ty => elements.push(Ty::Unary(TypeUnary::new(UnaryOp::Spread, ty))),
+        }
+    }
+
+    fn push_dict_spread(fields: &mut Vec<(Interned<str>, Ty)>, spread: Ty) {
+        match spread {
+            Ty::Dict(record) => fields.extend(
+                record
+                    .interface()
+                    .map(|(name, ty)| (name.clone(), ty.clone())),
+            ),
+            Ty::Args(args) => fields.extend(
+                args.named_params()
+                    .map(|(name, ty)| (name.clone(), ty.clone())),
+            ),
+            _ => {}
+        }
+    }
+
+    fn push_arg_spread(
+        args_res: &mut Vec<Ty>,
+        named: &mut Vec<(Interned<str>, Ty)>,
+        rest: &mut Option<Ty>,
+        spread: Ty,
+    ) {
+        match spread {
+            Ty::Tuple(elems) => {
+                for elem in elems.iter() {
+                    if let Ty::Unary(unary) = elem
+                        && unary.op == UnaryOp::Spread
+                    {
+                        Self::push_arg_spread(args_res, named, rest, unary.lhs.clone());
+                        continue;
+                    }
+
+                    args_res.push(elem.clone());
+                }
+            }
+            Ty::Args(args) => {
+                args_res.extend(args.positional_params().cloned());
+                named.extend(
+                    args.named_params()
+                        .map(|(name, ty)| (name.clone(), ty.clone())),
+                );
+                if let Some(rest_ty) = args.rest_param() {
+                    *rest = Some(rest_ty.clone());
+                }
+            }
+            Ty::Dict(record) => {
+                named.extend(
+                    record
+                        .interface()
+                        .map(|(name, ty)| (name.clone(), ty.clone())),
+                );
+            }
+            Ty::Array(elem) => *rest = Some(Ty::Array(elem)),
+            ty => *rest = Some(ty),
+        }
     }
 
     fn check_pattern_exp(&mut self, pat: &Interned<Pattern>) -> Ty {
@@ -385,7 +458,7 @@ impl TypeChecker<'_> {
             }
             ast::BinOp::Assign => {
                 self.check_assignable(&lhs, &rhs);
-                self.possible_ever_be(&lhs, &rhs);
+                self.constrain_assignment(&lhs, &rhs);
             }
             ast::BinOp::AddAssign
             | ast::BinOp::SubAssign
@@ -431,6 +504,7 @@ impl TypeChecker<'_> {
     fn check_apply(&mut self, apply: &Interned<ApplyExpr>) -> Ty {
         let args = self.check(&apply.args);
         let callee = self.check(&apply.callee);
+        self.summarize_mutation_call(&apply.callee, &args);
 
         // Treat `dict.at("key")` as `dict.key` when the key is a constant string.
         if let Expr::Select(select) = &apply.callee
@@ -455,6 +529,12 @@ impl TypeChecker<'_> {
         crate::log_debug_ct!("func_call: {callee:?} with {args:?}");
 
         if let Ty::Args(args) = args {
+            if Self::is_builtin_panic_callee(&callee) {
+                let res = Ty::Builtin(BuiltinTy::Never);
+                self.info.witness_at_least(apply.span, res.clone());
+                return res;
+            }
+
             let mut worker = ApplyTypeChecker {
                 base: self,
                 call_site: apply.callee.span(),
@@ -463,11 +543,164 @@ impl TypeChecker<'_> {
             };
             callee.call(&args, true, &mut worker);
             let res = Ty::from_types(worker.resultant.into_iter());
+            let res = self.materialize_tuple_spreads(res);
             self.info.witness_at_least(apply.span, res.clone());
             return res;
         }
 
         Ty::Any
+    }
+
+    fn is_builtin_panic_callee(callee: &Ty) -> bool {
+        match callee {
+            Ty::Value(ins_ty) => match &ins_ty.val {
+                Value::Func(func) => func.name().is_some_and(|name| name == "panic"),
+                _ => false,
+            },
+            Ty::Union(types) => types.iter().any(Self::is_builtin_panic_callee),
+            _ => false,
+        }
+    }
+
+    fn is_arguments_like(&self, ty: &Ty) -> bool {
+        match ty {
+            Ty::Args(_) | Ty::Builtin(BuiltinTy::Args) => true,
+            Ty::Var(var) => {
+                let Some(bounds) = self.info.vars.get(&var.def) else {
+                    return false;
+                };
+                let lbs = bounds.bounds.bounds().read().lbs.clone();
+                lbs.iter().any(|lb| self.is_arguments_like(lb))
+            }
+            Ty::Let(bounds) => bounds.lbs.iter().any(|lb| self.is_arguments_like(lb)),
+            Ty::Union(types) => types.iter().any(|ty| self.is_arguments_like(ty)),
+            _ => false,
+        }
+    }
+
+    fn materialize_tuple_spreads(&self, ty: Ty) -> Ty {
+        match ty {
+            Ty::Tuple(elems) => {
+                let elems = elems
+                    .iter()
+                    .map(|elem| {
+                        if let Ty::Unary(unary) = elem
+                            && unary.op == UnaryOp::Spread
+                        {
+                            let lhs = match &unary.lhs {
+                                Ty::Var(var) if self.live_input_vars.contains(&var.def) => {
+                                    unary.lhs.clone()
+                                }
+                                lhs => self.info.simplify(lhs.clone(), true),
+                            };
+                            return Ty::Unary(TypeUnary::new(UnaryOp::Spread, lhs));
+                        }
+
+                        elem.clone()
+                    })
+                    .collect::<Vec<_>>();
+
+                Ty::Tuple(elems.into())
+            }
+            ty => ty,
+        }
+    }
+
+    fn summarize_mutation_call(&mut self, callee: &Expr, args: &Ty) {
+        let Expr::Select(select) = callee else {
+            return;
+        };
+        if select.key.name().as_ref() != "push" {
+            return;
+        }
+
+        let Ty::Args(args) = args else {
+            return;
+        };
+        if args.positional_params().len() != 1
+            || args.named_params().len() != 0
+            || args.rest_param().is_some()
+        {
+            return;
+        }
+
+        let Some(elem) = args.pos(0).cloned() else {
+            return;
+        };
+        let receiver = self.check(&select.lhs);
+        self.summarize_array_push(receiver, elem);
+    }
+
+    fn summarize_array_push(&mut self, receiver: Ty, elem: Ty) {
+        let Ty::Var(var) = receiver else {
+            return;
+        };
+        let elem = self.shallow_lower_bound(elem);
+        let Some(bounds) = self.info.vars.get_mut(&var.def) else {
+            return;
+        };
+
+        let mut bounds = bounds.bounds.bounds().write();
+        let mut elems = vec![elem];
+        let mut kept_lbs = Vec::with_capacity(bounds.lbs.size());
+
+        for lb in bounds.lbs.iter() {
+            if Self::collect_array_builder_elems(lb, &mut elems) {
+                continue;
+            }
+            kept_lbs.push(lb.clone());
+        }
+
+        let elem = Ty::from_types(elems.into_iter());
+        kept_lbs.push(Ty::Array(elem.into()));
+        bounds.lbs = kept_lbs.into_iter().collect();
+    }
+
+    fn collect_array_builder_elems(ty: &Ty, elems: &mut Vec<Ty>) -> bool {
+        match ty {
+            Ty::Array(elem) => {
+                elems.push(elem.as_ref().clone());
+                true
+            }
+            Ty::Tuple(items) => {
+                for item in items.iter() {
+                    if let Ty::Unary(unary) = item
+                        && unary.op == UnaryOp::Spread
+                    {
+                        Self::collect_array_builder_elems(&unary.lhs, elems);
+                    } else {
+                        elems.push(item.clone());
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn shallow_lower_bound(&self, ty: Ty) -> Ty {
+        match ty {
+            Ty::Var(var) => {
+                let Some(bounds) = self.info.vars.get(&var.def) else {
+                    return Ty::Var(var);
+                };
+                let lbs = bounds
+                    .bounds
+                    .bounds()
+                    .read()
+                    .lbs
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if lbs.is_empty() {
+                    return Ty::Var(var);
+                }
+                Ty::from_types(lbs.into_iter())
+            }
+            Ty::Let(bounds) if !bounds.lbs.is_empty() => Ty::from_types(bounds.lbs.iter().cloned()),
+            Ty::Let(bounds) => Ty::Let(bounds),
+            ty => ty,
+        }
     }
 
     fn check_func(&mut self, func: &Interned<FuncExpr>) -> Ty {
@@ -480,17 +713,30 @@ impl TypeChecker<'_> {
         crate::log_debug_ct!("check closure: {func:?} with docs {docstring:#?}");
 
         let (sig, defaults) = self.check_pattern_sig(Some(&def_id), &func.params, docstring);
+        let input_bounds = self.snapshot_function_input_bounds(&sig);
+        let input_defs = input_bounds
+            .iter()
+            .map(|(binder, _)| binder.def.clone())
+            .collect::<Vec<_>>();
+        let escaped_input_vars = self.live_input_vars.clone();
+        for def in &input_defs {
+            self.input_contract_bounds.remove(def);
+            self.live_input_vars.insert(def.clone());
+        }
 
-        let body = self.check(&func.body);
+        let body = Self::function_return_type(self.check(&func.body));
         let res_ty = if let Some(annotated) = &docstring.res_ty {
             self.constrain(&body, annotated);
-            Ty::Let(Interned::new(TypeBounds {
-                lbs: vec![body],
-                ubs: vec![annotated.clone()],
-            }))
+            self.function_annotated_return_type(body, annotated)
         } else {
             body
         };
+        let res_ty = self.close_function_resultant_type(res_ty, &input_bounds, &escaped_input_vars);
+        let sig = self.rebind_overwritten_function_inputs(sig, input_bounds, &escaped_input_vars);
+        self.live_input_vars = escaped_input_vars;
+        for def in input_defs {
+            self.input_contract_bounds.remove(&def);
+        }
 
         // freeze the signature
         for inp in sig.inputs.iter() {
@@ -511,6 +757,45 @@ impl TypeChecker<'_> {
 
         self.constrain(&sig, &var);
         sig
+    }
+
+    fn function_return_type(ty: Ty) -> Ty {
+        match ty {
+            Ty::Unary(unary) if unary.op == UnaryOp::Return => unary.lhs.clone(),
+            Ty::If(if_ty) => Ty::If(IfTy::new(
+                if_ty.cond.clone(),
+                Self::function_return_type(if_ty.then.as_ref().clone()).into(),
+                Self::function_return_type(if_ty.else_.as_ref().clone()).into(),
+            )),
+            ty => ty,
+        }
+    }
+
+    fn function_annotated_return_type(&self, body: Ty, annotated: &Ty) -> Ty {
+        let body_is_open = matches!(
+            &body,
+            Ty::Any
+                | Ty::Builtin(
+                    BuiltinTy::None | BuiltinTy::FlowNone | BuiltinTy::Undef | BuiltinTy::Never,
+                )
+        );
+        if !body_is_open || !self.annotation_has_information(annotated) {
+            return body;
+        }
+
+        annotated.clone()
+    }
+
+    fn annotation_has_information(&self, annotated: &Ty) -> bool {
+        match annotated {
+            Ty::Any => false,
+            Ty::Var(var) => self.info.vars.get(&var.def).is_some_and(|bounds| {
+                let bounds = bounds.bounds.bounds().read();
+                !bounds.lbs.is_empty() || !bounds.ubs.is_empty()
+            }),
+            Ty::Let(bounds) => !bounds.lbs.is_empty() || !bounds.ubs.is_empty(),
+            _ => true,
+        }
     }
 
     fn check_let(&mut self, let_expr: &Interned<LetExpr>) -> Ty {
@@ -626,7 +911,12 @@ impl TypeChecker<'_> {
     fn check_ref(&mut self, r: &Interned<RefExpr>) -> Ty {
         let s = r.decl.span();
         let s = (!s.is_detached()).then_some(s);
-        let of = r.root.as_ref().map(|of| self.check(of));
+        let of = self
+            .info
+            .vars
+            .contains_key(&r.decl)
+            .then(|| Ty::Var(self.get_var(&r.decl)));
+        let of = of.or_else(|| r.root.as_ref().map(|of| self.check(of)));
         let of = of.or_else(|| r.term.clone());
         if let Some((s, of)) = s.zip(of.as_ref()) {
             self.info.witness_at_most(s, of.clone());
@@ -672,15 +962,23 @@ impl TypeChecker<'_> {
 
     fn check_conditional(&mut self, if_expr: &Interned<IfExpr>) -> Ty {
         let cond = self.check(&if_expr.cond);
+        let branch_live_input_vars = self.live_input_vars.clone();
         let then = self.check(&if_expr.then);
+        let then_live_input_vars = self.live_input_vars.clone();
+        self.live_input_vars = branch_live_input_vars;
         let else_ = self.check(&if_expr.else_);
+        // The current value can still be the input if either branch leaves it untouched.
+        self.live_input_vars.extend(then_live_input_vars);
 
         Ty::If(IfTy::new(cond.into(), then.into(), else_.into()))
     }
 
     fn check_while_loop(&mut self, while_loop: &Interned<WhileExpr>) -> Ty {
         let _cond = self.check(&while_loop.cond);
+        let loop_live_input_vars = self.live_input_vars.clone();
         let _body = self.check(&while_loop.body);
+        // A loop body may execute zero times.
+        self.live_input_vars.extend(loop_live_input_vars);
 
         Ty::Any
     }
@@ -697,11 +995,7 @@ impl TypeChecker<'_> {
         if matches!(for_loop.pattern.as_ref(), Pattern::Simple(..)) {
             match &iter {
                 Ty::Array(elem) => self.constrain(elem, &pattern),
-                Ty::Tuple(elems) => {
-                    for elem in elems.iter() {
-                        self.constrain(elem, &pattern);
-                    }
-                }
+                Ty::Tuple(elems) => self.constrain_tuple_iter_pattern(elems, &pattern),
                 Ty::Var(var) => {
                     if let Some(bounds) = self.info.vars.get(&var.def) {
                         let lbs = bounds.bounds.bounds().read().lbs.clone();
@@ -712,9 +1006,7 @@ impl TypeChecker<'_> {
                                     self.constrain(&iter, &Ty::Array(pattern.clone().into()));
                                 }
                                 Ty::Tuple(elems) => {
-                                    for elem in elems.iter() {
-                                        self.constrain(elem, &pattern);
-                                    }
+                                    self.constrain_tuple_iter_pattern(elems, &pattern);
                                     let tuple = Ty::Tuple(Interned::new(
                                         elems.iter().map(|_| pattern.clone()).collect::<Vec<_>>(),
                                     ));
@@ -729,11 +1021,7 @@ impl TypeChecker<'_> {
                     for lb in bounds.lbs.iter() {
                         match lb {
                             Ty::Array(elem) => self.constrain(elem, &pattern),
-                            Ty::Tuple(elems) => {
-                                for elem in elems.iter() {
-                                    self.constrain(elem, &pattern);
-                                }
-                            }
+                            Ty::Tuple(elems) => self.constrain_tuple_iter_pattern(elems, &pattern),
                             _ => {}
                         }
                     }
@@ -741,9 +1029,81 @@ impl TypeChecker<'_> {
                 _ => {}
             }
         }
+        let loop_live_input_vars = self.live_input_vars.clone();
         let _body = self.check(&for_loop.body);
+        // A loop body may execute zero times.
+        self.live_input_vars.extend(loop_live_input_vars);
 
         Ty::Any
+    }
+
+    fn constrain_tuple_iter_pattern(&mut self, elems: &[Ty], pattern: &Ty) {
+        if let Some(elem) = self.tuple_iter_element_type(elems) {
+            self.constrain(&elem, pattern);
+        }
+    }
+
+    fn tuple_iter_element_type(&self, elems: &[Ty]) -> Option<Ty> {
+        let mut types = vec![];
+
+        for elem in elems {
+            if let Ty::Unary(unary) = elem
+                && unary.op == UnaryOp::Spread
+            {
+                if let Some(elem) = self.spread_iter_element_type(&unary.lhs) {
+                    types.push(elem);
+                }
+                continue;
+            }
+
+            types.push(elem.clone());
+        }
+
+        (!types.is_empty()).then(|| Ty::from_types(types.into_iter()))
+    }
+
+    fn spread_iter_element_type(&self, source: &Ty) -> Option<Ty> {
+        match source {
+            Ty::Array(elem) => Some(elem.as_ref().clone()),
+            Ty::Tuple(elems) => self.tuple_iter_element_type(elems),
+            Ty::Args(args) => self.args_iter_element_type(args),
+            Ty::Var(var) if self.is_arguments_like(source) => Some(Ty::Unary(TypeUnary::new(
+                UnaryOp::ElementOf,
+                Ty::Var(var.clone()),
+            ))),
+            Ty::Var(var) => {
+                let bounds = self.info.vars.get(&var.def)?;
+                let lbs = bounds.bounds.bounds().read().lbs.clone();
+                let elems = lbs
+                    .iter()
+                    .filter_map(|lb| self.spread_iter_element_type(lb))
+                    .collect::<Vec<_>>();
+                (!elems.is_empty()).then(|| Ty::from_types(elems.into_iter()))
+            }
+            Ty::Let(bounds) => {
+                let elems = bounds
+                    .lbs
+                    .iter()
+                    .filter_map(|lb| self.spread_iter_element_type(lb))
+                    .collect::<Vec<_>>();
+                (!elems.is_empty()).then(|| Ty::from_types(elems.into_iter()))
+            }
+            _ => Some(Ty::Unary(TypeUnary::new(
+                UnaryOp::ElementOf,
+                source.clone(),
+            ))),
+        }
+    }
+
+    fn args_iter_element_type(&self, args: &ArgsTy) -> Option<Ty> {
+        let mut elems = args.positional_params().cloned().collect::<Vec<_>>();
+        if let Some(rest) = args.rest_param()
+            && let Some(elem) = self.spread_iter_element_type(rest)
+        {
+            elems.push(elem);
+        }
+
+        (!elems.is_empty()).then(|| Ty::from_types(elems.into_iter()))
     }
 
     fn check_type(&mut self, ty: &Ty) -> Ty {

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@cite_heading.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@cite_heading.typ.snap
@@ -7,6 +7,28 @@ input_file: crates/tinymist-query/src/fixtures/completion/cite_heading.typ
 [
  {
   "isIncomplete": false,
-  "items": []
+  "items": [
+   {
+    "kind": 18,
+    "label": "test",
+    "labelDetails": {
+     "description": "H"
+    },
+    "sortText": "001",
+    "textEdit": {
+     "newText": "test>",
+     "range": {
+      "end": {
+       "character": 15,
+       "line": 9
+      },
+      "start": {
+       "character": 13,
+       "line": 9
+      }
+     }
+    }
+   }
+  ]
  }
 ]

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@func_params.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@func_params.typ.snap
@@ -16,7 +16,7 @@ input_file: crates/tinymist-query/src/fixtures/completion/func_params.typ
     "kind": 3,
     "label": "aa",
     "labelDetails": {
-     "description": "(any, any, any) => none"
+     "description": "(any, any, any) => any"
     },
     "sortText": "000",
     "textEdit": {

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_doc.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_doc.typ.snap
@@ -10,7 +10,7 @@ let my-fun(
   note: any,
   mode: str = "typ",
   setting: (any) => any = Closure(..),
-) = none;
+) = any;
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_module.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_module.typ.snap
@@ -10,7 +10,7 @@ let my-fun(
   note: any,
   mode: str = "typ",
   setting: (any) => any = Closure(..),
-) = none;
+) = any;
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_module_example.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@error_in_module_example.typ.snap
@@ -10,7 +10,7 @@ let my-fun(
   note: any,
   mode: str = "typ",
   setting: (any) => any = Closure(..),
-) = none;
+) = any;
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@example.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@example.typ.snap
@@ -10,7 +10,7 @@ let speaker-note(
   note: any,
   mode: str = "typ",
   setting: (any) => any = Closure(..),
-) = none;
+) = any;
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@jsx.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@jsx.typ.snap
@@ -8,7 +8,7 @@ Range: 4:20:4:27
 ```typc
 let Counter(
   initialCounter: int = 0,
-) = content | none;
+) = content;
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@kleene_known_nonempty.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@kleene_known_nonempty.typ.snap
@@ -8,7 +8,7 @@ Range: 40:24:40:38
 ```typc
 let known-nonempty(
   pat: any | dictionary,
-  known: any,
+  known: dictionary,
 ) = any;
 ```
 
@@ -31,5 +31,5 @@ type: any | dictionary
 ## known (positional)
 
 ```typc
-type: 
+type: dictionary
 ```

--- a/crates/tinymist-query/src/fixtures/hover/snaps/test@value_repr.typ.snap
+++ b/crates/tinymist-query/src/fixtures/hover/snaps/test@value_repr.typ.snap
@@ -13,7 +13,7 @@ let f(
   w01: int = 1,
   w02: str = "test",
   w03: any = 1 + 2,
-  w04: any = Label(test),
+  w04: label = Label(test),
   w05: (content | none, baseline: alignment | auto | dictionary | relative, clip: bool, fill: color, height: auto | relative, inset: inset, outset: outset, radius: radius, stroke: stroke, width: auto | fraction | relative) => box = (content | none, baseline: alignment | auto | dictionary | relative, clip: bool, fill: color, height: auto | relative, inset: inset, outset: outset, radius: radius, stroke: stroke, width: auto | fraction | relative) => box,
   w06: (content) => item | any = (body-indent: length, indent: length, marker: array | content | function, marker-align: alignment, spacing: auto | length, tight: bool, ..: content) => list.item,
   w07: text = Expr(..),
@@ -92,7 +92,7 @@ type: any
 ## w04 (named)
 
 ```typc
-type: 
+type: label
 ```
 
 

--- a/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-cover-with-rect.typ.snap
+++ b/crates/tinymist-query/src/fixtures/pkgs/snaps/test@touying-utils-cover-with-rect.typ.snap
@@ -16,7 +16,7 @@ input_file: crates/tinymist-query/src/fixtures/pkgs/touying-utils-cover-with-rec
     "kind": 5,
     "label": "fill",
     "labelDetails": {
-     "description": "auto | color | int | ratio | type"
+     "description": "auto | color | int | ratio | str"
     },
     "sortText": "000",
     "textEdit": {

--- a/crates/tinymist-query/src/fixtures/post_type_check/snaps/test@include_path_for_loop.typ.snap
+++ b/crates/tinymist-query/src/fixtures/post_type_check/snaps/test@include_path_for_loop.typ.snap
@@ -4,4 +4,4 @@ description: "Check on \"\\\"a.typ\\\"\" (35)"
 expression: post_ty
 input_file: crates/tinymist-query/src/fixtures/post_type_check/include_path_for_loop.typ
 ---
-( ⪰ "a.typ" ⪯ "a.typ" & ( ⪰ "a.typ" | "b.typ" ⪯ Path(Source { allow_package: true })))
+( ⪰ "a.typ" ⪯ "a.typ" & ( ⪰ ("a.typ" | "b.typ") ⪯ Path(Source { allow_package: true })))

--- a/crates/tinymist-query/src/fixtures/type_check/ctz_resolve_point.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/ctz_resolve_point.typ
@@ -1,0 +1,21 @@
+#let ctz-get-points(ctx) = {
+  ctx.shared-state.at("ctz-points", default: (:))
+}
+
+#let ctz-resolve-point(ctx, p) = {
+  if type(p) == str {
+    let points = ctz-get-points(ctx)
+    if p in points {
+      return points.at(p)
+    }
+    let (_, point) = coordinate.resolve(ctx, p)
+    return point
+  }
+  panic("Cannot resolve point")
+}
+
+#let ctz-resolve-vector(ctx, vector) = {
+  let v1 = ctz-resolve-point(ctx, vector.at(0))
+  let v2 = ctz-resolve-point(ctx, vector.at(1))
+  (v2.at(0) - v1.at(0), v2.at(1) - v1.at(1), 0)
+}

--- a/crates/tinymist-query/src/fixtures/type_check/external_assigned_parameter.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_assigned_parameter.typ
@@ -1,0 +1,11 @@
+/// path: base.typ
+#let overwrite(value) = {
+  value = 3
+  value
+}
+
+-----
+#import "base.typ": *
+
+#let text-result = overwrite("ignored")
+#let number-result = overwrite(42)

--- a/crates/tinymist-query/src/fixtures/type_check/external_dependent_point.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_dependent_point.typ
@@ -1,0 +1,12 @@
+/// path: base.typ
+#let coordinate-resolve(ctx, p) = (none, p)
+
+#let resolve-point(ctx, p) = {
+  let (_, point) = coordinate-resolve(ctx, p)
+  point
+}
+-----
+#import "base.typ": *
+
+#let point = resolve-point(none, (1, 2, 3))
+#let first = point.at(0)

--- a/crates/tinymist-query/src/fixtures/type_check/external_empty_function.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_empty_function.typ
@@ -1,0 +1,8 @@
+/// path: base.typ
+/// -> tag(config)
+#let config-xxx() = {}
+
+-----
+#import "base.typ": *
+
+#let result = config-xxx()

--- a/crates/tinymist-query/src/fixtures/type_check/external_fixed_value.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_fixed_value.typ
@@ -1,0 +1,7 @@
+/// path: base.typ
+#let fixed = (1, 2)
+-----
+#import "base.typ": fixed
+
+#let copied = fixed
+#let first = fixed.at(0)

--- a/crates/tinymist-query/src/fixtures/type_check/external_input_contract.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_input_contract.typ
@@ -1,0 +1,9 @@
+/// path: base.typ
+#let scale-values(values, factor) = values.map(value => value * factor)
+#let seeded = scale-values(range(2), 2)
+
+-----
+#import "base.typ": scale-values
+
+#let use-scale(values) = scale-values(values, 2)
+#let result = use-scale

--- a/crates/tinymist-query/src/fixtures/type_check/external_nested_dependent.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_nested_dependent.typ
@@ -1,0 +1,10 @@
+/// path: base.typ
+#let make-pair(left) = right => (left, right)
+
+-----
+#import "base.typ": make-pair
+
+#let pair-builder = make-pair(1)
+#let pair = pair-builder("right")
+#let first = pair.at(0)
+#let second = pair.at(1)

--- a/crates/tinymist-query/src/fixtures/type_check/external_rest_builder.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/external_rest_builder.typ
@@ -1,0 +1,13 @@
+/// path: base.typ
+#let collect-rest(..items) = {
+  let result = ()
+  for item in items.pos() {
+    result.push(item)
+  }
+  (none, ..result)
+}
+-----
+#import "base.typ": *
+
+#let (_, collected) = collect-rest("external")
+#let (_, number) = collect-rest(1)

--- a/crates/tinymist-query/src/fixtures/type_check/local_call_input_contract.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/local_call_input_contract.typ
@@ -1,0 +1,42 @@
+#let make-array(value) = range(value)
+#let consume-array(values) = values
+#let use-array(value) = consume-array(make-array(value))
+
+#let consume-overwrite(values) = values
+#let normalize(value: auto) = {
+  value = make-array(2)
+  consume-overwrite(value)
+}
+
+#let consume-before-overwrite(values) = {
+  if values == none { none }
+  values.at(0) = 2
+  values = none
+  values
+}
+
+#let overwrite-callee(value) = {
+  if value == none { none }
+  value = 1
+  value
+}
+
+#let overwrite-tuple-callee(value) = {
+  if value == none { none }
+  value = 2
+  value
+}
+
+#let seeded-tuple = overwrite-tuple-callee((1,))
+
+#let call-before-refine() = {
+  let value = "called"
+  let result = overwrite-callee(value)
+  overwrite-tuple-callee(value)
+  result
+}
+
+#let result = use-array(2)
+#let normalized = normalize()
+#let consumed = consume-before-overwrite((1, 2))
+#let refined = call-before-refine()

--- a/crates/tinymist-query/src/fixtures/type_check/loop_array_builder.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/loop_array_builder.typ
@@ -1,0 +1,50 @@
+#let collect-pair() = {
+  let result = ()
+  for item in (1,) {
+    result.push(item)
+  }
+  (none, ..result)
+}
+
+#let (_, collected) = collect-pair()
+
+#let (_, direct-collected) = (none, ..(1,))
+
+#let collect-rest(..items) = {
+  let result = ()
+  for item in items.pos() {
+    result.push(item)
+  }
+  (none, ..result)
+}
+
+#let (_, rest-collected) = collect-rest("x")
+
+#let positional-via-binding(..items) = {
+  let positional = items.pos
+  positional()
+}
+
+#let rebound-pos = positional-via-binding("a", 2)
+
+/// -> array
+#let collect-annotated-rest(..items) = {
+  let result = ()
+  for item in items.pos() {
+    result.push(item)
+  }
+  (none, ..result)
+}
+
+#let (_, annotated-collected) = collect-annotated-rest("y")
+
+#let collect-reassigned(..items) = {
+  let result = ()
+  for item in items.pos() {
+    item = (1, 2, 0)
+    result.push(item)
+  }
+  (none, ..result)
+}
+
+#let (_, reassigned-collected) = collect-reassigned("z")

--- a/crates/tinymist-query/src/fixtures/type_check/multi_return_panic.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/multi_return_panic.typ
@@ -1,0 +1,12 @@
+#let choose(flag) = {
+  if flag == "tuple" {
+    return (1, 2)
+  }
+  if flag == "string" {
+    return "ok"
+  }
+  panic("bad flag")
+}
+
+#let tuple = choose("tuple")
+#let string = choose("string")

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_fn.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_fn.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/annotation_fn.typ
 ---
-"touying-fn-wrapper" = ((Type(function), "max-repetitions": Type(int), "repetitions": Type(int), ...: Any) => None).with(..("max-repetitions": None, "repetitions": None) => any)
+"touying-fn-wrapper" = ((@fn, "max-repetitions": @max-repetitions, "repetitions": @repetitions, ...: @args) => None).with(..("max-repetitions": None, "repetitions": None) => any)
 "fn" = Any
 "max-repetitions" = None
 "repetitions" = None

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_fn2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_fn2.typ.snap
@@ -4,7 +4,7 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/annotation_fn2.typ
 ---
 "args" = Any
-"fn-wrapper" = ((Type(function) | (...: Any) => Any), ...: Any) => None
+"fn-wrapper" = (@fn, ...: @args) => None
 "fn" = Any
 "args" = Args
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_sum.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_sum.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/annotation_sum.typ
 ---
-"sum" = (...: Array<Type(int)>) => None
+"sum" = (...: @args) => None
 "args" = Args
 =====
 65..68 -> @sum

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_tag.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_tag.typ.snap
@@ -3,6 +3,6 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/annotation_tag.typ
 ---
-"config-common" = () => None
+"config-common" = () => Tag("configs") of @ws/p0
 =====
 113..126 -> @config-common

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_var.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@annotation_var.typ.snap
@@ -5,8 +5,8 @@ input_file: crates/tinymist-query/src/fixtures/type_check/annotation_var.typ
 ---
 "x" = Any
 "y" = Any
-"mapper" = (Type(function) | (Any, Any) => Any)
-"" = (Any, Any) => Any
+"mapper" = (Type(function) | (@x, @y) => @x)
+"" = (@x, @f) => Any
 "x" = Any
 "f" = Any
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@at_default.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@at_default.typ.snap
@@ -3,10 +3,10 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/at_default.typ
 ---
-"dynamic-default" = (Any, Any) => Any
+"dynamic-default" = (@d, @key) => Any
 "d" = Any
 "key" = Any
-"static-param" = (Any) => Any
+"static-param" = (@d) => Any
 "d" = Any
 "static-default" = Any
 "static-existing" = Any

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@binary_union.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@binary_union.typ.snap
@@ -3,20 +3,20 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/binary_union.typ
 ---
-"f" = (Any) => TypeBinary { operands: (IfTy { cond: Any, then: 1, else_: "s" }, IfTy { cond: Any, then: 1, else_: "s" }), op: Add }
+"f" = (@flag) => TypeBinary { operands: (IfTy { cond: @flag, then: 1, else_: "s" }, IfTy { cond: @flag, then: 1, else_: "s" }), op: Add }
 "flag" = Any
 "x" = IfTy { cond: Any, then: 1, else_: "s" }
-"sub-any" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Sub }
+"sub-any" = (@a, @b) => TypeBinary { operands: (@a, @b), op: Sub }
 "a" = Any
 "b" = Any
-"mul-any" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Mul }
+"mul-any" = (@a, @b) => TypeBinary { operands: (@a, @b), op: Mul }
 "a" = Any
 "b" = Any
-"cross" = (Any, Any, Any) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }), op: Mul }, TypeBinary { operands: (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }), op: Mul }), op: Sub }
+"cross" = (@o, @a, @b) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }), op: Mul }, TypeBinary { operands: (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }), op: Mul }), op: Sub }
 "o" = Any
 "a" = Any
 "b" = Any
-"call-sub" = (Any, Any) => TypeBinary { operands: (Any, Any), op: Sub }
+"call-sub" = (@a, @b) => TypeBinary { operands: (@a, @b), op: Sub }
 "a" = Any
 "b" = Any
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@bug_cite_func_infer.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@bug_cite_func_infer.typ.snap
@@ -3,9 +3,9 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/bug_cite_func_infer.typ
 ---
-"cite_prose" = (RefLabel) => Content(ref)
+"cite_prose" = (@labl) => Content(ref)
 "labl" = Any
-"cite_prose_different_name" = (RefLabel) => Content(ref)
+"cite_prose_different_name" = (@labl) => Content(ref)
 "labl" = Any
 =====
 5..15 -> @cite_prose

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@compound_assignment_loop.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@compound_assignment_loop.typ.snap
@@ -3,11 +3,11 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/compound_assignment_loop.typ
 ---
-"scan-backwards" = (Any) => Any
+"scan-backwards" = (@s) => TypeBinary { operands: (Any, 1), op: Sub }
 "s" = Any
 "len" = TypeBinary { operands: (Any, 1), op: Sub }
-"i" = Any
-"assign-from-unknown" = (Any) => 0
+"i" = TypeBinary { operands: (Any, 1), op: Sub }
+"assign-from-unknown" = (@unknown) => 0
 "unknown" = Any
 "i" = 0
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@confusing-name.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@confusing-name.typ.snap
@@ -3,11 +3,11 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/confusing-name.typ
 ---
-"x" = (Any) => Any
+"x" = (@date) => Any
 "date" = Any
 "x" = Any
 "x" = Any
-"master-cover" = ((Any, "x": Any) => TypeBinary { operands: (Any, TypeBinary { operands: ({"submit-date": 0}, Any), op: Add }), op: Assign }).with(..("x": Any) => any)
+"master-cover" = ((@info, "x": @x) => Any).with(..("x": Any) => any)
 "info" = Any
 "x" = Any
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@constants.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@constants.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/constants.typ
 ---
-"f" = (Any) => TypeBinary { operands: (1, 1), op: Add }
+"f" = (@x) => TypeBinary { operands: (1, 1), op: Add }
 "x" = Any
 =====
 5..6 -> @f

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_return.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_return.typ.snap
@@ -3,12 +3,12 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/content_return.typ
 ---
-"interpolated" = (Any, Any, Any) => None
+"interpolated" = (@day, @month, @year) => Any
 "day" = Any
 "month" = Any
 "year" = Any
 "month-name" = Any
-"final-unknown" = (Any) => Any
+"final-unknown" = (@x) => @x
 "x" = Any
 =====
 5..17 -> @interpolated

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_sequence.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@content_sequence.typ.snap
@@ -4,15 +4,15 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/content_sequence.typ
 ---
 "joined-context" = () => TypeUnary { lhs: Undef, op: Context }
-"mixed-context" = (Any) => TypeUnary { lhs: Any, op: Context }
+"mixed-context" = (@x) => TypeUnary { lhs: @x, op: Context }
 "x" = Any
-"return-or-content" = (Any) => TypeUnary { lhs: Undef, op: Context }
+"return-or-content" = (@cond) => TypeUnary { lhs: Content(text), op: Context }
 "cond" = Any
-"repeated-content-loops" = (Any) => None
+"repeated-content-loops" = (@items) => Any
 "items" = Any
 "item" = Any
 "item" = Any
-"conditional-content-loop" = (Any, Any) => IfTy { cond: Any, then: None, else_: Content(text) }
+"conditional-content-loop" = (@items, @cond) => IfTy { cond: @cond, then: Any, else_: Content(text) }
 "items" = Any
 "cond" = Any
 "item" = Any

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@ctz_resolve_point.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@ctz_resolve_point.typ.snap
@@ -1,0 +1,80 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/ctz_resolve_point.typ
+---
+"ctz-get-points" = (@ctx) => Any
+"ctx" = Any
+"ctz-resolve-point" = (@ctx, @p) => Any
+"ctx" = Any
+"p" = ( ⪰ Any | Type(str))
+"points" = Any
+"point" = Any
+"ctz-resolve-vector" = (@ctx, @vector) => (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }, 0, )
+"ctx" = Any
+"vector" = Any
+"v1" = Any
+"v2" = Any
+=====
+5..19 -> @ctz-get-points
+20..23 -> @ctx
+31..34 -> @ctx
+31..47 -> @v"ctx".shared-state
+31..50 -> @v"ctx".shared-state.at
+31..78 -> Any
+74..77 -> {}
+87..104 -> @ctz-resolve-point
+105..108 -> @ctx
+110..111 -> @p
+122..126 -> Type(type)
+122..129 -> (Type(type) | TypeUnary { lhs: @p, op: TypeOf })
+127..128 -> @p
+133..136 -> Type(string)
+147..153 -> @points
+156..170 -> @ctz-get-points
+156..175 -> Any
+171..174 -> @ctx
+183..184 -> @p
+188..194 -> @points
+210..216 -> @points
+210..219 -> @v"points".at
+210..222 -> Any
+220..221 -> @p
+241..246 -> @point
+250..268 -> Any.resolve
+250..276 -> Any
+269..272 -> @ctx
+274..275 -> @p
+288..293 -> @point
+300..305 -> Func(panic)
+300..329 -> Never
+338..356 -> @ctz-resolve-vector
+357..360 -> @ctx
+362..368 -> @vector
+380..382 -> @v1
+385..402 -> @ctz-resolve-point
+385..421 -> (Any | Any)
+403..406 -> @ctx
+408..414 -> @vector
+408..417 -> @v"vector".at
+408..420 -> Any
+428..430 -> @v2
+433..450 -> @ctz-resolve-point
+433..469 -> (Any | Any)
+451..454 -> @ctx
+456..462 -> @vector
+456..465 -> @v"vector".at
+456..468 -> Any
+472..517 -> (TypeBinary { operands: (Any, Any), op: Sub }, TypeBinary { operands: (Any, Any), op: Sub }, 0, )
+473..475 -> @v2
+473..478 -> @v"v2".at
+473..481 -> Any
+484..486 -> @v1
+484..489 -> @v"v1".at
+484..492 -> Any
+494..496 -> @v2
+494..499 -> @v"v2".at
+494..502 -> Any
+505..507 -> @v1
+505..510 -> @v"v1".at
+505..513 -> Any

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@cyclic_scope_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@cyclic_scope_deferred.typ.snap
@@ -5,10 +5,12 @@ input_file: crates/tinymist-query/src/fixtures/type_check/cyclic_scope_deferred.
 ---
 "a" = Any
 "b" = Any
-"f" = Any
-"g" = Any
-"use-f" = () => IfTy { cond: Any, then: 1, else_: IfTy { cond: Any, then: "done", else_: None } }
-"use-g" = () => IfTy { cond: Any, then: "done", else_: None }
+"f" = (@flag) => IfTy { cond: @flag, then: 1, else_: IfTy { cond: true, then: "done", else_: Any } }
+"flag" = Any
+"g" = (@flag) => IfTy { cond: @flag, then: "done", else_: Any }
+"flag" = Any
+"use-f" = () => IfTy { cond: false, then: 1, else_: IfTy { cond: true, then: "done", else_: Any } }
+"use-g" = () => IfTy { cond: false, then: "done", else_: Any }
 =====
 0..0 -> @f
 0..0 -> @g
@@ -18,7 +20,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/cyclic_scope_deferred.
 36..37 -> @g
 44..49 -> @use-f
 54..55 -> @f
-54..62 -> IfTy { cond: Any, then: 1, else_: IfTy { cond: Any, then: "done", else_: None } }
+54..62 -> IfTy { cond: false, then: 1, else_: IfTy { cond: true, then: "done", else_: Any } }
 68..73 -> @use-g
 78..79 -> @g
-78..86 -> IfTy { cond: Any, then: "done", else_: None }
+78..86 -> IfTy { cond: false, then: "done", else_: Any }

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_if_fold_after_bind.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_if_fold_after_bind.typ.snap
@@ -3,11 +3,11 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/deferred_if_fold_after_bind.typ
 ---
-"make-path" = (("mode": Any) => {"close": TypeBinary { operands: (Any, "OPEN"), op: Neq }}).with(..("mode": "OPEN") => any)
+"make-path" = (("mode": @mode) => {"close": TypeBinary { operands: (@mode, "OPEN"), op: Neq }}).with(..("mode": "OPEN") => any)
 "mode" = ( ⪰ Type(str) | "OPEN")
 "close" = TypeBinary { operands: (( ⪰ Type(str) | "OPEN"), "OPEN"), op: Neq }
-"default-path" = {"close": TypeBinary { operands: (( ⪰ Type(str) | "OPEN"), "OPEN"), op: Neq }}
-"pie-path" = {"close": TypeBinary { operands: (( ⪰ Type(str) | "OPEN"), "OPEN"), op: Neq }}
+"default-path" = {"close": TypeBinary { operands: ("OPEN", "OPEN"), op: Neq }}
+"pie-path" = {"close": TypeBinary { operands: ("PIE", "OPEN"), op: Neq }}
 =====
 5..14 -> @make-path
 15..19 -> @mode
@@ -17,7 +17,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/deferred_if_fold_after
 72..77 -> @close
 87..99 -> @default-path
 102..111 -> @make-path
-102..113 -> {"close": @close}
+102..113 -> {"close": TypeBinary { operands: ("OPEN", "OPEN"), op: Neq }}
 119..127 -> @pie-path
 130..139 -> @make-path
-130..152 -> {"close": @close}
+130..152 -> {"close": TypeBinary { operands: ("PIE", "OPEN"), op: Neq }}

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_selected_apply.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@deferred_selected_apply.typ.snap
@@ -3,18 +3,18 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/deferred_selected_apply.typ
 ---
-"via-method" = (Any, Any) => Any
+"via-method" = (@ctx, @layer) => Any
 "ctx" = Any
 "layer" = Any
 "mapping" = Any
 "known-layer" = {"mapping": {"x": "x"}}
-"known-ctx" = {"resolve-mapping": (Any) => IfTy { cond: TypeBinary { operands: (Any, None), op: Eq }, then: None, else_: Any.mapping }}
-"" = (Any) => IfTy { cond: TypeBinary { operands: (Any, None), op: Eq }, then: None, else_: Any.mapping }
-"layer" = None
+"known-ctx" = {"resolve-mapping": (@layer) => IfTy { cond: TypeBinary { operands: (@layer, None), op: Eq }, then: None, else_: @v"layer".mapping }}
+"" = (@layer) => IfTy { cond: TypeBinary { operands: (@layer, None), op: Eq }, then: None, else_: @v"layer".mapping }
+"layer" = ( ⪰ None | {"mapping": {"x": "x"}})
 "known-result" = IfTy { cond: TypeBinary { operands: ({"mapping": {"x": "x"}}, None), op: Eq }, then: None, else_: {"mapping": {"x": "x"}}.mapping }
 "direct-known" = () => IfTy { cond: TypeBinary { operands: ({"mapping": {"y": "y"}}, None), op: Eq }, then: None, else_: {"mapping": {"y": "y"}}.mapping }
-"obj" = {"f": (Any) => IfTy { cond: TypeBinary { operands: (Any, None), op: Eq }, then: None, else_: Any.mapping }}
-"" = (Any) => IfTy { cond: TypeBinary { operands: (Any, None), op: Eq }, then: None, else_: Any.mapping }
+"obj" = {"f": (@x) => IfTy { cond: TypeBinary { operands: (@x, None), op: Eq }, then: None, else_: @v"x".mapping }}
+"" = (@x) => IfTy { cond: TypeBinary { operands: (@x, None), op: Eq }, then: None, else_: @v"x".mapping }
 "x" = ( ⪰ None | {"mapping": {"y": "y"}})
 =====
 5..15 -> @via-method

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@doc_param_annotation_survives_infer.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@doc_param_annotation_survives_infer.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/doc_param_annotation_survives_infer.typ
 ---
-"hook" = (Any) => {"name": Any, "type": "hook"}
+"hook" = (@name) => {"name": @name, "type": "hook"}
 "name" = Type(str)
 "hook-value" = {"name": "h", "type": "hook"}
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external.typ.snap
@@ -4,8 +4,9 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/external.typ
 ---
 "base" = Any
-"bad-instantiate" = Any
-"prefix" = (("title": Any) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (Any, None), op: Add }, None), op: Add }, None), op: Add }).with(..("title": None) => any)
+"bad-instantiate" = (@x) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (@x, None), op: Add }, None), op: Add }, None), op: Add }
+"x" = Any
+"prefix" = (("title": @title) => TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (@title, None), op: Add }, None), op: Add }, None), op: Add }).with(..("title": None) => any)
 "title" = None
 =====
 0..0 -> @bad-instantiate
@@ -13,5 +14,5 @@ input_file: crates/tinymist-query/src/fixtures/type_check/external.typ
 27..33 -> @prefix
 34..39 -> @title
 53..68 -> @bad-instantiate
-53..75 -> TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (Any, None), op: Add }, None), op: Add }, None), op: Add }
+53..75 -> TypeBinary { operands: (TypeBinary { operands: (TypeBinary { operands: (@title, None), op: Add }, None), op: Add }, None), op: Add }
 69..74 -> @title

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_assigned_parameter.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_assigned_parameter.typ.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_assigned_parameter.typ
+---
+"value" = Any
+"base" = Any
+"overwrite" = (@value) => 3
+"text-result" = 3
+"number-result" = 3
+=====
+0..0 -> @overwrite
+1..21 -> @base
+28..39 -> @text-result
+42..51 -> @overwrite
+42..62 -> 3
+68..81 -> @number-result
+84..93 -> @overwrite
+84..97 -> 3

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_dependent_point.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_dependent_point.typ.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_dependent_point.typ
+---
+"base" = Any
+"coordinate-resolve" = (@ctx, @p) => (None, @p, )
+"ctx" = Any
+"p" = Any
+"resolve-point" = (@ctx, @p) => @p
+"ctx" = Any
+"p" = Any
+"point" = (1, 2, 3, )
+"first" = 1
+=====
+0..0 -> @resolve-point
+0..0 -> @coordinate-resolve
+1..21 -> @base
+28..33 -> @point
+36..49 -> @resolve-point
+36..66 -> (1, 2, 3, )
+56..65 -> (1, 2, 3, )
+72..77 -> @first
+80..85 -> @point
+80..88 -> (Func(at) | (Func(at) | @v"point".at))
+80..91 -> (Any | 1)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_empty_function.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_empty_function.typ.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_empty_function.typ
+---
+"base" = Any
+"config-xxx" = () => None
+"result" = None
+=====
+0..0 -> @config-xxx
+1..21 -> @base
+28..34 -> @result
+37..47 -> @config-xxx
+37..49 -> None

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_fixed_value.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_fixed_value.typ.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_fixed_value.typ
+---
+"base" = Any
+"fixed" = (1, 2, )
+"copied" = (1, 2, )
+"first" = 1
+=====
+0..0 -> @fixed
+1..25 -> @base
+20..25 -> @fixed
+32..38 -> @copied
+41..46 -> @fixed
+52..57 -> @first
+60..65 -> @fixed
+60..68 -> (Func(at) | (Func(at) | @v"fixed".at))
+60..71 -> (Any | 1)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_input_contract.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_input_contract.typ.snap
@@ -1,0 +1,23 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_input_contract.typ
+---
+"base" = Any
+"scale-values" = (@values, @factor) => Any
+"values" = Type(array)
+"factor" = Type(int)
+"use-scale" = (@values) => Any
+"values" = Any
+"result" = (@values) => Any
+=====
+0..0 -> @scale-values
+1..32 -> @base
+20..32 -> @scale-values
+39..48 -> @use-scale
+49..55 -> @values
+59..71 -> @scale-values
+59..82 -> Any
+72..78 -> @values
+88..94 -> @result
+97..106 -> @use-scale

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_nested_dependent.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_nested_dependent.typ.snap
@@ -1,0 +1,31 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_nested_dependent.typ
+---
+"base" = Any
+"make-pair" = (@left) => (@right) => (@left, @right, )
+"left" = Any
+"right" = Any
+"pair-builder" = (@right) => (1, @right, )
+"pair" = (1, "right", )
+"first" = 1
+"second" = "right"
+=====
+0..0 -> @make-pair
+1..29 -> @base
+20..29 -> @make-pair
+36..48 -> @pair-builder
+51..60 -> @make-pair
+51..63 -> (@right) => (1, @right, )
+69..73 -> @pair
+76..88 -> @pair-builder
+76..97 -> (1, "right", )
+103..108 -> @first
+111..115 -> @pair
+111..118 -> (Func(at) | (Func(at) | @v"pair".at))
+111..121 -> (Any | 1)
+127..133 -> @second
+136..140 -> @pair
+136..143 -> (Func(at) | (Func(at) | @v"pair".at))
+136..146 -> (Any | "right")

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_rest_builder.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@external_rest_builder.typ.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/external_rest_builder.typ
+---
+"base" = Any
+"collect-rest" = (...: @items) => (None, TypeUnary { lhs: Array<TypeUnary { lhs: @items, op: ElementOf }>, op: Spread }, )
+"items" = Args
+"collected" = "external"
+"number" = 1
+=====
+0..0 -> @collect-rest
+1..21 -> @base
+32..41 -> @collected
+45..57 -> @collect-rest
+45..69 -> (None, TypeUnary { lhs: Array<"external">, op: Spread }, )
+79..85 -> @number
+89..101 -> @collect-rest
+89..104 -> (None, TypeUnary { lhs: Array<1>, op: Spread }, )

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/fn_named.typ
 ---
-"foo" = (("d": Any) => Any).with(..("d": 3) => any)
+"foo" = (("d": @d) => @d).with(..("d": 3) => any)
 "d" = ( ⪰ Type(int) | 3)
 "x" = 3
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named2.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named2.typ.snap
@@ -4,9 +4,9 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/fn_named2.typ
 ---
 "val" = 1
-"foo" = (("a": Any) => Any).with(..("a": 1) => any)
-"a" = Any
-"x" = Any
+"foo" = (("a": @a) => @a).with(..("a": 1) => any)
+"a" = 1
+"x" = 1
 =====
 5..8 -> @val
 18..21 -> @foo

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named3.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named3.typ.snap
@@ -3,17 +3,17 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/fn_named3.typ
 ---
-"fun" = () => TypeUnary { lhs: 2, op: Return }
-"foo" = (("b": Any) => Any).with(..("b": TypeUnary { lhs: 2, op: Return }) => any)
-"b" = TypeUnary { lhs: 2, op: Return }
-"x" = TypeUnary { lhs: 2, op: Return }
+"fun" = () => 2
+"foo" = (("b": @b) => @b).with(..("b": 2) => any)
+"b" = ( ⪰ Type(int) | 2)
+"x" = 2
 =====
 5..8 -> @fun
 33..36 -> @foo
 37..38 -> @b
 40..43 -> @fun
-40..45 -> TypeUnary { lhs: 2, op: Return }
+40..45 -> 2
 49..50 -> @b
 56..57 -> @x
 60..63 -> @foo
-60..65 -> TypeUnary { lhs: 2, op: Return }
+60..65 -> 2

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named4.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@fn_named4.typ.snap
@@ -4,7 +4,7 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/fn_named4.typ
 ---
 "dict" = {"x": 3}
-"foo" = (("c": Any) => Any).with(..("c": (3 | {"x": 3}.x)) => any)
+"foo" = (("c": @c) => @c).with(..("c": (3 | {"x": 3}.x)) => any)
 "c" = (3 | {"x": 3}.x)
 "x" = (3 | {"x": 3}.x)
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@local_call_input_contract.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@local_call_input_contract.typ.snap
@@ -1,0 +1,105 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/local_call_input_contract.typ
+---
+"value" = Auto
+"values" = ( ⪰ None | (1, 2, ))
+"value" = ( ⪰ None | Type(str))
+"value" = ( ⪰ None | Type(str) | (1, ))
+"make-array" = (@value) => Type(array)
+"value" = Type(int)
+"consume-array" = (@values) => @values
+"values" = Type(array)
+"use-array" = (@value) => Type(array)
+"value" = Type(int)
+"consume-overwrite" = (@values) => @values
+"values" = Type(array)
+"normalize" = (("value": @value) => Type(array)).with(..("value": Auto) => any)
+"value" = Type(array)
+"consume-before-overwrite" = (@values) => None
+"values" = None
+"overwrite-callee" = (@value) => 1
+"value" = 1
+"overwrite-tuple-callee" = (@value) => 2
+"value" = 2
+"seeded-tuple" = 2
+"call-before-refine" = () => 1
+"value" = "called"
+"result" = 1
+"result" = Type(array)
+"normalized" = Type(array)
+"consumed" = None
+"refined" = 1
+=====
+5..15 -> @make-array
+16..21 -> @value
+25..30 -> Func(range)
+25..37 -> Type(array)
+31..36 -> @value
+43..56 -> @consume-array
+57..63 -> @values
+67..73 -> @values
+79..88 -> @use-array
+89..94 -> @value
+98..111 -> @consume-array
+98..130 -> Type(array)
+112..122 -> @make-array
+112..129 -> Type(array)
+123..128 -> @value
+137..154 -> @consume-overwrite
+155..161 -> @values
+165..171 -> @values
+177..186 -> @normalize
+187..192 -> @value
+206..211 -> @value
+214..224 -> @make-array
+214..227 -> Type(array)
+230..247 -> @consume-overwrite
+230..254 -> @value
+248..253 -> @value
+263..287 -> @consume-before-overwrite
+288..294 -> @values
+305..311 -> @values
+331..337 -> @values
+331..340 -> @v"values".at
+331..343 -> Any
+350..356 -> @values
+366..372 -> @values
+381..397 -> @overwrite-callee
+398..403 -> @value
+414..419 -> @value
+439..444 -> @value
+451..456 -> @value
+465..487 -> @overwrite-tuple-callee
+488..493 -> @value
+504..509 -> @value
+529..534 -> @value
+541..546 -> @value
+555..567 -> @seeded-tuple
+570..592 -> @overwrite-tuple-callee
+570..598 -> 2
+593..597 -> (1, )
+605..623 -> @call-before-refine
+636..641 -> @value
+659..665 -> @result
+668..684 -> @overwrite-callee
+668..691 -> 1
+685..690 -> @value
+694..716 -> @overwrite-tuple-callee
+694..723 -> 2
+717..722 -> @value
+726..732 -> @result
+741..747 -> @result
+750..759 -> @use-array
+750..762 -> Type(array)
+768..778 -> @normalized
+781..790 -> @normalize
+781..792 -> Type(array)
+798..806 -> @consumed
+809..833 -> @consume-before-overwrite
+809..841 -> None
+834..840 -> (1, 2, )
+847..854 -> @refined
+857..875 -> @call-before-refine
+857..877 -> 1

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_array_builder.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_array_builder.typ.snap
@@ -1,0 +1,110 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/loop_array_builder.typ
+---
+"collect-pair" = () => (None, TypeUnary { lhs: Array<1>, op: Spread }, )
+"result" = Array<1>
+"item" = 1
+"collected" = 1
+"direct-collected" = 1
+"collect-rest" = (...: @items) => (None, TypeUnary { lhs: Array<TypeUnary { lhs: @items, op: ElementOf }>, op: Spread }, )
+"items" = ( ⪰ Args | &(("x") => any))
+"result" = Array<"x">
+"item" = "x"
+"rest-collected" = "x"
+"positional-via-binding" = (...: @items) => (TypeUnary { lhs: @items, op: Spread }, )
+"items" = ( ⪰ Args | &(("a", 2) => any))
+"positional" = ( ⪰ Args | &(("a", 2) => any)).pos
+"rebound-pos" = ("a", 2, )
+"collect-annotated-rest" = (...: @items) => (None, TypeUnary { lhs: Array<TypeUnary { lhs: @items, op: ElementOf }>, op: Spread }, )
+"items" = ( ⪰ Args | &(("y") => any))
+"result" = Array<"y">
+"item" = "y"
+"annotated-collected" = "y"
+"collect-reassigned" = (...: @items) => (None, TypeUnary { lhs: Array<(1, 2, 0, )>, op: Spread }, )
+"items" = ( ⪰ Args | &(("z") => any))
+"result" = Array<(1, 2, 0, )>
+"item" = (1, 2, 0, )
+"reassigned-collected" = (1, 2, 0, )
+=====
+5..17 -> @collect-pair
+30..36 -> @result
+39..41 -> ()
+48..52 -> @item
+56..60 -> (1, )
+67..73 -> @result
+67..78 -> (Func(push) | (Func(push) | @v"result".push))
+67..84 -> Type(none)
+79..83 -> @item
+91..107 -> (None, TypeUnary { lhs: @result, op: Spread }, )
+100..106 -> @result
+120..129 -> @collected
+133..145 -> @collect-pair
+133..147 -> (None, TypeUnary { lhs: Array<1>, op: Spread }, )
+158..174 -> @direct-collected
+178..192 -> (None, 1, )
+187..191 -> (1, )
+199..211 -> @collect-rest
+214..219 -> @items
+231..237 -> @result
+240..242 -> ()
+249..253 -> @item
+257..262 -> @items
+257..266 -> @v"items".pos
+257..268 -> (TypeUnary { lhs: @items, op: Spread }, )
+275..281 -> @result
+275..286 -> (Func(push) | (Func(push) | @v"result".push))
+275..292 -> Type(none)
+287..291 -> @item
+299..315 -> (None, TypeUnary { lhs: @result, op: Spread }, )
+308..314 -> @result
+328..342 -> @rest-collected
+346..358 -> @collect-rest
+346..363 -> (None, TypeUnary { lhs: Array<"x">, op: Spread }, )
+370..392 -> @positional-via-binding
+395..400 -> @items
+412..422 -> @positional
+425..430 -> @items
+425..434 -> @v"items".pos
+437..447 -> @positional
+437..449 -> (TypeUnary { lhs: @items, op: Spread }, )
+458..469 -> @rebound-pos
+472..494 -> @positional-via-binding
+472..502 -> ("a", 2, )
+522..544 -> @collect-annotated-rest
+547..552 -> @items
+564..570 -> @result
+573..575 -> ()
+582..586 -> @item
+590..595 -> @items
+590..599 -> @v"items".pos
+590..601 -> (TypeUnary { lhs: @items, op: Spread }, )
+608..614 -> @result
+608..619 -> (Func(push) | (Func(push) | @v"result".push))
+608..625 -> Type(none)
+620..624 -> @item
+632..648 -> (None, TypeUnary { lhs: @result, op: Spread }, )
+641..647 -> @result
+661..680 -> @annotated-collected
+684..706 -> @collect-annotated-rest
+684..711 -> (None, TypeUnary { lhs: Array<"y">, op: Spread }, )
+718..736 -> @collect-reassigned
+739..744 -> @items
+756..762 -> @result
+765..767 -> ()
+774..778 -> @item
+782..787 -> @items
+782..791 -> @v"items".pos
+782..793 -> (TypeUnary { lhs: @items, op: Spread }, )
+800..804 -> @item
+807..816 -> (1, 2, 0, )
+821..827 -> @result
+821..832 -> (Func(push) | (Func(push) | @v"result".push))
+821..838 -> Type(none)
+833..837 -> @item
+845..861 -> (None, TypeUnary { lhs: @result, op: Spread }, )
+854..860 -> @result
+874..894 -> @reassigned-collected
+898..916 -> @collect-reassigned
+898..921 -> (None, TypeUnary { lhs: Array<(1, 2, 0, )>, op: Spread }, )

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_mutation_then_record.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_mutation_then_record.typ.snap
@@ -3,14 +3,14 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/loop_mutation_then_record.typ
 ---
-"bucket-by" = (Any, Any) => {"buckets": {}, "order": ()}
+"bucket-by" = (@data, @key-col) => {"buckets": {}, "order": Array<(Type(str) | "")>}
 "data" = Any
 "key-col" = Any
 "buckets" = {}
-"order" = ()
+"order" = Array<(Type(str) | "")>
 "row" = Any
 "key" = ( ⪰ Type(str) | "")
-"bucket" = Any
+"bucket" = ( ⪰ Any | Array<Any>)
 =====
 5..14 -> @bucket-by
 15..19 -> @data

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_result.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_result.typ.snap
@@ -3,23 +3,23 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/loop_result.typ
 ---
-"loop-none" = () => None
+"loop-none" = () => Any
 "i" = Any
 "x" = Any
-"loop-tuple" = (("size": Any) => None).with(..("size": 50) => any)
+"loop-tuple" = (("size": @size) => Any).with(..("size": 50) => any)
 "size" = 50
 "i" = Any
-"loop-command" = () => None
+"loop-command" = () => Any
 "i" = Any
-"" = (Any) => Any
+"" = (@ctx) => @ctx
 "ctx" = Any
-"loop-continue-command" = () => None
+"loop-continue-command" = () => Any
 "i" = 0
-"" = (Any) => Any
+"" = (@ctx) => @ctx
 "ctx" = Any
-"loop-conditional-break" = () => None
+"loop-conditional-break" = () => Any
 "i" = 1
-"" = (Any) => Any
+"" = (@ctx) => @ctx
 "ctx" = Any
 "loop-break" = () => 3
 "i" = Any

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_unknown_then_final.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@loop_unknown_then_final.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/loop_unknown_then_final.typ
 ---
-"loop-unknown-then-dict" = (...: Any) => {}
+"loop-unknown-then-dict" = (...: @args) => {}
 "args" = Args
 "out" = {}
 "k" = Any
@@ -16,8 +16,8 @@ input_file: crates/tinymist-query/src/fixtures/type_check/loop_unknown_then_fina
 63..64 -> @k
 66..67 -> @v
 72..76 -> @args
-72..82 -> @v"args".named
-72..84 -> Any
+72..82 -> (Func(named) | (Func(named) | @v"args".named))
+72..84 -> Type(dictionary)
 94..95 -> @v
 131..134 -> @out
 131..141 -> @v"out".insert

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@method_split.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@method_split.typ.snap
@@ -3,8 +3,8 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/method_split.typ
 ---
-"resolve-key" = (Any) => Any
-"" = (Any) => Any
+"resolve-key" = (@key) => Any
+"" = (@key) => Any
 "key" = Any
 "split-literal" = Type(array)
 =====

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@multi_return_panic.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@multi_return_panic.typ.snap
@@ -1,0 +1,23 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/multi_return_panic.typ
+---
+"choose" = (@flag) => ("ok" | (1, 2, ))
+"flag" = ( ⪰ Type(str) | "string" | "tuple")
+"tuple" = ("ok" | (1, 2, ))
+"string" = ("ok" | (1, 2, ))
+=====
+5..11 -> @choose
+12..16 -> @flag
+27..31 -> @flag
+56..62 -> (1, 2, )
+72..76 -> @flag
+113..118 -> Func(panic)
+113..130 -> Never
+139..144 -> @tuple
+147..153 -> @choose
+147..162 -> ("ok" | (1, 2, ))
+168..174 -> @string
+177..183 -> @choose
+177..193 -> ("ok" | (1, 2, ))

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@mutation_methods.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@mutation_methods.typ.snap
@@ -4,24 +4,24 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/mutation_methods.typ
 ---
 "array-push" = () => Type(none)
-"a" = ()
-"dict-insert" = () => None
+"a" = Array<1>
+"dict-insert" = () => Any
 "d" = {}
-"push-loop" = () => ()
-"a" = ()
+"push-loop" = () => Array<Any>
+"a" = Array<Any>
 "i" = Any
 "push-dict-loop" = () => Type(array)
-"guides" = ()
+"guides" = Array<{"kind": "x"}>
 "grp" = {"members": (1, )}
 "g" = {"kind": "x"}
-"" = (Any) => Any.kind
+"" = (@g) => @v"g".kind
 "g" = Any
 "push-dict-loop-if" = () => Type(array)
-"guides" = ()
+"guides" = Array<IfTy { cond: true, then: Undef, else_: {"kind": "other"} }>
 "first" = true
 "g" = IfTy { cond: true, then: Undef, else_: {"kind": "other"} }
-"levels" = ( ⪰ Type(array) | ())
-"" = (Any) => Any.kind
+"levels" = Type(array)
+"" = (@g) => @v"g".kind
 "g" = Any
 =====
 5..15 -> @array-push

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_contains.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_contains.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/op_contains.typ
 ---
-"f" = (("line" | "number")) => Type(none)
+"f" = (@x) => Type(none)
 "x" = Any
 =====
 5..6 -> @f

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_contains_str.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_contains_str.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/op_contains_str.typ
 ---
-"f" = (TypeUnary { lhs: "abc", op: ElementOf }) => Type(none)
+"f" = (@x) => Type(none)
 "x" = Any
 =====
 5..6 -> @f

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_type_of.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@op_type_of.typ.snap
@@ -3,8 +3,8 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/op_type_of.typ
 ---
-"f" = (Any) => Type(none)
-"x" = Type(integer)
+"f" = (@x) => Type(none)
+"x" = Type(int)
 =====
 5..6 -> @f
 7..8 -> @x

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@param_pollution_from_helper.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@param_pollution_from_helper.typ.snap
@@ -3,9 +3,9 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/param_pollution_from_helper.typ
 ---
-"check-free-var" = (Any) => IfTy { cond: TypeBinary { operands: (Any, "i"), op: Eq }, then: Any, else_: None }
-"v" = "i"
-"public" = (Any, Any) => Any
+"check-free-var" = (@v) => None
+"v" = ( ⪰ Type(str) | "i")
+"public" = (@expr, @var) => @expr
 "expr" = Type(int)
 "var" = Type(str)
 "use-public" = 1
@@ -14,12 +14,12 @@ input_file: crates/tinymist-query/src/fixtures/type_check/param_pollution_from_h
 20..21 -> @v
 32..33 -> @v
 47..52 -> Func(panic)
-47..73 -> ()
+47..73 -> Never
 86..92 -> @public
 93..97 -> @expr
 99..102 -> @var
 110..124 -> @check-free-var
-110..129 -> IfTy { cond: TypeBinary { operands: (@var, "i"), op: Eq }, then: (), else_: None }
+110..129 -> None
 125..128 -> @var
 132..136 -> @expr
 145..155 -> @use-public

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive.typ.snap
@@ -4,7 +4,8 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/recursive.typ
 ---
 "base" = Any
-"a" = Any
+"a" = (@x) => Any
+"x" = Any
 "f" = () => Any
 =====
 0..0 -> @a

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_dispatch_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_dispatch_deferred.typ.snap
@@ -3,15 +3,15 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/recursive_dispatch_deferred.typ
 ---
-"done" = (Any) => {"kind": "done", "value": Any}
-"value" = Any
-"forward" = (Any, Any) => IfTy { cond: TypeBinary { operands: (Any, 0), op: Eq }, then: {"kind": "done", "value": Any}, else_: None }
-"handler" = Any
-"value" = ( ⪰ 0 | TypeBinary { operands: (( ⪰ Type(int) | 0 | 1), 1), op: Sub })
-"dispatch" = (Any) => IfTy { cond: TypeBinary { operands: (Any, 0), op: Eq }, then: {"kind": "done", "value": Any}, else_: IfTy { cond: TypeBinary { operands: (Any, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (Any, 0), op: Eq }, then: {"kind": "done", "value": Any}, else_: None }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (Any, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (Any, 1), op: Sub }}, else_: None } } }
+"done" = (@value) => {"kind": "done", "value": @value}
+"value" = ( ⪰ ( ⪰ Type(int) | 0 | 1) | ( ⪰ 0 | ( ⪰ Type(int) | 0 | 1) | TypeBinary { operands: (( ⪰ Type(int) | 0 | 1), 1), op: Sub }))
+"forward" = (@handler, @value) => IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: Any }
+"handler" = (@value) => IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: IfTy { cond: TypeBinary { operands: (@value, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (@value, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (@value, 1), op: Sub }}, else_: Any } } }
+"value" = ( ⪰ 0 | ( ⪰ Type(int) | 0 | 1) | TypeBinary { operands: (( ⪰ Type(int) | 0 | 1), 1), op: Sub })
+"dispatch" = (@value) => IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: IfTy { cond: TypeBinary { operands: (@value, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (@value, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (@value, 1), op: Sub }}, else_: Any } } }
 "value" = ( ⪰ Type(int) | 0 | 1)
-"use-zero" = IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: IfTy { cond: TypeBinary { operands: (0, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: None }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (0, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (0, 1), op: Sub }}, else_: None } } }
-"use-one" = IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: IfTy { cond: TypeBinary { operands: (1, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: None }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (1, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (1, 1), op: Sub }}, else_: None } } }
+"use-zero" = IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: IfTy { cond: TypeBinary { operands: (0, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (0, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (0, 1), op: Sub }}, else_: Any } } }
+"use-one" = IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: IfTy { cond: TypeBinary { operands: (1, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (1, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (1, 1), op: Sub }}, else_: Any } } }
 =====
 5..9 -> @done
 10..15 -> @value
@@ -35,16 +35,16 @@ input_file: crates/tinymist-query/src/fixtures/type_check/recursive_dispatch_def
 209..214 -> @value
 228..233 -> @value
 245..252 -> @forward
-245..269 -> IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: None }
+245..269 -> IfTy { cond: TypeBinary { operands: (@value, 0), op: Eq }, then: {"kind": "done", "value": @value}, else_: Any }
 253..261 -> @dispatch
 263..268 -> @value
 285..292 -> @forward
-285..313 -> IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (@value, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (@value, 1), op: Sub }}, else_: None }
+285..313 -> IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (@value, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (@value, 1), op: Sub }}, else_: Any }
 293..301 -> @dispatch
 303..308 -> @value
 326..334 -> @use-zero
 337..345 -> @dispatch
-337..348 -> IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: IfTy { cond: TypeBinary { operands: (0, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: None }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (0, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (0, 1), op: Sub }}, else_: None } } }
+337..348 -> IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: IfTy { cond: TypeBinary { operands: (0, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (0, 0), op: Eq }, then: {"kind": "done", "value": 0}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (0, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (0, 1), op: Sub }}, else_: Any } } }
 354..361 -> @use-one
 364..372 -> @dispatch
-364..375 -> IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: IfTy { cond: TypeBinary { operands: (1, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: None }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (1, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (1, 1), op: Sub }}, else_: None } } }
+364..375 -> IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: IfTy { cond: TypeBinary { operands: (1, 1), op: Eq }, then: IfTy { cond: TypeBinary { operands: (1, 0), op: Eq }, then: {"kind": "done", "value": 1}, else_: Any }, else_: IfTy { cond: TypeBinary { operands: (TypeBinary { operands: (1, 1), op: Sub }, 0), op: Eq }, then: {"kind": "done", "value": TypeBinary { operands: (1, 1), op: Sub }}, else_: Any } } }

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_slow.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_slow.typ.snap
@@ -3,19 +3,19 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/recursive_slow.typ
 ---
-"l" = (Any) => (Any) => Any
-"" = (Any) => (Any) => Any
+"l" = (@a) => (@b) => Any
+"" = (@a) => (@b) => Any
 "a" = Any
-"" = (Any) => Any
+"" = (@b) => Any
 "b" = Any
-"r" = (Any) => (Any) => (Any) => Any
-"" = (Any) => (Any) => (Any) => Any
+"r" = (@a) => (@b) => (@c) => Any
+"" = (@a) => (@b) => (@c) => Any
 "a" = Any
-"" = (Any) => (Any) => Any
+"" = (@b) => (@c) => Any
 "b" = Any
-"" = (Any) => Any
+"" = (@c) => Any
 "c" = Any
-"merged" = IfTy { cond: true, then: (Any) => (Any) => Any, else_: (Any) => (Any) => (Any) => Any }
+"merged" = IfTy { cond: true, then: (@a) => (@b) => Any, else_: (@a) => (@b) => (@c) => Any }
 "use" = Any
 =====
 5..6 -> @l

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_use.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@recursive_use.typ.snap
@@ -4,7 +4,8 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/recursive_use.typ
 ---
 "base" = Any
-"a" = Any
+"a" = (@x) => Any
+"x" = Any
 "f" = () => Any
 =====
 0..0 -> @a

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred.typ.snap
@@ -3,14 +3,14 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred.typ
 ---
-"f" = () => Undef
-"g" = () => TypeUnary { lhs: 1, op: Return }
-"h" = () => Undef
-"g" = () => TypeUnary { lhs: 1, op: Return }
+"f" = () => 1
+"g" = () => 1
+"h" = () => 0
+"g" = () => 1
 =====
 5..6 -> @f
 19..20 -> @g
 53..54 -> @g
-53..56 -> TypeUnary { lhs: 1, op: Return }
+53..56 -> 1
 65..66 -> @h
 79..80 -> @g

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred_apply.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@scope_deferred_apply.typ.snap
@@ -3,38 +3,38 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.typ
 ---
-"f" = () => Undef
-"id" = (Any) => Any
+"f" = () => 1
+"id" = (@x) => @x
 "x" = Type(int)
-"h" = () => Undef
-"choose" = (Any, Any) => IfTy { cond: true, then: Any, else_: Any }
+"h" = () => IfTy { cond: true, then: 1, else_: "x" }
+"choose" = (@x, @y) => IfTy { cond: true, then: @x, else_: @y }
 "x" = Type(int)
 "y" = Type(str)
-"k" = () => Undef
-"fill" = (Any) => Any
-"d" = Any
+"k" = () => {}
+"fill" = (@d) => @d
+"d" = {}
 "entry" = {}
-"m" = () => Undef
-"complete" = (Any, Any) => Any
+"m" = () => {}
+"complete" = (@key, @definitions) => @definitions
 "key" = Type(str)
-"definitions" = Any
+"definitions" = {}
 "entry" = {}
-"n" = () => Undef
-"complete" = (Any, Any) => Any
+"n" = () => {}
+"complete" = (@key, @definitions) => @definitions
 "key" = Type(str)
-"definitions" = Any
+"definitions" = {}
 "entry" = {}
-"top-complete" = (Any, Any) => Any
+"top-complete" = (@key, @definitions) => @definitions
 "key" = Type(str)
-"definitions" = Any
-"p" = (Any) => TypeUnary { lhs: {}, op: Return }
-"definitions" = Any
-"entry" = {}
-"q" = (Any) => {}
+"definitions" = {}
+"p" = (@definitions) => {}
 "definitions" = Any
 "entry" = {}
-"r" = (( ⪯ Any & Type(array))) => {}
-"definitions" = ( ⪰ Type(array) | Type(dictionary) | Type(string))
+"q" = (@definitions) => {}
+"definitions" = Any
+"entry" = {}
+"r" = (@definitions) => {}
+"definitions" = ( ⪰ Type(array) | Type(dictionary) | Type(str))
 "entry" = {}
 "n_defs" = ( ⪰ 0 | (Type(int) | Type(int)))
 "key" = Any
@@ -75,7 +75,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 300..311 -> @definitions
 338..349 -> @definitions
 358..363 -> Func(panic)
-358..368 -> ()
+358..368 -> Never
 397..408 -> @definitions
 417..428 -> @definitions
 417..435 -> @v"definitions".insert
@@ -93,7 +93,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 560..571 -> @definitions
 598..609 -> @definitions
 618..623 -> Func(panic)
-618..628 -> ()
+618..628 -> Never
 657..668 -> @definitions
 677..688 -> @definitions
 677..695 -> @v"definitions".insert
@@ -117,7 +117,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 922..933 -> @definitions
 958..969 -> @definitions
 976..981 -> Func(panic)
-976..986 -> ()
+976..986 -> Never
 1011..1022 -> @definitions
 1029..1040 -> @definitions
 1029..1047 -> @v"definitions".insert
@@ -174,10 +174,10 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 1613..1630 -> (Type(int) | Type(int))
 1638..1644 -> @n_defs
 1658..1663 -> Func(panic)
-1658..1668 -> ()
+1658..1668 -> Never
 1683..1689 -> @n_defs
 1702..1707 -> Func(panic)
-1702..1712 -> ()
+1702..1712 -> Never
 1728..1731 -> @key
 1733..1736 -> @def
 1741..1760 -> ("long", "long-pl", )
@@ -195,7 +195,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 1848..1858 -> Type(dictionary)
 1882..1893 -> @definitions
 1902..1907 -> Func(panic)
-1902..1912 -> ()
+1902..1912 -> Never
 1928..1931 -> @key
 1933..1936 -> @def
 1941..1952 -> @definitions
@@ -207,9 +207,9 @@ input_file: crates/tinymist-query/src/fixtures/type_check/scope_deferred_apply.t
 2035..2038 -> @key
 2040..2043 -> @def
 2068..2073 -> Func(panic)
-2068..2078 -> ()
+2068..2078 -> Never
 2108..2113 -> Func(panic)
-2108..2118 -> ()
+2108..2118 -> Never
 2125..2137 -> @top-complete
 2125..2149 -> @entry
 2143..2148 -> @entry

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/show.typ
 ---
-"" = (Any) => Any.it
+"" = (@it) => @v"it".it
 "it" = Content(text)
 =====
 26..31 -> Type(regex)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/show_raw.typ
 ---
-"" = (Any) => Any.it
+"" = (@it) => @v"it".it
 "it" = Content(raw)
 =====
 26..29 -> Func(raw)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw_where.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@show_raw_where.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/show_raw_where.typ
 ---
-"" = (Any) => Any.it
+"" = (@it) => @v"it".it
 "it" = Content(raw)
 =====
 26..29 -> Func(raw)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@sig_template.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@sig_template.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/sig_template.typ
 ---
-"tmpl" = (Any) => Any
+"tmpl" = (@content) => @content
 "content" = Any
 =====
 5..9 -> @tmpl

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@sig_template_set.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@sig_template_set.typ.snap
@@ -3,7 +3,7 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/sig_template_set.typ
 ---
-"tmpl" = ((Any, "authors": (Type(array) | Type(str)), "class": Any, "font": (TextFont | Array<TextFont>)) => Any).with(..("authors": (), "class": "article", "font": None) => any)
+"tmpl" = ((@content, "authors": @authors, "class": @class, "font": @font) => @content).with(..("authors": (), "class": "article", "font": None) => any)
 "content" = Any
 "authors" = ()
 "font" = None
@@ -18,7 +18,7 @@ input_file: crates/tinymist-query/src/fixtures/type_check/sig_template_set.typ
 71..76 -> @class
 94..99 -> @class
 118..123 -> Func(panic)
-118..127 -> ()
+118..127 -> Never
 139..147 -> Func(document)
 156..163 -> @authors
 171..175 -> Func(text)

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@tuple_map.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@tuple_map.typ.snap
@@ -4,10 +4,11 @@ expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/tuple_map.typ
 ---
 "a" = (1, )
-"f" = ((Type(bytes) | Type(decimal) | Type(float) | Type(int) | Type(label) | Type(str) | Type(type) | Type(version))) => Type(str)
-"" = ((Type(bytes) | Type(decimal) | Type(float) | Type(int) | Type(label) | Type(str) | Type(type) | Type(version))) => Type(str)
+"f" = (@x) => Type(str)
+"" = (@x) => Type(str)
 "x" = Type(int)
 "b" = (Type(array) | ((Type(array) | Type(str)), ))
+"conditional" = (((Type(array) | Type(str)), (Type(array) | Type(str)), ) | ((Type(array) | Type(str)), (Type(array) | Type(str)), ))
 =====
 5..6 -> @a
 9..13 -> (1, )
@@ -22,3 +23,9 @@ input_file: crates/tinymist-query/src/fixtures/type_check/tuple_map.typ
 46..51 -> (Func(map) | (Func(map) | @v"a".map))
 46..54 -> (Type(array) | ((Type(array) | Type(str)), ))
 52..53 -> @f
+61..72 -> @conditional
+75..115 -> IfTy { cond: true, then: (1, 2, ), else_: (3, 4, ) }.map
+75..118 -> (((Type(array) | Type(str)), (Type(array) | Type(str)), ) | ((Type(array) | Type(str)), (Type(array) | Type(str)), ))
+86..92 -> (1, 2, )
+102..108 -> (3, 4, )
+116..117 -> @f

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@tuple_spread.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@tuple_spread.typ.snap
@@ -1,0 +1,39 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: result
+input_file: crates/tinymist-query/src/fixtures/type_check/tuple_spread.typ
+---
+"fixed" = (1, 2, )
+"direct" = (0, 1, 2, 3, )
+"prepend" = (@head, ...: @tail) => (@head, TypeUnary { lhs: @tail, op: Spread }, )
+"head" = Type(int)
+"tail" = ( ⪰ Args | &((1, 2) => any))
+"prepended" = (0, 1, 2, )
+"identity-args" = (...: @args) => @args
+"args" = ( ⪰ Args | &(("x", "y") => any))
+"captured" = &(("x", "y") => any)
+"respread" = (0, "x", "y", 3, )
+=====
+5..10 -> @fixed
+13..19 -> (1, 2, )
+25..31 -> @direct
+34..49 -> (0, TypeUnary { lhs: @fixed, op: Spread }, 3, )
+40..45 -> @fixed
+56..63 -> @prepend
+64..68 -> @head
+72..76 -> @tail
+80..94 -> (@head, TypeUnary { lhs: @tail, op: Spread }, )
+81..85 -> @head
+89..93 -> @tail
+100..109 -> @prepended
+112..119 -> @prepend
+112..128 -> (0, 1, 2, )
+135..148 -> @identity-args
+151..155 -> @args
+159..163 -> @args
+169..177 -> @captured
+180..193 -> @identity-args
+180..203 -> &(("x", "y") => any)
+209..217 -> @respread
+220..238 -> (0, TypeUnary { lhs: @captured, op: Spread }, 3, )
+226..234 -> @captured

--- a/crates/tinymist-query/src/fixtures/type_check/snaps/test@with.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_check/snaps/test@with.typ.snap
@@ -3,9 +3,9 @@ source: crates/tinymist-query/src/analysis.rs
 expression: result
 input_file: crates/tinymist-query/src/fixtures/type_check/with.typ
 ---
-"f" = (Any) => Any
+"f" = (@x) => @x
 "x" = Type(int)
-"g" = ((Any) => Any).with(..(1) => any)
+"g" = ((@x) => @x).with(..(1) => any)
 "x" = 1
 =====
 5..6 -> @f

--- a/crates/tinymist-query/src/fixtures/type_check/tuple_map.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/tuple_map.typ
@@ -1,3 +1,4 @@
 #let a = (1,);
 #let f = x => str(x);
 #let b = a.map(f);
+#let conditional = (if true { (1, 2) } else { (3, 4) }).map(f);

--- a/crates/tinymist-query/src/fixtures/type_check/tuple_spread.typ
+++ b/crates/tinymist-query/src/fixtures/type_check/tuple_spread.typ
@@ -1,0 +1,9 @@
+#let fixed = (1, 2)
+#let direct = (0, ..fixed, 3)
+
+#let prepend(head, ..tail) = (head, ..tail)
+#let prepended = prepend(0, 1, 2)
+
+#let identity-args(..args) = args
+#let captured = identity-args("x", "y")
+#let respread = (0, ..captured, 3)

--- a/crates/tinymist-query/src/fixtures/type_describe/external_branch_overwrite_input.typ
+++ b/crates/tinymist-query/src/fixtures/type_describe/external_branch_overwrite_input.typ
@@ -1,0 +1,14 @@
+/// path: base.typ
+#let normalize(value) = {
+  if value == auto {
+    value = it => it
+  } else {
+    assert(type(value) == function)
+  }
+  return none
+}
+
+-----
+#import "base.typ": normalize
+
+#(/* position after */ normalize)

--- a/crates/tinymist-query/src/fixtures/type_describe/external_pre_overwrite_input.typ
+++ b/crates/tinymist-query/src/fixtures/type_describe/external_pre_overwrite_input.typ
@@ -1,0 +1,12 @@
+/// path: base.typ
+#let normalize(value) = {
+  assert(type(value) == float)
+  calc.max(value, 0.1)
+  value = 3
+  value
+}
+
+-----
+#import "base.typ": normalize
+
+#(/* position after */ normalize)

--- a/crates/tinymist-query/src/fixtures/type_describe/snaps/test@ever_intern_use.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_describe/snaps/test@ever_intern_use.typ.snap
@@ -4,4 +4,4 @@ description: "Check on \"tmpl\" (113)"
 expression: post_ty
 input_file: crates/tinymist-query/src/fixtures/type_describe/ever_intern_use.typ
 ---
-(1 | 2 | 3 | int) => 1 | 2 | 3 | int
+(any) => 3

--- a/crates/tinymist-query/src/fixtures/type_describe/snaps/test@external_branch_overwrite_input.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_describe/snaps/test@external_branch_overwrite_input.typ.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+description: "Check on \"normalize\" (54)"
+expression: post_ty
+input_file: crates/tinymist-query/src/fixtures/type_describe/external_branch_overwrite_input.typ
+---
+(auto | function) => none

--- a/crates/tinymist-query/src/fixtures/type_describe/snaps/test@external_pre_overwrite_input.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_describe/snaps/test@external_pre_overwrite_input.typ.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+description: "Check on \"normalize\" (54)"
+expression: post_ty
+input_file: crates/tinymist-query/src/fixtures/type_describe/external_pre_overwrite_input.typ
+---
+(float) => 3

--- a/openspec/changes/compile-before-type-check/design.md
+++ b/openspec/changes/compile-before-type-check/design.md
@@ -24,6 +24,9 @@ The new pipeline should make bytecode evaluation the deduce stage. Checking beco
 - Keep checking logic as VM primitives or post-evaluation checks rather than duplicating expression traversal.
 - Make `precise_sig_of_def` force the relevant closure result through the VM and quote the final signature.
 - Represent cycles as neutral residuals, not as blocking waits or immediate `Any`.
+- Keep function parameters as signature input binders. Close each checked resultant so it only retains the current signature inputs and escaped outer input binders; close every other variable through its bounds.
+- Separate an overwritten parameter's body-flow variable from its signature input binder so later assignments cannot rewrite the function's accepted input contract.
+- Across file boundaries, copy only the fixed bounds of signature input binders. Never import the callee's ordinary local-variable graph.
 - Resolve documentation annotations through existing flow semantic types before applying them as input contracts. A wholly unresolved annotation contributes no bound instead of a synthetic `Any` bound.
 - Keep old checker paths behind tests during migration only if needed for diff analysis, not as a permanent dual implementation.
 

--- a/openspec/changes/compile-before-type-check/proposal.md
+++ b/openspec/changes/compile-before-type-check/proposal.md
@@ -7,6 +7,7 @@ The current PR's deferred inference model improves precision but still leaves de
 - Replace the current deduce path with compile-to-bytecode followed by VM evaluation.
 - Keep a check phase that applies existing compatibility and warning logic after semantic results are available.
 - Preserve `precise_sig_of_def` as the public query for docs/signature consumers.
+- Preserve parameter-dependent function resultants across file boundaries without copying callee-local variables into caller scopes.
 - Avoid exposing shallow signatures through documentation APIs.
 - Retain snapshots as the primary correctness signal for this migration.
 

--- a/openspec/changes/compile-before-type-check/specs/compile-before-type-check/spec.md
+++ b/openspec/changes/compile-before-type-check/specs/compile-before-type-check/spec.md
@@ -14,6 +14,10 @@ The checker SHALL evaluate function bodies on demand when a call needs the calle
 - **WHEN** a function body calls a same-scope helper whose closure is not running
 - **THEN** the VM evaluates the helper body and uses the resulting semantic type to compute the caller result
 
+#### Scenario: Cross-file dependent result
+- **WHEN** an imported function result depends on one of its parameters through local intermediate variables
+- **THEN** the checker substitutes the call arguments into the closed result without importing callee-local variables into the caller scope
+
 ### Requirement: Cycle residualization
 The checker SHALL residualize cyclic function-result dependencies as neutral values.
 

--- a/openspec/changes/compile-before-type-check/tasks.md
+++ b/openspec/changes/compile-before-type-check/tasks.md
@@ -9,6 +9,7 @@
 - [ ] 2.1 Replace deferred function body vectors with closure state in the VM path.
 - [ ] 2.2 Force non-running closures on demand at call sites.
 - [ ] 2.3 Residualize recursive or blocked calls as neutral values.
+- [x] 2.4 Preserve parameter-dependent resultants across file boundaries without importing callee-local variables.
 
 ## 3. Checking Semantics
 

--- a/tests/e2e/e2e/lsp.rs
+++ b/tests/e2e/e2e/lsp.rs
@@ -22,7 +22,7 @@ fn test_lsp() {
         });
 
         let hash = replay_log(&root.join("neovim"));
-        insta::assert_snapshot!(hash, @"siphash128_13:55108ba6479fea30ddf2edd4a5347457");
+        insta::assert_snapshot!(hash, @"siphash128_13:3d874d884ffadc490b30e6556ca535e6");
     }
 
     {


### PR DESCRIPTION
- Improve tuple, spread, loop, and array-builder inference used by CeTZ-style code.
- Preserve parameter-dependent resultants and overwritten input contracts without importing callee-local variables.
- Add focused local and cross-file type-checker fixtures.