### PR TITLE
perf(query): speed up package type scope dumps

### DIFF
--- a/crates/tinymist-analysis/src/adt/interner.rs
+++ b/crates/tinymist-analysis/src/adt/interner.rs
@@ -233,7 +233,11 @@ impl<T: Internable> Eq for Interned<T> {}
 impl<T: Internable + PartialOrd> PartialOrd for Interned<T> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.as_ref().partial_cmp(other.as_ref())
+        if self == other {
+            Some(std::cmp::Ordering::Equal)
+        } else {
+            self.as_ref().partial_cmp(other.as_ref())
+        }
     }
 }
 
@@ -409,3 +413,38 @@ pub use crate::_impl_internable as impl_internable;
 use crate::stats::AllocStats;
 
 impl_internable!(str,);
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use super::*;
+
+    static PARTIAL_CMP_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Eq, Hash, PartialEq)]
+    struct Counted(u8);
+
+    impl PartialOrd for Counted {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            PARTIAL_CMP_CALLS.fetch_add(1, AtomicOrdering::Relaxed);
+            self.0.partial_cmp(&other.0)
+        }
+    }
+
+    impl_internable!(Counted);
+
+    #[test]
+    fn partial_cmp_short_circuits_shared_values() {
+        let value = Interned::new(Counted(1));
+
+        PARTIAL_CMP_CALLS.store(0, AtomicOrdering::Relaxed);
+        assert_eq!(value.partial_cmp(&value.clone()), Some(Ordering::Equal));
+        assert_eq!(PARTIAL_CMP_CALLS.load(AtomicOrdering::Relaxed), 0);
+
+        let other = Interned::new(Counted(2));
+        assert_eq!(value.partial_cmp(&other), Some(Ordering::Less));
+        assert_eq!(PARTIAL_CMP_CALLS.load(AtomicOrdering::Relaxed), 1);
+    }
+}

--- a/crates/tinymist-analysis/src/ty/simplify.rs
+++ b/crates/tinymist-analysis/src/ty/simplify.rs
@@ -16,45 +16,50 @@ struct CompactTy {
     is_final: bool,
 }
 
