### PR TITLE
fix(query): resolve semantic types in doc annotations

### DIFF
--- a/crates/tinymist-query/src/fixtures/docs/snaps/docs@stroke.typ.snap
+++ b/crates/tinymist-query/src/fixtures/docs/snaps/docs@stroke.typ.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+expression: "snap.join(\"\\n\")"
+input_file: crates/tinymist-query/src/fixtures/docs/stroke.typ
+---
+= docstings
+Func(f)@54..55 in /s0.typ -> DocString { docs: Some(""), var_bounds: {}, vars: {"value": VarDoc { docs: "A documented stroke value.", ty: Some(Stroke) }}, res_ty: None }

--- a/crates/tinymist-query/src/fixtures/docs/stroke.typ
+++ b/crates/tinymist-query/src/fixtures/docs/stroke.typ
@@ -1,0 +1,2 @@
+/// - value (stroke): A documented stroke value.
+#let f(value: none) = value

--- a/crates/tinymist-query/src/fixtures/type_describe/doc_param_stroke.typ
+++ b/crates/tinymist-query/src/fixtures/type_describe/doc_param_stroke.typ
@@ -1,0 +1,4 @@
+/// - value (stroke): A documented stroke value.
+#let f(value: none) = value
+
+#(/* position after */ f)

--- a/crates/tinymist-query/src/fixtures/type_describe/snaps/test@doc_param_stroke.typ.snap
+++ b/crates/tinymist-query/src/fixtures/type_describe/snaps/test@doc_param_stroke.typ.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tinymist-query/src/analysis.rs
+description: "Check on \"f\" (101)"
+expression: post_ty
+input_file: crates/tinymist-query/src/fixtures/type_describe/doc_param_stroke.typ
+---
+(value: none | stroke) => none | stroke

--- a/crates/tinymist-query/src/syntax/docs.rs
+++ b/crates/tinymist-query/src/syntax/docs.rs
@@ -162,7 +162,7 @@ impl DocsChecker<'_> {
             terms.push(ty);
         }
 
-        Some(Ty::from_types(terms.into_iter()))
+        (!terms.is_empty()).then(|| Ty::from_types(terms.into_iter()))
     }
 
     fn check_type_ident(&mut self, m: &Module, name: &str) -> Option<Ty> {
@@ -217,6 +217,11 @@ impl DocsChecker<'_> {
                 ("boolean", Ty::Boolean(None)),
                 ("false", Ty::Boolean(Some(false))),
                 ("true", Ty::Boolean(Some(true))),
+                ("stroke", Ty::Builtin(BuiltinTy::Stroke)),
+                ("margin", Ty::Builtin(BuiltinTy::Margin)),
+                ("inset", Ty::Builtin(BuiltinTy::Inset)),
+                ("outset", Ty::Builtin(BuiltinTy::Outset)),
+                ("radius", Ty::Builtin(BuiltinTy::Radius)),
             ];
             HashMap::from_iter(shorts.chain(longs).chain(builtins))
         });

--- a/openspec/changes/compile-before-type-check/design.md
+++ b/openspec/changes/compile-before-type-check/design.md
@@ -24,6 +24,7 @@ The new pipeline should make bytecode evaluation the deduce stage. Checking beco
 - Keep checking logic as VM primitives or post-evaluation checks rather than duplicating expression traversal.
 - Make `precise_sig_of_def` force the relevant closure result through the VM and quote the final signature.
 - Represent cycles as neutral residuals, not as blocking waits or immediate `Any`.
+- Resolve documentation annotations through existing flow semantic types before applying them as input contracts. A wholly unresolved annotation contributes no bound instead of a synthetic `Any` bound.
 - Keep old checker paths behind tests during migration only if needed for diff analysis, not as a permanent dual implementation.
 
 ## Risks / Trade-offs


### PR DESCRIPTION
- Resolve flow semantic type names such as `stroke` in documentation annotations.
- Treat wholly unresolved annotations as absent bounds instead of synthetic `Any` bounds.
- Add parser and rendered-signature regressions.