### PR TITLE
fix(query): surface traced diagnostics at main callsites

### DIFF
--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -139,26 +139,35 @@ impl<'w> DiagWorker<'w> {
             diag
         };
 
-        let (id, span) = self.diagnostic_span_id(&typst_diagnostic);
+        let (origin_id, origin_span) = self.diagnostic_origin_span_id(&typst_diagnostic);
+        let (id, span) =
+            self.diagnostic_display_span_id(&typst_diagnostic, (origin_id, origin_span));
         let uri = self.ctx.uri_for_id(id)?;
         let source = self.ctx.source_by_id(id)?;
         let lsp_range = self.diagnostic_range(&source, span);
 
         let lsp_severity = diagnostic_severity(typst_diagnostic.severity);
         let lsp_message = diagnostic_message(&typst_diagnostic);
+        let mut related_information = typst_diagnostic
+            .trace
+            .iter()
+            .flat_map(|tracepoint| self.to_related_info(tracepoint))
+            .collect::<Vec<_>>();
+
+        if id != origin_id {
+            if let Some(origin) =
+                self.to_related_span(origin_id, origin_span, "diagnostic originated here")
+            {
+                related_information.insert(0, origin);
+            }
+        }
 
         let diagnostic = Diagnostic {
             range: lsp_range,
             severity: Some(lsp_severity),
             message: lsp_message,
             source: Some(self.source.to_owned()),
-            related_information: (!typst_diagnostic.trace.is_empty()).then(|| {
-                typst_diagnostic
-                    .trace
-                    .iter()
-                    .flat_map(|tracepoint| self.to_related_info(tracepoint))
-                    .collect()
-            }),
+            related_information: (!related_information.is_empty()).then_some(related_information),
             ..Default::default()
         };
 
@@ -170,11 +179,20 @@ impl<'w> DiagWorker<'w> {
         tracepoint: &Spanned<Tracepoint>,
     ) -> Option<DiagnosticRelatedInformation> {
         let id = tracepoint.span.id()?;
+        self.to_related_span(id, tracepoint.span.into(), tracepoint.v.to_string())
+    }
+
+    fn to_related_span(
+        &self,
+        id: TypstFileId,
+        span: DiagSpan,
+        message: impl Into<String>,
+    ) -> Option<DiagnosticRelatedInformation> {
         // todo: expensive uri_for_id
         let uri = self.ctx.uri_for_id(id).ok()?;
         let source = self.ctx.source_by_id(id).ok()?;
 
-        let typst_range = source_range(&source, tracepoint.span)?;
+        let typst_range = source_range(&source, span)?;
         let lsp_range = self.ctx.to_lsp_range(typst_range, &source);
 
         Some(DiagnosticRelatedInformation {
@@ -182,11 +200,35 @@ impl<'w> DiagWorker<'w> {
                 uri,
                 range: lsp_range,
             },
-            message: tracepoint.v.to_string(),
+            message: message.into(),
         })
     }
 
