### PR TITLE
fix(analysis): `@` should be classified as ref marker only in markup

### DIFF
--- a/crates/tinymist-analysis/src/syntax/matcher.rs
+++ b/crates/tinymist-analysis/src/syntax/matcher.rs
@@ -890,6 +890,7 @@ pub fn classify_syntax(node: LinkedNode<'_>, cursor: usize) -> Option<SyntaxClas
     if node.kind() == SyntaxKind::Text
         && node.offset() + 1 == cursor
         && node.leaf_text().starts_with('@')
+        && matches!(interpret_mode_at(Some(&node)), InterpretMode::Markup)
     {
         return Some(SyntaxClass::At { node });
     }

--- a/crates/tinymist-query/src/fixtures/completion/ref_empty_in_raw.typ
+++ b/crates/tinymist-query/src/fixtures/completion/ref_empty_in_raw.typ
@@ -1,0 +1,7 @@
+/// compile: true
+
+#set heading(numbering: "1.1")
+
+= H <t>
+
+`@` /* range -2..-1 */

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@ref_empty_in_raw.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@ref_empty_in_raw.typ.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: "Completion on ` (62..63)"
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/ref_empty_in_raw.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]


### PR DESCRIPTION
Fixed: `@` in raw could trigger completion.