### PR TITLE
fix(query): don't invert completion range on spread with extra dots

### DIFF
--- a/crates/tinymist-query/src/analysis/completion.rs
+++ b/crates/tinymist-query/src/analysis/completion.rs
@@ -702,7 +702,10 @@ impl CompletionPair<'_, '_, '_> {
                 let target = var.accessed_node()?;
                 let field = var.accessing_field()?;
 
-                self.cursor.from = field.offset(&self.cursor.source)?;
+                // The field offset can land past the cursor on incomplete input
+                // like `f(...x)`, where the classified dot access is the whole
+                // call. Keep `from <= cursor` so the replace range stays valid.
+                self.cursor.from = field.offset(&self.cursor.source)?.min(self.cursor.cursor);
 
                 self.doc_access_completions(&target);
                 return Some(());

--- a/crates/tinymist-query/src/fixtures/completion/dot_spread.typ
+++ b/crates/tinymist-query/src/fixtures/completion/dot_spread.typ
@@ -1,0 +1,4 @@
+/// contains: args
+
+#let f(..args) = args
+#f(...args)/* range -5..-4 */

--- a/crates/tinymist-query/src/fixtures/completion/snaps/test@dot_spread.typ.snap
+++ b/crates/tinymist-query/src/fixtures/completion/snaps/test@dot_spread.typ.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tinymist-query/src/completion.rs
+description: Completion on a (48..49)
+expression: "JsonRepr::new_pure(results)"
+input_file: crates/tinymist-query/src/fixtures/completion/dot_spread.typ
+---
+[
+ {
+  "isIncomplete": false,
+  "items": []
+ }
+]


### PR DESCRIPTION
Typing a spread with an extra dot, e.g. `#f(...args)`, panics the server with `assertion failed: min <= max` from `Ord::clamp` in `insert_range_of`. The third dot is classified as a dot access whose target ends up being the whole call, so `field.offset()` lands past the cursor and the replace range `from..cursor` is inverted. Clamp `from` to the cursor, and add a completion fixture that panics without this change.

Fixes #2669