### PR TITLE
fix(release): keep editor assets out of draft flow

### DIFF
--- a/.github/workflows/build-intellij-plugin.yml
+++ b/.github/workflows/build-intellij-plugin.yml
@@ -1,12 +1,14 @@
-# GitHub Actions Workflow is created for testing and preparing the plugin release in the following steps:
+# GitHub Actions workflow for testing and packaging the IntelliJ plugin:
 # - Validate Gradle Wrapper.
 # - Run 'test' and 'verifyPlugin' tasks.
 # - Run Qodana inspections.
 # - Run the 'buildPlugin' task and prepare artifact for further tests.
 # - Run the 'runPluginVerifier' task.
-# - Create a draft release.
+# - Upload the built plugin as an Actions artifact for release assembly.
 #
-# The workflow is triggered on push and pull_request events.
+# This workflow does not create or modify GitHub Releases.
+#
+# The workflow is reusable from CI and can also be manually dispatched.
 #
 # GitHub Actions reference: https://help.github.com/en/actions
 #
@@ -50,23 +52,22 @@ jobs:
       - name: Build plugin
         run: ./gradlew :intellij:buildPlugin
 
-      # Prepare plugin archive content for creating artifact
+      # Prepare the plugin archive for release assembly and manual installation
       - name: Prepare Plugin Artifact
         id: artifact
         shell: bash
         run: |
           cd ${{ github.workspace }}/editors/intellij/build/distributions
-          FILENAME=`ls *.zip`
-          unzip "$FILENAME" -d content
+          FILENAME=$(find . -maxdepth 1 -type f -name '*.zip' -printf '%f\n' | head -n 1)
+          test -n "$FILENAME"
+          echo "filename=${FILENAME}" >> "$GITHUB_OUTPUT"
 