-    fn diagnostic_span_id(&self, typst_diagnostic: &TypstDiagnostic) -> (TypstFileId, DiagSpan) {
+    fn diagnostic_display_span_id(
+        &self,
+        typst_diagnostic: &TypstDiagnostic,
+        origin: (TypstFileId, DiagSpan),
+    ) -> (TypstFileId, DiagSpan) {
+        let main = self.ctx.world().main();
+        if origin.0 == main {
+            return origin;
+        }
+
+        typst_diagnostic
+            .trace
+            .iter()
+            .rev()
+            .find_map(|tracepoint| {
+                let id = tracepoint.span.id()?;
+                (id == main).then_some((id, tracepoint.span.into()))
+            })
+            .unwrap_or(origin)
+    }
+
+    fn diagnostic_origin_span_id(
+        &self,
+        typst_diagnostic: &TypstDiagnostic,
+    ) -> (TypstFileId, DiagSpan) {
         iter::once(typst_diagnostic.span)
             .chain(typst_diagnostic.trace.iter().map(|trace| trace.span.into()))
             .find_map(|span| Some((span.id()?, span)))
@@ -269,5 +311,33 @@ impl DiagnosticRefiner for OutOfRootHintRefiner {
     fn refine(&self, mut raw: TypstDiagnostic) -> TypstDiagnostic {
         raw.hints.clear();
         raw.with_hint("Cannot read file outside of project root.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use typst::diag::Warned;
+    use typst_layout::PagedDocument;
+
+    use super::*;
+    use crate::tests::*;
+
+    #[test]
+    fn test() {
+        snapshot_testing("diagnostics", &|ctx, _| {
+            let Warned { output, warnings } = typst_shim::compile_opt::<PagedDocument>(ctx.world());
+            let errors = output.err().unwrap_or_default();
+            let diagnostics = warnings.iter().chain(errors.iter());
+
+            let result = DiagWorker::new(ctx)
+                .convert_all(diagnostics)
+                .into_iter()
+                .map(|(uri, diagnostics)| (file_uri_(&uri), diagnostics))
+                .collect::<BTreeMap<_, _>>();
+
+            assert_snapshot!(JsonRepr::new_redacted(result, &REDACT_LOC));
+        });
     }
 }

--- a/crates/tinymist-query/src/diagnostics.rs
+++ b/crates/tinymist-query/src/diagnostics.rs
@@ -154,12 +154,11 @@ impl<'w> DiagWorker<'w> {
             .flat_map(|tracepoint| self.to_related_info(tracepoint))
             .collect::<Vec<_>>();
 
-        if id != origin_id {
-            if let Some(origin) =
+        if id != origin_id
+            && let Some(origin) =
                 self.to_related_span(origin_id, origin_span, "diagnostic originated here")
-            {
-                related_information.insert(0, origin);
-            }
+        {
+            related_information.insert(0, origin);
         }
 
         let diagnostic = Diagnostic {

--- a/crates/tinymist-query/src/fixtures/diagnostics/callsite.typ
+++ b/crates/tinymist-query/src/fixtures/diagnostics/callsite.typ
@@ -1,0 +1,7 @@
+/// path: library.typ
+#let inner() = panic("the value is invalid")
+#let outer() = inner()
+-----
+#import "library.typ": outer
+
+#outer()

--- a/crates/tinymist-query/src/fixtures/diagnostics/same_file.typ
+++ b/crates/tinymist-query/src/fixtures/diagnostics/same_file.typ
@@ -1,0 +1,1 @@
+#let value =

--- a/crates/tinymist-query/src/fixtures/diagnostics/snaps/test@callsite.typ.snap
+++ b/crates/tinymist-query/src/fixtures/diagnostics/snaps/test@callsite.typ.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tinymist-query/src/diagnostics.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/diagnostics/callsite.typ
+---
+{
+ "s1.typ": [
+  {
+   "message": "panicked with: the value is invalid",
+   "range": "2:1:2:8",
+   "relatedInformation": [
+    {
+     "message": "diagnostic originated here"
+    },
+    {
+     "message": "while calling `inner`"
+    },
+    {
+     "message": "while calling `outer`"
+    }
+   ],
+   "severity": 1,
+   "source": "typst"
+  }
+ ]
+}

--- a/crates/tinymist-query/src/fixtures/diagnostics/snaps/test@same_file.typ.snap
+++ b/crates/tinymist-query/src/fixtures/diagnostics/snaps/test@same_file.typ.snap
@@ -1,0 +1,15 @@
+---
+source: crates/tinymist-query/src/diagnostics.rs
+expression: "JsonRepr::new_redacted(result, &REDACT_LOC)"
+input_file: crates/tinymist-query/src/fixtures/diagnostics/same_file.typ
+---
+{
+ "s0.typ": [
+  {
+   "message": "expected expression",
+   "range": "0:12:0:12",
+   "severity": 1,
+   "source": "typst"
+  }
+ ]
+}


### PR DESCRIPTION
## Summary

When Typst reports an error inside an imported module or package, Tinymist assigns the primary LSP diagnostic to the internal source span and sends the user callsite through `relatedInformation`.

VS Code lists the diagnostic in the Problems panel, but Error Lens cannot display it beside the call that caused the error. Neovim clients have the same problem when they do not expose `relatedInformation`.

This change uses the outermost trace span in the main document as the displayed diagnostic location when the original error comes from another file. It keeps the original source location in `relatedInformation` with the message `diagnostic originated here`.

Diagnostics that originate in the main document keep their current location.

## Tests

Added diagnostic fixtures covering:

- an error raised in an imported file with a callsite in the main document;
- an error raised directly in the main document.

Ran:

- `cargo test -p tinymist-query`
- `cargo build -p tinymist-cli --release`

Addresses #1870.