### PR TITLE
docs: change json.decode(...) to json(bytes(...)) for preview args

### DIFF
--- a/docs/tinymist/feature/preview.typ
+++ b/docs/tinymist/feature/preview.typ
@@ -127,7 +127,7 @@ tinymist preview /abs-path/to/main.typ --partial-rendering
 If the document is compiled by lsp, you can use `sys.inputs` to get the preview arguments:
 
 ```typ
-#let preview-args = json.decode(sys.inputs.at("x-preview", default: "{}"))
+#let preview-args = json(bytes(sys.inputs.at("x-preview", default: "{}")))
 ```
 
 There is a `version` field in the `preview-args` object, which will increase when the scheme of the preview arguments is changed.


### PR DESCRIPTION
Typst deprecated `json.decode` in favor of `json(bytes(...))` since 0.13: https://typst.app/blog/2025/typst-0.13/