### PR TITLE
fix: replace the outdated link to detypify supported-symbols.txt

### DIFF
--- a/tools/editor-tools/src/features/symbol-view/components/canvas-panel.ts
+++ b/tools/editor-tools/src/features/symbol-view/components/canvas-panel.ts
@@ -19,10 +19,10 @@ const HelpPanel = () => {
     ),
     h4("Cannot find some symbols?"),
     p(
-      "🔍: Check the supported symbols listed in ",
+      "🔍: Check the supported symbols in ",
       a(
-        { href: "https://github.com/QuarticCat/detypify/blob/main/assets/supported-symbols.txt" },
-        "supported-symbols.txt",
+        { href: "https://github.com/QuarticCat/detypify-data" },
+        "Detypify Data",
       ),
       ".",
     ),


### PR DESCRIPTION
The txt file was removed on 2026-01-19 in the following commit.

https://github.com/QuarticCat/detypify/commit/89d0d88c9cb054781cb4018ff176291d9e492b5b
> do not generate supported-symbols.txt anymore

The last edit to this tinymist tool description is #2101.