### PR TITLE
feat(vscode): add PDF export editor context action

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1300,6 +1300,10 @@
         "category": "Typst"
       },
       {
+        "command": "tinymist.exportCurrentPdfFromContext",
+        "title": "%extension.tinymist.command.tinymist.exportCurrentPdfFromContext%"
+      },
+      {
         "command": "tinymist.pinMainToCurrent",
         "title": "%extension.tinymist.command.tinymist.pinMainToCurrent%",
         "category": "Typst"
@@ -1490,6 +1494,10 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "tinymist.exportCurrentPdfFromContext",
+          "when": "false"
+        },
+        {
           "command": "tinymist.exportCurrentPdf",
           "when": "editorLangId == typst"
         },
@@ -1535,6 +1543,11 @@
         }
       ],
       "editor/context": [
+        {
+          "command": "tinymist.exportCurrentPdfFromContext",
+          "when": "resourceLangId == typst && editorTextFocus",
+          "group": "1_modification@100"
+        },
         {
           "command": "tinymist.copyAnsiHighlight",
           "when": "resourceLangId == typst && editorTextFocus",

--- a/editors/vscode/src/features/export.ts
+++ b/editors/vscode/src/features/export.ts
@@ -26,12 +26,47 @@ export type ExportKind =
 
 export function exportActivate(context: IContext) {
   context.subscriptions.push(
-    commands.registerCommand("tinymist.exportCurrentPdf", () => commandExport("Pdf")),
+    commands.registerCommand("tinymist.exportCurrentPdf", commandExportCurrentPdf),
+    commands.registerCommand("tinymist.exportCurrentPdfFromContext", commandExportCurrentPdf),
     commands.registerCommand("tinymist.export", commandExport),
     commands.registerCommand("tinymist.exportCurrentFile", commandAskAndExport),
     commands.registerCommand("tinymist.showPdf", () => commandShow("Pdf")),
     commands.registerCommand("tinymist.exportCurrentFileAndShow", commandAskAndShow),
   );
+}
+
+export async function commandExportCurrentPdf(): Promise<ExportResponse | null> {
+  let exportResponse: ExportResponse | null;
+  try {
+    exportResponse = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Window,
+        title: l10nMsg("Exporting PDF"),
+      },
+      async () => await commandExport("Pdf"),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await vscode.window.showErrorMessage(
+      l10nMsg("Failed to export PDF: {message}", { message }),
+    );
+    return null;
+  }
+
+  if (!exportResponse) {
+    await vscode.window.showErrorMessage(l10nMsg("Failed to export PDF"));
+    return null;
+  }
+
+  if ("path" in exportResponse && exportResponse.path) {
+    await vscode.window.showInformationMessage(
+      l10nMsg("Exported successfully to: {path}", { path: exportResponse.path }),
+    );
+  } else {
+    await vscode.window.showInformationMessage(l10nMsg("Export completed"));
+  }
+
+  return exportResponse;
 }
 
 export interface QuickExportFormatMeta {

--- a/locales/tinymist-vscode-rt.toml
+++ b/locales/tinymist-vscode-rt.toml
@@ -56,6 +56,10 @@ zh = "合并页面并导出为单个 PNG"
 en = "Export as a single SVG by merging pages"
 zh = "合并页面并导出为单个 SVG"
 
+["Export completed"]
+en = "Export completed"
+zh = "导出完成"
+
 ["Export the specified pages as multiple PNGs"]
 en = "Export the specified pages as multiple PNGs"
 zh = "将指定页面导出为多个单独 PNG"
@@ -63,6 +67,22 @@ zh = "将指定页面导出为多个单独 PNG"
 ["Export the specified pages as multiple SVGs"]
 en = "Export the specified pages as multiple SVGs"
 zh = "将指定页面导出为多个单独 SVG"
+
+["Exported successfully to: {path}"]
+en = "Exported successfully to: {path}"
+zh = "已成功导出到：{path}"
+
+["Exporting PDF"]
+en = "Exporting PDF"
+zh = "正在导出 PDF"
+
+["Failed to export PDF"]
+en = "Failed to export PDF"
+zh = "PDF 导出失败"
+
+["Failed to export PDF: {message}"]
+en = "Failed to export PDF: {message}"
+zh = "PDF 导出失败：{message}"
 
 ["Hint: you can create and find local packages in the sidebar. See https://github.com/Myriad-Dreamin/tinymist/tree/bc15eb55cee9f9b048aafd5f22472894961a1f51/editors/vscode/e2e-workspaces/ieee-paper for more information."]
 en = "Hint: you can create and find local packages in the sidebar. See https://github.com/Myriad-Dreamin/tinymist/tree/bc15eb55cee9f9b048aafd5f22472894961a1f51/editors/vscode/e2e-workspaces/ieee-paper for more information."

--- a/locales/tinymist-vscode.toml
+++ b/locales/tinymist-vscode.toml
@@ -85,6 +85,11 @@ vi = "Xuất tệp đã mở dưới dạng PDF"
 zh = "将当前打开的文件导出为 PDF"
 zh-TW = "將當前打開的文件導出為 PDF"
 
+[extension.tinymist.command.tinymist.exportCurrentPdfFromContext]
+en = "Typst: Export as PDF"
+zh = "Typst：导出为 PDF"
+zh-TW = "Typst：匯出為 PDF"
+
 [extension.tinymist.command.tinymist.pinMainToCurrent]
 en = "Pin the Main File to the Currently Open Document"
 ar = "تثبيت الملف الرئيسي على المستند المفتوح"


### PR DESCRIPTION
- Add a localized 'Typst: Export as PDF' action to the Typst editor context menu.
- Show progress and success or failure notifications for manual PDF exports.

Closes #2513