### PR TITLE
fix(project): Dynamically update dependencies

### DIFF
--- a/crates/tinymist/src/route.rs
+++ b/crates/tinymist/src/route.rs
@@ -91,7 +91,7 @@ impl ProjectRouteState {
         Some(())
     }
 
-    pub fn update_existing_material(
+    pub fn update_material(
         &mut self,
         lock_dir: ImmutPath,
         snap: &LspCompileSnapshot,
@@ -104,8 +104,7 @@ impl ProjectRouteState {
         let deps = snap.world.depended_fs_paths();
         let material = ProjectPathMaterial::from_deps(id, deps);
 
-        let old = path_route.materials.get_mut(&material.id)?;
-        if old == &material {
+        if path_route.materials.get(&material.id).is_some_and(|old| old == &material) {
             return Some(());
         }
 

--- a/crates/tinymist/src/server.rs
+++ b/crates/tinymist/src/server.rs
@@ -417,6 +417,19 @@ impl ServerState {
             return Ok(());
         };
 
+        // Update the in-memory route/material state after each compilation so
+        // that newly imported files are mapped to the correct project.
+        #[cfg(feature = "lock")]
+        {
+            use crate::project::EntryReader;
+            if let LspInterrupt::Compiled(artifact) = &params {
+                let entry = artifact.world().entry_state();
+                if let Some(lock_dir) = ready.entry_resolver().resolve_lock(&entry) {
+                    ready.route.update_material(lock_dir, &artifact.snap);
+                }
+            }
+        }
+
         ready.project.interrupt(params);
 
         ready.schedule_async();


### PR DESCRIPTION
update_existing_material was unused before.

Partially fixes #2625.
The `path-material.json` should probably also be updated, that's not part of this PR as it is.

The trigger being placed into compile_interrupt might be questionable design (I'm not familiar with the code base); feel free to suggest something else.