-          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
-
-      # Store an already-built plugin as an artifact for downloading
+      # Store the plugin archive as an artifact for release assembly
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.artifact.outputs.filename }}
-          path: ${{ github.workspace }}/editors/intellij/build/distributions/content/*/*
+          name: tinymist-intellij-plugin
+          path: ${{ github.workspace }}/editors/intellij/build/distributions/${{ steps.artifact.outputs.filename }}
 
   # Run tests and upload a code coverage report
   test:
@@ -173,41 +174,3 @@ jobs:
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/editors/intellij/build/reports/pluginVerifier
-
-  # Prepare a draft release for GitHub Releases page for the manual verification
-  # If accepted and published, the release workflow would be triggered
-  releaseDraft:
-    name: Release draft
-    if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-
-      # Check out the current repository
-      - name: Fetch Sources
-        uses: actions/checkout@v4
-
-      # Remove old release drafts by using the curl request for the available releases with a draft flag
-      - name: Remove Old Release Drafts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/{owner}/{repo}/releases \
-            --jq '.[] | select(.draft == true) | .id' \
-            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
-
-      # Create a new release draft which is not publicly visible and requires manual acceptance
-      - name: Create Release Draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(./gradlew :intellij:properties --property version --quiet --console=plain | tail -n 1 | cut -f2- -d ' ')
-          RELEASE_NOTE="/tmp/release_note.txt"
-          ./gradlew :intellij:getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
-          
-          gh release create $VERSION \
-            --draft \
-            --title $VERSION \
-            --notes-file $RELEASE_NOTE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,29 @@ jobs:
   build-intellij:
     uses: ./.github/workflows/build-intellij-plugin.yml
 
+  release-intellij:
+    name: Upload IntelliJ plugin to release
+    needs: [prepare-build, announce, build, build-intellij]
+    if: ${{ success() && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download IntelliJ plugin artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tinymist-intellij-plugin
+          path: artifacts
+      - name: Upload IntelliJ plugin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare-build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          plugin=$(find artifacts -type f -name '*.zip' -print -quit)
+          test -n "$plugin"
+          gh release upload "$RELEASE_TAG" "$plugin" --clobber
+
   checks-neovim:
     name: Neovim Spec Tests
     runs-on: ubuntu-latest

--- a/scripts/draft-release.mjs
+++ b/scripts/draft-release.mjs
@@ -97,6 +97,82 @@ ${table}
 `;
 };
 
+const generateGpuViewerInstall = (version) => {
+  const platforms = [
+    {
+      name: "win32-x64",
+      displayName: "x64 Windows",
+      viewerTarget: "x86_64-pc-windows-msvc",
+      viewerArchive: "zip",
+    },
+    {
+      name: "win32-arm64",
+      displayName: "ARM64 Windows",
+      viewerTarget: "aarch64-pc-windows-msvc",
+      viewerArchive: "zip",
+    },
+    {
+      name: "linux-x64",
+      displayName: "x64 Linux",
+      viewerTarget: "x86_64-unknown-linux-gnu",
+      viewerArchive: "tar.gz",
+    },
+    {
+      name: "linux-arm64",
+      displayName: "ARM64 Linux",
+      viewerTarget: "aarch64-unknown-linux-gnu",
+      viewerArchive: "tar.gz",
+    },
+    {
+      name: "linux-armhf",
+      displayName: "ARMv7 Linux",
+      viewerTarget: "arm-unknown-linux-gnueabihf",
+      viewerArchive: "tar.gz",
+    },
+    {
+      name: "darwin-x64",
+      displayName: "Intel macOS",
+      viewerTarget: "x86_64-apple-darwin",
+      viewerArchive: "tar.gz",
+    },
+    {
+      name: "darwin-arm64",
+      displayName: "Apple Silicon macOS",
+      viewerTarget: "aarch64-apple-darwin",
+      viewerArchive: "tar.gz",
+    },
+  ];
+
+  const urlBase = `https://github.com/Myriad-Dreamin/tinymist/releases/download/v${version}`;
+  const rows = platforms.map((platform) => {
+    const extension = `tinymist-gpu-viewer-${platform.name}.vsix`;
+    const viewer = `tinymist-viewer-${platform.viewerTarget}.${platform.viewerArchive}`;
+    return `| [${extension}](${urlBase}/${extension}) | ${platform.displayName} | [${viewer}](${urlBase}/${viewer}) |`;
+  });
+
+  return `## Download tinymist-gpu-viewer VS Code Extension ${version}
+|  Extension  | Platform | Native Viewer |
+|-------------|----------|----------------|
+${rows.join("\n")}
+`;
+};
+
+const generateIntellijPluginInstall = (version) => {
+  const gradleProperties = fs.readFileSync("editors/intellij/gradle.properties", "utf8");
+  const pluginVersion = gradleProperties.match(/^pluginVersion\s*=\s*(.+)$/m)?.[1].trim();
+  if (!pluginVersion) {
+    throw new Error(
+      "Failed to find the IntelliJ plugin version in editors/intellij/gradle.properties",
+    );
+  }
+
+  const file = `tinymist-intellij-${pluginVersion}.zip`;
+  const url = `https://github.com/Myriad-Dreamin/tinymist/releases/download/v${version}/${file}`;
+  return `## Download Tinymist IntelliJ Plugin ${pluginVersion}
+[${file}](${url})
+`;
+};
+
 const collapsed = (content, summary) => {
   return `<details>
 
@@ -168,11 +244,24 @@ const main = async () => {
 
   fs.writeFileSync("target/announcement-changelog.md", changelogPlain);
 
-  const extensionInstallText = generateExtensionInstall(versionToUpload);
+  const extensionInstallText = [
+    generateExtensionInstall(versionToUpload),
+    generateGpuViewerInstall(versionToUpload),
+  ].join("\n\n");
+  const intellijPluginInstallText = generateIntellijPluginInstall(versionToUpload);
   // concat and generate final announcement
   const binInstallSection = collapsed(binInstallText, `Download Binary`);
-  const extensionInstallSection = collapsed(extensionInstallText, `Download VS Code Extension`);
-  const announcement = [changelogPlain, binInstallSection, extensionInstallSection].join("\n\n");
+  const extensionInstallSection = collapsed(extensionInstallText, `Download VS Code Extensions`);
+  const intellijPluginInstallSection = collapsed(
+    intellijPluginInstallText,
+    `Download IntelliJ Plugin`,
+  );
+  const announcement = [
+    changelogPlain,
+    binInstallSection,
+    extensionInstallSection,
+    intellijPluginInstallSection,
+  ].join("\n\n");
   fs.writeFileSync("target/announcement.gen.md", announcement);
 
   console.log("Please check the generated announcement in target/announcement.gen.md");


### PR DESCRIPTION
- Make the IntelliJ workflow artifact-only; it no longer creates or modifies GitHub Release drafts.
- Add GPU viewer/native viewer and IntelliJ plugin downloads to generated release notes.
- Upload the IntelliJ plugin archive from the top-level release workflow after the release is finalized.