### PR TITLE
fix: validate is_dir after applying export extension to output path

### DIFF
--- a/crates/tinymist/src/task/export.rs
+++ b/crates/tinymist/src/task/export.rs
@@ -363,9 +363,6 @@ impl ExportTask {
         if write_to.is_relative() {
             bail!("ExportTask({task:?}): output path is relative: {write_to:?}");
         }
-        if write_to.is_dir() {
-            bail!("ExportTask({task:?}): output path is a directory: {write_to:?}");
-        }
 
         // Apply page template if any
         let write_to = match task {
@@ -380,7 +377,10 @@ impl ExportTask {
             _ => write_to,
         };
         let write_to = write_to.with_extension(task.extension());
-
+        if write_to.is_dir() {
+            bail!("ExportTask({task:?}): output path is a directory: {write_to:?}");
+        }
+        
         Ok(Some(write_to))
     }
 


### PR DESCRIPTION
Change `is_dir` to execute after `with_extension`.

# Reproduction
`main.typ`
export pdf fail if there is a directory named  `main`
`crates/tinymist/src/task/export.rs:377:13: ExportTask(ExportPdf(ExportPdfTask { export: ExportTask { when: Never, output: Some(PathPattern("")), transform: [] }, pages: None, pdf_standards: [], no_pdf_tags: false, creation_timestamp: None })): output path is a directory: "/Users/test/projects/test/main"`