-fn collect_input_type_vars(ty: &Ty, vars: &mut FxHashSet<DeclExpr>) {
+#[allow(clippy::mutable_key_type)]
+fn collect_input_type_vars(ty: &Ty, vars: &mut FxHashSet<DeclExpr>, traversed: &mut FxHashSet<Ty>) {
+    if !traversed.insert(ty.clone()) {
+        return;
+    }
+
     match ty {
         Ty::Var(var) => {
             vars.insert(var.def.clone());
         }
         Ty::Func(_) | Ty::With(_) => {}
-        Ty::Param(param) => collect_input_type_vars(&param.ty, vars),
+        Ty::Param(param) => collect_input_type_vars(&param.ty, vars, traversed),
         Ty::Union(types) | Ty::Tuple(types) => {
             for ty in types.iter() {
-                collect_input_type_vars(ty, vars);
+                collect_input_type_vars(ty, vars, traversed);
             }
         }
         Ty::Let(bounds) => {
             for ty in bounds.lbs.iter().chain(&bounds.ubs) {
-                collect_input_type_vars(ty, vars);
+                collect_input_type_vars(ty, vars, traversed);
             }
         }
         Ty::Dict(record) => {
             for ty in record.types.iter() {
-                collect_input_type_vars(ty, vars);
+                collect_input_type_vars(ty, vars, traversed);
             }
         }
-        Ty::Array(elem) => collect_input_type_vars(elem, vars),
+        Ty::Array(elem) => collect_input_type_vars(elem, vars, traversed),
         Ty::Args(sig) | Ty::Pattern(sig) => {
             for input in sig.inputs() {
-                collect_input_type_vars(input, vars);
+                collect_input_type_vars(input, vars, traversed);
             }
         }
-        Ty::Select(select) => collect_input_type_vars(&select.ty, vars),
-        Ty::Unary(unary) => collect_input_type_vars(&unary.lhs, vars),
+        Ty::Select(select) => collect_input_type_vars(&select.ty, vars, traversed),
+        Ty::Unary(unary) => collect_input_type_vars(&unary.lhs, vars, traversed),
         Ty::Binary(binary) => {
             let [lhs, rhs] = binary.operands();
-            collect_input_type_vars(lhs, vars);
-            collect_input_type_vars(rhs, vars);
+            collect_input_type_vars(lhs, vars, traversed);
+            collect_input_type_vars(rhs, vars, traversed);
         }
         Ty::If(if_ty) => {
-            collect_input_type_vars(&if_ty.cond, vars);
-            collect_input_type_vars(&if_ty.then, vars);
-            collect_input_type_vars(&if_ty.else_, vars);
+            collect_input_type_vars(&if_ty.cond, vars, traversed);
+            collect_input_type_vars(&if_ty.then, vars, traversed);
+            collect_input_type_vars(&if_ty.else_, vars, traversed);
         }
         Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
     }
@@ -78,6 +83,8 @@ impl TypeInfo {
             cano_cache: &mut cache.cano_cache,
             transform_cache: &mut cache.transform_cache,
             cano_local_cache: &mut cache.cano_local_cache,
+            analyze_cache: FxHashSet::default(),
+            input_var_cache: FxHashSet::default(),
 
             positives: &mut cache.positives,
             negatives: &mut cache.negatives,
@@ -96,6 +103,8 @@ struct TypeSimplifier<'a, 'b> {
     cano_cache: &'b mut FxHashMap<(Ty, bool), Ty>,
     transform_cache: &'b mut FxHashMap<(Ty, bool), Ty>,
     cano_local_cache: &'b mut FxHashMap<(DeclExpr, bool), Ty>,
+    analyze_cache: FxHashSet<(Ty, bool)>,
+    input_var_cache: FxHashSet<Ty>,
     negatives: &'b mut FxHashSet<DeclExpr>,
     positives: &'b mut FxHashSet<DeclExpr>,
 }
@@ -120,6 +129,10 @@ impl TypeSimplifier<'_, '_> {
 
     /// Analyzes the given type.
     fn analyze(&mut self, ty: &Ty, pol: bool, signature_binders: &mut FxHashSet<DeclExpr>) {
+        if !self.analyze_cache.insert((ty.clone(), pol)) {
+            return;
+        }
+
         match ty {
             Ty::Var(var) => {
                 if self.principal && signature_binders.contains(&var.def) {
@@ -156,7 +169,11 @@ impl TypeSimplifier<'_, '_> {
             Ty::Func(func) => {
                 if self.principal {
                     for input in func.inputs() {
-                        collect_input_type_vars(input, signature_binders);
+                        collect_input_type_vars(
+                            input,
+                            signature_binders,
+                            &mut self.input_var_cache,
+                        );
                     }
                 }
                 for input_ty in func.inputs() {
@@ -193,7 +210,11 @@ impl TypeSimplifier<'_, '_> {
             Ty::Pattern(pat) => {
                 if self.principal {
                     for input in pat.inputs() {
-                        collect_input_type_vars(input, signature_binders);
+                        collect_input_type_vars(
+                            input,
+                            signature_binders,
+                            &mut self.input_var_cache,
+                        );
                     }
                 }
                 for input in pat.inputs() {
@@ -568,6 +589,40 @@ mod tests {
         res.extend(vec![ch("c"), val(Value::None), ch("a")]);
 
         test_sort_ty(res);
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn test_analyze_memoizes_shared_type_dag() {
+        const DEPTH: usize = 16;
+
+        let mut shared = Ty::Any;
+        for _ in 0..DEPTH {
+            shared = Ty::Tuple(vec![shared.clone(), shared].into());
+        }
+
+        let info = TypeInfo::default();
+        let mut cano_cache = FxHashMap::default();
+        let mut transform_cache = FxHashMap::default();
+        let mut cano_local_cache = FxHashMap::default();
+        let mut positives = FxHashSet::default();
+        let mut negatives = FxHashSet::default();
+        let mut worker = TypeSimplifier {
+            principal: true,
+            vars: &info.vars,
+            cano_cache: &mut cano_cache,
+            transform_cache: &mut transform_cache,
+            cano_local_cache: &mut cano_local_cache,
+            analyze_cache: FxHashSet::default(),
+            input_var_cache: FxHashSet::default(),
+            positives: &mut positives,
+            negatives: &mut negatives,
+        };
+        let mut signature_binders = FxHashSet::default();
+
+        worker.analyze(&shared, true, &mut signature_binders);
+
+        assert_eq!(worker.analyze_cache.len(), DEPTH + 1);
     }
 
     fn var(name: &str) -> TypeVarBounds {

--- a/crates/tinymist-analysis/src/ty/subst.rs
+++ b/crates/tinymist-analysis/src/ty/subst.rs
@@ -9,7 +9,7 @@ impl Sig<'_> {
             let body = self.check_bind(args, ctx)?;
 
             // Substitute the bound variables in the body or just body
-            let mut checker = SubstituteChecker { ctx };
+            let mut checker = SubstituteChecker::new(ctx);
             Some(checker.ty(&body, pol).unwrap_or(body))
         })
     }
@@ -73,9 +73,17 @@ impl Sig<'_> {
 /// A checker to substitute the bound variables.
 struct SubstituteChecker<'a, T: TyCtxMut> {
     ctx: &'a mut T,
+    memo: FxHashMap<(Ty, bool), Option<Ty>>,
 }
 
 impl<T: TyCtxMut> SubstituteChecker<'_, T> {
+    fn new(ctx: &mut T) -> SubstituteChecker<'_, T> {
+        SubstituteChecker {
+            ctx,
+            memo: FxHashMap::default(),
+        }
+    }
+
     /// Substitutes the bound variables in the given type.
     fn ty(&mut self, body: &Ty, pol: bool) -> Option<Ty> {
         body.mutate(pol, self)
@@ -84,8 +92,13 @@ impl<T: TyCtxMut> SubstituteChecker<'_, T> {
 
 impl<T: TyCtxMut> TyMutator for SubstituteChecker<'_, T> {
     fn mutate(&mut self, ty: &Ty, pol: bool) -> Option<Ty> {
+        let key = (ty.clone(), pol);
+        if let Some(result) = self.memo.get(&key) {
+            return result.clone();
+        }
+
         // todo: extrude the type into a polarized type
-        match ty {
+        let result = match ty {
             Ty::Var(var) => self.ctx.local_bind_of(var),
             Ty::Let(bounds) => {
                 let mut lbs = bounds
@@ -99,15 +112,17 @@ impl<T: TyCtxMut> TyMutator for SubstituteChecker<'_, T> {
                     .map(|bound| self.mutate(bound, pol).unwrap_or_else(|| bound.clone()))
                     .collect::<Vec<_>>();
                 if ubs.is_empty() && lbs.len() == 1 {
-                    return lbs.pop();
+                    lbs.pop()
+                } else if lbs.is_empty() && ubs.len() == 1 {
+                    ubs.pop()
+                } else {
+                    Some(Ty::Let(TypeBounds { lbs, ubs }.into()))
                 }
-                if lbs.is_empty() && ubs.len() == 1 {
-                    return ubs.pop();
-                }
-                Some(Ty::Let(TypeBounds { lbs, ubs }.into()))
             }
             _ => self.mutate_rec(ty, pol),
-        }
+        };
+        self.memo.insert(key, result.clone());
+        result
     }
 }
 
@@ -166,5 +181,45 @@ mod tests {
 
         assert_snapshot!(call(literal_sig!(p1 -> p1), literal_args!(q1)), @"@q1");
         assert_snapshot!(call(literal_sig!(!u1: w1 -> w1), literal_args!(!u1: w2)), @"@w2");
+    }
+
+    #[test]
+    fn test_substitute_checker_memoizes_shared_type_dag() {
+        use super::*;
+        use crate::syntax::Decl;
+
+        let var = TypeVar::new("input".into(), Decl::lit("input").into());
+        let var_ty = Ty::Var(var.clone());
+        let changed = Ty::If(IfTy::new(
+            var_ty.clone().into(),
+            var_ty.clone().into(),
+            var_ty.clone().into(),
+        ));
+        let unchanged = Ty::If(IfTy::new(
+            Ty::Boolean(Some(true)).into(),
+            Ty::Boolean(Some(true)).into(),
+            Ty::Boolean(Some(true)).into(),
+        ));
+        let body = Ty::Tuple(
+            vec![
+                changed.clone(),
+                changed.clone(),
+                unchanged.clone(),
+                unchanged.clone(),
+            ]
+            .into(),
+        );
+
+        let mut ctx = TypeInfo::default();
+        ctx.bind_local(&var, Ty::Boolean(Some(false)));
+        let mut checker = SubstituteChecker::new(&mut ctx);
+        let result = checker.ty(&body, false);
+
+        assert!(result.is_some());
+        assert!(matches!(
+            checker.memo.get(&(changed, false)),
+            Some(Some(Ty::If(_)))
+        ));
+        assert_eq!(checker.memo.get(&(unchanged, false)), Some(&None));
     }
 }

--- a/crates/tinymist-query/src/analysis/tyck.rs
+++ b/crates/tinymist-query/src/analysis/tyck.rs
@@ -272,10 +272,18 @@ impl TypeChecker<'_> {
         Some((bounds, docs, input_bounds))
     }
 
+    #[allow(clippy::mutable_key_type)]
     fn copy_external_input_bounds(type_info: &TypeInfo, ty: &Ty) -> Vec<TypeVarBounds> {
         let mut pending = vec![];
         let mut seen = FxHashSet::default();
-        Self::collect_signature_input_binders(ty, &FxHashSet::default(), &mut seen, &mut pending);
+        let mut traversed = FxHashSet::default();
+        Self::collect_signature_input_binders(
+            ty,
+            &FxHashSet::default(),
+            &mut seen,
+            &mut traversed,
+            &mut pending,
+        );
 
         let mut copied = vec![];
         let mut idx = 0;
@@ -290,15 +298,16 @@ impl TypeChecker<'_> {
             let bounds = source.bounds.bounds().read().freeze();
 
             for bound in bounds.lbs.iter().chain(&bounds.ubs) {
-                Self::collect_signature_input_binders(bound, &escaped, &mut seen, &mut pending);
+                Self::collect_signature_input_binders(
+                    bound,
+                    &escaped,
+                    &mut seen,
+                    &mut traversed,
+                    &mut pending,
+                );
             }
 
-            let mut closer = FunctionResultantCloser {
-                vars: &type_info.vars,
-                params: escaped,
-                visiting: FxHashSet::default(),
-                visited: 0,
-            };
+            let mut closer = FunctionResultantCloser::new(&type_info.vars, escaped);
             let bounds = closer.close_bounds(&bounds);
             let mut imported =
                 TypeVarBounds::new(binder.as_ref().clone(), DynTypeBounds::from(bounds));
@@ -311,18 +320,32 @@ impl TypeChecker<'_> {
         copied
     }
 
+    #[allow(clippy::mutable_key_type)]
     fn collect_signature_input_binders(
         ty: &Ty,
         escaped: &FxHashSet<DeclExpr>,
         seen: &mut FxHashSet<DeclExpr>,
+        traversed: &mut FxHashSet<Ty>,
         binders: &mut Vec<(Interned<TypeVar>, FxHashSet<DeclExpr>)>,
     ) {
+        // Binder discovery is monotonic: the first full visit records every
+        // binder reachable from this interned type, regardless of later scopes.
+        if !traversed.insert(ty.clone()) {
+            return;
+        }
+
         match ty {
             Ty::Func(sig) => {
                 let mut direct = vec![];
                 let mut direct_seen = FxHashSet::default();
+                let mut direct_traversed = FxHashSet::default();
                 for input in sig.inputs() {
-                    Self::collect_input_binders(input, &mut direct_seen, &mut direct);
+                    Self::collect_input_binders(
+                        input,
+                        &mut direct_seen,
+                        &mut direct_traversed,
+                        &mut direct,
+                    );
                 }
 
                 let mut scope = escaped.clone();
@@ -334,73 +357,99 @@ impl TypeChecker<'_> {
                 }
 
                 for input in sig.inputs() {
-                    Self::collect_signature_input_binders(input, &scope, seen, binders);
+                    Self::collect_signature_input_binders(input, &scope, seen, traversed, binders);
                 }
                 if let Some(body) = &sig.body {
-                    Self::collect_signature_input_binders(body, &scope, seen, binders);
+                    Self::collect_signature_input_binders(body, &scope, seen, traversed, binders);
                 }
             }
             Ty::With(with) => {
-                Self::collect_signature_input_binders(&with.sig, escaped, seen, binders);
+                Self::collect_signature_input_binders(&with.sig, escaped, seen, traversed, binders);
                 for input in with.with.inputs() {
-                    Self::collect_signature_input_binders(input, escaped, seen, binders);
+                    Self::collect_signature_input_binders(input, escaped, seen, traversed, binders);
                 }
                 if let Some(body) = &with.with.body {
-                    Self::collect_signature_input_binders(body, escaped, seen, binders);
+                    Self::collect_signature_input_binders(body, escaped, seen, traversed, binders);
                 }
             }
             Ty::Args(sig) | Ty::Pattern(sig) => {
                 for input in sig.inputs() {
-                    Self::collect_signature_input_binders(input, escaped, seen, binders);
+                    Self::collect_signature_input_binders(input, escaped, seen, traversed, binders);
                 }
                 if let Some(body) = &sig.body {
-                    Self::collect_signature_input_binders(body, escaped, seen, binders);
+                    Self::collect_signature_input_binders(body, escaped, seen, traversed, binders);
                 }
             }
             Ty::Param(param) => {
-                Self::collect_signature_input_binders(&param.ty, escaped, seen, binders)
+                Self::collect_signature_input_binders(&param.ty, escaped, seen, traversed, binders)
             }
             Ty::Union(types) | Ty::Tuple(types) => {
                 for ty in types.iter() {
-                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                    Self::collect_signature_input_binders(ty, escaped, seen, traversed, binders);
                 }
             }
             Ty::Let(bounds) => {
                 for ty in bounds.lbs.iter().chain(&bounds.ubs) {
-                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                    Self::collect_signature_input_binders(ty, escaped, seen, traversed, binders);
                 }
             }
             Ty::Dict(record) => {
                 for ty in record.types.iter() {
-                    Self::collect_signature_input_binders(ty, escaped, seen, binders);
+                    Self::collect_signature_input_binders(ty, escaped, seen, traversed, binders);
                 }
             }
-            Ty::Array(elem) => Self::collect_signature_input_binders(elem, escaped, seen, binders),
+            Ty::Array(elem) => {
+                Self::collect_signature_input_binders(elem, escaped, seen, traversed, binders)
+            }
             Ty::Select(select) => {
-                Self::collect_signature_input_binders(&select.ty, escaped, seen, binders)
+                Self::collect_signature_input_binders(&select.ty, escaped, seen, traversed, binders)
             }
             Ty::Unary(unary) => {
-                Self::collect_signature_input_binders(&unary.lhs, escaped, seen, binders)
+                Self::collect_signature_input_binders(&unary.lhs, escaped, seen, traversed, binders)
             }
             Ty::Binary(binary) => {
                 let [lhs, rhs] = binary.operands();
-                Self::collect_signature_input_binders(lhs, escaped, seen, binders);
-                Self::collect_signature_input_binders(rhs, escaped, seen, binders);
+                Self::collect_signature_input_binders(lhs, escaped, seen, traversed, binders);
+                Self::collect_signature_input_binders(rhs, escaped, seen, traversed, binders);
             }
             Ty::If(if_ty) => {
-                Self::collect_signature_input_binders(&if_ty.cond, escaped, seen, binders);
-                Self::collect_signature_input_binders(&if_ty.then, escaped, seen, binders);
-                Self::collect_signature_input_binders(&if_ty.else_, escaped, seen, binders);
+                Self::collect_signature_input_binders(
+                    &if_ty.cond,
+                    escaped,
+                    seen,
+                    traversed,
+                    binders,
+                );
+                Self::collect_signature_input_binders(
+                    &if_ty.then,
+                    escaped,
+                    seen,
+                    traversed,
+                    binders,
+                );
+                Self::collect_signature_input_binders(
+                    &if_ty.else_,
+                    escaped,
+                    seen,
+                    traversed,
+                    binders,
+                );
             }
             Ty::Var(_) | Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     fn collect_input_binders(
         ty: &Ty,
         seen: &mut FxHashSet<DeclExpr>,
+        traversed: &mut FxHashSet<Ty>,
         binders: &mut Vec<Interned<TypeVar>>,
     ) {
+        if !traversed.insert(ty.clone()) {
+            return;
+        }
+
         match ty {
             Ty::Var(var) => {
                 if seen.insert(var.def.clone()) {
@@ -408,39 +457,39 @@ impl TypeChecker<'_> {
                 }
             }
             Ty::Func(_) | Ty::With(_) => {}
-            Ty::Param(param) => Self::collect_input_binders(&param.ty, seen, binders),
+            Ty::Param(param) => Self::collect_input_binders(&param.ty, seen, traversed, binders),
             Ty::Union(types) | Ty::Tuple(types) => {
                 for ty in types.iter() {
-                    Self::collect_input_binders(ty, seen, binders);
+                    Self::collect_input_binders(ty, seen, traversed, binders);
                 }
             }
             Ty::Let(bounds) => {
                 for ty in bounds.lbs.iter().chain(&bounds.ubs) {
-                    Self::collect_input_binders(ty, seen, binders);
+                    Self::collect_input_binders(ty, seen, traversed, binders);
                 }
             }
             Ty::Dict(record) => {
                 for ty in record.types.iter() {
-                    Self::collect_input_binders(ty, seen, binders);
+                    Self::collect_input_binders(ty, seen, traversed, binders);
                 }
             }
-            Ty::Array(elem) => Self::collect_input_binders(elem, seen, binders),
+            Ty::Array(elem) => Self::collect_input_binders(elem, seen, traversed, binders),
             Ty::Args(sig) | Ty::Pattern(sig) => {
                 for input in sig.inputs() {
-                    Self::collect_input_binders(input, seen, binders);
+                    Self::collect_input_binders(input, seen, traversed, binders);
                 }
             }
-            Ty::Select(select) => Self::collect_input_binders(&select.ty, seen, binders),
-            Ty::Unary(unary) => Self::collect_input_binders(&unary.lhs, seen, binders),
+            Ty::Select(select) => Self::collect_input_binders(&select.ty, seen, traversed, binders),
+            Ty::Unary(unary) => Self::collect_input_binders(&unary.lhs, seen, traversed, binders),
             Ty::Binary(binary) => {
                 let [lhs, rhs] = binary.operands();
-                Self::collect_input_binders(lhs, seen, binders);
-                Self::collect_input_binders(rhs, seen, binders);
+                Self::collect_input_binders(lhs, seen, traversed, binders);
+                Self::collect_input_binders(rhs, seen, traversed, binders);
             }
             Ty::If(if_ty) => {
-                Self::collect_input_binders(&if_ty.cond, seen, binders);
-                Self::collect_input_binders(&if_ty.then, seen, binders);
-                Self::collect_input_binders(&if_ty.else_, seen, binders);
+                Self::collect_input_binders(&if_ty.cond, seen, traversed, binders);
+                Self::collect_input_binders(&if_ty.then, seen, traversed, binders);
+                Self::collect_input_binders(&if_ty.else_, seen, traversed, binders);
             }
             Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => {}
         }
@@ -543,12 +592,7 @@ impl TypeChecker<'_> {
             return Ty::Any;
         }
 
-        let mut closer = FunctionResultantCloser {
-            vars: &self.info.vars,
-            params: FxHashSet::default(),
-            visiting: FxHashSet::default(),
-            visited: 0,
-        };
+        let mut closer = FunctionResultantCloser::new(&self.info.vars, FxHashSet::default());
         let mut bounds = closer.close_bounds(&bounds);
         if bounds.ubs.is_empty() && bounds.lbs.len() == 1 {
             return bounds.lbs.pop().unwrap();
@@ -560,11 +604,13 @@ impl TypeChecker<'_> {
         left.root() == right.root() && left.vpath() == right.vpath()
     }
 
+    #[allow(clippy::mutable_key_type)]
     fn snapshot_function_input_bounds(&self, sig: &SigTy) -> Vec<(Interned<TypeVar>, TypeBounds)> {
         let mut seen = FxHashSet::default();
+        let mut traversed = FxHashSet::default();
         let mut binders = vec![];
         for input in sig.inputs() {
-            Self::collect_input_binders(input, &mut seen, &mut binders);
+            Self::collect_input_binders(input, &mut seen, &mut traversed, &mut binders);
         }
 
         binders
@@ -596,12 +642,7 @@ impl TypeChecker<'_> {
                 .cloned(),
         );
 
-        let mut closer = FunctionResultantCloser {
-            vars: &self.info.vars,
-            params: resultant_params,
-            visiting: FxHashSet::default(),
-            visited: 0,
-        };
+        let mut closer = FunctionResultantCloser::new(&self.info.vars, resultant_params);
 
         closer.mutate(&body, true).unwrap_or(body)
     }
@@ -630,12 +671,7 @@ impl TypeChecker<'_> {
             bounds.ubs.sort();
             bounds.ubs.dedup();
 
-            let mut closer = FunctionResultantCloser {
-                vars: &self.info.vars,
-                params: scope.clone(),
-                visiting: FxHashSet::default(),
-                visited: 0,
-            };
+            let mut closer = FunctionResultantCloser::new(&self.info.vars, scope.clone());
             let mut bounds = closer.close_bounds(&bounds);
             bounds.lbs.sort();
             bounds.lbs.dedup();
@@ -1416,21 +1452,58 @@ struct ControlSplit {
     terminal: bool,
 }
 
+#[derive(Clone, Eq, Hash, PartialEq)]
+enum FunctionResultantEnvironmentTransition {
+    Visiting(DeclExpr),
+    Params(Vec<DeclExpr>),
+}
+
 struct FunctionResultantCloser<'a> {
     vars: &'a FxHashMap<DeclExpr, TypeVarBounds>,
     params: FxHashSet<DeclExpr>,
     visiting: FxHashSet<DeclExpr>,
     visited: usize,
+    environment: usize,
+    environments: FxHashMap<(usize, FunctionResultantEnvironmentTransition), usize>,
+    memo: FxHashMap<(usize, Ty, bool), Option<Ty>>,
 }
 
-impl FunctionResultantCloser<'_> {
+impl<'a> FunctionResultantCloser<'a> {
     const NODE_BUDGET: usize = 4096;
 
+    fn new(vars: &'a FxHashMap<DeclExpr, TypeVarBounds>, params: FxHashSet<DeclExpr>) -> Self {
+        Self {
+            vars,
+            params,
+            visiting: FxHashSet::default(),
+            visited: 0,
+            environment: 0,
+            environments: FxHashMap::default(),
+            memo: FxHashMap::default(),
+        }
+    }
+
+    fn enter_environment(&mut self, transition: FunctionResultantEnvironmentTransition) -> usize {
+        let parent = self.environment;
+        let key = (parent, transition);
+        let environment = if let Some(environment) = self.environments.get(&key) {
+            *environment
+        } else {
+            let environment = self.environments.len() + 1;
+            self.environments.insert(key, environment);
+            environment
+        };
+        self.environment = environment;
+        parent
+    }
+
+    #[allow(clippy::mutable_key_type)]
     fn close_scoped_sig(&mut self, sig: &SigTy, pol: bool) -> Option<SigTy> {
         let mut seen = FxHashSet::default();
+        let mut traversed = FxHashSet::default();
         let mut binders = vec![];
         for input in sig.inputs() {
-            TypeChecker::collect_input_binders(input, &mut seen, &mut binders);
+            TypeChecker::collect_input_binders(input, &mut seen, &mut traversed, &mut binders);
         }
         let inserted = binders
             .into_iter()
@@ -1440,12 +1513,20 @@ impl FunctionResultantCloser<'_> {
                     .then_some(binder.def.clone())
             })
             .collect::<Vec<_>>();
+        let parent_environment = (!inserted.is_empty()).then(|| {
+            self.enter_environment(FunctionResultantEnvironmentTransition::Params(
+                inserted.clone(),
+            ))
+        });
 
         let inputs = self.mutate_vec(&sig.inputs, pol);
         let body = self.mutate_option(sig.body.as_ref(), pol);
 
-        for def in inserted {
-            self.params.remove(&def);
+        for def in &inserted {
+            self.params.remove(def);
+        }
+        if let Some(parent_environment) = parent_environment {
+            self.environment = parent_environment;
         }
         if inputs.is_none() && body.is_none() {
             return None;
@@ -1473,20 +1554,24 @@ impl FunctionResultantCloser<'_> {
         if !self.visiting.insert(var.def.clone()) {
             return Some(Ty::Any);
         }
+        let parent_environment = self.enter_environment(
+            FunctionResultantEnvironmentTransition::Visiting(var.def.clone()),
+        );
 
-        let Some(bounds) = self.vars.get(&var.def) else {
-            self.visiting.remove(&var.def);
-            return Some(Ty::Any);
+        let bounds = self
+            .vars
+            .get(&var.def)
+            .map(|bounds| bounds.bounds.bounds().read().freeze());
+        let result = match bounds {
+            Some(bounds) if !bounds.lbs.is_empty() || !bounds.ubs.is_empty() => {
+                Some(Ty::Let(Interned::new(self.close_bounds(&bounds))))
+            }
+            _ => Some(Ty::Any),
         };
-        let bounds = bounds.bounds.bounds().read().freeze();
-        if bounds.lbs.is_empty() && bounds.ubs.is_empty() {
-            self.visiting.remove(&var.def);
-            return Some(Ty::Any);
-        }
 
-        let bounds = self.close_bounds(&bounds);
+        self.environment = parent_environment;
         self.visiting.remove(&var.def);
-        Some(Ty::Let(Interned::new(bounds)))
+        result
     }
 
     fn close_bounds(&mut self, bounds: &TypeBounds) -> TypeBounds {
@@ -1506,7 +1591,12 @@ impl FunctionResultantCloser<'_> {
 
 impl TyMutator for FunctionResultantCloser<'_> {
     fn mutate(&mut self, ty: &Ty, pol: bool) -> Option<Ty> {
-        match ty {
+        let key = (self.environment, ty.clone(), pol);
+        if let Some(result) = self.memo.get(&key) {
+            return result.clone();
+        }
+
+        let result = match ty {
             Ty::Var(var) => self.lower_bounds_of(var),
             Ty::Let(bounds) => Some(Ty::Let(Interned::new(self.close_bounds(bounds)))),
             Ty::Func(sig) => self
@@ -1516,7 +1606,9 @@ impl TyMutator for FunctionResultantCloser<'_> {
                 .close_scoped_sig(sig, pol)
                 .map(|sig| Ty::Pattern(Interned::new(sig))),
             _ => self.mutate_rec(ty, pol),
-        }
+        };
+        self.memo.insert(key, result.clone());
+        result
     }
 }
 
@@ -1743,5 +1835,71 @@ impl TyMutator for VarReplacer {
         }
 
         self.mutate_rec(ty, pol)
+    }
+}
+
+#[cfg(test)]
+mod function_resultant_closer_tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn signature_binder_collection_visits_shared_type_once() {
+        const DEPTH: usize = 16;
+
+        let def: DeclExpr = Decl::lit("input").into();
+        let var = TypeVar::new("input".into(), def);
+        let var_ty = Ty::Var(var);
+        let mut shared = Ty::Func(SigTy::unary(var_ty.clone(), var_ty));
+        for _ in 0..DEPTH {
+            shared = Ty::Tuple(vec![shared.clone(), shared].into());
+        }
+
+        let mut seen = FxHashSet::default();
+        let mut traversed = FxHashSet::default();
+        let mut binders = vec![];
+        TypeChecker::collect_signature_input_binders(
+            &shared,
+            &FxHashSet::default(),
+            &mut seen,
+            &mut traversed,
+            &mut binders,
+        );
+
+        assert_eq!(binders.len(), 1);
+        assert!(binders[0].1.is_empty());
+        assert_eq!(traversed.len(), DEPTH + 2);
+    }
+
+    #[test]
+    fn memo_isolated_by_signature_binder_scope() {
+        let def: DeclExpr = Decl::lit("input").into();
+        let var = TypeVar::new("input".into(), def.clone());
+        let var_ty = Ty::Var(var.clone());
+        let bound = Ty::Boolean(Some(true));
+
+        let mut var_bounds = DynTypeBounds::default();
+        var_bounds.lbs.insert_mut(bound.clone());
+        let mut vars = FxHashMap::default();
+        vars.insert(def, TypeVarBounds::new(var.as_ref().clone(), var_bounds));
+
+        let scoped = Ty::Func(SigTy::unary(var_ty.clone(), var_ty.clone()));
+        let body = Ty::Tuple(vec![var_ty.clone(), scoped.clone(), var_ty.clone()].into());
+        let mut closer = FunctionResultantCloser::new(&vars, FxHashSet::default());
+
+        let closed = closer.mutate(&body, true).expect("outer variables close");
+        let Ty::Tuple(items) = closed else {
+            panic!("expected tuple resultant");
+        };
+        let expected = Ty::Let(
+            TypeBounds {
+                lbs: vec![bound],
+                ubs: vec![],
+            }
+            .into(),
+        );
+
+        assert_eq!(items.as_ref(), &[expected.clone(), scoped, expected]);
+        assert_eq!(closer.visited, 2);
     }
 }

--- a/crates/tinymist-query/src/package.rs
+++ b/crates/tinymist-query/src/package.rs
@@ -10,7 +10,7 @@ use ecow::eco_format;
 #[cfg(feature = "local-registry")]
 use ecow::{EcoVec, eco_vec};
 // use reflexo_typst::typst::prelude::*;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use tinymist_world::package::registry::PackageIndexEntry;
 use tinymist_world::package::{PackageSpec, PackageSpecExt};
@@ -162,8 +162,29 @@ pub fn package_tyck_scope(
     let toml_id = get_manifest_id(spec)?;
     let manifest = ctx.get_manifest(toml_id)?;
     let entry_point = package_entrypoint_id(toml_id, &manifest.package.entrypoint);
-    let package_root = entry_point.root().clone();
+    let files = collect_package_tyck_files(ctx, entry_point, options)?;
 
+    Ok(PackageTyckDump {
+        schema: 1,
+        package: DumpPackageInfo {
+            namespace: spec.namespace.to_string(),
+            name: spec.name.to_string(),
+            version: spec.version.clone(),
+            spec: format!("@{}/{}:{}", spec.namespace, spec.name, spec.version),
+            path: spec.path.to_string_lossy().into_owned(),
+            entrypoint: manifest.package.entrypoint.to_string(),
+        },
+        entrypoint: dump_file_id(entry_point),
+        files,
+    })
+}
+
+fn collect_package_tyck_files(
+    ctx: &mut LocalContext,
+    entry_point: FileId,
+    options: PackageTyckDumpOptions,
+) -> StrResult<Vec<DumpFile>> {
+    let package_root = entry_point.root().clone();
     let mut files = vec![];
     let mut seen = FxHashSet::default();
     let mut queue = VecDeque::from([entry_point]);
@@ -173,9 +194,18 @@ pub fn package_tyck_scope(
             continue;
         }
 
-        let source = ctx
-            .source_by_id(fid)
-            .map_err(|err| eco_format!("failed to read package source {fid:?}: {err}"))?;
+        let source = match ctx.source_by_id(fid) {
+            Ok(source) => source,
+            Err(err) if fid == entry_point => {
+                return Err(eco_format!(
+                    "failed to read package entrypoint {fid:?}: {err}"
+                ));
+            }
+            Err(err) => {
+                log::warn!("skipping unreadable package source {fid:?}: {err}");
+                continue;
+            }
+        };
         let expr_info = ctx.expr_stage(&source);
         let type_info = ctx.type_check(&source);
 
@@ -204,20 +234,7 @@ pub fn package_tyck_scope(
     }
 
     files.sort_by(|left, right| left.file_id.cmp(&right.file_id));
-
-    Ok(PackageTyckDump {
-        schema: 1,
-        package: DumpPackageInfo {
-            namespace: spec.namespace.to_string(),
-            name: spec.name.to_string(),
-            version: spec.version.clone(),
-            spec: format!("@{}/{}:{}", spec.namespace, spec.name, spec.version),
-            path: spec.path.to_string_lossy().into_owned(),
-            entrypoint: manifest.package.entrypoint.to_string(),
-        },
-        entrypoint: dump_file_id(entry_point),
-        files,
-    })
+    Ok(files)
 }
 
 /// Options for dumping package scope and type-checker information.
@@ -306,12 +323,52 @@ struct DumpDecl {
     range: Option<DumpRange>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DumpType {
-    debug: String,
-    describe: Option<String>,
-    repr: Option<String>,
+    debug: EcoString,
+    describe: Option<EcoString>,
+    repr: Option<EcoString>,
+}
+
+struct TypeDumper<'a> {
+    type_info: &'a TypeInfo,
+    options: PackageTyckDumpOptions,
+    cache: FxHashMap<Ty, DumpType>,
+}
+
+impl<'a> TypeDumper<'a> {
+    fn new(type_info: &'a TypeInfo, options: PackageTyckDumpOptions) -> Self {
+        Self {
+            type_info,
+            options,
+            cache: FxHashMap::default(),
+        }
+    }
+
+    fn dump(&mut self, source: Ty) -> DumpType {
+        if let Some(dump) = self.cache.get(&source) {
+            return dump.clone();
+        }
+
+        let ty = self.type_info.simplify(source.clone(), true);
+        let display_ty = if contains_signature_binders(&ty) {
+            self.type_info.simplify(source.clone(), false)
+        } else {
+            ty.clone()
+        };
+        let dump = DumpType {
+            debug: format_debug_dump(&ty, self.options.max_type_chars).into(),
+            describe: display_ty.describe().map(|text| {
+                truncate_dump_string(text.to_string(), self.options.max_type_chars).into()
+            }),
+            repr: display_ty.repr().map(|text| {
+                truncate_dump_string(text.to_string(), self.options.max_type_chars).into()
+            }),
+        };
+        self.cache.insert(source, dump.clone());
+        dump
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -338,16 +395,17 @@ fn dump_file_scope(
 ) -> DumpFile {
     let fid = source.id();
     let file = dump_file_id(fid);
+    let mut types = TypeDumper::new(type_info, options);
 
     let file_scope = DumpScope {
         kind: "file",
         name: file.path.clone(),
         declaration: None,
-        variables: dump_scope_variables(source, type_info, exports, "export", true, options),
+        variables: dump_scope_variables(source, &mut types, exports, "export", true),
     };
 
     let mut scopes = vec![file_scope];
-    collect_function_scopes(source, type_info, root_expr, &mut scopes, options);
+    collect_function_scopes(source, &mut types, root_expr, &mut scopes);
 
     DumpFile {
         file_id: file.file_id,
@@ -355,17 +413,16 @@ fn dump_file_scope(
         path: file.path,
         imports,
         scopes,
-        type_mappings: dump_type_mappings(source, type_info, options),
+        type_mappings: dump_type_mappings(source, &mut types),
     }
 }
 
 fn dump_scope_variables(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     scope: &LexicalScope,
     var_source: &'static str,
     exported: bool,
-    options: PackageTyckDumpOptions,
 ) -> Vec<DumpVariable> {
     let origin = DumpVariableOrigin {
         source: var_source,
@@ -377,12 +434,11 @@ fn dump_scope_variables(
             let decl = expr_decl(expr)?;
             Some(dump_variable(
                 source,
-                type_info,
+                types,
                 name.as_ref(),
                 decl,
                 Some(expr),
                 origin,
-                options,
             ))
         })
         .collect::<Vec<_>>();
@@ -396,22 +452,14 @@ fn dump_scope_variables(
 
 fn collect_function_scopes(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     expr: &Expr,
     scopes: &mut Vec<DumpScope>,
-    options: PackageTyckDumpOptions,
 ) {
     if let Expr::Func(func) = expr {
         let mut variables = vec![];
-        collect_pattern_sig_variables(
-            source,
-            type_info,
-            &func.params,
-            "parameter",
-            &mut variables,
-            options,
-        );
-        collect_local_variables(source, type_info, &func.body, &mut variables, options);
+        collect_pattern_sig_variables(source, types, &func.params, "parameter", &mut variables);
+        collect_local_variables(source, types, &func.body, &mut variables);
         variables.sort_by(variable_cmp);
         variables.dedup_by(|left, right| {
             left.name == right.name && left.declaration.debug == right.declaration.debug
@@ -424,52 +472,37 @@ fn collect_function_scopes(
             variables,
         });
 
-        collect_function_scopes(source, type_info, &func.body, scopes, options);
+        collect_function_scopes(source, types, &func.body, scopes);
         return;
     }
 
     walk_expr_children(expr, &mut |child| {
-        collect_function_scopes(source, type_info, child, scopes, options);
+        collect_function_scopes(source, types, child, scopes);
     });
 }
 
 fn collect_local_variables(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     expr: &Expr,
     variables: &mut Vec<DumpVariable>,
-    options: PackageTyckDumpOptions,
 ) {
     match expr {
         Expr::Func(_) => {}
         Expr::Let(let_expr) => {
-            collect_pattern_variables(
-                source,
-                type_info,
-                &let_expr.pattern,
-                "local",
-                variables,
-                options,
-            );
+            collect_pattern_variables(source, types, &let_expr.pattern, "local", variables);
             if let Some(body) = &let_expr.body {
-                collect_local_variables(source, type_info, body, variables, options);
+                collect_local_variables(source, types, body, variables);
             }
         }
         Expr::ForLoop(for_loop) => {
-            collect_pattern_variables(
-                source,
-                type_info,
-                &for_loop.pattern,
-                "local",
-                variables,
-                options,
-            );
-            collect_local_variables(source, type_info, &for_loop.iter, variables, options);
-            collect_local_variables(source, type_info, &for_loop.body, variables, options);
+            collect_pattern_variables(source, types, &for_loop.pattern, "local", variables);
+            collect_local_variables(source, types, &for_loop.iter, variables);
+            collect_local_variables(source, types, &for_loop.body, variables);
         }
         _ => {
             walk_expr_children(expr, &mut |child| {
-                collect_local_variables(source, type_info, child, variables, options);
+                collect_local_variables(source, types, child, variables);
             });
         }
     }
@@ -477,19 +510,18 @@ fn collect_local_variables(
 
 fn collect_pattern_sig_variables(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     sig: &PatternSig,
     var_source: &'static str,
     variables: &mut Vec<DumpVariable>,
-    options: PackageTyckDumpOptions,
 ) {
     for pattern in &sig.pos {
-        collect_pattern_variables(source, type_info, pattern, var_source, variables, options);
+        collect_pattern_variables(source, types, pattern, var_source, variables);
     }
     for (decl, pattern) in &sig.named {
         variables.push(dump_variable(
             source,
-            type_info,
+            types,
             decl.name().as_ref(),
             decl,
             None,
@@ -497,14 +529,13 @@ fn collect_pattern_sig_variables(
                 source: var_source,
                 exported: false,
             },
-            options,
         ));
-        collect_pattern_variables(source, type_info, pattern, var_source, variables, options);
+        collect_pattern_variables(source, types, pattern, var_source, variables);
     }
     for (decl, pattern) in sig.spread_left.iter().chain(sig.spread_right.iter()) {
         variables.push(dump_variable(
             source,
-            type_info,
+            types,
             decl.name().as_ref(),
             decl,
             None,
@@ -512,26 +543,24 @@ fn collect_pattern_sig_variables(
                 source: var_source,
                 exported: false,
             },
-            options,
         ));
-        collect_pattern_variables(source, type_info, pattern, var_source, variables, options);
+        collect_pattern_variables(source, types, pattern, var_source, variables);
     }
 }
 
 fn collect_pattern_variables(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     pattern: &Pattern,
     var_source: &'static str,
     variables: &mut Vec<DumpVariable>,
-    options: PackageTyckDumpOptions,
 ) {
     match pattern {
-        Pattern::Expr(expr) => collect_local_variables(source, type_info, expr, variables, options),
+        Pattern::Expr(expr) => collect_local_variables(source, types, expr, variables),
         Pattern::Simple(decl) => {
             variables.push(dump_variable(
                 source,
-                type_info,
+                types,
                 decl.name().as_ref(),
                 decl,
                 None,
@@ -539,11 +568,10 @@ fn collect_pattern_variables(
                     source: var_source,
                     exported: false,
                 },
-                options,
             ));
         }
         Pattern::Sig(sig) => {
-            collect_pattern_sig_variables(source, type_info, sig, var_source, variables, options);
+            collect_pattern_sig_variables(source, types, sig, var_source, variables);
         }
     }
 }
@@ -677,13 +705,19 @@ fn expr_decl(expr: &Expr) -> Option<&DeclExpr> {
 
 fn dump_variable(
     source: &Source,
-    type_info: &TypeInfo,
+    types: &mut TypeDumper,
     name: &str,
     decl: &DeclExpr,
     expr: Option<&Expr>,
     origin: DumpVariableOrigin,
-    options: PackageTyckDumpOptions,
 ) -> DumpVariable {
+    let ty = types
+        .type_info
+        .vars
+        .get(decl)
+        .map(|bounds| bounds.as_type())
+        .map(|ty| types.dump(ty));
+
     DumpVariable {
         name: name.to_owned(),
         kind: decl.kind().to_string(),
@@ -691,10 +725,7 @@ fn dump_variable(
         exported: origin.exported,
         declaration: dump_decl(source, decl),
         expression: expr.map(ToString::to_string),
-        ty: type_info
-            .vars
-            .get(decl)
-            .map(|bounds| dump_type(type_info, bounds.as_type(), options)),
+        ty,
     }
 }
 
@@ -707,111 +738,150 @@ fn dump_decl(source: &Source, decl: &DeclExpr) -> DumpDecl {
     }
 }
 
-fn dump_type(type_info: &TypeInfo, ty: Ty, options: PackageTyckDumpOptions) -> DumpType {
-    let display_source = ty.clone();
-    let ty = type_info.simplify(ty, true);
-    let display_ty = if contains_signature_binders(&ty) {
-        type_info.simplify(display_source, false)
-    } else {
-        ty.clone()
-    };
-    DumpType {
-        debug: format_debug_dump(&ty, options.max_type_chars),
-        describe: display_ty
-            .describe()
-            .map(|text| truncate_dump_string(text.to_string(), options.max_type_chars)),
-        repr: display_ty
-            .repr()
-            .map(|text| truncate_dump_string(text.to_string(), options.max_type_chars)),
-    }
+fn contains_signature_binders(ty: &Ty) -> bool {
+    contains_signature_binders_inner(ty, &mut FxHashSet::default(), &mut FxHashSet::default())
 }
 
-fn contains_signature_binders(ty: &Ty) -> bool {
+#[allow(clippy::mutable_key_type)]
+fn contains_signature_binders_inner(
+    ty: &Ty,
+    traversed: &mut FxHashSet<Ty>,
+    type_var_traversed: &mut FxHashSet<Ty>,
+) -> bool {
+    if !traversed.insert(ty.clone()) {
+        return false;
+    }
+
     match ty {
         Ty::Func(sig) | Ty::Pattern(sig) => {
-            sig.inputs().any(contains_type_var)
-                || sig.inputs().any(contains_signature_binders)
-                || sig.body.as_ref().is_some_and(contains_signature_binders)
+            sig.inputs()
+                .any(|ty| contains_type_var(ty, type_var_traversed))
+                || sig
+                    .inputs()
+                    .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed))
+                || sig.body.as_ref().is_some_and(|ty| {
+                    contains_signature_binders_inner(ty, traversed, type_var_traversed)
+                })
         }
         Ty::Args(sig) => {
-            sig.inputs().any(contains_signature_binders)
-                || sig.body.as_ref().is_some_and(contains_signature_binders)
+            sig.inputs()
+                .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed))
+                || sig.body.as_ref().is_some_and(|ty| {
+                    contains_signature_binders_inner(ty, traversed, type_var_traversed)
+                })
         }
         Ty::With(with) => {
-            contains_signature_binders(&with.sig)
-                || with.with.inputs().any(contains_signature_binders)
+            contains_signature_binders_inner(&with.sig, traversed, type_var_traversed)
                 || with
                     .with
-                    .body
-                    .as_ref()
-                    .is_some_and(contains_signature_binders)
+                    .inputs()
+                    .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed))
+                || with.with.body.as_ref().is_some_and(|ty| {
+                    contains_signature_binders_inner(ty, traversed, type_var_traversed)
+                })
         }
-        Ty::Param(param) => contains_signature_binders(&param.ty),
-        Ty::Union(types) | Ty::Tuple(types) => types.iter().any(contains_signature_binders),
+        Ty::Param(param) => {
+            contains_signature_binders_inner(&param.ty, traversed, type_var_traversed)
+        }
+        Ty::Union(types) | Ty::Tuple(types) => types
+            .iter()
+            .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed)),
         Ty::Let(bounds) => bounds
             .lbs
             .iter()
             .chain(&bounds.ubs)
-            .any(contains_signature_binders),
-        Ty::Dict(record) => record.types.iter().any(contains_signature_binders),
-        Ty::Array(elem) => contains_signature_binders(elem),
-        Ty::Select(select) => contains_signature_binders(&select.ty),
-        Ty::Unary(unary) => contains_signature_binders(&unary.lhs),
+            .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed)),
+        Ty::Dict(record) => record
+            .types
+            .iter()
+            .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed)),
+        Ty::Array(elem) => contains_signature_binders_inner(elem, traversed, type_var_traversed),
+        Ty::Select(select) => {
+            contains_signature_binders_inner(&select.ty, traversed, type_var_traversed)
+        }
+        Ty::Unary(unary) => {
+            contains_signature_binders_inner(&unary.lhs, traversed, type_var_traversed)
+        }
         Ty::Binary(binary) => binary
             .operands()
             .iter()
-            .any(|ty| contains_signature_binders(ty)),
+            .any(|ty| contains_signature_binders_inner(ty, traversed, type_var_traversed)),
         Ty::If(if_ty) => {
-            contains_signature_binders(&if_ty.cond)
-                || contains_signature_binders(&if_ty.then)
-                || contains_signature_binders(&if_ty.else_)
+            contains_signature_binders_inner(&if_ty.cond, traversed, type_var_traversed)
+                || contains_signature_binders_inner(&if_ty.then, traversed, type_var_traversed)
+                || contains_signature_binders_inner(&if_ty.else_, traversed, type_var_traversed)
         }
         Ty::Var(_) | Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => false,
     }
 }
 
-fn contains_type_var(ty: &Ty) -> bool {
+#[allow(clippy::mutable_key_type)]
+fn contains_type_var(ty: &Ty, traversed: &mut FxHashSet<Ty>) -> bool {
+    if !traversed.insert(ty.clone()) {
+        return false;
+    }
+
     match ty {
         Ty::Var(_) => true,
         Ty::Func(sig) | Ty::Args(sig) | Ty::Pattern(sig) => {
-            sig.inputs().any(contains_type_var) || sig.body.as_ref().is_some_and(contains_type_var)
+            sig.inputs().any(|ty| contains_type_var(ty, traversed))
+                || sig
+                    .body
+                    .as_ref()
+                    .is_some_and(|ty| contains_type_var(ty, traversed))
         }
         Ty::With(with) => {
-            contains_type_var(&with.sig)
-                || with.with.inputs().any(contains_type_var)
-                || with.with.body.as_ref().is_some_and(contains_type_var)
+            contains_type_var(&with.sig, traversed)
+                || with
+                    .with
+                    .inputs()
+                    .any(|ty| contains_type_var(ty, traversed))
+                || with
+                    .with
+                    .body
+                    .as_ref()
+                    .is_some_and(|ty| contains_type_var(ty, traversed))
         }
-        Ty::Param(param) => contains_type_var(&param.ty),
-        Ty::Union(types) | Ty::Tuple(types) => types.iter().any(contains_type_var),
-        Ty::Let(bounds) => bounds.lbs.iter().chain(&bounds.ubs).any(contains_type_var),
-        Ty::Dict(record) => record.types.iter().any(contains_type_var),
-        Ty::Array(elem) => contains_type_var(elem),
-        Ty::Select(select) => contains_type_var(&select.ty),
-        Ty::Unary(unary) => contains_type_var(&unary.lhs),
-        Ty::Binary(binary) => binary.operands().iter().any(|ty| contains_type_var(ty)),
+        Ty::Param(param) => contains_type_var(&param.ty, traversed),
+        Ty::Union(types) | Ty::Tuple(types) => {
+            types.iter().any(|ty| contains_type_var(ty, traversed))
+        }
+        Ty::Let(bounds) => bounds
+            .lbs
+            .iter()
+            .chain(&bounds.ubs)
+            .any(|ty| contains_type_var(ty, traversed)),
+        Ty::Dict(record) => record
+            .types
+            .iter()
+            .any(|ty| contains_type_var(ty, traversed)),
+        Ty::Array(elem) => contains_type_var(elem, traversed),
+        Ty::Select(select) => contains_type_var(&select.ty, traversed),
+        Ty::Unary(unary) => contains_type_var(&unary.lhs, traversed),
+        Ty::Binary(binary) => binary
+            .operands()
+            .iter()
+            .any(|ty| contains_type_var(ty, traversed)),
         Ty::If(if_ty) => {
-            contains_type_var(&if_ty.cond)
-                || contains_type_var(&if_ty.then)
-                || contains_type_var(&if_ty.else_)
+            contains_type_var(&if_ty.cond, traversed)
+                || contains_type_var(&if_ty.then, traversed)
+                || contains_type_var(&if_ty.else_, traversed)
         }
         Ty::Any | Ty::Boolean(_) | Ty::Builtin(_) | Ty::Value(_) => false,
     }
 }
 
-fn dump_type_mappings(
-    source: &Source,
-    type_info: &TypeInfo,
-    options: PackageTyckDumpOptions,
-) -> Vec<DumpTypeMapping> {
+fn dump_type_mappings(source: &Source, types: &mut TypeDumper) -> Vec<DumpTypeMapping> {
+    let type_info = types.type_info;
     let mut mappings = type_info
         .mapping
         .iter()
-        .filter_map(|(span, types)| {
+        .filter_map(|(span, mapped_types)| {
             let range = dump_span_range(source, *span)?;
-            let ty = Ty::from_types(types.clone().into_iter());
+            let ty = Ty::from_types(mapped_types.clone().into_iter());
             Some(DumpTypeMapping {
                 range,
-                ty: dump_type(type_info, ty, options),
+                ty: types.dump(ty),
             })
         })
         .collect::<Vec<_>>();
@@ -1106,6 +1176,9 @@ mod tests {
     use typst::syntax::package::PackageSpec;
 
     use super::*;
+    use crate::syntax::Decl;
+    use crate::tests::{run_with_ctx, run_with_sources};
+    use crate::ty::{SigTy, TypeVar};
 
     fn manifest_id() -> FileId {
         FileId::new(RootedPath::new(
@@ -1132,5 +1205,131 @@ mod tests {
 
         assert_eq!(entrypoint.root(), manifest_id.root());
         assert_eq!(entrypoint.vpath().get_with_slash(), "/lib.typ");
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn signature_binder_detection_visits_shared_type_once() {
+        const DEPTH: usize = 16;
+
+        let mut shared = Ty::Any;
+        for _ in 0..DEPTH {
+            shared = Ty::Tuple(vec![shared.clone(), shared].into());
+        }
+        let mut traversed = FxHashSet::default();
+        assert!(!contains_signature_binders_inner(
+            &shared,
+            &mut traversed,
+            &mut FxHashSet::default(),
+        ));
+        assert_eq!(traversed.len(), DEPTH + 1);
+
+        let binder = TypeVar::new("input".into(), Decl::lit("input").into());
+        let binder_ty = Ty::Var(binder);
+        assert!(contains_signature_binders(&Ty::Func(SigTy::unary(
+            binder_ty,
+            Ty::Any,
+        ))));
+    }
+
+    #[test]
+    fn type_dumper_reuses_dumped_types() {
+        let info = TypeInfo::default();
+        let mut dumper = TypeDumper::new(
+            &info,
+            PackageTyckDumpOptions {
+                max_type_chars: Some(128),
+            },
+        );
+
+        let first = dumper.dump(Ty::Any);
+        let second = dumper.dump(Ty::Any);
+
+        assert_eq!(dumper.cache.len(), 1);
+        assert_eq!(first.debug, second.debug);
+        assert_eq!(first.describe, second.describe);
+        assert_eq!(first.repr, second.repr);
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn principal_dump_preserves_type_guard_branches() {
+        run_with_sources(
+            r#"
+#let auto-cast(pat) = {
+  if type(pat) == dictionary {
+    pat
+  } else if type(pat) == array {
+    pat.map(auto-cast)
+  }
+}
+"#,
+            |verse, path| {
+                run_with_ctx(verse, path, &|ctx, path| {
+                    let source = ctx.source_by_path(&path).unwrap();
+                    let info = ctx.type_check(&source);
+                    let mapped = info
+                        .mapping
+                        .iter()
+                        .find_map(|(span, mapped)| {
+                            let range = source_range(&source, *span)?;
+                            (source.text().get(range) == Some("pat.map")).then_some(mapped)
+                        })
+                        .expect("pat.map must have a mapped type");
+                    let source_ty = Ty::from_types(mapped.clone().into_iter());
+                    let mut dumper = TypeDumper::new(
+                        &info,
+                        PackageTyckDumpOptions {
+                            max_type_chars: Some(1024),
+                        },
+                    );
+                    let dumped = dumper.dump(source_ty);
+
+                    assert!(dumped.debug.contains("Type(array)"));
+                    assert!(dumped.debug.contains("Type(dictionary)"));
+                    assert!(dumped.debug.contains(".map"));
+                });
+            },
+        );
+    }
+
+    #[test]
+    fn package_tyck_files_skip_unreadable_imports() {
+        run_with_sources(
+            r#"
+// path: present.typ
+#let present = true
+-----
+// path: main.typ
+#import "present.typ"
+#import "missing.typ"
+"#,
+            |verse, path| {
+                run_with_ctx(verse, path, &|ctx, path| {
+                    let entrypoint = ctx.source_by_path(&path).unwrap().id();
+                    let files = collect_package_tyck_files(ctx, entrypoint, Default::default())
+                        .expect("missing imports should not abort a package scan");
+
+                    assert_eq!(
+                        files
+                            .iter()
+                            .map(|file| file.path.as_str())
+                            .collect::<Vec<_>>(),
+                        ["main.typ", "present.typ"]
+                    );
+                    let main = files
+                        .iter()
+                        .find(|file| file.path == "main.typ")
+                        .expect("entrypoint must be dumped");
+                    assert_eq!(
+                        main.imports
+                            .iter()
+                            .map(|import| import.path.as_str())
+                            .collect::<Vec<_>>(),
+                        ["missing.typ", "present.typ"]
+                    );
+                });
+            },
+        );
     }
 }


### PR DESCRIPTION
- Memoize substitution, simplification, and resultant closing across shared type DAGs.
- Short-circuit identical interned comparisons and reuse rendered package types.
- Skip unreadable non-entry package imports while preserving their import edges.