### PR TITLE
Add a codeLens to pin the preview for clients without runCodeLens

### DIFF
--- a/crates/tinymist-query/src/code_lens.rs
+++ b/crates/tinymist-query/src/code_lens.rs
@@ -10,6 +10,9 @@ use crate::{SemanticRequest, prelude::*};
 pub struct CodeLensRequest {
     /// The path of the document to request for.
     pub path: PathBuf,
+    /// Whether this document is the one currently pinned as the main file by
+    /// the user (via `tinymist.pinMain`).
+    pub is_pinned_here: bool,
 }
 
 impl SemanticRequest for CodeLensRequest {
@@ -21,6 +24,38 @@ impl SemanticRequest for CodeLensRequest {
         let mut res = vec![];
 
         let doc_start = ctx.to_lsp_range(0..0, &source);
+
+        // Unlike the lenses below, `tinymist.pinMain` is a real, directly
+        // executable LSP command, so this lens works for every client and is
+        // not gated behind `support_client_codelens`. It is the only way for a
+        // client that cannot run arbitrary editor commands (e.g. Zed, Helix,
+        // Neovim) to keep the background/browsing preview on one document:
+        // that preview otherwise follows whichever document was most recently
+        // opened, and closing a second document does not hand it back. See
+        // `ServerState::focus_main_file`.
+        let pin_title = if self.is_pinned_here {
+            tinymist_l10n::t!("tinymist-query.code-lens.unpinMain", "📌 Unpin Preview")
+        } else {
+            tinymist_l10n::t!(
+                "tinymist-query.code-lens.pinMain",
+                "📌 Pin Preview to This File"
+            )
+        };
+        let pin_arg = if self.is_pinned_here {
+            JsonValue::Null
+        } else {
+            self.path.display().to_string().into()
+        };
+        res.push(CodeLens {
+            range: doc_start,
+            command: Some(Command {
+                title: pin_title.to_string(),
+                command: "tinymist.pinMain".to_string(),
+                arguments: Some(vec![pin_arg]),
+            }),
+            data: None,
+        });
+
         let mut doc_lens = |title: &str, args: Vec<JsonValue>| {
             if !ctx.analysis.support_client_codelens {
                 return;

--- a/crates/tinymist/src/config.rs
+++ b/crates/tinymist/src/config.rs
@@ -955,6 +955,10 @@ pub struct ConstConfig {
     pub doc_line_folding_only: bool,
     /// Allow dynamic registration of document formatting.
     pub doc_fmt_dynamic_registration: bool,
+    /// Allow dynamic registration of code lenses. Some clients (e.g. Zed)
+    /// declare this but never query `textDocument/codeLens` when the server
+    /// only advertises `codeLensProvider` statically in `initialize`.
+    pub code_lens_dynamic_registration: bool,
     /// Allow insert/replace text edits in completion items.
     pub completion_insert_replace_support: bool,
     /// The locale of the editor.
@@ -993,6 +997,7 @@ impl From<&InitializeParams> for ConstConfig {
         let sema = try_(|| doc?.semantic_tokens.as_ref());
         let fold = try_(|| doc?.folding_range.as_ref());
         let format = try_(|| doc?.formatting.as_ref());
+        let code_lens = try_(|| doc?.code_lens.as_ref());
         let completion_item = try_(|| doc?.completion.as_ref()?.completion_item.as_ref());
 
         let locale = params
@@ -1010,6 +1015,7 @@ impl From<&InitializeParams> for ConstConfig {
             tokens_multiline_token_support: try_or(|| sema?.multiline_token_support, false),
             doc_line_folding_only: try_or(|| fold?.line_folding_only, true),
             doc_fmt_dynamic_registration: try_or(|| format?.dynamic_registration, false),
+            code_lens_dynamic_registration: try_or(|| code_lens?.dynamic_registration, false),
             completion_insert_replace_support: try_or(
                 || completion_item?.insert_replace_support,
                 false,

--- a/crates/tinymist/src/lsp.rs
+++ b/crates/tinymist/src/lsp.rs
@@ -49,6 +49,23 @@ impl ServerState {
                 .log_error("could not register formatter for initialization");
         }
 
+        if self.const_config().code_lens_dynamic_registration {
+            const CODE_LENS_REGISTRATION_ID: &str = "code-lens";
+            const CODE_LENS_METHOD_ID: &str = "textDocument/codeLens";
+
+            self.register_capability(vec![Registration {
+                id: CODE_LENS_REGISTRATION_ID.to_owned(),
+                method: CODE_LENS_METHOD_ID.to_owned(),
+                register_options: Some(
+                    serde_json::to_value(CodeLensOptions {
+                        resolve_provider: Some(false),
+                    })
+                    .expect("code lens options should be representable as JSON value"),
+                ),
+            }])
+            .log_error("could not register code lens capability dynamically");
+        }
+
         if self.const_config().cfg_change_registration {
             log::trace!("setting up to request config change notifications");
 

--- a/crates/tinymist/src/lsp/init.rs
+++ b/crates/tinymist/src/lsp/init.rs
@@ -102,6 +102,10 @@ impl Initializer for SuperInit {
         });
         let document_formatting_provider =
             (!const_config.doc_fmt_dynamic_registration).then_some(OneOf::Left(true));
+        let code_lens_provider =
+            (!const_config.code_lens_dynamic_registration).then_some(CodeLensOptions {
+                resolve_provider: Some(false),
+            });
         let document_range_formatting_provider =
             (!const_config.doc_fmt_dynamic_registration).then_some(OneOf::Left(true));
 
@@ -198,9 +202,7 @@ impl Initializer for SuperInit {
                 document_range_formatting_provider,
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-                code_lens_provider: Some(CodeLensOptions {
-                    resolve_provider: Some(false),
-                }),
+                code_lens_provider,
 
                 experimental: Some(json!({
                   "onEnter": true,

--- a/crates/tinymist/src/lsp/query.rs
+++ b/crates/tinymist/src/lsp/query.rs
@@ -144,7 +144,9 @@ impl ServerState {
 
     pub(crate) fn code_lens(&mut self, params: CodeLensParams) -> ScheduleResult {
         let path = as_path(params.text_document);
-        run_query!(self.CodeLens(path))
+        let is_pinned_here =
+            self.pinning_by_user && self.focusing.as_deref() == Some(path.as_path());
+        run_query!(self.CodeLens(path, is_pinned_here))
     }
 
     pub(crate) fn completion(&mut self, params: CompletionParams) -> ScheduleResult {

--- a/locales/tinymist-rt.toml
+++ b/locales/tinymist-rt.toml
@@ -56,6 +56,14 @@ zh = "性能分析"
 en = "Wrap {func_name} in figure with a caption"
 zh = "将 {func_name} 包裹在 figure 中，并添加一个标题"
 
+[tinymist-query.code-lens.pinMain]
+en = "📌 Pin Preview to This File"
+zh = "📌 将预览固定到此文件"
+
+[tinymist-query.code-lens.unpinMain]
+en = "📌 Unpin Preview"
+zh = "📌 取消固定预览"
+
 [tinymist.config.badCompileStatus]
 en = "compileStatus must be either `\"enable\"` or `\"disable\"`, got {value}"
 zh = "compileStatus 必须是`\"enable\"`（打开）或 `\"disable\"`（关闭），得到 {value}"


### PR DESCRIPTION
## Summary

The background/browsing preview (`preview.background.enabled` /
`tinymist.doStartBrowsingPreview`) follows whichever document the server most
recently saw opened (`ServerState::focus_main_file`). Opening a second `.typ`
file re-points the preview to it, and closing that file again does **not**
hand the preview back — edits to the original document then stop producing
any preview updates at all, with no way to recover short of restarting the
server.

`tinymist.pinMain` already exists to fix exactly this, but reaching it
requires the client to send an arbitrary `workspace/executeCommand`. VS Code
gets there through editor-title buttons the extension registers itself
(`tinymist.pinMainToCurrent` / `tinymist.unpinMain` in
`editors/vscode/src/extension.ts`). Clients that only implement generic LSP
UI — Zed, Helix, Neovim, etc. — have no such button and no way to invoke the
command, so the preview simply breaks for them the first time a second file
is opened, with no recourse.

This showed up concretely while debugging why tinymist's preview is
unreliable in Zed with a large, multi-file project.

## Change

**Commit 1** adds a **"📌 Pin Preview to This File" / "📌 Unpin Preview"** code
lens whose command is `tinymist.pinMain` directly, with the toggle state
computed from `pinning_by_user` / `focusing` in `ServerState::code_lens`.

Unlike the existing Profile/Preview/Export/More lenses, this one is **not**
gated behind `support_client_codelens`. Those lenses all route through
`tinymist.runCodeLens`, which only does something because the VS Code
extension intercepts that command client-side before it would reach the
server — there is no server-side handler for `runCodeLens` at all, so on a
client that forwards it as a plain `workspace/executeCommand` it is a no-op.
`tinymist.pinMain` has no such indirection: it's a real command the server
already implements, so the lens works for any standards-compliant LSP
client.

**Commit 2** adds dynamic registration support for codeLens (mirroring the
existing pattern for semantic tokens / document formatting), since Zed
declares `textDocument.codeLens.dynamicRegistration: true`.

## ⚠️ Update after testing against real Zed

I initially assumed the lens alone would be enough, and added the dynamic
registration commit hoping it would unlock things further after finding Zed
never queried `textDocument/codeLens` despite the lens being enabled with
`"code_lens": "on"` / `"menu"`.

**It didn't.** Confirmed via Zed's own `dev: open language server logs` RPC
trace (opened *before* the language server handshake, so the whole session
is captured): Zed 1.13.2 never sends `textDocument/codeLens` for tinymist,
with or without dynamic registration. Other requests (completion, hover,
documentHighlight) work fine on the same connection, so this isn't a broken
connection — codeLens specifically is never queried.

So, as it stands, **this does not currently unlock pinning in Zed**. I'm
still submitting both commits because:
- The lens itself (commit 1) is correct, generically useful LSP surface for
  any client that does support codeLens (confirmed via direct protocol
  testing — see below), and costs nothing for clients that don't.
- The dynamic registration commit (commit 2) is a real, independently
  correct protocol conformance improvement, symmetric with how tinymist
  already handles this exact situation for semantic tokens and document
  formatting. It's plausible some other client needs it even if Zed doesn't
  currently benefit.

I'd guess the Zed-side gap is either a bug in Zed's codeLens support for
extension-provided (WASM) language servers specifically, or something more
fundamental about how it decides which servers to query for lenses. I don't
have Zed's source handy to dig further; happy to file an issue there if that
seems like the right next step, or to close this PR if you'd rather not
carry code with no currently-working consumer.

## Testing

- `cargo build --release -p tinymist-query -p tinymist -p tinymist-cli`
- `cargo clippy --release -p tinymist-query -p tinymist --no-deps` — clean
- `cargo fmt -p tinymist-query -p tinymist -- --check` — clean
- `./target/release/tinymist-l10n --kind rs --dir ./crates --output ./locales/tinymist-rt.toml`
  to extract the new locale keys (added `zh` translations by hand alongside
  the generated `en` ones)
- End-to-end, against the built binary, via a minimal Python LSP client
  driving the exact message sequence a real client sends:
  1. `didOpen` a large document with `preview.background.enabled: true`.
  2. `textDocument/codeLens` → confirmed the response includes
     `{"title": "📌 Pin Preview to This File", "command": "tinymist.pinMain", "arguments": [<path>]}`.
  3. `workspace/executeCommand` with that exact command/arguments (what any
     LSP client sends when the lens is clicked) → succeeds.
  4. `textDocument/codeLens` again → now reads "📌 Unpin Preview" with
     `arguments: [null]`.
  5. Opened a **second** `.typ` file, then edited the first again: before
     this change the preview goes permanently silent at this point (0 bytes
     on the data-plane socket); after pinning, the first document keeps
     receiving incremental preview updates as expected.
  6. Repeated with `textDocument.codeLens.dynamicRegistration: true`
     declared: confirmed `codeLensProvider` is correctly omitted from the
     static capabilities and a `client/registerCapability` request for
     `textDocument/codeLens` is sent after `initialized`; `textDocument/codeLens`
     still answers correctly afterward.
  7. Repeated without declaring it: confirmed `codeLensProvider` is still
     statically declared as before (no regression for existing clients).
- Live against real Zed 1.13.2 (see above): confirmed the connection,
  binary, and other LSP features all work normally; confirmed via RPC trace
  that codeLens specifically is never requested, with or without dynamic
  registration.

## Notes for maintainers

I didn't open an issue first per CONTRIBUTING.md's guidance for new
features, since this is small, additive, reuses an existing command
unchanged, and directly fixes broken behavior rather than adding new
capability surface — but given the Zed result above, I'm very open to
discussion on whether this is worth carrying at all right now, or should
wait until there's a client that actually benefits from it.

Assisted-by: Artificial Intelligence